### PR TITLE
Prevent passing binary on stdin to pre-receive hook

### DIFF
--- a/stickshift/abstract/abstract/info/bin/restore.sh
+++ b/stickshift/abstract/abstract/info/bin/restore.sh
@@ -10,7 +10,8 @@ done
 
 if [ "$include_git" = "INCLUDE_GIT" ]
 then
-  ~/git/${OPENSHIFT_GEAR_NAME}.git/hooks/pre-receive 1>&2
+  # prevent feeding the tarball to pre-receive on stdin
+  ~/git/${OPENSHIFT_GEAR_NAME}.git/hooks/pre-receive < /dev/null 1>&2
   echo "Removing old git repo: ~/git/${OPENSHIFT_GEAR_NAME}.git/" 1>&2
   /bin/rm -rf ~/git/${OPENSHIFT_GEAR_NAME}.git/[^h]*/*
 else


### PR DESCRIPTION
The pre-receive hook expects text on stdin for commit processing. In the
context of a restore, the tarball being restored is on stdin. Make sure
to feed /dev/null on stdin when calling the pre-receive hook manually,
otherwise it will choke and die, corrupting the tarball in the process.
