### PR TITLE
Implement update-namespace hook in jbossas-7 cart

### DIFF
--- a/cartridges/jbossas-7/info/bin/update_namespace.sh
+++ b/cartridges/jbossas-7/info/bin/update_namespace.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Exit on any errors
+set -e
+ 
+source "/etc/stickshift/stickshift-node.conf"
+source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
+
+CART_INFO_DIR=${CARTRIDGE_BASE_PATH}/jbossas-7/info
+
+function print_help {
+    echo "Usage: $0 app-name new_namespace old_namespace uuid"
+
+    echo "$0 $@" | logger -p local0.notice -t stickshift_jboss_update_namespace
+
+    exit 1
+}
+
+[ $# -eq 4 ] || print_help
+
+application="$1"
+new_namespace="$2"
+old_namespace="$3"
+uuid=$4
+
+setup_app_dir_vars
+setup_user_vars
+
+OPENSHIFT_JBOSS_CLUSTER="$APP_HOME/.env/OPENSHIFT_JBOSS_CLUSTER"
+
+if [ -f $OPENSHIFT_JBOSS_CLUSTER ]
+then
+  echo "Updating OPENSHIFT_JBOSS_CLUSTER with new namespace, ${old_namespace} => ${new_namespace}"
+  sed -i "s/${old_namespace}/${new_namespace}/g" $APP_HOME/.env/OPENSHIFT_JBOSS_CLUSTER
+  run_as_user "$APP_DIR/${application}_ctl.sh restart"
+else
+  echo "Not updating OPENSHIFT_JBOSS_CLUSTER in response to namespace update as the file doesn't exist"
+fi

--- a/cartridges/jbossas-7/info/configuration/standalone.xml
+++ b/cartridges/jbossas-7/info/configuration/standalone.xml
@@ -257,7 +257,7 @@
                     <property name="bind_addr">${env.OPENSHIFT_INTERNAL_IP}</property>
                 </transport>
                 <protocol type="TCPPING">
-                	<property name="timeout">3000</property>
+                	<property name="timeout">30000</property>
                 	<property name="initial_hosts">${env.OPENSHIFT_JBOSS_CLUSTER}</property>
                 	<property name="port_range">0</property>
                 	<property name="num_initial_members">1</property>


### PR DESCRIPTION
The standalone.xml configuration file sources environment vars
from OPENSHIFT_JBOSS_CLUSTER which contains the entire universe
of cluster participant hostnames. Upon namespace alter, the
file needs updated and the JBoss server restarted in order
to reform the cluster with the new hostnames. In addition to
all this, the cluster configuration must have a lengthy timeout
to ensure DNS for the new namespace has propagated.

To ensure the cluster survives the domain alter, we:
- Rewrite the OPENSHIFT_JBOSS_CLUSTER file in the hook
- Restart the application gear in the hook
- Specify a 30 second timeout in the cluster configuration
  within standalone.xml

This resolves bugs:
- https://bugzilla.redhat.com/show_bug.cgi?id=811671
