### PR TITLE
print clean json by default from ss-cartridge-info

### DIFF
--- a/stickshift/node/bin/ss-cartridge-info
+++ b/stickshift/node/bin/ss-cartridge-info
@@ -68,7 +68,8 @@ begin
     begin
       cart = StickShift::Cartridge.new.from_descriptor(YAML.load(File.open(path)))
       if cart.name == cart_name
-        print "CLIENT_RESULT: ",cart.to_descriptor.to_json
+        print "CLIENT_RESULT: " if $ss_debug
+        print cart.to_descriptor.to_json
         cart_found = true
         break
       end
@@ -86,7 +87,8 @@ begin
       begin
         cart = StickShift::Cartridge.new.from_descriptor(YAML.load(File.open(path)))
         if cart.name == cart_name
-          print "CLIENT_RESULT: ",cart.to_descriptor.to_json
+          print "CLIENT_RESULT: " if $ss_debug
+          print cart.to_descriptor.to_json
           break
         end
       rescue Exception => e


### PR DESCRIPTION
print clean json by default so it can be passed into a json parser/navigator such as jazor
