### PR TITLE
Add hot deployment support via hot_deploy marker

### DIFF
--- a/cartridges/jbossas-7/info/bin/build.sh
+++ b/cartridges/jbossas-7/info/bin/build.sh
@@ -7,6 +7,7 @@ do
 done
 
 source "/etc/stickshift/stickshift-node.conf"
+source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
 CONFIG_DIR="$CARTRIDGE_BASE_PATH/$OPENSHIFT_GEAR_TYPE/info/configuration"
 OPENSHIFT_MAVEN_MIRROR="$CONFIG_DIR/settings.base.xml"
@@ -44,6 +45,43 @@ case "$node_profile" in
         OPENSHIFT_MAVEN_XMX="-Xmx396m"
     ;;
 esac
+
+# If hot deploy is enabled, we need to restrict the Maven memory size to fit
+# alongside the running application server. For now, just hard-code it to 64
+# and figure out how to apply a scaling factor later.
+if ! in_ci_build && hot_deploy_marker_is_present ; then
+    echo "Scaling down Maven heap settings due to presence of hot_deploy marker"
+    
+    case "$node_profile" in
+        micro)
+            # 256 - (100 + 100) = 56
+            OPENSHIFT_MAVEN_XMX="-Xmx32m"
+        ;;
+        small)
+            # 512 - (256 + 128) = 128
+            OPENSHIFT_MAVEN_XMX="-Xmx96m"
+        ;;
+        medium)
+            # 1024 - (664 + 128) = 232
+            OPENSHIFT_MAVEN_XMX="-Xmx192m"
+        ;;
+        large)
+            # 2048 - (1456 + 148) = 444
+            OPENSHIFT_MAVEN_XMX="-Xmx384m"
+        ;;
+        exlarge)
+            # 4096 - (2888 + 184) = 1024
+            OPENSHIFT_MAVEN_XMX="-Xmx896m"
+        ;;
+        jumbo)
+            # 8192 - (5888 + 256) = 2048
+            OPENSHIFT_MAVEN_XMX="-Xm1584m"
+        ;;
+        *)
+            OPENSHIFT_MAVEN_XMX="-Xmx96m"
+        ;;
+    esac
+fi
 
 if [ -z "$BUILD_NUMBER" ]
 then

--- a/cartridges/jbossas-7/info/bin/deploy.sh
+++ b/cartridges/jbossas-7/info/bin/deploy.sh
@@ -9,19 +9,32 @@ done
 source "/etc/stickshift/stickshift-node.conf"
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
-start_dbs
+if hot_deploy_marker_is_present; then
+  echo "Skipping DB startup and JBoss temp dir cleanup due to presence of hot_deploy marker"
+else
+  start_dbs
 
