### PR TITLE
Add test step which verifies phpmyadmin httpd proxy configuration 

### DIFF
--- a/stickshift/controller/test/cucumber/cartridge-phpmyadmin.feature
+++ b/stickshift/controller/test/cucumber/cartridge-phpmyadmin.feature
@@ -20,8 +20,10 @@ Feature: phpMyAdmin Embedded Cartridge
     And phpmyadmin is stopped
     When I start phpmyadmin
     Then a phpmyadmin httpd will be running
+    And the phpmyadmin web console url will be accessible
     When I restart phpmyadmin
     Then a phpmyadmin httpd will be running
+    And the phpmyadmin web console url will be accessible
 
     When I deconfigure phpmyadmin
     Then a phpmyadmin http proxy file will not exist


### PR DESCRIPTION
An httpd proxy configuration is written by the deploy_httpd_proxy.sh
script. Test the proxy configuration and ensure phpmyadmin is
actually accessible after it has been installed by sending an HTTP
GET to a well-known phpmyadmin URL via the instance's external
address.

By themselves, checks which ensure the phpmyadmin httpd is available
are not sufficient to indicate that the cartridge is actually working
from the perspective of the user who will access the cartridge
through the front facing httpd proxy.
