### PR TITLE
made dns_service @ss_dns_provider consistent with uplift-bind-plugin

### DIFF
--- a/stickshift/controller/lib/stickshift-controller/lib/stickshift/dns_service.rb
+++ b/stickshift/controller/lib/stickshift-controller/lib/stickshift/dns_service.rb
@@ -1,13 +1,13 @@
 module StickShift
   class DnsService
-    @dns_provider = StickShift::DnsService
+    @ss_dns_provider = StickShift::DnsService
 
     def self.provider=(provider_class)
-      @dns_provider = provider_class
+      @ss_dns_provider = provider_class
     end
 
     def self.instance
-      @dns_provider.new
+      @ss_dns_provider.new
     end
 
     def initialize


### PR DESCRIPTION
The rubygem-stickshift-broker StickShift::DnsService class uses @dns_provider as instance variable for the service class factory.

The rubygem-uplift-bind-plugin package uses 'ss_dns_provider' for the same purpose.  The other external service classes use the 'ss_' prefix as well.

It seems trailing underscores are being marked out of the text above. ss__dns_provider

This change makes the two consistent by updating the StickShift::DnsService class.

https://bugzilla.redhat.com/show_bug.cgi?id=821925
