### PR TITLE
Refactor hot deploy support in Jenkins templates

### DIFF
--- a/cartridges/jbossas-7/info/configuration/jenkins_job_template.xml
+++ b/cartridges/jbossas-7/info/configuration/jenkins_job_template.xml
@@ -62,11 +62,7 @@
   <builders>
     <hudson.tasks.Shell>
       <command>
-# For some reason, WORKSPACE is set to a relative path, although the Jenkins
-# docs specify it should be absolute. Play it safe by getting the absolute
-# path manually and doing checks relative to our own variable.
-workspace_abs=`cd ~/$WORKSPACE; pwd`
-hot_deploy_file="${workspace_abs}/.openshift/markers/hot_deploy"
+source /usr/libexec/stickshift/cartridges/abstract/info/lib/jenkins_util
 
 alias rsync="rsync --delete-after -az -e '$GIT_SSH'"
 
@@ -82,11 +78,7 @@ mvn --global-settings $OPENSHIFT_MAVEN_MIRROR clean package -Popenshift -DskipTe
 # Deploy new build
 
 # Stop app
-if [ -f $hot_deploy_file ]; then
-  echo "Skipping application stop due to presence of hot_deploy marker"
-else
-  $GIT_SSH UPSTREAM_SSH 'ctl_all stop'
-fi
+jenkins_stop_app UPSTREAM_SSH
 
 # Push content back to application
 rsync ~/.m2/ UPSTREAM_SSH:~/.m2/
@@ -96,11 +88,7 @@ rsync ~/$WORKSPACE/.openshift/ UPSTREAM_SSH:~/UPSTREAM_APP_NAME/repo/.openshift/
 # Configure / start app
 $GIT_SSH UPSTREAM_SSH deploy.sh
 
-if [ -f $hot_deploy_file ]; then
-  echo "Skipping application start due to presence of hot_deploy marker"
-else
-  $GIT_SSH UPSTREAM_SSH 'ctl_all start'
-fi
+jenkins_start_app UPSTREAM_SSH
 
 $GIT_SSH UPSTREAM_SSH post_deploy.sh
       </command>

--- a/cartridges/perl-5.10/info/configuration/jenkins_job_template.xml
+++ b/cartridges/perl-5.10/info/configuration/jenkins_job_template.xml
@@ -62,11 +62,7 @@
   <builders>
     <hudson.tasks.Shell>
       <command>
-# For some reason, WORKSPACE is set to a relative path, although the Jenkins
-# docs specify it should be absolute. Play it safe by getting the absolute
-# path manually and doing checks relative to our own variable.
-workspace_abs=`cd ~/$WORKSPACE; pwd`
-hot_deploy_file="${workspace_abs}/.openshift/markers/hot_deploy"
+source /usr/libexec/stickshift/cartridges/abstract/info/lib/jenkins_util
 
 alias rsync="rsync --delete-after -az -e '$GIT_SSH'"
 
@@ -79,11 +75,7 @@ rsync UPSTREAM_SSH:~/UPSTREAM_APP_NAME/perl5lib/ ~/${OPENSHIFT_GEAR_NAME}/perl5l
 # Deploy new build
 
 # Stop app
-if [ -f $hot_deploy_file ]; then
-  echo "Skipping application stop due to presence of hot_deploy marker"
-else
-  $GIT_SSH UPSTREAM_SSH 'ctl_all stop'
-fi
+jenkins_stop_app UPSTREAM_SSH
 
 # Push content back to application
 rsync ~/${OPENSHIFT_GEAR_NAME}/perl5lib/ UPSTREAM_SSH:~/UPSTREAM_APP_NAME/perl5lib/
@@ -92,11 +84,7 @@ rsync ~/$WORKSPACE/ UPSTREAM_SSH:~/UPSTREAM_APP_NAME/repo/
 # Configure / start app
 $GIT_SSH UPSTREAM_SSH deploy.sh
 
-if [ -f $hot_deploy_file ]; then
-  echo "Skipping application start due to presence of hot_deploy marker"
-else
-  $GIT_SSH UPSTREAM_SSH 'ctl_all start'
-fi
+jenkins_start_app UPSTREAM_SSH
 
 $GIT_SSH UPSTREAM_SSH post_deploy.sh
       </command>

