### PR TITLE
Application pre/post start/stop hooks.

### DIFF
--- a/cartridges/10gen-mms-agent-0.1/info/bin/10gen_mms_agent_ctl.sh
+++ b/cartridges/10gen-mms-agent-0.1/info/bin/10gen_mms_agent_ctl.sh
@@ -30,7 +30,7 @@ case "$1" in
             echo "Application is already running!  Use 'rhc app cartridge restart -a ${OPENSHIFT_GEAR_NAME} -c 10gen-mms-agent-0.1' to restart." 1>&2
             exit 0
         fi
-
+        src_user_hook pre_start_10gen_mms_agent
         #
         # Remove the compiled versions of the settings.py file and reset the mms credentials from the file in repo
         # This is required so that any user changes to credentials in this file can be picked up and recompiled
@@ -45,14 +45,17 @@ case "$1" in
 
         nohup python ${OPENSHIFT_10GEN_MMS_AGENT_GEAR_DIR}mms-agent/${OPENSHIFT_GEAR_UUID}_agent.py > ${OPENSHIFT_10GEN_MMS_AGENT_GEAR_DIR}logs/agent.log 2>&1 &
         echo $! > ${OPENSHIFT_10GEN_MMS_AGENT_GEAR_DIR}run/mms-agent.pid
+        run_user_hook post_start_10gen_mms_agent
     ;;
 
     graceful-stop|stop)
         if [ -f ${OPENSHIFT_10GEN_MMS_AGENT_GEAR_DIR}run/mms-agent.pid ]
         then
+            src_user_hook pre_stop_10gen_mms_agent
             mms_agent_pid=`cat ${OPENSHIFT_10GEN_MMS_AGENT_GEAR_DIR}run/mms-agent.pid 2> /dev/null`
             kill -9 $mms_agent_pid > /dev/null
             rm -f ${OPENSHIFT_10GEN_MMS_AGENT_GEAR_DIR}run/mms-agent.pid > /dev/null
+            run_user_hook post_stop_10gen_mms_agent
         else
             if ps -ef | grep ${OPENSHIFT_GEAR_UUID}_agent.py | grep -qv grep > /dev/null 2>&1; then
                 echo "Failed to stop 10gen-mms-agent-0.1 as the pid file is missing!" 1>&2

