### PR TITLE
fixes to cucumber test runs on OpenShift Origin

### DIFF
--- a/stickshift/controller/test/cucumber/cartridge-jbosseap.feature
+++ b/stickshift/controller/test/cucumber/cartridge-jbosseap.feature
@@ -1,6 +1,7 @@
 @internals
 @internals1
 @node
+@not-origin
 Feature: JBossEAP Application
 
    Scenario: Create Delete one JBoss EAP Application
@@ -47,4 +48,3 @@ Feature: JBossEAP Application
      When I deconfigure the jbosseap application
      Then a jbosseap daemon will not be running
      
-

--- a/stickshift/controller/test/cucumber/cartridge-lifecycle-jbosseap.feature
+++ b/stickshift/controller/test/cucumber/cartridge-lifecycle-jbosseap.feature
@@ -1,6 +1,7 @@
 @verify
 @verify2
 @broker
+@not-origin
 Feature: Cartridge Lifecycle JBossEAP Verification Tests
   Scenario Outline: Application Creation
     Given the libra client tools

--- a/stickshift/controller/test/cucumber/cartridge-ruby.feature
+++ b/stickshift/controller/test/cucumber/cartridge-ruby.feature
@@ -3,8 +3,6 @@
 @node
 Feature: RUBY Application
 
-  # runcon -u ?? -r system_r -t libra_initrc_t
-
   Scenario Outline: Create Delete one RUBY Application
     Given a new guest account
     And the guest account has no application installed
@@ -51,4 +49,3 @@ Feature: RUBY Application
    | version |
    |   1.8   |
    |   1.9   |
-

--- a/stickshift/controller/test/cucumber/step_definitions/cartridge_steps.rb
+++ b/stickshift/controller/test/cucumber/step_definitions/cartridge_steps.rb
@@ -5,7 +5,7 @@ When /^the application is prepared for git pushes$/ do
   app_name = @account['appnames'][0]
   namespace = @account['namespace']
 
-  ssh_key = IO.read(File.expand_path("~/.ssh/id_rsa.pub")).chomp.split[1]
+  ssh_key = IO.read($test_pub_key).chomp.split[1]
   run "echo \"127.0.0.1 #{app_name}-#{namespace}.dev.rhcloud.com # Added by cucumber\" >> /etc/hosts"
   run "ss-authorized-ssh-key-add -a #{account_name} -c #{account_name} -s #{ssh_key} -t ssh-rsa -m default"
   run "echo -e \"Host #{app_name}-#{namespace}.dev.rhcloud.com\n\tStrictHostKeyChecking no\n\" >> ~/.ssh/config"

--- a/stickshift/controller/test/cucumber/support/00_setup_helper.rb
+++ b/stickshift/controller/test/cucumber/support/00_setup_helper.rb
@@ -49,8 +49,8 @@ $rhc_domain_script = "/usr/bin/rhc-domain"
 $rhc_sshkey_script = "/usr/bin/rhc-sshkey"
 
 # RSA Key constants
-$test_pub_key = File.expand_path("~/.ssh/libra_id_rsa.pub")
-$test_priv_key = File.expand_path("~/.ssh/libra_id_rsa")
+$test_pub_key = File.expand_path("~/.ssh/id_rsa.pub")
+$test_priv_key = File.expand_path("~/.ssh/id_rsa")
 
 module SetupHelper
   def self.setup


### PR DESCRIPTION
- fixing ssh key setup
- adding tags to ignore JBoss EAP cucumber tests in OpenShift Origin
