### PR TITLE
Fix for bug 820337

### DIFF
--- a/stickshift/controller/lib/stickshift-controller/app/controllers/app_events_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/app_events_controller.rb
@@ -58,6 +58,13 @@ class AppEventsController < BaseController
           respond_with @reply, :status => @reply.status   
           return
         end
+    rescue StickShift::UserException => e
+      log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "#{event.sub('-', '_').upcase}_APPLICATION", false, "Application event '#{event}' failed: #{e.message}")
+      @reply = RestReply.new(:unprocessable_entity)
+      message = Message.new(:error, "Failed to add event #{event} to application #{id} due to: #{e.message}", e.code) 
+      @reply.messages.push(message)
+      respond_with @reply, :status => @reply.status
+      return
     rescue Exception => e
       Rails.logger.error e
       log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "#{event.sub('-', '_').upcase}_APPLICATION", false, "Application event '#{event}' failed: #{e.message}")

--- a/stickshift/controller/lib/stickshift-controller/app/models/application.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/application.rb
@@ -1006,6 +1006,10 @@ Configure-Order: [\"proxy/#{framework}\", \"proxy/haproxy-1.4\"]
   end
   
   def add_alias(server_alias)
+    if !(server_alias =~ /\A[\w\-\.]+\z/) or (server_alias =~ /#{Rails.configuration.ss[:domain_suffix]}$/)
+      raise StickShift::UserException.new("Invalid Server Alias '#{server_alias}' specified", 105) 
+    end
+    
     self.aliases = [] unless self.aliases
     raise StickShift::UserException.new("Alias '#{server_alias}' already exists for '#{@name}'", 255) if self.aliases.include? server_alias
     reply = ResultIO.new

--- a/stickshift/controller/test/cucumber/rest-applications.feature
+++ b/stickshift/controller/test/cucumber/rest-applications.feature
@@ -160,6 +160,8 @@ Feature: applications
     Then the response should be "200"
     When I send a POST request to "/domains/cucumber<random>/applications/app/events" with the following:"event=remove-alias&alias=app-cucumber.foobar.com"
     Then the response should be "200"
+    When I send a POST request to "/domains/cucumber<random>/applications/app/events" with the following:"event=add-alias&alias=app-@#$cucumber.foobar.com"
+    Then the response should be "422"
     When I send a DELETE request to "/domains/cucumber<random>/applications/app"
     Then the response should be "204"
     


### PR DESCRIPTION
- validating against invalid server alias in the rest controller
- handling user exceptions separately and returning 400 instead of 500 HTTP status in case of invalid alias
- added cucumber test case for testing invalid application server alias
