### PR TITLE
Reenabling snapshot and restore tests

### DIFF
--- a/stickshift/controller/test/cucumber/cartridge-lifecycle-jbossas.feature
+++ b/stickshift/controller/test/cucumber/cartridge-lifecycle-jbossas.feature
@@ -40,16 +40,16 @@ Feature: Cartridge Lifecycle JBossAS Verification Tests
     |      type     |
     |   jbossas-7   |
     
-#  Scenario Outline: Application Snapshot
-#    Given an existing <type> application
-#    When I snapshot the application
-#    Then the application should be accessible
-#    When I restore the application
-#    Then the application should be accessible
-#
-#  Scenarios: Application Snapshot Scenarios
-#    |      type     |
-#    |   jbossas-7   |
+  Scenario Outline: Application Snapshot
+    Given an existing <type> application
+    When I snapshot the application
+    Then the application should be accessible
+    When I restore the application
+    Then the application should be accessible
+
+  Scenarios: Application Snapshot Scenarios
+    |      type     |
+    |   jbossas-7   |
 
   Scenario Outline: Application Destroying
     Given an existing <type> application

--- a/stickshift/controller/test/cucumber/cartridge-lifecycle-php.feature
+++ b/stickshift/controller/test/cucumber/cartridge-lifecycle-php.feature
@@ -86,16 +86,16 @@ Feature: Cartridge Lifecycle PHP Verification Tests
     |      type     |
     |   php-5.3     |
     
-#  Scenario Outline: Application Snapshot
-#    Given an existing <type> application
-#    When I snapshot the application
-#    Then the application should be accessible
-#    When I restore the application
-#    Then the application should be accessible
-#
-#  Scenarios: Application Snapshot Scenarios
-#    |      type     |
-#    |   php-5.3     |
+  Scenario Outline: Application Snapshot
+    Given an existing <type> application
+    When I snapshot the application
+    Then the application should be accessible
+    When I restore the application
+    Then the application should be accessible
+
+  Scenarios: Application Snapshot Scenarios
+    |      type     |
+    |   php-5.3     |
 
   Scenario Outline: Application Destroying
     Given an existing <type> application


### PR DESCRIPTION
Bugzilla ticket 824312 had broken the build.  In order to allow the remainder of OpenShift to be tested we commented these tests out.  The bug has been resolved and I'm able to verify it by hand.  Re-enabling the tests back in the build.