--- a/cartridges/php-5.3/info/configuration/jenkins_job_template.xml
+++ b/cartridges/php-5.3/info/configuration/jenkins_job_template.xml
@@ -62,11 +62,8 @@
   <builders>
     <hudson.tasks.Shell>
       <command>
-# For some reason, WORKSPACE is set to a relative path, although the Jenkins
-# docs specify it should be absolute. Play it safe by getting the absolute
-# path manually and doing checks relative to our own variable.
-workspace_abs=`cd ~/$WORKSPACE; pwd`
-hot_deploy_file="${workspace_abs}/.openshift/markers/hot_deploy"
+source /usr/libexec/stickshift/cartridges/abstract/info/lib/jenkins_util
+
 alias rsync="rsync --delete-after -az -e '$GIT_SSH'"
 
 # Sync libs - Faster builds
@@ -80,11 +77,7 @@ rsync UPSTREAM_SSH:~/UPSTREAM_APP_NAME/phplib/ ~/${OPENSHIFT_GEAR_NAME}/phplib/
 # Deploy new build
 
 # Stop app
-if [ -f $hot_deploy_file ]; then
-  echo "Skipping application stop due to presence of hot_deploy marker"
-else
-  $GIT_SSH UPSTREAM_SSH 'ctl_all stop'
-fi
+jenkins_stop_app UPSTREAM_SSH
 
 # Push content back to application
 rsync ~/${OPENSHIFT_GEAR_NAME}/phplib/ UPSTREAM_SSH:~/UPSTREAM_APP_NAME/phplib/
@@ -93,11 +86,7 @@ rsync ~/$WORKSPACE/ UPSTREAM_SSH:~/UPSTREAM_APP_NAME/repo/
 # Configure / start app
 $GIT_SSH UPSTREAM_SSH deploy.sh
 
-if [ -f $hot_deploy_file ]; then
-  echo "Skipping application start due to presence of hot_deploy marker"
-else
-  $GIT_SSH UPSTREAM_SSH 'ctl_all start'
-fi
+jenkins_start_app UPSTREAM_SSH
 
 $GIT_SSH UPSTREAM_SSH post_deploy.sh
       </command>

--- a/stickshift/abstract/abstract/info/lib/jenkins_util
+++ b/stickshift/abstract/abstract/info/lib/jenkins_util
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# This script defines various utility functions which are useful in the context
+# of a Jenkins 'Shell' build task.
+
+
+# Checks for the presence of the hot_deploy marker in the git repo inside
+# the Jenkins workspace. Returns 0 if the marker is present, otherwise 1.
+function hot_deploy_marker_present_in_workspace {
+	# For some reason, WORKSPACE is set to a relative path, although the Jenkins
+  # docs specify it should be absolute. Play it safe by getting the absolute
+  # path manually and doing checks relative to our own variable.
+	workspace_abs=`cd ~/$WORKSPACE; pwd`
+	hot_deploy_file="${workspace_abs}/.openshift/markers/hot_deploy"
+
+	if [ -f $hot_deploy_file ]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+# Wraps the remote call to the app start script with a check for the hot
+# deployment marker. If the marker is present, the start will be skipped.
+#
+# Usage: jenkins_start_app <uuid@host>
+function jenkins_start_app {
+	UPSTREAM_SSH=$1
+
+	if hot_deploy_marker_present_in_workspace; then
+  	echo "Skipping application start due to presence of hot_deploy marker"
+	else
+  	$GIT_SSH $UPSTREAM_SSH 'ctl_all start'
+	fi
+}
+
+# Wraps the remote call to the app stop script with a check for the hot
+# deployment marker. If the marker is present, the stop script will be
+# skipped.
+#
+# Usage: jenkins_stop_app <uuid@host>
+function jenkins_stop_app {
+	UPSTREAM_SSH=$1
+
+	if hot_deploy_marker_present_in_workspace; then
+  	echo "Skipping application stop due to presence of hot_deploy marker"
+	else
+  	$GIT_SSH $UPSTREAM_SSH 'ctl_all stop'
+	fi
+}


### PR DESCRIPTION
Extract common branching logic which concerns hot deployment into a
new Jenkins-specific utility script. This will help reduce duplicate
code throughout current and future build templates and provide
something more meaningful and useful to end users constructing their
own build tasks.
