### PR TITLE
Remove the hard-coded list of node types.

### DIFF
--- a/stickshift/broker/test/unit/legacy_request_test.rb
+++ b/stickshift/broker/test/unit/legacy_request_test.rb
@@ -49,9 +49,6 @@ class LegacyRequestTest < ActiveSupport::TestCase
       req = LegacyRequest.new.from_json("{\"node_profile\": \"#{n}\"}")
       assert req.valid?
     end
-    
-    req = LegacyRequest.new.from_json('{"node_profile": "other"}')
-    assert req.invalid?
   end
   
   test "Request validation: cartridge" do

--- a/stickshift/controller/lib/stickshift-controller/app/models/legacy_request.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/legacy_request.rb
@@ -64,9 +64,6 @@ class LegacyRequest < StickShift::Model
   end
   
   validates_each :node_profile, :allow_nil =>true do |record, attribute, val|
-    if !(val =~ /\A(small|medium)\z/)
-      record.errors.add attribute, {:message => "Invalid Profile: #{val}.  Must be: (medium|small)", :exit_code => 1}
-    end
   end
   
   validates_each :debug, :alter, :delete, :allow_nil =>true do |record, attribute, val|


### PR DESCRIPTION
For bugzilla ticket 808355, the layers of duplicate checking gear sizes are being removed in favour of allowing the broker to make a decision based on what the user is allowed and eventually how the cloud is defined.
