### PR TITLE
bugfix# 806273

### DIFF
--- a/cartridges/mysql-5.1/info/manifest.yml
+++ b/cartridges/mysql-5.1/info/manifest.yml
@@ -30,6 +30,8 @@ Provides: mysql
 Native-Requires: 
   - mysql-server
   - mysql-devel
+Conflicts:
+  - postgresql-8.4
 Profiles:
   singleton-master:
     Provides: mysql-singleton-master

--- a/cartridges/postgresql-8.4/info/manifest.yml
+++ b/cartridges/postgresql-8.4/info/manifest.yml
@@ -25,6 +25,8 @@ Cart-Data:
     Type: cart_data
     Description: "MySQL DB connection URL"
 Provides: rhc-cartridge-postgresql
+Conflicts:
+  - mysql-5.1
 Suggests:
 Native-Requires: 
   - postgresql

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_application.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_application.rb
@@ -81,7 +81,7 @@ class RestApplication < StickShift::Model
       "DELETE" => Link.new("Delete application", "DELETE", URI::join(url, "domains/#{@domain_id}/applications/#{@name}")),
       
       "ADD_CARTRIDGE" => Link.new("Add embedded cartridge", "POST", URI::join(url, "domains/#{@domain_id}/applications/#{@name}/cartridges"),[
-        Param.new("cartridge", "string", "framework-type, e.g.: mysql-5.1", carts)
+        Param.new("cartridge", "string", "framework-type, e.g.: metrics-0.1", carts)
       ]),
       "LIST_CARTRIDGES" => Link.new("List embedded cartridges", "GET", URI::join(url, "domains/#{@domain_id}/applications/#{@name}/cartridges"))
     }


### PR DESCRIPTION
Don't show postgresql-8.4 as valid options to embed cartridge when mysql is already installed and viceversa.
