### PR TITLE
Add pre/post start/stop hooks to app_ctl scripts

### DIFF
--- a/cartridges/jbossas-7/info/bin/app_ctl_impl.sh
+++ b/cartridges/jbossas-7/info/bin/app_ctl_impl.sh
@@ -73,17 +73,19 @@ function start_app() {
         if isrunning; then
             echo "Application is already running" 1>&2
         else
+            run_user_hook pre start
             set_app_state started
             # Start
             jopts="${JAVA_OPTS}"
             [ "${ENABLE_JPDA:-0}" -eq 1 ] && jopts="-Xdebug -Xrunjdwp:transport=dt_socket,address=$OPENSHIFT_INTERNAL_IP:8787,server=y,suspend=n ${JAVA_OPTS}"
             JAVA_OPTS="${jopts}" $APP_JBOSS_BIN_DIR/standalone.sh > ${APP_JBOSS_TMP_DIR}/${OPENSHIFT_GEAR_NAME}.log 2>&1 &
-	        PROCESS_ID=$!
-	        echo $PROCESS_ID > $JBOSS_PID_FILE
-	        if ! ishttpup; then
-	            echo "Timed out waiting for http listening port"
-	            exit 1
-	        fi
+	    PROCESS_ID=$!
+	    echo $PROCESS_ID > $JBOSS_PID_FILE
+	    if ! ishttpup; then
+	      echo "Timed out waiting for http listening port"
+	      exit 1
+	    fi
+            run_user_hook post start
         fi
     fi
 }
@@ -94,9 +96,11 @@ function stop_app() {
         jbpid=$(cat $JBOSS_PID_FILE);
         echo "Application($jbpid) is already stopped" 1>&2
     elif [ -f "$JBOSS_PID_FILE" ]; then
+        run_user_hook pre stop
         pid=$(cat $JBOSS_PID_FILE);
         echo "Sending SIGTERM to jboss:$pid ..." 1>&2
         killtree $pid
+        run_user_hook post stop
     else 
         echo "Failed to locate JBOSS PID File" 1>&2
     fi

--- a/cartridges/nodejs-0.6/info/bin/app_ctl.sh
+++ b/cartridges/nodejs-0.6/info/bin/app_ctl.sh
@@ -147,8 +147,6 @@ translate_env_vars
 
 validate_run_as_user
 
-arm_ctl_script_timeout
-
 # Handle commands.
 case "$1" in
     start)               _start_node_service    ;;