-standalone_tmp=${OPENSHIFT_GEAR_DIR}${OPENSHIFT_GEAR_TYPE}/standalone/tmp
-if [ -d $standalone_tmp ]
-then
-    for d in $standalone_tmp/*
-    do
-        if [ -d $d ]
-        then
-            echo "Emptying tmp dir: $d"
-            rm -rf $d/* $d/.[^.]*
-        fi
-    done
+  standalone_tmp=${OPENSHIFT_GEAR_DIR}${OPENSHIFT_GEAR_TYPE}/standalone/tmp
+  if [ -d $standalone_tmp ]
+  then
+      for d in $standalone_tmp/*
+      do
+          if [ -d $d ]
+          then
+              echo "Emptying tmp dir: $d"
+              rm -rf $d/* $d/.[^.]*
+          fi
+      done
+  fi
 fi
+
+# Sync everything in the repo deployments directory with the live
+# JBoss deployments directory.
+sync_source="${OPENSHIFT_REPO_DIR}/deployments/"
+sync_desc="${OPENSHIFT_GEAR_DIR}${OPENSHIFT_GEAR_TYPE}/standalone/deployments/"
+
+echo "Syncing Git deployments directory [${sync_source}] with JBoss deployments directory [${sync_desc}]"
+
+rsync -vr --delete --exclude=*.git --exclude=.gitignore $sync_source $sync_desc
 
 user_deploy.sh

--- a/cartridges/jbossas-7/info/configuration/jenkins_job_template.xml
+++ b/cartridges/jbossas-7/info/configuration/jenkins_job_template.xml
@@ -62,6 +62,12 @@
   <builders>
     <hudson.tasks.Shell>
       <command>
+# For some reason, WORKSPACE is set to a relative path, although the Jenkins
+# docs specify it should be absolute. Play it safe by getting the absolute
+# path manually and doing checks relative to our own variable.
+workspace_abs=`cd ~/$WORKSPACE; pwd`
+hot_deploy_file="${workspace_abs}/.openshift/markers/hot_deploy"
+
 alias rsync="rsync --delete-after -az -e '$GIT_SSH'"
 
 rsync UPSTREAM_SSH:~/.m2/ ~/.m2/
@@ -76,7 +82,11 @@ mvn --global-settings $OPENSHIFT_MAVEN_MIRROR clean package -Popenshift -DskipTe
 # Deploy new build
 
 # Stop app
-$GIT_SSH UPSTREAM_SSH 'ctl_all stop'
+if [ -f $hot_deploy_file ]; then
+  echo "Skipping application stop due to presence of hot_deploy marker"
+else
+  $GIT_SSH UPSTREAM_SSH 'ctl_all stop'
+fi
 
 # Push content back to application
 rsync ~/.m2/ UPSTREAM_SSH:~/.m2/
@@ -85,7 +95,13 @@ rsync ~/$WORKSPACE/.openshift/ UPSTREAM_SSH:~/UPSTREAM_APP_NAME/repo/.openshift/
 
 # Configure / start app
 $GIT_SSH UPSTREAM_SSH deploy.sh
-$GIT_SSH UPSTREAM_SSH 'ctl_all start'
+
+if [ -f $hot_deploy_file ]; then
+  echo "Skipping application start due to presence of hot_deploy marker"
+else
+  $GIT_SSH UPSTREAM_SSH 'ctl_all start'
+fi
+
 $GIT_SSH UPSTREAM_SSH post_deploy.sh
       </command>
     </hudson.tasks.Shell>

--- a/cartridges/jbossas-7/info/hooks/configure
+++ b/cartridges/jbossas-7/info/hooks/configure
@@ -164,9 +164,8 @@ else
 	create_repo $application $user_id $group_id $uuid
 fi
 
-# Create a link from the repo/deployments directory to the standalone/deployments content
 mkdir -p "$APP_REPO_DIR"/deployments
-ln -s ../../../app-root/repo/deployments "$APP_JBOSS"/standalone/deployments
+mkdir -p "$APP_JBOSS"/standalone/deployments
 
 # Create a link from the standalone/log directory to ${APP_DIR}/logs for rhc app tail
 ln -s ${jboss_version}/standalone/log "$JBOSS_INSTANCE_DIR"/logs
@@ -175,7 +174,8 @@ create_app_ctl_script "$cartridge_type"
 
 populate_repo_dir
 
-cp ${JBOSS_CARTRIDGE_ROOT}/info/data/ROOT.war $APP_REPO_DIR/deployments
+# Copy the example WAR to the live deployments directory
+cp ${JBOSS_CARTRIDGE_ROOT}/info/data/ROOT.war $APP_JBOSS/standalone/deployments
 pushd $M2_DIR > /dev/null
 tar -xf ${JBOSS_CARTRIDGE_ROOT}/info/data/m2_repository.tar.gz
 popd > /dev/null

--- a/cartridges/jbossas-7/template/.openshift/markers/README
+++ b/cartridges/jbossas-7/template/.openshift/markers/README
@@ -13,3 +13,7 @@ skip_maven_build - Maven build step will be skipped
 force_clean_build - Will start the build process by removing all non 
 essential Maven dependencies.  Any current dependencies specified in 
 your pom.xml file will then be re-downloaded.
+
+hot_deploy - Will prevent a JBoss container restart during build/deployment.
+             Newly build archives will be re-deployed automatically by the
+             JBoss HDScanner component.

--- a/stickshift/abstract/abstract/info/bin/ci_build.sh
+++ b/stickshift/abstract/abstract/info/bin/ci_build.sh
@@ -17,6 +17,10 @@ then
   ln -s ~/$WORKSPACE $REPO_LINK
 fi
 
+# Export the CI_BUILD variable which will allow the downstream build
+# scripts to know they are running in the context of a CI build.
+export CI_BUILD=0
+
 set_app_state building
 
 user_pre_build.sh

--- a/stickshift/abstract/abstract/info/bin/post_receive_app.sh
+++ b/stickshift/abstract/abstract/info/bin/post_receive_app.sh
@@ -44,7 +44,11 @@ then
         deploy.sh
 
         # Start the app
-        start_app.sh
+        if hot_deploy_marker_is_present; then
+            echo "App will not be started due to presence of hot_deploy marker"
+        else
+            start_app.sh
+        fi
 
         # Run any steps required after startup
         post_deploy.sh

--- a/stickshift/abstract/abstract/info/bin/pre_receive_app.sh
+++ b/stickshift/abstract/abstract/info/bin/pre_receive_app.sh
@@ -1,15 +1,112 @@
 #!/bin/bash
 
-# Import Environment Variables
+# This hook is what drives the initial shutdown of the application prior to 
+# applying incoming commits. Because it must respect the presence of the
+# hot_deploy marker, this becomes a bit tricky as we must take into account
+# the possibility that the marker is being added or removed during the
+# commit, possibly for the first time. The stop should only occur if the
+# marker is present and will remain present after the commit is applied.
+
+source "/etc/stickshift/stickshift-node.conf"
+source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
+
+# Determines if the given file is present in the given commit with
+# the provided status (e.g. add, delete, modified). Returns 0 if
+# there is a match, otherwise 1.
+function commit_contains_file_with_status () {
+  sha1=$1
+  filename=$2
+  status=$3
+
+  match_present=1
+
+  # compare the diff list filenames with the argument filename
+  list=$(git show --pretty="format:" --name-only --diff-filter=[${status}] $sha1)
+  for tmpfile in ${list}; do
+    if [ "$tmpfile" == "${filename}" ]; then
+      match_present=0
+      break
+    fi
+  done
+
+  return $match_present
+}
+
+# Stops the app (or not), taking into account the hot_deploy marker.
+function stop_app () {
+  # We ONLY want to disable this if the hot deploy marker will be present
+  # following the commit application.
+  stop_required=true
+
+
+  # All our decisions will be based on these three states. It is
+  # assumed that added/deleted are mutually exclusive states.
+  hot_deploy_preexists=false
+  hot_deploy_added=false
+  hot_deploy_deleted=false
+
+
+  # Check to see if the marker is already on disk
+  if hot_deploy_marker_is_present; then
+    hot_deploy_preexists=true
+  fi
+
+
+  # Peek into the inbound push and see if the marker state is being updated
+  # in any notable way
+  while read old_sha1 new_sha1 refname ; do
+    # Detect the addition of the marker
+    if commit_contains_file_with_status "$new_sha1" ".openshift/markers/hot_deploy" "A"; then
+      hot_deploy_added=true
+      break
+    fi
+
+    # Detect the deletion of the marker
+    if commit_contains_file_with_status "$new_sha1" ".openshift/markers/hot_deploy" "D"; then
+      hot_deploy_deleted=true
+      break
+    fi
+  done
+
+  # Debug use
+  #echo "hot_deploy_added=${hot_deploy_added}"
+  #echo "hot_deploy_deleted=${hot_deploy_deleted}"
+  #echo "hot_deploy_preexists=${hot_deploy_preexists}"
+
+  # There are only two cases which should cause the stop to be disabled:
+  # 1. The marker is being added and was not present in the first place
+  if ! $hot_deploy_preexists && $hot_deploy_added; then
+    echo "Will add new hot deploy marker"
+    stop_required=false
+  fi
+
+  # 2. The marker is already present and is not modified with this commit
+  if $hot_deploy_preexists && ! $hot_deploy_added && ! $hot_deploy_deleted; then
+    echo "Existing hot deploy marker will remain unchanged"
+    stop_required=false
+  fi
+
+
+  # And finally...
+  if $stop_required; then
+    stop_app.sh
+  else
+    echo "App will not be stopped due to presence of hot_deploy marker"
+  fi
+}
+
+# Import environment variables
 for f in ~/.env/*
 do
     . $f
 done
 
+# Only handle app stopping here if hooks are enabled and if this
+# Jenkins is not embedded
 if [ -z $OPENSHIFT_SKIP_GIT_HOOKS ]
 then
     if [ -z "$OPENSHIFT_CI_TYPE" ] || [ -z "$JENKINS_URL" ]
     then
-        stop_app.sh
+        stop_app
     fi
 fi

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -765,6 +765,27 @@ function resolve_application_dependencies {
     popd
 }
 
+# Checks for the presence of the user-specified hot_deploy marker in the app
+# repo. Returns 0 if the marker is present, otherwise 1.
+function hot_deploy_marker_is_present {
+  if [ -f "${OPENSHIFT_REPO_DIR}/.openshift/markers/hot_deploy" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Checks for the CI_BUILD variable. Returns 0 if the variable is not empty,
+# otherwise 1. This is used to provide scripts with information about the
+# build context (e.g., are we currently executing in a Jenkins build).
+function in_ci_build {
+  if [ -z "$CI_BUILD" ]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
 if [ -f /usr/libexec/stickshift/lib/util_ext ]
 then
     source /usr/libexec/stickshift/lib/util_ext

--- a/stickshift/controller/test/cucumber/cartridge-jbossas.feature
+++ b/stickshift/controller/test/cucumber/cartridge-jbossas.feature
@@ -47,4 +47,23 @@ Feature: JBossAS Application
      When I deconfigure the jbossas application
      Then a jbossas daemon will not be running
      
+   Scenario: Push code change to application with hot deployment enabled
+     Given an accepted node
+     And a new guest account
+     When I configure a jbossas application
+     And the application is prepared for git pushes
+     And hot deployment is enabled for the jbossas-7 application
+     Then a jbossas daemon will be running
+     When the jbossas-7 application code is changed
+     Then a jbossas daemon will be running
+     And the jbossas-7 application should not change pids
 
+   Scenario: Push code change to the application
+     Given an accepted node
+     And a new guest account
+     When I configure a jbossas application
+     And the application is prepared for git pushes
+     Then a jbossas daemon will be running
+     When the jbossas-7 application code is changed
+     Then a jbossas daemon will be running
+     And the jbossas-7 application should change pids

--- a/stickshift/controller/test/cucumber/cartridge-nodejs.feature
+++ b/stickshift/controller/test/cucumber/cartridge-nodejs.feature
@@ -31,3 +31,14 @@ Feature: Node.js Application
     When I start the nodejs application
     Then the nodejs application will be running
     And a node process will be running
+
+  Scenario: Push a code change to a new Node application
+    Given an accepted node
+    And a new guest account
+    And the guest account has no application installed
+    When I configure a nodejs application
+    And the application is prepared for git pushes
+    Then a node process will be running
+    When the nodejs-0.6 application code is changed
+    Then a node process will be running
+    And the nodejs-0.6 application should change pids

--- a/stickshift/controller/test/cucumber/cartridge-perl.feature
+++ b/stickshift/controller/test/cucumber/cartridge-perl.feature
@@ -29,3 +29,14 @@ Feature: PERL Application
     And a perl application git repo will not exist
     And a perl application source tree will not exist
     And a perl application httpd will not be running   
+
+  Scenario: Push a code change to a new PERL application
+    Given an accepted node
+    And a new guest account
+    And the guest account has no application installed
+    When I configure a perl application
+    And the application is prepared for git pushes
+    Then a perl application httpd will be running 
+    When the perl-5.10 application code is changed
+    Then a perl application httpd will be running 
+    And the perl-5.10 application should change pids

--- a/stickshift/controller/test/cucumber/cartridge-php.feature
+++ b/stickshift/controller/test/cucumber/cartridge-php.feature
@@ -47,3 +47,14 @@ Feature: PHP Application
     Then the php application will not be aliased 
     When I deconfigure the php application
     Then a php application http proxy file will not exist
+
+  Scenario: Push a code change to a new PHP application
+    Given an accepted node
+    And a new guest account
+    And the guest account has no application installed
+    When I configure a php application
+    And the application is prepared for git pushes
+    Then the php application will be running
+    When the php-5.3 application code is changed
+    Then the php application will be running
+    And the php-5.3 application should change pids

--- a/stickshift/controller/test/cucumber/cartridge-python.feature
+++ b/stickshift/controller/test/cucumber/cartridge-python.feature
@@ -28,3 +28,14 @@ Feature: PYTHON Application
     And a python application git repo will not exist
     And a python application source tree will not exist
     And a python application httpd will not be running
+
+  Scenario: Push a code change to a new Python application
+    Given an accepted node
+    And a new guest account
+    And the guest account has no application installed
+    When I configure a python application
+    And the application is prepared for git pushes
+    Then a python application httpd will be running 
+    When the python-2.6 application code is changed
+    Then a python application httpd will be running 
+    And the python-2.6 application should change pids

--- a/stickshift/controller/test/cucumber/cartridge-ruby.feature
+++ b/stickshift/controller/test/cucumber/cartridge-ruby.feature
@@ -30,3 +30,14 @@ Feature: RUBY Application
     And a ruby application git repo will not exist
     And a ruby application source tree will not exist
     And a ruby application httpd will not be running
+
+  Scenario: Push a code change to a new Ruby application
+    Given an accepted node
+    And a new guest account
+    And the guest account has no application installed
+    When I configure a ruby application
+    And the application is prepared for git pushes
+    Then a ruby application httpd will be running 
+    When the ruby-1.8 application code is changed
+    Then a ruby application httpd will be running 
+    And the ruby-1.8 application should change pids

--- a/stickshift/controller/test/cucumber/step_definitions/cartridge-jbossas_steps.rb
+++ b/stickshift/controller/test/cucumber/step_definitions/cartridge-jbossas_steps.rb
@@ -253,8 +253,10 @@ Then /^a jbossas deployments directory will( not)? exist$/ do |negate|
   acct_name = @account['accountname']
   app_name = @app['name']
 
-  app_root = "#{$home_root}/#{acct_name}/app-root"
-  deploy_root = Dir.new "#{app_root}/repo/deployments"
+  cart_instance_dir = "#{$home_root}/#{acct_name}/jbossas-7"
+  jboss_root = cart_instance_dir + "/" + $jbossas_version
+
+  deploy_root = Dir.new "#{jboss_root}/standalone/deployments"
   
   deploy_contents = ['ROOT.war']
 

--- a/stickshift/controller/test/cucumber/step_definitions/cartridge_steps.rb
+++ b/stickshift/controller/test/cucumber/step_definitions/cartridge_steps.rb
@@ -1,0 +1,100 @@
+require 'fileutils'
+
+When /^the application is prepared for git pushes$/ do
+  account_name = @account['accountname']
+  app_name = @account['appnames'][0]
+  namespace = @account['namespace']
+
+  ssh_key = IO.read(File.expand_path("~/.ssh/id_rsa.pub")).chomp.split[1]
+  run "echo \"127.0.0.1 #{app_name}-#{namespace}.dev.rhcloud.com # Added by cucumber\" >> /etc/hosts"
+  run "ss-authorized-ssh-key-add -a #{account_name} -c #{account_name} -s #{ssh_key} -t ssh-rsa -m default"
+  run "echo -e \"Host #{app_name}-#{namespace}.dev.rhcloud.com\n\tStrictHostKeyChecking no\n\" >> ~/.ssh/config"
+end
+
+When /^hot deployment is enabled for the (.+) application$/ do |type|
+  pid_file = get_pid_file(type)
+
+  File.exists?(pid_file).should be_true "#{type} pid file missing #{pid_file}"
+  @app['pid'] = IO.read(pid_file).chomp
+  @app['hot_deploy'] = true
+end
+
+When /^the (.+) application code is changed$/ do |type|
+  # hack until we have a better lifecycle on the @node side
+  @app['pid'] = IO.read(get_pid_file(type)).chomp unless @app.has_key?('pid')
+
+  acct_name = @account['accountname']
+  app_name = @app['name']
+  namespace = @account['namespace']
+  uuid = @account['accountname']
+
+  tmp_git_root = "#{$temp}/#{acct_name}-#{app_name}-clone"
+
+  run "git clone ssh://#{uuid}@#{app_name}-#{namespace}.dev.rhcloud.com/~/git/#{app_name}.git #{tmp_git_root}"
+
+  marker_file = File.join(tmp_git_root, '.openshift', 'markers', 'hot_deploy')
+  if @app.has_key?('hot_deploy') && @app['hot_deploy']
+    FileUtils.touch(marker_file)
+  else
+    FileUtils.rm_f(marker_file)
+  end
+
+  Dir.chdir(tmp_git_root) do
+    @update = "TEST"
+
+    # Make a change to the app index file
+    run "sed -i 's/Welcome/#{@update}/' #{get_index_file(type)}"
+    run "git add ."
+    run "git commit -m 'Test change'"
+    run "git push"
+  end
+end
+
+Then /^the (.+) application should( not)? change pids$/ do |type, negate|
+  pid_file = get_pid_file(type)
+
+  File.exists?(pid_file).should be_true "#{type} pid file missing #{pid_file}"
+  current_pid = IO.read(pid_file).chomp
+  if negate
+    @app['pid'].should == current_pid
+  else
+    @app['pid'].should_not == current_pid
+  end
+end
+
+def get_pid_file(type)
+  pid_files_by_type = {
+    "jbossas-7" => "jboss.pid",
+    "php-5.3" => "httpd.pid",
+    "nodejs-0.6" => "node.pid",
+    "perl-5.10" => "httpd.pid",
+    "python-2.6" => "httpd.pid",
+    "ruby-1.8" => "httpd.pid"
+  }
+
+  raise "No pid filename is configured for cartridge type #{type}" unless pid_files_by_type.has_key?(type)
+
+  acct_name = @account['accountname']
+  app_name = @app['name']
+
+  cart_instance_dir = "#{$home_root}/#{acct_name}/#{type}"
+  pid_file = "#{cart_instance_dir}/run/#{pid_files_by_type[type]}"
+
+  return pid_file
+end
+  
+def get_index_file(type)
+  index_files_by_type = {
+    "php-5.3" => "php/index.php",
+    "ruby-1.8" => "config.ru",
+    "python-2.6" => "wsgi/application",
+    "perl-5.10" => "perl/index.pl",
+    "jbossas-7" => "src/main/webapp/index.html",
+    "jbosseap-6.0" => "src/main/webapp/index.html",
+    "nodejs-0.6" => "index.html"
+  }
+
+  raise "No index file configured for cartridge type #{type}" unless index_files_by_type.has_key?(type)
+  
+  return index_files_by_type[type]
+end


### PR DESCRIPTION
Implement hot deployment support in the abstract cartridge framework.
When the hot_deployment marker is present in the application git
repository, modify the push cycle by:
- Preventing application stop prior to the build
- Preventing application start after the build
- Scaling down the memory allocated to Maven during a non-Jenkins
  build so that Maven will fit alongside the application process

Cartridges must explicitly implement support for the marker. Merely
enabling the marker for an application based on a cartridge without
explicit support will have undefined results.

Initial marker support is provided for the jbossas-7 cartridge.
