### PR TITLE
Fix to get build up and running

### DIFF
--- a/cartridges/nodejs-0.6/info/hooks/configure
+++ b/cartridges/nodejs-0.6/info/hooks/configure
@@ -55,7 +55,7 @@ pushd "$APP_HOME" > /dev/null
 mkdir node_modules
 npmgl="$CART_INFO_DIR/configuration/npm_global_module_list"
 module_list=$(perl -ne 'print if /^\s*[^#\s]/' "$npmgl" | tr '\n' ' ')
-npm link $module_list
+npm link $module_list > /dev/null 2>&1
 popd > /dev/null
 
 #


### PR DESCRIPTION
Get build working - mcollective client/broker is failing to parse some output. Disable the npm link output for now.