--- a/cartridges/nodejs-0.6/info/bin/app_ctl.sh
+++ b/cartridges/nodejs-0.6/info/bin/app_ctl.sh
@@ -45,6 +45,8 @@ function _start_node_service() {
 
     #  Got here - it means that we need to start up Node.
 
+    run_user_hook pre start
+
     envf="$OPENSHIFT_GEAR_DIR/conf/node.env"
     logf="$OPENSHIFT_GEAR_DIR/logs/node.log"
 
@@ -68,6 +70,7 @@ function _start_node_service() {
     popd > /dev/null
     if [ $ret -eq 0 ]; then
         echo "$npid" > "$OPENSHIFT_GEAR_DIR/run/node.pid"
+        run_user_hook post start
     else
         echo "Application '$OPENSHIFT_GEAR_NAME' failed to start - $ret" 1>&2
     fi
@@ -81,6 +84,8 @@ function _stop_node_service() {
     fi
 
     if [ -n "$node_pid" ]; then
+        run_user_hook pre stop
+
         logf="$OPENSHIFT_GEAR_DIR/logs/node.log"
         echo "`date +"$FMT"`: Stopping application '$OPENSHIFT_GEAR_NAME' ..." >> $logf
         /bin/kill $node_pid
@@ -101,6 +106,8 @@ function _stop_node_service() {
 
         echo "`date +"$FMT"`: Stopped Node application '$OPENSHIFT_GEAR_NAME'" >> $logf
         rm -f $OPENSHIFT_GEAR_DIR/run/node.pid
+        
+        run_user_hook post stop
     else
         if `pgrep -x node -u $(id -u)  > /dev/null 2>&1`; then
             echo "Warning: Application '$OPENSHIFT_GEAR_NAME' Node server exists without a pid file.  Use force-stop to kill." 1>&2
@@ -139,6 +146,8 @@ done
 translate_env_vars
 
 validate_run_as_user
+
+arm_ctl_script_timeout
 
 # Handle commands.
 case "$1" in

--- a/cartridges/nodejs-0.6/info/hooks/configure
+++ b/cartridges/nodejs-0.6/info/hooks/configure
@@ -82,6 +82,7 @@ create_standard_env_vars
 create_standard_network_env_vars
 create_standard_repo_dir_env_var
 create_standard_path_env_var
+set_ctl_script_timeout
 
 # And prepend to path variable so that Node app_ctl.sh script is called.
 sed -i 's#export \s*PATH=#export PATH=$CART_INFO_DIR/bin/:#' $APP_HOME/.env/PATH

--- a/cartridges/nodejs-0.6/info/hooks/configure
+++ b/cartridges/nodejs-0.6/info/hooks/configure
@@ -82,7 +82,6 @@ create_standard_env_vars
 create_standard_network_env_vars
 create_standard_repo_dir_env_var
 create_standard_path_env_var
-set_ctl_script_timeout
 
 # And prepend to path variable so that Node app_ctl.sh script is called.
 sed -i 's#export \s*PATH=#export PATH=$CART_INFO_DIR/bin/:#' $APP_HOME/.env/PATH

--- a/stickshift/abstract/abstract-httpd/info/bin/app_ctl.sh
+++ b/stickshift/abstract/abstract-httpd/info/bin/app_ctl.sh
@@ -30,15 +30,19 @@ case "$1" in
             echo "Application is explicitly stopped!  Use 'rhc app start -a ${OPENSHIFT_GEAR_NAME}' to start back up." 1>&2
             exit 0
         else
+            run_user_hook pre start
             set_app_state started
             /usr/sbin/httpd -C "Include ${OPENSHIFT_GEAR_DIR}conf.d/*.conf" -f $CART_CONF_DIR/httpd_nolog.conf -k $1
+            run_user_hook post start
         fi
     ;;
     graceful-stop|stop)
         app_ctl_stop.sh $1
     ;;
     restart|graceful)
+        run_user_hook pre start
         set_app_state started
         /usr/sbin/httpd -C "Include ${OPENSHIFT_GEAR_DIR}conf.d/*.conf" -f $CART_CONF_DIR/httpd_nolog.conf -k $1
+        run_user_hook post start
     ;;
 esac

--- a/stickshift/abstract/abstract-httpd/info/bin/app_ctl_stop.sh
+++ b/stickshift/abstract/abstract-httpd/info/bin/app_ctl_stop.sh
@@ -12,7 +12,9 @@ done
 CART_CONF_DIR=${CARTRIDGE_BASE_PATH}/${OPENSHIFT_GEAR_TYPE}/info/configuration/etc/conf
 
 # Stop the app
+run_user_hook pre stop
 set_app_state stopped
 httpd_pid=`cat ${OPENSHIFT_RUN_DIR}httpd.pid 2> /dev/null`
 /usr/sbin/httpd -C "Include ${OPENSHIFT_GEAR_DIR}conf.d/*.conf" -f $CART_CONF_DIR/httpd_nolog.conf -k $1
 wait_for_stop $httpd_pid
+run_user_hook post stop

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -113,6 +113,7 @@ function create_standard_network_env_vars {
     echo "export OPENSHIFT_INTERNAL_IP='$IP'" > $APP_HOME/.env/OPENSHIFT_INTERNAL_IP
     echo "export OPENSHIFT_INTERNAL_PORT='8080'" > $APP_HOME/.env/OPENSHIFT_INTERNAL_PORT
     echo "export OPENSHIFT_GEAR_CTL_SCRIPT='$APP_DIR/${application}_ctl.sh'" > $APP_HOME/.env/OPENSHIFT_GEAR_CTL_SCRIPT
+    echo "export OPENSHIFT_GEAR_CTL_TIMEOUT='30'" > $APP_HOME/.env/OPENSHIFT_GEAR_CTL_TIMEOUT
     echo "export OPENSHIFT_GEAR_DNS='${application}-${namespace}.${CLOUD_DOMAIN}'" > $APP_HOME/.env/OPENSHIFT_GEAR_DNS
 }
 

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -639,6 +639,27 @@ function test_cartridge_state {
   return `test "$_state" = $2`
 }
 
+function run_user_hook {
+  local position="$1"
+  local event="$2"
+
+  local hook="$APP_HOME/.openshift/action-hooks/${position}-${event}"
+
+  if [ $(id -u) -eq 0 ]; then
+    echo "ERROR: run_user_hook called as root" 1>&2
+    exit 15
+  fi
+
+  if [ -f "$hook" ]; then
+    if [ "$position" = "pre" ]; then
+      source "$hook"
+    else
+      "$hook"
+    fi
+  fi
+}
+
+
 if [ -f /usr/libexec/stickshift/lib/util_ext ]
 then
     source /usr/libexec/stickshift/lib/util_ext

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -616,10 +616,12 @@ function test_cartridge_state {
 }
 
 function run_user_hook {
+  # Run pre_start, pre_stop, post_start, post_stop hooks.
+  # The pre_* hooks may modify environment.
   local position="$1"
   local event="$2"
 
-  local hook="$APP_HOME/.openshift/action-hooks/${position}-${event}"
+  local hook="$APP_HOME/.openshift/action-hooks/${position}_${event}"
 
   if [ $(id -u) -eq 0 ]; then
     echo "ERROR: run_user_hook called as root" 1>&2

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -113,8 +113,17 @@ function create_standard_network_env_vars {
     echo "export OPENSHIFT_INTERNAL_IP='$IP'" > $APP_HOME/.env/OPENSHIFT_INTERNAL_IP
     echo "export OPENSHIFT_INTERNAL_PORT='8080'" > $APP_HOME/.env/OPENSHIFT_INTERNAL_PORT
     echo "export OPENSHIFT_GEAR_CTL_SCRIPT='$APP_DIR/${application}_ctl.sh'" > $APP_HOME/.env/OPENSHIFT_GEAR_CTL_SCRIPT
-    echo "export OPENSHIFT_GEAR_CTL_TIMEOUT='30'" > $APP_HOME/.env/OPENSHIFT_GEAR_CTL_TIMEOUT
     echo "export OPENSHIFT_GEAR_DNS='${application}-${namespace}.${CLOUD_DOMAIN}'" > $APP_HOME/.env/OPENSHIFT_GEAR_DNS
+}
+
+function set_ctl_script_timeout {
+  local timeout
+  if [ -z "$1" ]; then
+    timeout="$1"
+  else
+    timeout=30
+  fi
+  echo "export OPENSHIFT_GEAR_CTL_TIMEOUT='$timeout'" > $APP_HOME/.env/OPENSHIFT_GEAR_CTL_TIMEOUT
 }
 
 function create_standard_repo_dir_env_var {

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -4,6 +4,11 @@
 SS_CONTROLLER_LIB_UTIL=true
 source /etc/stickshift/stickshift-node.conf
 
+function source_if_exists {
+    [ -f "$1" ]  &&  source "$1"
+    return 0
+}
+
 function start_app {
     for env_var in  $APP_HOME/.env/*_CTL_SCRIPT
     do
@@ -53,11 +58,6 @@ function start_dbs {
     do
         $cmd start || error "Failed to start ${cmd}" 121
     done
-}
-
-function source_if_exists {
-    [ -f "$1" ]  &&  source "$1"
-    return 0
 }
 
 function get_app_type {
@@ -118,12 +118,26 @@ function create_standard_network_env_vars {
 
 function set_ctl_script_timeout {
   local timeout
-  if [ -z "$1" ]; then
+  if [ "$1" ]; then
     timeout="$1"
   else
-    timeout=30
+    timeout="30"
   fi
   echo "export OPENSHIFT_GEAR_CTL_TIMEOUT='$timeout'" > $APP_HOME/.env/OPENSHIFT_GEAR_CTL_TIMEOUT
+}
+
+function arm_ctl_script_timeout {
+  source_if_exists "$APP_HOME/.env/OPENSHIFT_GEAR_CTL_TIMEOUT"
+  
+  if [ "$OPENSHIFT_GEAR_CTL_TIMEOUT" ]; then
+    # Force integer comparison.  We want to fail here otherwise.
+    if [ "$OPENSHIFT_GEAR_CTL_TIMEOUT" -gt 0 ]; then
+      local ctl_pid ctl_time
+      ctl_pid=$$
+      ctl_time=$(( $(date '+%s') + $OPENSHIFT_GEAR_CTL_TIMEOUT ))
+      ( while [ $(date '+%s') -lt $ctl_time ]; do kill -s 0 $ctl_pid || exit 0 ; usleep 100000; done; kill $ctl_pid ) & </dev/null >/dev/null 2>&1
+    fi
+  fi
 }
 
 function create_standard_repo_dir_env_var {

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -116,30 +116,6 @@ function create_standard_network_env_vars {
     echo "export OPENSHIFT_GEAR_DNS='${application}-${namespace}.${CLOUD_DOMAIN}'" > $APP_HOME/.env/OPENSHIFT_GEAR_DNS
 }
 
-function set_ctl_script_timeout {
-  local timeout
-  if [ "$1" ]; then
-    timeout="$1"
-  else
-    timeout="30"
-  fi
-  echo "export OPENSHIFT_GEAR_CTL_TIMEOUT='$timeout'" > $APP_HOME/.env/OPENSHIFT_GEAR_CTL_TIMEOUT
-}
-
-function arm_ctl_script_timeout {
-  source_if_exists "$APP_HOME/.env/OPENSHIFT_GEAR_CTL_TIMEOUT"
-  
-  if [ "$OPENSHIFT_GEAR_CTL_TIMEOUT" ]; then
-    # Force integer comparison.  We want to fail here otherwise.
-    if [ "$OPENSHIFT_GEAR_CTL_TIMEOUT" -gt 0 ]; then
-      local ctl_pid ctl_time
-      ctl_pid=$$
-      ctl_time=$(( $(date '+%s') + $OPENSHIFT_GEAR_CTL_TIMEOUT ))
-      ( while [ $(date '+%s') -lt $ctl_time ]; do kill -s 0 $ctl_pid || exit 0 ; usleep 100000; done; kill $ctl_pid ) & </dev/null >/dev/null 2>&1
-    fi
-  fi
-}
-
 function create_standard_repo_dir_env_var {
     echo "export OPENSHIFT_REPO_DIR='$APP_DIR/repo/'" > $APP_HOME/.env/OPENSHIFT_REPO_DIR
 }

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -621,7 +621,7 @@ function run_user_hook {
   local position="$1"
   local event="$2"
 
-  local hook="$APP_HOME/.openshift/action_hooks/${position}_${event}"
+  local hook="${OPENSHIFT_REPO_DIR}.openshift/action_hooks/${position}_${event}"
 
   if [ $(id -u) -eq 0 ]; then
     echo "ERROR: run_user_hook called as root" 1>&2

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -621,7 +621,7 @@ function run_user_hook {
   local position="$1"
   local event="$2"
 
-  local hook="$APP_HOME/.openshift/action-hooks/${position}_${event}"
+  local hook="$APP_HOME/.openshift/action_hooks/${position}_${event}"
 
   if [ $(id -u) -eq 0 ]; then
     echo "ERROR: run_user_hook called as root" 1>&2


### PR DESCRIPTION
This adds the ability for an application developer to specify pre/post start/stop scripts.  The pre_start and pre_stop scripts can modify the application environment.
