### PR TITLE
Security - BZ785050 remove mod_autoindex from all httpd.confs

### DIFF
--- a/cartridges/python-2.6/cartridge-python-2.6.spec
+++ b/cartridges/python-2.6/cartridge-python-2.6.spec
@@ -116,6 +116,9 @@ rm -rf %{buildroot}
 %doc %{cartridgedir}/LICENSE
 
 %changelog
+* Fri Jun 15 2012 Tim Kramer <tkramer@redhat.com>
+- Security - BZ785050 removed mod_autoindex from both httpd.conf files (tkramer@redhat.com)
+
 * Fri Jun 08 2012 Adam Miller <admiller@redhat.com> 0.94.2-1
 - Fix for bugz 827827. Use freetype-devel (as that's available on rhel-6.2).
   (ramr@redhat.com)

--- a/cartridges/python-2.6/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/python-2.6/info/configuration/etc/conf/httpd.conf
@@ -41,7 +41,7 @@ LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule mime_module modules/mod_mime.so
 #LoadModule dav_module modules/mod_dav.so
 LoadModule status_module modules/mod_status.so
-LoadModule autoindex_module modules/mod_autoindex.so
+#BZ785050 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule info_module modules/mod_info.so
 #LoadModule dav_fs_module modules/mod_dav_fs.so
 #LoadModule vhost_alias_module modules/mod_vhost_alias.so
@@ -107,41 +107,41 @@ Alias /icons/ "/var/www/icons/"
     Order allow,deny
     Allow from all
 </Directory>
-IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
-AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
+#BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
+#BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 
-AddIconByType (TXT,/icons/text.gif) text/*
-AddIconByType (IMG,/icons/image2.gif) image/*
-AddIconByType (SND,/icons/sound2.gif) audio/*
-AddIconByType (VID,/icons/movie.gif) video/*
+#BZ785050 AddIconByType (TXT,/icons/text.gif) text/*
+#BZ785050 AddIconByType (IMG,/icons/image2.gif) image/*
+#BZ785050 AddIconByType (SND,/icons/sound2.gif) audio/*
+#BZ785050 AddIconByType (VID,/icons/movie.gif) video/*
 
-AddIcon /icons/binary.gif .bin .exe
-AddIcon /icons/binhex.gif .hqx
-AddIcon /icons/tar.gif .tar
-AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
-AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
-AddIcon /icons/a.gif .ps .ai .eps
-AddIcon /icons/layout.gif .html .shtml .htm .pdf
-AddIcon /icons/text.gif .txt
-AddIcon /icons/c.gif .c
-AddIcon /icons/p.gif .pl .py
-AddIcon /icons/f.gif .for
-AddIcon /icons/dvi.gif .dvi
-AddIcon /icons/uuencoded.gif .uu
-AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
-AddIcon /icons/tex.gif .tex
-AddIcon /icons/bomb.gif core
+#BZ785050 AddIcon /icons/binary.gif .bin .exe
+#BZ785050 AddIcon /icons/binhex.gif .hqx
+#BZ785050 AddIcon /icons/tar.gif .tar
+#BZ785050 AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
+#BZ785050 AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
+#BZ785050 AddIcon /icons/a.gif .ps .ai .eps
+#BZ785050 AddIcon /icons/layout.gif .html .shtml .htm .pdf
+#BZ785050 AddIcon /icons/text.gif .txt
+#BZ785050 AddIcon /icons/c.gif .c
+#BZ785050 AddIcon /icons/p.gif .pl .py
+#BZ785050 AddIcon /icons/f.gif .for
+#BZ785050 AddIcon /icons/dvi.gif .dvi
+#BZ785050 AddIcon /icons/uuencoded.gif .uu
+#BZ785050 AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
+#BZ785050 AddIcon /icons/tex.gif .tex
+#BZ785050 AddIcon /icons/bomb.gif core
 
-AddIcon /icons/back.gif ..
-AddIcon /icons/hand.right.gif README
-AddIcon /icons/folder.gif ^^DIRECTORY^^
-AddIcon /icons/blank.gif ^^BLANKICON^^
+#BZ785050 AddIcon /icons/back.gif ..
+#BZ785050 AddIcon /icons/hand.right.gif README
+#BZ785050 AddIcon /icons/folder.gif ^^DIRECTORY^^
+#BZ785050 AddIcon /icons/blank.gif ^^BLANKICON^^
 
-DefaultIcon /icons/unknown.gif
+#BZ785050 DefaultIcon /icons/unknown.gif
 
-ReadmeName README.html
-HeaderName HEADER.html
-IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
+#BZ785050 ReadmeName README.html
+#BZ785050 HeaderName HEADER.html
+#BZ785050 IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
 AddLanguage ca .ca
 AddLanguage cs .cz .cs
 AddLanguage da .dk

--- a/cartridges/python-2.6/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/python-2.6/info/configuration/etc/conf/httpd_nolog.conf
@@ -41,7 +41,7 @@ LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule mime_module modules/mod_mime.so
 #LoadModule dav_module modules/mod_dav.so
 LoadModule status_module modules/mod_status.so
-LoadModule autoindex_module modules/mod_autoindex.so
+#BZ785050 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule info_module modules/mod_info.so
 #LoadModule dav_fs_module modules/mod_dav_fs.so
 #LoadModule vhost_alias_module modules/mod_vhost_alias.so
@@ -107,41 +107,41 @@ Alias /icons/ "/var/www/icons/"
     Order allow,deny
     Allow from all
 </Directory>
-IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
-AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
+#BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
+#BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 
-AddIconByType (TXT,/icons/text.gif) text/*
-AddIconByType (IMG,/icons/image2.gif) image/*
-AddIconByType (SND,/icons/sound2.gif) audio/*
-AddIconByType (VID,/icons/movie.gif) video/*
+#BZ785050 AddIconByType (TXT,/icons/text.gif) text/*
+#BZ785050 AddIconByType (IMG,/icons/image2.gif) image/*
+#BZ785050 AddIconByType (SND,/icons/sound2.gif) audio/*
+#BZ785050 AddIconByType (VID,/icons/movie.gif) video/*
 
-AddIcon /icons/binary.gif .bin .exe
-AddIcon /icons/binhex.gif .hqx
-AddIcon /icons/tar.gif .tar
-AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
-AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
-AddIcon /icons/a.gif .ps .ai .eps
-AddIcon /icons/layout.gif .html .shtml .htm .pdf
-AddIcon /icons/text.gif .txt
-AddIcon /icons/c.gif .c
-AddIcon /icons/p.gif .pl .py
-AddIcon /icons/f.gif .for
-AddIcon /icons/dvi.gif .dvi
-AddIcon /icons/uuencoded.gif .uu
-AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
-AddIcon /icons/tex.gif .tex
-AddIcon /icons/bomb.gif core
+#BZ785050 AddIcon /icons/binary.gif .bin .exe
+#BZ785050 AddIcon /icons/binhex.gif .hqx
+#BZ785050 AddIcon /icons/tar.gif .tar
+#BZ785050 AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
+#BZ785050 AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
+#BZ785050 AddIcon /icons/a.gif .ps .ai .eps
+#BZ785050 AddIcon /icons/layout.gif .html .shtml .htm .pdf
+#BZ785050 AddIcon /icons/text.gif .txt
+#BZ785050 AddIcon /icons/c.gif .c
+#BZ785050 AddIcon /icons/p.gif .pl .py
+#BZ785050 AddIcon /icons/f.gif .for
+#BZ785050 AddIcon /icons/dvi.gif .dvi
+#BZ785050 AddIcon /icons/uuencoded.gif .uu
+#BZ785050 AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
+#BZ785050 AddIcon /icons/tex.gif .tex
+#BZ785050 AddIcon /icons/bomb.gif core
 
-AddIcon /icons/back.gif ..
-AddIcon /icons/hand.right.gif README
-AddIcon /icons/folder.gif ^^DIRECTORY^^
-AddIcon /icons/blank.gif ^^BLANKICON^^
+#BZ785050 AddIcon /icons/back.gif ..
+#BZ785050 AddIcon /icons/hand.right.gif README
+#BZ785050 AddIcon /icons/folder.gif ^^DIRECTORY^^
+#BZ785050 AddIcon /icons/blank.gif ^^BLANKICON^^
 
-DefaultIcon /icons/unknown.gif
+#BZ785050 DefaultIcon /icons/unknown.gif
 
-ReadmeName README.html
-HeaderName HEADER.html
-IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
+#BZ785050 ReadmeName README.html
+#BZ785050 HeaderName HEADER.html
+#BZ785050 IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
 AddLanguage ca .ca
 AddLanguage cs .cz .cs
 AddLanguage da .dk

--- a/cartridges/ruby-1.8/cartridge-ruby-1.8.spec
+++ b/cartridges/ruby-1.8/cartridge-ruby-1.8.spec
@@ -131,6 +131,9 @@ rm -rf %{buildroot}
 %doc %{cartridgedir}/LICENSE
 
 %changelog
+* Fri Jun 15 2012 Tim Kramer <tkramer@redhat.com>
+- Security BZ785050 Removed mod_autoindex from both httpd.conf files (tkramer@redhat.com)
+
 * Fri Jun 01 2012 Adam Miller <admiller@redhat.com> 0.94.1-1
 - bumping spec versions (admiller@redhat.com)
 

--- a/cartridges/ruby-1.8/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/ruby-1.8/info/configuration/etc/conf/httpd.conf
@@ -41,7 +41,7 @@ LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule mime_module modules/mod_mime.so
 #LoadModule dav_module modules/mod_dav.so
 LoadModule status_module modules/mod_status.so
-LoadModule autoindex_module modules/mod_autoindex.so
+#BZ785050 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule info_module modules/mod_info.so
 #LoadModule dav_fs_module modules/mod_dav_fs.so
 #LoadModule vhost_alias_module modules/mod_vhost_alias.so
@@ -107,41 +107,41 @@ Alias /icons/ "/var/www/icons/"
     Order allow,deny
     Allow from all
 </Directory>
-IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
-AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
+#BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
+#BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 
-AddIconByType (TXT,/icons/text.gif) text/*
-AddIconByType (IMG,/icons/image2.gif) image/*
-AddIconByType (SND,/icons/sound2.gif) audio/*
-AddIconByType (VID,/icons/movie.gif) video/*
+#BZ785050 AddIconByType (TXT,/icons/text.gif) text/*
+#BZ785050 AddIconByType (IMG,/icons/image2.gif) image/*
+#BZ785050 AddIconByType (SND,/icons/sound2.gif) audio/*
+#BZ785050 AddIconByType (VID,/icons/movie.gif) video/*
 
-AddIcon /icons/binary.gif .bin .exe
-AddIcon /icons/binhex.gif .hqx
-AddIcon /icons/tar.gif .tar
-AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
-AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
-AddIcon /icons/a.gif .ps .ai .eps
-AddIcon /icons/layout.gif .html .shtml .htm .pdf
-AddIcon /icons/text.gif .txt
-AddIcon /icons/c.gif .c
-AddIcon /icons/p.gif .pl .py
-AddIcon /icons/f.gif .for
-AddIcon /icons/dvi.gif .dvi
-AddIcon /icons/uuencoded.gif .uu
-AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
-AddIcon /icons/tex.gif .tex
-AddIcon /icons/bomb.gif core
+#BZ785050 AddIcon /icons/binary.gif .bin .exe
+#BZ785050 AddIcon /icons/binhex.gif .hqx
+#BZ785050 AddIcon /icons/tar.gif .tar
+#BZ785050 AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
+#BZ785050 AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
+#BZ785050 AddIcon /icons/a.gif .ps .ai .eps
+#BZ785050 AddIcon /icons/layout.gif .html .shtml .htm .pdf
+#BZ785050 AddIcon /icons/text.gif .txt
+#BZ785050 AddIcon /icons/c.gif .c
+#BZ785050 AddIcon /icons/p.gif .pl .py
+#BZ785050 AddIcon /icons/f.gif .for
+#BZ785050 AddIcon /icons/dvi.gif .dvi
+#BZ785050 AddIcon /icons/uuencoded.gif .uu
+#BZ785050 AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
+#BZ785050 AddIcon /icons/tex.gif .tex
+#BZ785050 AddIcon /icons/bomb.gif core
 
-AddIcon /icons/back.gif ..
-AddIcon /icons/hand.right.gif README
-AddIcon /icons/folder.gif ^^DIRECTORY^^
-AddIcon /icons/blank.gif ^^BLANKICON^^
+#BZ785050 AddIcon /icons/back.gif ..
+#BZ785050 AddIcon /icons/hand.right.gif README
+#BZ785050 AddIcon /icons/folder.gif ^^DIRECTORY^^
+#BZ785050 AddIcon /icons/blank.gif ^^BLANKICON^^
 
-DefaultIcon /icons/unknown.gif
+#BZ785050 DefaultIcon /icons/unknown.gif
 
-ReadmeName README.html
-HeaderName HEADER.html
-IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
+#BZ785050 ReadmeName README.html
+#BZ785050 HeaderName HEADER.html
+#BZ785050 IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
 AddLanguage ca .ca
 AddLanguage cs .cz .cs
 AddLanguage da .dk

--- a/cartridges/ruby-1.8/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/ruby-1.8/info/configuration/etc/conf/httpd_nolog.conf
@@ -41,7 +41,7 @@ LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule mime_module modules/mod_mime.so
 #LoadModule dav_module modules/mod_dav.so
 LoadModule status_module modules/mod_status.so
-LoadModule autoindex_module modules/mod_autoindex.so
+#BZ785050 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule info_module modules/mod_info.so
 #LoadModule dav_fs_module modules/mod_dav_fs.so
 #LoadModule vhost_alias_module modules/mod_vhost_alias.so
@@ -107,41 +107,41 @@ Alias /icons/ "/var/www/icons/"
     Order allow,deny
     Allow from all
 </Directory>
-IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
-AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
+#BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
+#BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 
-AddIconByType (TXT,/icons/text.gif) text/*
-AddIconByType (IMG,/icons/image2.gif) image/*
-AddIconByType (SND,/icons/sound2.gif) audio/*
-AddIconByType (VID,/icons/movie.gif) video/*
+#BZ785050 AddIconByType (TXT,/icons/text.gif) text/*
+#BZ785050 AddIconByType (IMG,/icons/image2.gif) image/*
+#BZ785050 AddIconByType (SND,/icons/sound2.gif) audio/*
+#BZ785050 AddIconByType (VID,/icons/movie.gif) video/*
 
-AddIcon /icons/binary.gif .bin .exe
-AddIcon /icons/binhex.gif .hqx
-AddIcon /icons/tar.gif .tar
-AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
-AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
-AddIcon /icons/a.gif .ps .ai .eps
-AddIcon /icons/layout.gif .html .shtml .htm .pdf
-AddIcon /icons/text.gif .txt
-AddIcon /icons/c.gif .c
-AddIcon /icons/p.gif .pl .py
-AddIcon /icons/f.gif .for
-AddIcon /icons/dvi.gif .dvi
-AddIcon /icons/uuencoded.gif .uu
-AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
-AddIcon /icons/tex.gif .tex
-AddIcon /icons/bomb.gif core
+#BZ785050 AddIcon /icons/binary.gif .bin .exe
+#BZ785050 AddIcon /icons/binhex.gif .hqx
+#BZ785050 AddIcon /icons/tar.gif .tar
+#BZ785050 AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
+#BZ785050 AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
+#BZ785050 AddIcon /icons/a.gif .ps .ai .eps
+#BZ785050 AddIcon /icons/layout.gif .html .shtml .htm .pdf
+#BZ785050 AddIcon /icons/text.gif .txt
+#BZ785050 AddIcon /icons/c.gif .c
+#BZ785050 AddIcon /icons/p.gif .pl .py
+#BZ785050 AddIcon /icons/f.gif .for
+#BZ785050 AddIcon /icons/dvi.gif .dvi
+#BZ785050 AddIcon /icons/uuencoded.gif .uu
+#BZ785050 AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
+#BZ785050 AddIcon /icons/tex.gif .tex
+#BZ785050 AddIcon /icons/bomb.gif core
 
-AddIcon /icons/back.gif ..
-AddIcon /icons/hand.right.gif README
-AddIcon /icons/folder.gif ^^DIRECTORY^^
-AddIcon /icons/blank.gif ^^BLANKICON^^
+#BZ785050 AddIcon /icons/back.gif ..
+#BZ785050 AddIcon /icons/hand.right.gif README
+#BZ785050 AddIcon /icons/folder.gif ^^DIRECTORY^^
+#BZ785050 AddIcon /icons/blank.gif ^^BLANKICON^^
 
-DefaultIcon /icons/unknown.gif
+#BZ785050 DefaultIcon /icons/unknown.gif
 
-ReadmeName README.html
-HeaderName HEADER.html
-IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
+#BZ785050 ReadmeName README.html
+#BZ785050 HeaderName HEADER.html
+#BZ785050 IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
 AddLanguage ca .ca
 AddLanguage cs .cz .cs
 AddLanguage da .dk

--- a/cartridges/ruby-1.9/cartridge-ruby-1.9.spec
+++ b/cartridges/ruby-1.9/cartridge-ruby-1.9.spec
@@ -205,6 +205,9 @@ rm -rf %{buildroot}
 %doc %{cartridgedir}/LICENSE
 
 %changelog
+* Fri Jun 15 2012 Tim Kramer <tkramer@redhat.com>
+- Security BZ785050 Removed mod_autoindex from both httpd.conf files (tkramer@redhat.com)
+
 * Thu Jun 14 2012 Adam Miller <admiller@redhat.com> 0.1.3-1
 - Use the right hook names -- thanks mpatel. (ramr@redhat.com)
 - Checkpoint ruby-1.9 work (ruby-1.9 disabled for now in framework cartridges).

--- a/cartridges/ruby-1.9/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/ruby-1.9/info/configuration/etc/conf/httpd.conf
@@ -41,7 +41,7 @@ LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule mime_module modules/mod_mime.so
 #LoadModule dav_module modules/mod_dav.so
 LoadModule status_module modules/mod_status.so
-LoadModule autoindex_module modules/mod_autoindex.so
+#BZ785050 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule info_module modules/mod_info.so
 #LoadModule dav_fs_module modules/mod_dav_fs.so
 #LoadModule vhost_alias_module modules/mod_vhost_alias.so
@@ -107,41 +107,41 @@ Alias /icons/ "/var/www/icons/"
     Order allow,deny
     Allow from all
 </Directory>
-IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
-AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
+#BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
+#BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 
-AddIconByType (TXT,/icons/text.gif) text/*
-AddIconByType (IMG,/icons/image2.gif) image/*
-AddIconByType (SND,/icons/sound2.gif) audio/*
-AddIconByType (VID,/icons/movie.gif) video/*
+#BZ785050 AddIconByType (TXT,/icons/text.gif) text/*
+#BZ785050 AddIconByType (IMG,/icons/image2.gif) image/*
+#BZ785050 AddIconByType (SND,/icons/sound2.gif) audio/*
+#BZ785050 AddIconByType (VID,/icons/movie.gif) video/*
 
-AddIcon /icons/binary.gif .bin .exe
-AddIcon /icons/binhex.gif .hqx
-AddIcon /icons/tar.gif .tar
-AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
-AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
-AddIcon /icons/a.gif .ps .ai .eps
-AddIcon /icons/layout.gif .html .shtml .htm .pdf
-AddIcon /icons/text.gif .txt
-AddIcon /icons/c.gif .c
-AddIcon /icons/p.gif .pl .py
-AddIcon /icons/f.gif .for
-AddIcon /icons/dvi.gif .dvi
-AddIcon /icons/uuencoded.gif .uu
-AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
-AddIcon /icons/tex.gif .tex
-AddIcon /icons/bomb.gif core
+#BZ785050 AddIcon /icons/binary.gif .bin .exe
+#BZ785050 AddIcon /icons/binhex.gif .hqx
+#BZ785050 AddIcon /icons/tar.gif .tar
+#BZ785050 AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
+#BZ785050 AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
+#BZ785050 AddIcon /icons/a.gif .ps .ai .eps
+#BZ785050 AddIcon /icons/layout.gif .html .shtml .htm .pdf
+#BZ785050 AddIcon /icons/text.gif .txt
+#BZ785050 AddIcon /icons/c.gif .c
+#BZ785050 AddIcon /icons/p.gif .pl .py
+#BZ785050 AddIcon /icons/f.gif .for
+#BZ785050 AddIcon /icons/dvi.gif .dvi
+#BZ785050 AddIcon /icons/uuencoded.gif .uu
+#BZ785050 AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
+#BZ785050 AddIcon /icons/tex.gif .tex
+#BZ785050 AddIcon /icons/bomb.gif core
 
-AddIcon /icons/back.gif ..
-AddIcon /icons/hand.right.gif README
-AddIcon /icons/folder.gif ^^DIRECTORY^^
-AddIcon /icons/blank.gif ^^BLANKICON^^
+#BZ785050 AddIcon /icons/back.gif ..
+#BZ785050 AddIcon /icons/hand.right.gif README
+#BZ785050 AddIcon /icons/folder.gif ^^DIRECTORY^^
+#BZ785050 AddIcon /icons/blank.gif ^^BLANKICON^^
 
-DefaultIcon /icons/unknown.gif
+#BZ785050 DefaultIcon /icons/unknown.gif
 
-ReadmeName README.html
-HeaderName HEADER.html
-IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
+#BZ785050 ReadmeName README.html
+#BZ785050 HeaderName HEADER.html
+#BZ785050 IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
 AddLanguage ca .ca
 AddLanguage cs .cz .cs
 AddLanguage da .dk

--- a/cartridges/ruby-1.9/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/ruby-1.9/info/configuration/etc/conf/httpd_nolog.conf
@@ -41,7 +41,7 @@ LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule mime_module modules/mod_mime.so
 #LoadModule dav_module modules/mod_dav.so
 LoadModule status_module modules/mod_status.so
-LoadModule autoindex_module modules/mod_autoindex.so
+#BZ785050 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule info_module modules/mod_info.so
 #LoadModule dav_fs_module modules/mod_dav_fs.so
 #LoadModule vhost_alias_module modules/mod_vhost_alias.so
@@ -107,41 +107,41 @@ Alias /icons/ "/var/www/icons/"
     Order allow,deny
     Allow from all
 </Directory>
-IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
-AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
+#BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
+#BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 
-AddIconByType (TXT,/icons/text.gif) text/*
-AddIconByType (IMG,/icons/image2.gif) image/*
-AddIconByType (SND,/icons/sound2.gif) audio/*
-AddIconByType (VID,/icons/movie.gif) video/*
+#BZ785050 AddIconByType (TXT,/icons/text.gif) text/*
+#BZ785050 AddIconByType (IMG,/icons/image2.gif) image/*
+#BZ785050 AddIconByType (SND,/icons/sound2.gif) audio/*
+#BZ785050 AddIconByType (VID,/icons/movie.gif) video/*
 
-AddIcon /icons/binary.gif .bin .exe
-AddIcon /icons/binhex.gif .hqx
-AddIcon /icons/tar.gif .tar
-AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
-AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
-AddIcon /icons/a.gif .ps .ai .eps
-AddIcon /icons/layout.gif .html .shtml .htm .pdf
-AddIcon /icons/text.gif .txt
-AddIcon /icons/c.gif .c
-AddIcon /icons/p.gif .pl .py
-AddIcon /icons/f.gif .for
-AddIcon /icons/dvi.gif .dvi
-AddIcon /icons/uuencoded.gif .uu
-AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
-AddIcon /icons/tex.gif .tex
-AddIcon /icons/bomb.gif core
+#BZ785050 AddIcon /icons/binary.gif .bin .exe
+#BZ785050 AddIcon /icons/binhex.gif .hqx
+#BZ785050 AddIcon /icons/tar.gif .tar
+#BZ785050 AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
+#BZ785050 AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
+#BZ785050 AddIcon /icons/a.gif .ps .ai .eps
+#BZ785050 AddIcon /icons/layout.gif .html .shtml .htm .pdf
+#BZ785050 AddIcon /icons/text.gif .txt
+#BZ785050 AddIcon /icons/c.gif .c
+#BZ785050 AddIcon /icons/p.gif .pl .py
+#BZ785050 AddIcon /icons/f.gif .for
+#BZ785050 AddIcon /icons/dvi.gif .dvi
+#BZ785050 AddIcon /icons/uuencoded.gif .uu
+#BZ785050 AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
+#BZ785050 AddIcon /icons/tex.gif .tex
+#BZ785050 AddIcon /icons/bomb.gif core
 
-AddIcon /icons/back.gif ..
-AddIcon /icons/hand.right.gif README
-AddIcon /icons/folder.gif ^^DIRECTORY^^
-AddIcon /icons/blank.gif ^^BLANKICON^^
+#BZ785050 AddIcon /icons/back.gif ..
+#BZ785050 AddIcon /icons/hand.right.gif README
+#BZ785050 AddIcon /icons/folder.gif ^^DIRECTORY^^
+#BZ785050 AddIcon /icons/blank.gif ^^BLANKICON^^
 
-DefaultIcon /icons/unknown.gif
+#BZ785050 DefaultIcon /icons/unknown.gif
 
-ReadmeName README.html
-HeaderName HEADER.html
-IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
+#BZ785050 ReadmeName README.html
+#BZ785050 HeaderName HEADER.html
+#BZ785050 IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
 AddLanguage ca .ca
 AddLanguage cs .cz .cs
 AddLanguage da .dk


### PR DESCRIPTION
Security - BZ785050 remove mod_autoindex from all httpd.confs for python ruby 1.8 and ruby 1.9 cartridges
