### PR TITLE
Adding a new REST endpoint for gear group information

### DIFF
--- a/stickshift/controller/lib/stickshift-controller/app/controllers/gear_groups_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/gear_groups_controller.rb
@@ -1,0 +1,23 @@
+class GearGroupsController < BaseController
+  respond_to :xml, :json
+  before_filter :authenticate, :check_version
+  include LegacyBrokerHelper
+  
+  def show
+    domain_id = params[:domain_id]
+    app_id = params[:application_id]
+    
+    app = Application.find(@cloud_user,app_id)
+    
+    if app.nil?
+      @reply = RestReply.new(:not_found)
+      message = Message.new(:error, "Application not found.", 101)
+      @reply.messages.push(message)
+      respond_with @reply, :status => @reply.status
+    else
+      group_instances = app.group_instances.map{ |group_inst| RestGearGroup.new(group_inst)}
+      @reply = RestReply.new(:ok, "gear_groups", group_instances)
+      respond_with @reply, :status => @reply.status
+    end
+  end
+end

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_gear_group.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_gear_group.rb
@@ -1,0 +1,16 @@
+class RestGearGroup < StickShift::Model
+  attr_accessor :name, :cartridge, :gears
+
+  def initialize(group_instance)
+    app             = group_instance.app
+    self.name       = group_instance.name
+    self.gears      = group_instance.gears.map{ |gear| {:id => gear.uuid} }
+    self.cartridge = group_instance.component_instances.map{ |comp_inst| {:type => app.comp_instance_map[comp_inst].parent_cart_name}}
+    self.cartridge.delete_if{ |comp| comp[:type] == app.name }
+  end
+
+  def to_xml(options={})
+    options[:tag_name] = "gear_group"
+    super(options)
+  end
+end

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_gear_group.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_gear_group.rb
@@ -5,8 +5,8 @@ class RestGearGroup < StickShift::Model
     app             = group_instance.app
     self.name       = group_instance.name
     self.gears      = group_instance.gears.map{ |gear| {:id => gear.uuid} }
-    self.cartridge = group_instance.component_instances.map{ |comp_inst| {:type => app.comp_instance_map[comp_inst].parent_cart_name}}
-    self.cartridge.delete_if{ |comp| comp[:type] == app.name }
+    self.cartridge = group_instance.component_instances.map{ |comp_inst| {:name => app.comp_instance_map[comp_inst].parent_cart_name}}
+    self.cartridge.delete_if{ |comp| comp[:name] == app.name }
   end
 
   def to_xml(options={})

--- a/stickshift/controller/lib/stickshift-controller/config/routes.rb
+++ b/stickshift/controller/lib/stickshift-controller/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       resources :applications, :constraints => { :id => /[\w]+/ } do
         resource :descriptor, :only => [:show]
         resource :gears, :only => [:show]
+        resource :gear_groups, :only => [:show]
         resources :cartridges, :controller => :emb_cart, :only => [:index, :show, :create, :destroy], :constraints => { :id => /[\w\-\.]+/ } do
             resources :events, :controller => :emb_cart_events, :only => [:create]
         end


### PR DESCRIPTION
Provides a grouped set of gears that share the same cartridges.

Eg:

```
<gear-group>
  <gears>
    <gear>
      <id>88913fdd37d143f2a625139ce7475f9e</id>
    </gear>
  </gears>
  <cartridge>
    <cartridge>
      <type>jbossas-7</type>
    </cartridge>
    <cartridge>
      <type>jenkins-client-1.4</type>
    </cartridge>
  </cartridge>
  <name>@@app/cart-jenkins-client-1.4</name>
</gear-group>
```
