### PR TITLE
Install initial ROOT.war into app-root during configure

### DIFF
--- a/cartridges/jbossas-7/info/hooks/configure
+++ b/cartridges/jbossas-7/info/hooks/configure
@@ -174,7 +174,8 @@ create_app_ctl_script "$cartridge_type"
 
 populate_repo_dir
 
-# Copy the example WAR to the live deployments directory
+# Copy the example WAR to the deployments directories
+cp ${JBOSS_CARTRIDGE_ROOT}/info/data/ROOT.war $APP_REPO_DIR/deployments
 cp ${JBOSS_CARTRIDGE_ROOT}/info/data/ROOT.war $APP_JBOSS/standalone/deployments
 pushd $M2_DIR > /dev/null
 tar -xf ${JBOSS_CARTRIDGE_ROOT}/info/data/m2_repository.tar.gz


### PR DESCRIPTION
The initial ROOT.war should be deployed in a manner consistent with
the user build/deployment workflow to enable deploy.sh calls during
scaling to function correctly. In addition to copying ROOT.war to the
live JBoss deployments directory, copy it to the app-root deployments
directory. Otherwise, rsync calls invoked from the deploy script will
purge the live deployments directory to match the empty app-root
deployments directory.

This resolves the following bug:
- https://bugzilla.redhat.com/show_bug.cgi?id=833213
