### PR TITLE
fix for bug#826002

### DIFF
--- a/stickshift/controller/lib/stickshift-controller/app/models/group_instance.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/group_instance.rb
@@ -92,10 +92,7 @@ class GroupInstance < StickShift::Model
   def fulfil_requirements(app)
     result_io = ResultIO.new
     return result_io if not app.scalable
-    cart = CartridgeCache::find_cartridge(self.cart_name)
-    profile = cart.profiles(self.profile_name)
-    group = profile.groups(self.group_name)
-    deficit = group.scaling.min - self.gears.length
+    deficit = self.min - self.gears.length
     deficit.times do
       result, new_gear = add_gear(app)
       result_io.append result


### PR DESCRIPTION
This is an important plug for scalable apps... irrespective of the bug#826002.
The previous piece of code picked up the deficiency from the last cartridge that got added to a scalable app (which all worked out fine because of the order in which ruby arranges its hash, and the fact that the scaling requirement of all cartridges was the same).

We should just look at the minimum requirement of group instance as a whole (now that we have this feature).
