### PR TITLE
jboss add custom module dir

### DIFF
--- a/cartridges/jbossas-7/info/bin/standalone.conf
+++ b/cartridges/jbossas-7/info/bin/standalone.conf
@@ -4,6 +4,8 @@ do
     . $f
 done
 
+source /usr/libexec/stickshift/cartridges/abstract/info/lib/util
+
 # This uses the sun jdk install since the current open-jdk version has a bug
 # Once this has been upgrade to something based on 1.6.0_20 or higher,
 # such as java-1.6.0-openjdk-1.6.0.0-1.39.1.9.7.el6, require the sun jdk.
@@ -48,13 +50,13 @@ then
     POSTGRESQL_ENABLED="true"
 fi
 
+sedEnvReplace=$(getSedExpression_replaceEnvVariables)
+
 sed -i -e "s/\${mysql.enabled}/$MYSQL_ENABLED/g" \
        -e "s/\${postgresql.enabled}/$POSTGRESQL_ENABLED/g" \
        -e "s/<loopback-address value=\".*\"\/>/<loopback-address value=\"${OPENSHIFT_INTERNAL_IP}\"\/>/g" \
-       -e "s/\${env.OPENSHIFT_JBOSS_CLUSTER}/$OPENSHIFT_JBOSS_CLUSTER/g" \
-       -e "s/\${env.OPENSHIFT_JBOSS_CLUSTER_PROXY_PORT}/$OPENSHIFT_JBOSS_CLUSTER_PROXY_PORT/g" \
-       -e "s/\${env.OPENSHIFT_GEAR_DNS}/$OPENSHIFT_GEAR_DNS/g" \
-       -e "s/\${env.OPENSHIFT_INTERNAL_IP}/$OPENSHIFT_INTERNAL_IP/g" "${OPENSHIFT_GEAR_DIR}${OPENSHIFT_GEAR_TYPE}"/standalone/configuration/standalone.xml > /dev/null 2>&1
+       ${sedEnvReplace} \
+       "${OPENSHIFT_GEAR_DIR}${OPENSHIFT_GEAR_TYPE}"/standalone/configuration/standalone.xml > /dev/null 2>&1
        
 resource_limits_file=`readlink -f /etc/stickshift/resource_limits.conf`
 resource_limits_file_name=`basename $resource_limits_file`

--- a/cartridges/jbossas-7/info/bin/standalone.conf
+++ b/cartridges/jbossas-7/info/bin/standalone.conf
@@ -91,4 +91,8 @@ if [ "x$JAVA_OPTS" = "x" ]; then
 fi
 
 # Add the user module path ahead of the server modules root
-export JBOSS_MODULEPATH="${OPENSHIFT_GEAR_DIR}${OPENSHIFT_GEAR_TYPE}"/standalone/configuration/modules:"${OPENSHIFT_GEAR_DIR}jbossas-7"/modules
+if [ "x$JBOSS_MODULEPATH_ADD" = "x" ]; then
+   export JBOSS_MODULEPATH="${OPENSHIFT_GEAR_DIR}${OPENSHIFT_GEAR_TYPE}"/standalone/configuration/modules:"${OPENSHIFT_GEAR_DIR}jbossas-7"/modules
+else
+   export JBOSS_MODULEPATH="${OPENSHIFT_GEAR_DIR}${OPENSHIFT_GEAR_TYPE}"/standalone/configuration/modules:"${JBOSS_MODULEPATH_ADD}":"${OPENSHIFT_GEAR_DIR}jbossas-7"/modules
+fi

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -172,6 +172,28 @@ function create_custom_uservars_var {
     echo "$2" > "$APP_HOME/.env/.uservars/$1"
 }
 
+#example usage: sed -i $(getSedExpression_replaceEnvVariables) path/to/file.conf
+function getSedExpression_replaceEnvVariables {
+        pathToEnvFolder="${OPENSHIFT_HOMEDIR}.env"
+
+        variableFiles=`find ${pathToEnvFolder} -type f -print`
+
+        sedCmd=""
+
+        for variableFile in $variableFiles
+        do
+                arrVarFile=(`echo $variableFile | tr "/" "\n"`)
+                arrSize=${#arrVarFile[@]}
+                #use file name as variable name
+                variableName=${arrVarFile[$arrSize - 1]}
+                variableVal=(`echo ${!variableName//\//\\\/}`)
+
+                sedCmd="${sedCmd} -e s/\${env.${variableName}}/${variableVal}/g"
+        done
+        
+        printf "%s\n" "$sedCmd"
+}
+
 function create_standard_app_dirs {
     mkdir -p run tmp ci
     [ -e repo ] || ln -s ../app-root/repo repo


### PR DESCRIPTION
Allow users to define env variable JBOSS_MODULEPATH_ADD in pre_start_jbossas-7 hook to add custom path where jboss as looks for modules.
