### PR TITLE
BZ 826819: Fix access to git directory

### DIFF
--- a/stickshift/abstract/abstract/info/bin/redeploy_repo_dir.sh
+++ b/stickshift/abstract/abstract/info/bin/redeploy_repo_dir.sh
@@ -6,5 +6,12 @@ do
     . $f
 done
 
-rm -rf ${OPENSHIFT_REPO_DIR}* ${OPENSHIFT_REPO_DIR}.[^.]*
-deploy_git_dir.sh . ${OPENSHIFT_REPO_DIR}
+if [ -z "${GIT_DIR}" ]
+then
+    GIT_DIR="~/git/${OPENSHIFT_GEAR_NAME}.git/"
+fi
+
+if [ -d "${OPENSHIFT_REPO_DIR}/" -a ! "${OPENSHIFT_REPO_DIR}/" -ef "/" ]; then
+    rm -rf ${OPENSHIFT_REPO_DIR}/* ${OPENSHIFT_REPO_DIR}/.[^.]*
+fi
+deploy_git_dir.sh ${GIT_DIR} ${OPENSHIFT_REPO_DIR}


### PR DESCRIPTION
The redeploy_repo_dir assumed . was the git repo and that assumption had changed somewhere along the line.

Also, for BZ 827111, added a safety check around rm -rf.
