### PR TITLE
Make a client's SSL Certificate value available in a python-2.6 application

### DIFF
--- a/cartridges/python-2.6/info/configuration/node_ssl_template.conf
+++ b/cartridges/python-2.6/info/configuration/node_ssl_template.conf
@@ -6,3 +6,9 @@
   SSLCertificateChainFile /etc/pki/tls/certs/localhost.crt
   SSLCipherSuite RSA:!EXPORT:!DH:!LOW:!NULL:+MEDIUM:+HIGH
   SSLProtocol -ALL +SSLv3 +TLSv1
+  SSLOptions +StdEnvVars +ExportCertData
+  # SSLVerifyClient must be set for +ExportCertData to take effect, so just use
+  # optional_no_ca.
+  SSLVerifyClient optional_no_ca
+
+  RequestHeader set X-Forwarded-SSL-Client-Cert %{SSL_CLIENT_CERT}e


### PR DESCRIPTION
This patch forwards the value of a client's SSL certificate to a running
application by setting a X-Forwarded-SSL-Client-Cert header whose value
is the PEM encoded client certificate.

Having access to the actual client SSL certificate used is useful to applications 
that need the certificate to do custom authentication/authorization.
