### PR TITLE
Disable automatic Jenkins update checking

### DIFF
--- a/cartridges/jenkins-1.4/info/bin/app_ctl.sh
+++ b/cartridges/jenkins-1.4/info/bin/app_ctl.sh
@@ -43,6 +43,7 @@ start_jenkins() {
         -Dhudson.slaves.NodeProvisioner.recurrencePeriod=500 \
         -Dhudson.slaves.NodeProvisioner.initialDelay=100 \
         -Dhudson.slaves.NodeProvisioner.MARGIN=100 \
+        -Dhudson.model.UpdateCenter.never=true \
         -Xmx168m \
         -XX:MaxPermSize=100m \
         -jar /usr/lib/jenkins/jenkins.war \


### PR DESCRIPTION
Users cannot upgrade the installed version of Jenkins, but are still
prompted to upgrade when new versions become available. Disable
automatic update checking to suppress the update prompt as it cannot
be acted upon by users.

Addresses the following bug:
- https://bugzilla.redhat.com/show_bug.cgi?id=836204
