### PR TITLE
Add max_file_uploads INI setting to php.ini files

### DIFF
--- a/cartridges/haproxy-1.4/info/configuration/etc/conf/php.ini
+++ b/cartridges/haproxy-1.4/info/configuration/etc/conf/php.ini
@@ -877,6 +877,9 @@ upload_tmp_dir = "TEMPLATE_SET_ME_UPLOAD_TMP_DIR"
 ; http://www.php.net/manual/en/ini.core.php#ini.upload-max-filesize
 upload_max_filesize = 200M
 
+; Maximum number of files that can be uploaded via a single request 
+max_file_uploads = 20 
+
 ;;;;;;;;;;;;;;;;;;
 ; Fopen wrappers ;
 ;;;;;;;;;;;;;;;;;;

--- a/cartridges/php-5.3/info/configuration/etc/conf/php.ini
+++ b/cartridges/php-5.3/info/configuration/etc/conf/php.ini
@@ -877,6 +877,9 @@ upload_tmp_dir = "TEMPLATE_SET_ME_UPLOAD_TMP_DIR"
 ; http://www.php.net/manual/en/ini.core.php#ini.upload-max-filesize
 upload_max_filesize = 200M
 
+; Maximum number of files that can be uploaded via a single request 
+max_file_uploads = 20 
+
 ;;;;;;;;;;;;;;;;;;
 ; Fopen wrappers ;
 ;;;;;;;;;;;;;;;;;;

--- a/cartridges/phpmyadmin-3.4/info/configuration/etc/conf/php.ini
+++ b/cartridges/phpmyadmin-3.4/info/configuration/etc/conf/php.ini
@@ -877,6 +877,9 @@ upload_tmp_dir = "TEMPLATE_SET_ME_UPLOAD_TMP_DIR"
 ; http://www.php.net/manual/en/ini.core.php#ini.upload-max-filesize
 upload_max_filesize = 200M
 
+; Maximum number of files that can be uploaded via a single request 
+max_file_uploads = 20 
+
 ;;;;;;;;;;;;;;;;;;
 ; Fopen wrappers ;
 ;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
PHP silently sets max_file_uploads = 20.
The INI setting was added in PHP 5.3.1 to fix CVE-2009-4017.
