### PR TITLE
Fix for bugz 837468 - time sync issue for rhc app threaddump log 

### DIFF
--- a/cartridges/ruby-1.8/info/hooks/threaddump
+++ b/cartridges/ruby-1.8/info/hooks/threaddump
@@ -37,7 +37,7 @@ setup_basic_hook "$1" $2 $3
 result=`run_as_user "$CARTRIDGE_BASE_PATH/ruby-1.8/info/bin/threaddump.sh $1 $3"`
 
 if [$result .eq ""]; then
-    DATE=`date '+%Y%m%d'`
+    DATE=`date -u '+%Y%m%d'`
     client_result "Success"
     client_result ""
     client_result "The thread dump file will be available via: rhc app tail -a ${application} -f ${application}/logs/error_log-$DATE-000000-EST -o '-n 250'"

--- a/cartridges/ruby-1.9/info/hooks/threaddump
+++ b/cartridges/ruby-1.9/info/hooks/threaddump
@@ -37,7 +37,7 @@ setup_basic_hook "$1" $2 $3
 result=`run_as_user "$CARTRIDGE_BASE_PATH/ruby-1.9/info/bin/threaddump.sh $1 $3"`
 
 if [$result .eq ""]; then
-    DATE=`date '+%Y%m%d'`
+    DATE=`date -u '+%Y%m%d'`
     client_result "Success"
     client_result ""
     client_result "The thread dump file will be available via: rhc app tail -a ${application} -f ${application}/logs/error_log-$DATE-000000-EST -o '-n 250'"

--- a/cartridges/ruby-1.9/template/thread-dumper.rb
+++ b/cartridges/ruby-1.9/template/thread-dumper.rb
@@ -19,10 +19,8 @@ module ThreadDumper
 end
 
 trap 'QUIT' do
-  datefmt = Time.now.strftime "%Y%m%d"
-  logf = File.join(ENV['OPENSHIFT_LOG_DIR'], "error_log-#{datefmt}-00000-EST")
   btraces = ThreadDumper::Dumper.dump_thread_backtraces
   Thread.start do
-    File.open(logf, 'a') { |f| f.write(btraces) }
+    STDERR.write(btraces)
   end
 end


### PR DESCRIPTION
Time sync issue as Apache rolls over the log files at midnight UTC (not local time).

Retrying pull request as something in site is failing.