--- a/cartridges/cron-1.4/info/bin/cron_ctl.sh
+++ b/cartridges/cron-1.4/info/bin/cron_ctl.sh
@@ -44,21 +44,25 @@ function _cronjobs_status() {
 
 
 function _cronjobs_enable() {
-   if _are_cronjobs_enabled; then
-      echo "$SERVICE_NAME scheduling service is already enabled" 1>&2
-   else
-      touch "$CART_INSTANCE_DIR/run/jobs.enabled"
-   fi
+    if _are_cronjobs_enabled; then
+        src_user_hook pre_start_cron
+        echo "$SERVICE_NAME scheduling service is already enabled" 1>&2
+        run_user_hook post_start_cron
+    else
+        touch "$CART_INSTANCE_DIR/run/jobs.enabled"
+    fi
 
 }  #  End of function  _cronjobs_enable.
 
 
 function _cronjobs_disable() {
-   if _are_cronjobs_enabled; then
-      rm -f $CART_INSTANCE_DIR/run/jobs.enabled
-   else
-      echo "$SERVICE_NAME scheduling service is already disabled" 1>&2
-   fi
+    if _are_cronjobs_enabled; then
+        src_user_hook pre_stop_cron
+        rm -f $CART_INSTANCE_DIR/run/jobs.enabled
+        run_user_hook post_stop_cron
+    else
+        echo "$SERVICE_NAME scheduling service is already disabled" 1>&2
+    fi
 
 }  #  End of function  _cronjobs_disable.
 

--- a/cartridges/haproxy-1.4/info/bin/app_ctl.sh
+++ b/cartridges/haproxy-1.4/info/bin/app_ctl.sh
@@ -48,18 +48,21 @@ start() {
     set_app_state started
     if ! isrunning
     then
+        src_user_hook pre_start
         /usr/sbin/haproxy -f $OPENSHIFT_HOMEDIR/haproxy-1.4/conf/haproxy.cfg > /dev/null 2>&1
         haproxy_ctld_daemon stop > /dev/null 2>&1  || :
         haproxy_ctld_daemon start > /dev/null 2>&1
+        wait_to_start
+        run_user_hook post_start
     else
         echo "Haproxy already running" 1>&2
+        wait_to_start
     fi
-
-    wait_to_start
 }
 
 
 stop() {
+    src_user_hook pre_stop
     set_app_state stopped
     haproxy_ctld_daemon stop > /dev/null 2>&1
     if [ -f $HAPROXY_PID ]; then
@@ -82,6 +85,7 @@ stop() {
             echo "Haproxy already stopped" 1>&2
         fi
     fi
+    run_user_hook post_stop
 }
 
 
@@ -93,7 +97,9 @@ function restart() {
 
 function _reload_haproxy_service() {
     [ -n "$1" ]  &&  zopts="-sf $1"
+    src_user_hook pre_start
     /usr/sbin/haproxy -f $OPENSHIFT_HOMEDIR/haproxy-1.4/conf/haproxy.cfg ${zopts} > /dev/null 2>&1
+    run_user_hook post_start
 
 }
 

--- a/cartridges/jbossas-7/info/bin/app_ctl_impl.sh
+++ b/cartridges/jbossas-7/info/bin/app_ctl_impl.sh
@@ -73,17 +73,19 @@ function start_app() {
         if isrunning; then
             echo "Application is already running" 1>&2
         else
+            src_user_hook pre_start
             set_app_state started
             # Start
             jopts="${JAVA_OPTS}"
             [ "${ENABLE_JPDA:-0}" -eq 1 ] && jopts="-Xdebug -Xrunjdwp:transport=dt_socket,address=$OPENSHIFT_INTERNAL_IP:8787,server=y,suspend=n ${JAVA_OPTS}"
             JAVA_OPTS="${jopts}" $APP_JBOSS_BIN_DIR/standalone.sh > ${APP_JBOSS_TMP_DIR}/${OPENSHIFT_GEAR_NAME}.log 2>&1 &
-	        PROCESS_ID=$!
-	        echo $PROCESS_ID > $JBOSS_PID_FILE
-	        if ! ishttpup; then
-	            echo "Timed out waiting for http listening port"
-	            exit 1
-	        fi
+            PROCESS_ID=$!
+            echo $PROCESS_ID > $JBOSS_PID_FILE
+            if ! ishttpup; then
+                echo "Timed out waiting for http listening port"
+                exit 1
+            fi
+            run_user_hook post_start
         fi
     fi
 }
@@ -94,9 +96,11 @@ function stop_app() {
         jbpid=$(cat $JBOSS_PID_FILE);
         echo "Application($jbpid) is already stopped" 1>&2
     elif [ -f "$JBOSS_PID_FILE" ]; then
+        src_user_hook pre_stop
         pid=$(cat $JBOSS_PID_FILE);
         echo "Sending SIGTERM to jboss:$pid ..." 1>&2
         killtree $pid
+        run_user_hook post_stop
     else 
         echo "Failed to locate JBOSS PID File" 1>&2
     fi

--- a/cartridges/mongodb-2.0/info/bin/mongodb_ctl.sh
+++ b/cartridges/mongodb-2.0/info/bin/mongodb_ctl.sh
@@ -52,7 +52,9 @@ repair() {
 start() {
     if ! isrunning
     then
+        src_user_hook pre_start_mongodb
         /usr/bin/mongod --auth --nojournal --smallfiles --quiet -f $MONGODB_DIR/etc/mongodb.conf run >/dev/null 2>&1 &
+        run_user_hook post_start_mongodb
     else
         echo "MongoDB already running" 1>&2
     fi
@@ -64,6 +66,7 @@ stop() {
     fi
 
     if [ -n "$pid" ]; then
+        src_user_hook pre_stop_mongodb
         /bin/kill $pid
         ret=$?
         if [ $ret -eq 0 ]; then
@@ -74,6 +77,7 @@ stop() {
                 let TIMEOUT=${TIMEOUT}-1
             done
         fi
+        run_user_hook post_stop_mongodb
     else
         if `pgrep -x mongod > /dev/null 2>&1`
         then

--- a/cartridges/mysql-5.1/info/bin/mysql_ctl.sh
+++ b/cartridges/mysql-5.1/info/bin/mysql_ctl.sh
@@ -40,10 +40,12 @@ isrunning() {
 }
 
 start() {
-	if ! isrunning
+    if ! isrunning
     then
+        src_user_hook pre_start_mysql
         /usr/bin/mysqld_safe --defaults-file=$MYSQL_DIR/etc/my.cnf >/dev/null 2>&1 &
         wait_to_start_as_user
+        run_user_hook post_start_mysql
     else
         echo "MySQL already running" 1>&2
     fi
@@ -51,7 +53,8 @@ start() {
 
 stop() {
     if [ -f $MYSQL_DIR/pid/mysql.pid ]; then
-    	pid=$( /bin/cat $MYSQL_DIR/pid/mysql.pid )
+        src_user_hook pre_stop_mysql
+        pid=$( /bin/cat $MYSQL_DIR/pid/mysql.pid )
         /bin/kill $pid
         ret=$?
         if [ $ret -eq 0 ]; then
@@ -62,6 +65,7 @@ stop() {
                 let TIMEOUT=${TIMEOUT}-1
             done
         fi
+        run_user_hook post_stop_mysql
     else
         if `pgrep -x mysqld_safe > /dev/null 2>&1`
         then

--- a/cartridges/nodejs-0.6/info/bin/app_ctl.sh
+++ b/cartridges/nodejs-0.6/info/bin/app_ctl.sh
@@ -45,6 +45,8 @@ function _start_node_service() {
 
     #  Got here - it means that we need to start up Node.
 
+    src_user_hook pre_start
+
     envf="$OPENSHIFT_GEAR_DIR/conf/node.env"
     logf="$OPENSHIFT_GEAR_DIR/logs/node.log"
 
@@ -68,6 +70,7 @@ function _start_node_service() {
     popd > /dev/null
     if [ $ret -eq 0 ]; then
         echo "$npid" > "$OPENSHIFT_GEAR_DIR/run/node.pid"
+        run_user_hook post_start
     else
         echo "Application '$OPENSHIFT_GEAR_NAME' failed to start - $ret" 1>&2
     fi
@@ -81,6 +84,8 @@ function _stop_node_service() {
     fi
 
     if [ -n "$node_pid" ]; then
+        src_user_hook pre_stop
+
         logf="$OPENSHIFT_GEAR_DIR/logs/node.log"
         echo "`date +"$FMT"`: Stopping application '$OPENSHIFT_GEAR_NAME' ..." >> $logf
         /bin/kill $node_pid
@@ -101,6 +106,8 @@ function _stop_node_service() {
 
         echo "`date +"$FMT"`: Stopped Node application '$OPENSHIFT_GEAR_NAME'" >> $logf
         rm -f $OPENSHIFT_GEAR_DIR/run/node.pid
+
+        run_user_hook post_stop
     else
         if `pgrep -x node -u $(id -u)  > /dev/null 2>&1`; then
             echo "Warning: Application '$OPENSHIFT_GEAR_NAME' Node server exists without a pid file.  Use force-stop to kill." 1>&2

--- a/cartridges/phpmyadmin-3.4/info/bin/phpmyadmin_ctl.sh
+++ b/cartridges/phpmyadmin-3.4/info/bin/phpmyadmin_ctl.sh
@@ -28,20 +28,26 @@ case "$1" in
             echo "Application is explicitly stopped!  Use 'rhc app cartridge start -a ${OPENSHIFT_GEAR_NAME} -c phpmyadmin-3.4' to start back up." 1>&2
             exit 0
         else
+            src_user_hook pre_start_phpmyadmin
             /usr/sbin/httpd -C "Include ${OPENSHIFT_PHPMYADMIN_GEAR_DIR}conf.d/*.conf" -f $CART_CONF_DIR/httpd_nolog.conf -k $1
+            run_user_hook post_start_phpmyadmin
         fi
     ;;
 
     graceful-stop|stop)
         if [ -f ${OPENSHIFT_PHPMYADMIN_GEAR_DIR}run/httpd.pid ]
         then
+            src_user_hook pre_stop_phpmyadmin
             httpd_pid=`cat ${OPENSHIFT_PHPMYADMIN_GEAR_DIR}run/httpd.pid 2> /dev/null`
             /usr/sbin/httpd -C "Include ${OPENSHIFT_PHPMYADMIN_GEAR_DIR}conf.d/*.conf" -f $CART_CONF_DIR/httpd_nolog.conf -k $1
             wait_for_stop $httpd_pid
+            run_user_hook post_stop_phpmyadmin
         fi
     ;;
 
     restart|graceful)
+        src_user_hook pre_start_phpmyadmin
         /usr/sbin/httpd -C "Include ${OPENSHIFT_PHPMYADMIN_GEAR_DIR}conf.d/*.conf" -f $CART_CONF_DIR/httpd_nolog.conf -k $1
+        run_user_hook post_start_phpmyadmin
     ;;
 esac

--- a/cartridges/postgresql-8.4/info/bin/postgresql_ctl.sh
+++ b/cartridges/postgresql-8.4/info/bin/postgresql_ctl.sh
@@ -37,49 +37,53 @@ function _service_status() {
 
 
 function _service_start() {
-   if _is_service_running; then
-      echo "$SERVICE_NAME server instance already running" 1>&2
-   else
-      pglogfile="$CART_INSTANCE_DIR/log/postgres.log"
-      /usr/bin/postgres -D $CART_INSTANCE_DIR/data > $pglogfile 2>&1 &
-      wait_to_start_as_user
-   fi
+    if _is_service_running; then
+        echo "$SERVICE_NAME server instance already running" 1>&2
+    else
+        src_user_hook pre_start_postgresql
+        pglogfile="$CART_INSTANCE_DIR/log/postgres.log"
+        /usr/bin/postgres -D $CART_INSTANCE_DIR/data > $pglogfile 2>&1 &
+        wait_to_start_as_user
+        run_user_hook post_start_postgresql
+    fi
 
 }  #  End of function  _service_start.
 
 
 function _service_stop() {
-   if [ -f $CART_INSTANCE_DIR/pid/postgres.pid ]; then
-      pid=$( /bin/cat $CART_INSTANCE_DIR/pid/postgres.pid )
-   fi
+    if [ -f $CART_INSTANCE_DIR/pid/postgres.pid ]; then
+        pid=$( /bin/cat $CART_INSTANCE_DIR/pid/postgres.pid )
+    fi
 
-   if [ -n "$pid" ]; then
-      # Fix for bugz 813934: Postgres gets into a bad state after a deploy
-      pglogfile="$CART_INSTANCE_DIR/log/postgres.log"
-      pg_ctl stop -D "$CART_INSTANCE_DIR/data" -m fast -w -t 30 >> $pglogfile 2>&1
-      sleep 1
-      if `pgrep -x postgres -u $(id -u) > /dev/null 2>&1`; then
-         /bin/kill $pid
-         ret=$?
-         if [ $ret -eq 0 ]; then
-            TIMEOUT="$STOPTIMEOUT"
-            while [ $TIMEOUT -gt 0 ]  &&  _is_service_running; do
-               /bin/kill -0 "$pid" >/dev/null 2>&1 || break
-               sleep 1
-               let TIMEOUT=${TIMEOUT}-1
-            done
-            if `pgrep -x postgres -u $(id -u) > /dev/null 2>&1`; then
-               pg_ctl stop -D "$CART_INSTANCE_DIR/data" -m immediate -w >> $pglogfile 2>&1
+    if [ -n "$pid" ]; then
+        src_user_hook pre_stop_postgresql
+        # Fix for bugz 813934: Postgres gets into a bad state after a deploy
+        pglogfile="$CART_INSTANCE_DIR/log/postgres.log"
+        pg_ctl stop -D "$CART_INSTANCE_DIR/data" -m fast -w -t 30 >> $pglogfile 2>&1
+        sleep 1
+        if `pgrep -x postgres -u $(id -u) > /dev/null 2>&1`; then
+            /bin/kill $pid
+            ret=$?
+            if [ $ret -eq 0 ]; then
+                TIMEOUT="$STOPTIMEOUT"
+                while [ $TIMEOUT -gt 0 ]  &&  _is_service_running; do
+                    /bin/kill -0 "$pid" >/dev/null 2>&1 || break
+                    sleep 1
+                    let TIMEOUT=${TIMEOUT}-1
+                done
+                if `pgrep -x postgres -u $(id -u) > /dev/null 2>&1`; then
+                    pg_ctl stop -D "$CART_INSTANCE_DIR/data" -m immediate -w >> $pglogfile 2>&1
+                fi
             fi
-         fi
-      fi
-   else
-      if `pgrep -x postgres -u $(id -u)  > /dev/null 2>&1`; then
-         echo "Warning: $SERVICE_NAME server instance exists without a pid file.  Use force-stop to kill." 1>&2
-      else
-         echo "$SERVICE_NAME server instance already stopped" 1>&2
-      fi
-   fi
+        fi
+        run_user_hook post_stop_postgresql
+    else
+        if `pgrep -x postgres -u $(id -u)  > /dev/null 2>&1`; then
+            echo "Warning: $SERVICE_NAME server instance exists without a pid file.  Use force-stop to kill." 1>&2
+        else
+            echo "$SERVICE_NAME server instance already stopped" 1>&2
+        fi
+    fi
 
 }  #  End of function  _service_stop.
 

--- a/cartridges/ruby-1.8/info/bin/app_ctl_stop.sh
+++ b/cartridges/ruby-1.8/info/bin/app_ctl_stop.sh
@@ -10,6 +10,7 @@ source "/etc/stickshift/stickshift-node.conf"
 CART_CONF_DIR=${CARTRIDGE_BASE_PATH}/${OPENSHIFT_GEAR_TYPE}/info/configuration/etc/conf
 
 # Stop the app
+src_user_hook pre_stop
 httpd_pid=`cat ${OPENSHIFT_RUN_DIR}httpd.pid 2> /dev/null`
 /usr/sbin/httpd -C "Include ${OPENSHIFT_GEAR_DIR}conf.d/*.conf" -f $CART_CONF_DIR/httpd_nolog.conf -k $1
 for i in {1..20}
@@ -33,3 +34,4 @@ do
         break
     fi
 done
+run_user_hook post_stop

--- a/stickshift/abstract/abstract-httpd/info/bin/app_ctl.sh
+++ b/stickshift/abstract/abstract-httpd/info/bin/app_ctl.sh
@@ -30,15 +30,19 @@ case "$1" in
             echo "Application is explicitly stopped!  Use 'rhc app start -a ${OPENSHIFT_GEAR_NAME}' to start back up." 1>&2
             exit 0
         else
+            src_user_hook pre_start
             set_app_state started
             /usr/sbin/httpd -C "Include ${OPENSHIFT_GEAR_DIR}conf.d/*.conf" -f $CART_CONF_DIR/httpd_nolog.conf -k $1
+            run_user_hook post_start
         fi
     ;;
     graceful-stop|stop)
         app_ctl_stop.sh $1
     ;;
     restart|graceful)
+        src_user_hook pre_start
         set_app_state started
         /usr/sbin/httpd -C "Include ${OPENSHIFT_GEAR_DIR}conf.d/*.conf" -f $CART_CONF_DIR/httpd_nolog.conf -k $1
+        run_user_hook post_start
     ;;
 esac

--- a/stickshift/abstract/abstract-httpd/info/bin/app_ctl_stop.sh
+++ b/stickshift/abstract/abstract-httpd/info/bin/app_ctl_stop.sh
@@ -12,7 +12,9 @@ done
 CART_CONF_DIR=${CARTRIDGE_BASE_PATH}/${OPENSHIFT_GEAR_TYPE}/info/configuration/etc/conf
 
 # Stop the app
+src_user_hook pre_stop
 set_app_state stopped
 httpd_pid=`cat ${OPENSHIFT_RUN_DIR}httpd.pid 2> /dev/null`
 /usr/sbin/httpd -C "Include ${OPENSHIFT_GEAR_DIR}conf.d/*.conf" -f $CART_CONF_DIR/httpd_nolog.conf -k $1
 wait_for_stop $httpd_pid
+run_user_hook post_stop

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -4,6 +4,11 @@
 SS_CONTROLLER_LIB_UTIL=true
 source /etc/stickshift/stickshift-node.conf
 
+function source_if_exists {
+    [ -f "$1" ]  &&  source "$1"
+    return 0
+}
+
 # Public: Start all processes in a given gear
 #
 # Examples:
@@ -85,11 +90,6 @@ function start_dbs {
     do
         $cmd start || error "Failed to start ${cmd}" 121
     done
-}
-
-function source_if_exists {
-    [ -f "$1" ]  &&  source "$1"
-    return 0
 }
 
 function get_app_type {
@@ -662,6 +662,40 @@ function test_cartridge_state {
   _state=`get_cartridge_state "$1"`
   return `test "$_state" = $2`
 }
+
+function src_user_hook {
+    # Run pre_start, pre_stop, post_start, post_stop hooks.
+    # The pre_* hooks may modify environment.
+    local hook="${OPENSHIFT_REPO_DIR}.openshift/action_hooks/$1"
+    shift
+
+    if [ $(id -u) -eq 0 ]; then
+        echo "ERROR: src_user_hook called as root" 1>&2
+        exit 15
+    fi
+
+    if [ -f "$hook" ]; then
+        source "$hook" "$@"
+    fi
+}
+
+
+function run_user_hook {
+    # Run pre_start, pre_stop, post_start, post_stop hooks.
+    # The pre_* hooks may modify environment.
+    local hook="${OPENSHIFT_REPO_DIR}.openshift/action_hooks/$1"
+    shift
+
+    if [ $(id -u) -eq 0 ]; then
+        echo "ERROR: run_user_hook called as root" 1>&2
+        exit 15
+    fi
+
+    if [ -f "$hook" ]; then
+        "$hook" "$@"
+    fi
+}
+
 
 if [ -f /usr/libexec/stickshift/lib/util_ext ]
 then


### PR DESCRIPTION
Add support for pre/post start/stop hooks to both web application service and embedded cartridges.  To avoid conflictsm embedded cartridges use hook names like pre_start_mysql which is similar to their start and stop ctl script nameing scheme.
