### PR TITLE
Disable restart of JBoss app on namespace alter

### DIFF
--- a/cartridges/jbossas-7/info/bin/update_namespace.sh
+++ b/cartridges/jbossas-7/info/bin/update_namespace.sh
@@ -32,7 +32,7 @@ if [ -f $OPENSHIFT_JBOSS_CLUSTER ]
 then
   echo "Updating OPENSHIFT_JBOSS_CLUSTER with new namespace, ${old_namespace} => ${new_namespace}"
   sed -i "s/${old_namespace}/${new_namespace}/g" $APP_HOME/.env/OPENSHIFT_JBOSS_CLUSTER
-  run_as_user "$APP_DIR/${application}_ctl.sh restart"
+  client_message "IMPORTANT: It is recommended that you restart your application to ensure all namespace related configurations are updated in the application's environment."
 else
   echo "Not updating OPENSHIFT_JBOSS_CLUSTER in response to namespace update as the file doesn't exist"
 fi


### PR DESCRIPTION
The application restart which is invoked during the update namespace
hook processing for JBoss carts is suspected to cause intermittent
timeouts in other processes, leaving the namespace alter incomplete.

To be absolutely sure the namespace alter is solid, replace the
restart call with a client message advising the user to restart their
application manually following the alter.
