### PR TITLE
Missing Requires for the jboss cartridges

### DIFF
--- a/cartridges/jbossas-7/cartridge-jbossas-7.spec
+++ b/cartridges/jbossas-7/cartridge-jbossas-7.spec
@@ -21,6 +21,7 @@ Requires: stickshift-abstract
 Requires: rubygem(stickshift-node)
 Requires: jboss-as7 >= %{jbossver}
 Requires: jboss-as7-modules >= %{jbossver}
+Requires: lsof
 
 %if 0%{?rhel}
 Requires: maven3

--- a/cartridges/jbosseap-6.0/cartridge-jbosseap-6.0.spec
+++ b/cartridges/jbosseap-6.0/cartridge-jbosseap-6.0.spec
@@ -21,6 +21,7 @@ Requires: stickshift-abstract
 Requires: rubygem(stickshift-node)
 Requires: jboss-eap6 >= %{jbossver}
 Requires: jboss-eap6-modules >= %{jbossver}
+Requires: lsof
 
 %if 0%{?rhel}
 Requires: maven3


### PR DESCRIPTION
A minimal RHEL/Fedora install does not include 'lsof'.  Only after installing
that package was I able to get a jbossas-7 app created.
