### PR TITLE
Fix for bug#825792

### DIFF
--- a/stickshift/abstract/abstract/info/bin/redeploy_repo_dir.sh
+++ b/stickshift/abstract/abstract/info/bin/redeploy_repo_dir.sh
@@ -6,5 +6,5 @@ do
     . $f
 done
 
-rm -rf ${OPENSHIFT_REPO_DIR}* ${OPENSHIFT_REPO_DIR}.[^.]*
+rm -rf ${OPENSHIFT_REPO_DIR}/* ${OPENSHIFT_REPO_DIR}/.[^.]*
 deploy_git_dir.sh . ${OPENSHIFT_REPO_DIR}


### PR DESCRIPTION
Character '/' missing from redeploy_repo. New value of the env variable does not have a '/' embedded already.
