### PR TITLE
BZ 828762: Change jboss default jenkins builder size to small

### DIFF
--- a/cartridges/jbossas-7/info/configuration/jenkins_job_template.xml
+++ b/cartridges/jbossas-7/info/configuration/jenkins_job_template.xml
@@ -11,7 +11,7 @@
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.openshift.OpenShiftBuilderSizeJobProperty>
-      <builderSize>medium</builderSize>
+      <builderSize>small</builderSize>
     </hudson.plugins.openshift.OpenShiftBuilderSizeJobProperty>
     <hudson.plugins.openshift.OpenShiftBuilderTypeJobProperty>
       <builderType>jbossas-7</builderType>


### PR DESCRIPTION
Having a default builder size of medium causes some confusion from time to time and appears to be unnecessary.  I can build kitchensink-example, kitchensink-html5-mobile-example, and jbossas-mongodb-quickstart with a small gear size.
