### PR TITLE
Fix to broker unit test.

### DIFF
--- a/stickshift/broker/test/unit/legacy_request_test.rb
+++ b/stickshift/broker/test/unit/legacy_request_test.rb
@@ -45,7 +45,7 @@ class LegacyRequestTest < ActiveSupport::TestCase
   end
   
   test "Request validation: node_profile" do
-    ["jumbo","exlarge","large","micro","medium","small"].each do |n|
+    ["small"].each do |n|
       req = LegacyRequest.new.from_json("{\"node_profile\": \"#{n}\"}")
       assert req.valid?
     end


### PR DESCRIPTION
The broker unit test was expecting a set of gear sizes that used to be hard-coded and don't exist in all environments.
