### PR TITLE
Haproxy should not be allowed to be removed from a scalable app

### DIFF
--- a/stickshift/controller/lib/stickshift-controller/app/models/application.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/application.rb
@@ -1077,6 +1077,7 @@ Configure-Order: [\"proxy/#{framework}\", \"proxy/haproxy-1.4\"]
     self.embedded = {} unless self.embedded
         
     raise StickShift::UserException.new("#{dep} not embedded in '#{@name}', try adding it first", 101) unless self.embedded.include? dep
+    raise StickShift::UserException.new("#{dep} is not allowed to be removed from '#{@name}'. It is a required dependency for a scalable application.", 101) if (self.scalable and self.proxy_cartridge==dep)
     remove_from_requires_feature(dep)
     reply.append self.configure_dependencies
     self.class.notify_observers(:after_remove_dependency, {:application => self, :dependency => dep, :reply => reply})

--- a/stickshift/controller/lib/stickshift-controller/app/models/component_instance.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/component_instance.rb
@@ -155,6 +155,7 @@ class ComponentInstance < StickShift::Model
 
     group_comp_refs = profile.groups.map { |g| g.component_refs }
     comp_refs = group_comp_refs.flatten
+    comp_inst = nil
     comp_refs.each { |comp_ref|
       name_prefix = comp_ref.get_name_prefix(profile)
       comp_inst = app.comp_instance_map[parent_path + name_prefix]


### PR DESCRIPTION
- Closed the previous pull request (#63) and merged into one commit
- The cucumber test has been checked in into li-repo under scaling tests rev#02fdc63236d90a4add03b294f52063248bafe81a
