### PR TITLE
Fixed template tests

### DIFF
--- a/stickshift/broker/test/helpers/rest/api_models_v1.rb
+++ b/stickshift/broker/test/helpers/rest/api_models_v1.rb
@@ -222,10 +222,12 @@ end
 
 class RestApplicationTemplate_V1 < BaseObj_V1
   attr_accessor :uuid, :display_name, :descriptor_yaml, :git_url, :tags, :gear_cost, :metadata
+  attr_accessor :links
 
   def initialize
     self.uuid, self.display_name, self.descriptor_yaml = nil, nil, nil
     self.git_url, self.tags, self.gear_cost, self.metadata = nil, nil, nil, nil
+    self.links = nil
   end
 end
 

--- a/stickshift/broker/test/helpers/rest/api_v1.rb
+++ b/stickshift/broker/test/helpers/rest/api_v1.rb
@@ -38,7 +38,9 @@ class RestApi_V1 < RestApi
           obj = RestApplicationEstimate_V1.to_obj(gear_hash)
         end
       when 'application_templates'
-        obj = RestApplicationTemplate_V1.to_obj(data)
+        data.each do |template_hash|
+          obj = RestApplicationTemplate_V1.to_obj(template_hash)
+        end
       when 'descriptor'
         # no-op
       when 'domain'


### PR DESCRIPTION
The template tests were failing on missing metadata. The problem was they were trying to operate on the array of template objects from the REST response. Needed to loop through the array instead and operate on each object individually. Also needed to add a `links` attribute to the ApplicationTemplate class.
