### PR TITLE
Fix for bug 806713

### DIFF
--- a/stickshift/controller/lib/stickshift-controller/app/controllers/domains_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/domains_controller.rb
@@ -80,7 +80,7 @@ class DomainsController < BaseController
     rescue Exception => e
       log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "ADD_DOMAIN", false, "Failed to create domain '#{namespace}': #{e.message}")
       Rails.logger.error e.backtrace
-      @reply = RestReply.new(:internal_server_error)
+      @reply = e.kind_of?(StickShift::DNSException) ? RestReply.new(:service_unavailable) : RestReply.new(:internal_server_error)
       error_code = e.respond_to?('code') ? e.code : 1
       @reply.messages.push(Message.new(:error, e.message, error_code))
       respond_with @reply, :status => @reply.status
@@ -181,7 +181,7 @@ class DomainsController < BaseController
     rescue Exception => e
       log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "UPDATE_DOMAIN", false, e.message)
       Rails.logger.error "Failed to update domain #{e.message} #{e.backtrace}"
-      @reply = RestReply.new(:internal_server_error)
+      @reply = e.kind_of?(StickShift::DNSException) ? RestReply.new(:service_unavailable) : RestReply.new(:internal_server_error)
       error_code = e.respond_to?('code') ? e.code : 1
       @reply.messages.push(Message.new(:error, e.message, error_code))
       respond_with(@reply) do |format|
@@ -266,7 +266,7 @@ class DomainsController < BaseController
     rescue Exception => e
       #Rails.logger.error "Failed to delete domain #{e.message}"
       log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "DELETE_DOMAIN", false, "Failed to delete domain '#{id}': #{e.message}")
-      @reply = RestReply.new(:internal_server_error)
+      @reply = e.kind_of?(StickShift::DNSException) ? RestReply.new(:service_unavailable) : RestReply.new(:internal_server_error)
       error_code = e.respond_to?('code') ? e.code : 1
       @reply.messages.push(Message.new(:error, e.message, error_code))
       respond_with(@reply) do |format|

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/legacy_broker_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/legacy_broker_controller.rb
@@ -428,6 +428,10 @@ class LegacyBrokerController < ApplicationController
       log_action(@request_id.nil? ? 'nil' : @request_id, @cloud_user.nil? ? 'nil' : @cloud_user.uuid, @login.nil? ? 'nil' : @login, "LEGACY_BROKER", false, "#{e.class.name} for #{request.path}: #{e.message}")
       @reply.resultIO << e.message
       status = :bad_request
+    when StickShift::DNSException
+      log_action(@request_id.nil? ? 'nil' : @request_id, @cloud_user.nil? ? 'nil' : @cloud_user.uuid, @login.nil? ? 'nil' : @login, "LEGACY_BROKER", false, "#{e.class.name} for #{request.path}: #{e.message}")
+      @reply.resultIO << e.message
+      status = :service_unavailable
     when StickShift::SSException
       log_action(@request_id.nil? ? 'nil' : @request_id, @cloud_user.nil? ? 'nil' : @cloud_user.uuid, @login.nil? ? 'nil' : @login, "LEGACY_BROKER", false, "#{e.class.name} for #{request.path}: #{e.message}")
       Rails.logger.error e.backtrace[0..5].join("\n")


### PR DESCRIPTION
We are now returning 503 instead of 500 for dns failures during application creation/deletion and domain creation/update/deletion.
