### PR TITLE
Fix to workaround a bug in mcollective that doesn't convert string representation of true to a boolean

### DIFF
--- a/gearchanger/mcollective/agent/src/stickshift.ddl
+++ b/gearchanger/mcollective/agent/src/stickshift.ddl
@@ -70,7 +70,7 @@ action "set_district", :description => "run a cartridge action" do
     input :active,
         :prompt         => "District active boolean",
         :description    => "District active boolean",
-        :type           => :boolean,
+        :type           => :any,
         :optional       => false
 
     output  :time,


### PR DESCRIPTION
Tried alternatives such as passing 1 instead of true, but they don't work.
