### PR TITLE
Code for min_gear settings for a scalable app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Openshift Origin - CrankCase
-==============
+============================
 
 CrankCase contains the core server components of the OpenShift service
 released under the [OpenShift Origin source

--- a/cartridges/haproxy-1.4/info/bin/haproxy_ctld
+++ b/cartridges/haproxy-1.4/info/bin/haproxy_ctld
@@ -204,7 +204,7 @@ class Haproxy
         # If active capacity is greater then gear_up pct. Add a gear
         if @session_capacity_pct >= @gear_up_pct
             @remove_count = 0
-            self.add_gear if @gear_count < max
+            self.add_gear if @gear_count < max and max > 0
         elsif @session_capacity_pct < @gear_remove_pct and @gear_count > 1
             # If active capacity is less then gear remove percentage
             # *AND* the last gear up happened longer then

--- a/cartridges/haproxy-1.4/info/bin/haproxy_ctld
+++ b/cartridges/haproxy-1.4/info/bin/haproxy_ctld
@@ -199,10 +199,12 @@ class Haproxy
         #       actually issue a remove_gear
 
 
+        min, max = get_scaling_limits
+
         # If active capacity is greater then gear_up pct. Add a gear
         if @session_capacity_pct >= @gear_up_pct
             @remove_count = 0
-            self.add_gear
+            self.add_gear if @gear_count < max
         elsif @session_capacity_pct < @gear_remove_pct and @gear_count > 1
             # If active capacity is less then gear remove percentage
             # *AND* the last gear up happened longer then
@@ -214,7 +216,7 @@ class Haproxy
 
             if self.last_scale_up_time_seconds.to_i > @flap_protection_time_seconds
                 if @remove_count >= @remove_count_threshold
-                    self.remove_gear
+                    self.remove_gear if @gear_count > min
                     @remove_count = 0
                 else
                     self.print_gear_stats if debug
@@ -226,6 +228,28 @@ class Haproxy
             @remove_count = 0
             self.print_gear_stats if debug
         end
+    end
+
+    def get_scaling_limits
+      data_dir = ENV['OPENSHIFT_DATA_DIR']
+      scale_file = "#{data_dir}/scale_limits.txt"
+      min = 1
+      max = -1
+      if File.exists? scale_file
+        scale_data = File.read(scale_file)
+        scale_hash = {}
+        scale_data.split("\n").each { |s| 
+          line = s.split("=")
+          scale_hash[line[0]] = line[1] 
+        }
+        begin
+          min = scale_hash["scale_min"].to_i
+          max = scale_hash["scale_max"].to_i
+        rescue Exception => e
+          @@log.error("Unable to get gear's min/max scaling limits because of #{e.message}")
+        end
+      end
+      return min, max
     end
 
     def stats()

--- a/cartridges/haproxy-1.4/info/manifest.yml
+++ b/cartridges/haproxy-1.4/info/manifest.yml
@@ -29,4 +29,6 @@ Subscribes:
   set-db-connection-info:
     Type: "NET_TCP:db:connection-info"
     Required: false
-
+Scaling:
+  Min: 1
+  Max: 1

--- a/cartridges/jbossas-7/info/manifest.yml
+++ b/cartridges/jbossas-7/info/manifest.yml
@@ -56,4 +56,7 @@ Profiles:
       app-servers:
         Components:
           jbossas-server: jbossas-server
+        Scaling:
+          Min: 2
+          Max: -1
 Default-Profile: standalone

--- a/stickshift/broker/test/helpers/rest/api_models_v1.rb
+++ b/stickshift/broker/test/helpers/rest/api_models_v1.rb
@@ -269,7 +269,7 @@ class RestKey_V1 < BaseObj_V1
 end
 
 class RestApplication_V1 < BaseObj_V1
-  attr_accessor :framework, :creation_time, :uuid, :embedded, :aliases, :name, :links, :domain_id, :git_url, :app_url, :gear_profile, :scalable, :health_check_path
+  attr_accessor :framework, :creation_time, :uuid, :embedded, :aliases, :name, :links, :domain_id, :git_url, :app_url, :gear_profile, :scalable, :health_check_path, :scale_min, :scale_max
 
   def initialize(name=nil, framework=nil, domain_id=nil, scalable=nil)
     self.name = name
@@ -283,6 +283,8 @@ class RestApplication_V1 < BaseObj_V1
     self.git_url = nil
     self.app_url = nil
     self.scalable = scalable
+    self.scale_min = 1
+    self.scale_max = -1
     self.health_check_path = nil
     self.links = {
       "GET" => Link_V1.new("GET", "domains/#{domain_id}/applications/#{name}"),

--- a/stickshift/common/lib/stickshift-common/models/profile.rb
+++ b/stickshift/common/lib/stickshift-common/models/profile.rb
@@ -125,6 +125,9 @@ module StickShift
         self.components.each do |c|
           group.add_component_ref(ComponentRef.new(c.name).from_descriptor(c.name))
         end
+        if spec_hash.has_key?("Scaling")
+          group.scaling = Scaling.new.from_descriptor(spec_hash["Scaling"])
+        end
         group.generated = true
         add_group(group)
       end
@@ -164,7 +167,9 @@ module StickShift
         end
       end
       
-      unless self.groups.length == 1 && self.groups.first.generated
+      if self.groups.length == 1 && self.groups.first.generated
+        h["Scaling"] = self.groups.first.scaling.to_descriptor
+      else
         h["Groups"] = {}
         self.groups.each do |v|
           h["Groups"][v.name] = v.to_descriptor

--- a/stickshift/controller/lib/stickshift-controller/app/models/application.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/application.rb
@@ -344,7 +344,7 @@ Configure-Order: [\"proxy/#{framework}\", \"proxy/haproxy-1.4\"]
     raise StickShift::NodeException.new("Cannot find #{comp_name} in app #{self.name}.", "-101", result_io) if cinst.nil?
     ginst = self.group_instance_map[cinst.group_instance_name]
     raise StickShift::NodeException.new("Cannot find group #{cinst.group_instance_name} for #{comp_name} in app #{self.name}.", "-101", result_io) if ginst.nil?
-    raise StickShift::NodeException.new("Cannot scale up beyond maximum gear limit '#{ginst.max}' in app #{self.name}.", "-101", result_io) if ginst.gears.length==ginst.max
+    raise StickShift::NodeException.new("Cannot scale up beyond maximum gear limit '#{ginst.max}' in app #{self.name}.", "-101", result_io) if ginst.gears.length>=ginst.max
     result, new_gear = ginst.add_gear(self)
     result_io.append result
     result_io.append self.configure_dependencies
@@ -364,7 +364,7 @@ Configure-Order: [\"proxy/#{framework}\", \"proxy/haproxy-1.4\"]
     ginst = self.group_instance_map[cinst.group_instance_name]
     raise StickShift::NodeException.new("Cannot find group #{cinst.group_instance_name} for #{comp_name} in app #{self.name}.", "-101", result_io) if ginst.nil?
     # remove any gear out of this ginst
-    raise StickShift::NodeException.new("Cannot scale below minimum gear requirements for group '#{ginst.min}'", "-100", result_io) if ginst.gears.length == ginst.min
+    raise StickShift::NodeException.new("Cannot scale below minimum gear requirements for group '#{ginst.min}'", "-100", result_io) if ginst.gears.length <= ginst.min
 
     gear = ginst.gears.first
 

--- a/stickshift/controller/lib/stickshift-controller/app/models/application.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/application.rb
@@ -344,7 +344,7 @@ Configure-Order: [\"proxy/#{framework}\", \"proxy/haproxy-1.4\"]
     raise StickShift::NodeException.new("Cannot find #{comp_name} in app #{self.name}.", "-101", result_io) if cinst.nil?
     ginst = self.group_instance_map[cinst.group_instance_name]
     raise StickShift::NodeException.new("Cannot find group #{cinst.group_instance_name} for #{comp_name} in app #{self.name}.", "-101", result_io) if ginst.nil?
-    raise StickShift::NodeException.new("Cannot scale up beyond maximum gear limit '#{ginst.max}' in app #{self.name}.", "-101", result_io) if ginst.gears.length>=ginst.max
+    raise StickShift::NodeException.new("Cannot scale up beyond maximum gear limit '#{ginst.max}' in app #{self.name}.", "-101", result_io) if ginst.gears.length>=ginst.max and ginst.max>0
     result, new_gear = ginst.add_gear(self)
     result_io.append result
     result_io.append self.configure_dependencies

--- a/stickshift/controller/lib/stickshift-controller/app/models/group_instance.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/group_instance.rb
@@ -1,6 +1,6 @@
 class GroupInstance < StickShift::Model
   attr_accessor :app, :gears, :node_profile, :component_instances, 
-    :name, :cart_name, :profile_name, :group_name, :reused_by
+    :name, :cart_name, :profile_name, :group_name, :reused_by, :min, :max
   exclude_attributes :app
 
   def initialize(app, cartname=nil, profname=nil, groupname=nil, path=nil)
@@ -13,6 +13,8 @@ class GroupInstance < StickShift::Model
     self.reused_by = []
     self.gears = []
     self.node_profile = app.node_profile
+    self.min = 1
+    self.max = -1
   end
 
   def merge_inst(ginst)
@@ -33,6 +35,7 @@ class GroupInstance < StickShift::Model
       self.gears = [] if self.gears.nil?
       @gears += ginst.gears
     end
+    self.min, self.max = GroupInstance::merge_min_max(self.min, self.max, ginst.min, ginst.max)
   end
 
   def merge(cartname, profname, groupname, path, comp_instance_list=nil)
@@ -79,6 +82,7 @@ class GroupInstance < StickShift::Model
 
   def fulfil_requirements(app)
     result_io = ResultIO.new
+    return result_io if not app.scalable
     cart = CartridgeCache::find_cartridge(self.cart_name)
     profile = cart.profiles(self.profile_name)
     group = profile.groups(self.group_name)
@@ -87,6 +91,7 @@ class GroupInstance < StickShift::Model
       result, new_gear = add_gear(app)
       result_io.append result
     end
+    result_io
   end
 
   def gears=(data)
@@ -119,6 +124,9 @@ class GroupInstance < StickShift::Model
       app.comp_instance_map[cpath] = ci
       app.working_comp_inst_hash[cpath] = ci
       comp_groups = ci.elaborate(app)
+      c_comp,c_prof,c_cart = ci.get_component_definition(app)
+      c_group = c_prof.groups(ci.parent_cart_group)
+      self.min, self.max = GroupInstance::merge_min_max(self.min, self.max, c_group.scaling.min, c_group.scaling.max)
       group_inst_hash[comp_ref.name] = comp_groups
     }
     
@@ -135,4 +143,26 @@ class GroupInstance < StickShift::Model
     self.component_instances.delete_if { |cpath| app.working_comp_inst_hash[cpath].nil? }
     new_components
   end
+
+  def self.merge_min_max(min1, max1, min2, max2)
+    newmin = min1>min2 ? min1 : min2
+
+    if max1 < max2 
+      if max1 >= 0
+        newmax = max1
+      else
+        newmax = max2
+      end
+    elsif max2 >= 0
+      newmax = max2
+    else
+      newmax = max1
+    end
+
+    if newmin > newmax and newmax >= 0
+      newmin = newmax  
+    end
+    return newmin,newmax
+  end
+
 end

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_application.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_application.rb
@@ -1,5 +1,5 @@
 class RestApplication < StickShift::Model
-  attr_accessor :framework, :creation_time, :uuid, :embedded, :aliases, :name, :links, :domain_id, :git_url, :app_url, :gear_profile, :scalable, :health_check_path
+  attr_accessor :framework, :creation_time, :uuid, :embedded, :aliases, :name, :links, :domain_id, :git_url, :app_url, :gear_profile, :scalable, :health_check_path, :scale_min, :scale_max
   include LegacyBrokerHelper
   
   def initialize(app, url)
@@ -12,6 +12,7 @@ class RestApplication < StickShift::Model
     self.domain_id = app.domain.namespace
     self.gear_profile = app.node_profile
     self.scalable = app.scalable
+    self.scale_min,self.scale_max = app.scaling_limits
     self.git_url = "ssh://#{@uuid}@#{@name}-#{@domain_id}.#{Rails.configuration.ss[:domain_suffix]}/~/git/#{@name}.git/"
     self.app_url = "http://#{@name}-#{@domain_id}.#{Rails.configuration.ss[:domain_suffix]}/"
     self.health_check_path = app.health_check_path

--- a/stickshift/controller/lib/stickshift-controller/lib/stickshift/mongo_data_store.rb
+++ b/stickshift/controller/lib/stickshift-controller/lib/stickshift/mongo_data_store.rb
@@ -60,6 +60,13 @@ module StickShift
         end
       end
     end
+
+    def find_by_gear_uuid(gear_uuid)
+      Rails.logger.debug "MongoDataStore.find_by_gear_uuid(#{gear_uuid})\n\n"
+      hash = find_one({ "apps.group_instances.gears.uuid" => gear_uuid })
+      return nil unless hash
+      user_hash_to_ret(hash)
+    end
     
     def find_by_uuid(obj_type_of_uuid, uuid)
       Rails.logger.debug "MongoDataStore.find_by_uuid(#{obj_type_of_uuid}, #{uuid})\n\n"


### PR DESCRIPTION
Features :
1. Rest GET call on app now also returns min/max limits for a scalable app based on the framework cartridge
2. haproxy daemon checks/caches on min/max limits of the application
3. min/max limits can be supplied in the cartridge's manifest.yml
4. min/max limits apply for scalable apps only, and are checked against on scale up/down events
5. In an application with multiple cartridges, scaling limits are suitably merged
