### PR TITLE
Bugz#838611 Bumped API version to 1.1 so that jboss tools are not affected by cartridge metadata changes

### DIFF
--- a/stickshift/broker/test/helpers/rest/api_models_v1.rb
+++ b/stickshift/broker/test/helpers/rest/api_models_v1.rb
@@ -174,8 +174,7 @@ class RestUser_V1 < BaseObj_V1
 end
 
 class RestCartridge_V1 < BaseObj_V1
-  attr_accessor :type, :name, :version, :license, :license_url, :tags, :website,
-    :help_topics, :links, :properties
+  attr_accessor :type, :name, :links, :properties                                                                                                                                                                                                                                 
   
   def initialize(type=nil, name=nil)
     self.name = name

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/cartridges_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/cartridges_controller.rb
@@ -20,7 +20,11 @@ class CartridgesController < BaseController
         Application.get_available_cartridges(cart_type)
       end
       carts.each do |cart|
-        cartridge = RestCartridge.new(cart_type, cart, nil, get_url)
+        if $requested_api_version >= 1.1
+          cartridge = RestCartridge11.new(cart_type, cart, nil, get_url)
+        else
+          cartridge = RestCartridge10.new(cart_type, cart, nil, get_url)
+        end
         cartridges.push(cartridge)
       end
     end
@@ -32,7 +36,11 @@ class CartridgesController < BaseController
         Application.get_available_cartridges(cart_type)
       end
       carts.each do |cart|
-        cartridge = RestCartridge.new(cart_type, cart, nil, get_url)
+	if $requested_api_version >= 1.1
+          cartridge = RestCartridge11.new(cart_type, cart, nil, get_url)
+        else
+          cartridge = RestCartridge10.new(cart_type, cart, nil, get_url)
+        end
         cartridges.push(cartridge)
       end
     end

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_cartridge10.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_cartridge10.rb
@@ -1,0 +1,37 @@
+class RestCartridge10 < StickShift::Model
+  attr_accessor :type, :name, :links, :properties
+  
+  def initialize(type, name, app, url)
+    self.name = name
+    self.type = type
+    self.properties = {}
+    if app
+      self.properties = app.embedded[name]
+      domain_id = app.domain.namespace
+      app_id = app.name
+      if type == "embedded" and not app_id.nil? and not domain_id.nil?
+        self.links = {
+            "GET" => Link.new("Get embedded cartridge", "GET", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/cartridges/#{name}")),
+            "START" => Link.new("Start embedded cartridge", "POST", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/cartridges/#{name}/events"), [
+              Param.new("event", "string", "event", "start")
+            ]),
+            "STOP" => Link.new("Stop embedded cartridge", "POST", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/cartridges/#{name}/events"), [
+              Param.new("event", "string", "event", "stop")
+            ]),
+            "RESTART" => Link.new("Restart embedded cartridge", "POST", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/cartridges/#{name}/events"), [
+              Param.new("event", "string", "event", "restart")
+            ]),
+            "RELOAD" => Link.new("Reload embedded cartridge", "POST", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/cartridges/#{name}/events"), [
+              Param.new("event", "string", "event", "reload")
+            ]),
+            "DELETE" => Link.new("Delete embedded cartridge", "DELETE", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/cartridges/#{name}"))
+          }
+      end
+    end
+  end
+
+  def to_xml(options={})
+    options[:tag_name] = "cartridge"
+    super(options)
+  end
+end

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_cartridge11.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_cartridge11.rb
@@ -1,4 +1,4 @@
-class RestCartridge < StickShift::Model
+class RestCartridge11 < StickShift::Model
   attr_accessor :type, :name, :version, :license, :license_url, :tags, :website,
   :help_topics, :links, :properties
   
@@ -35,8 +35,8 @@ class RestCartridge < StickShift::Model
       property = {}
       property["name"] = data_def["Key"]
       property["type"] = data_def["Type"]
-      property["Description"] = data_def["Description"]
-      property["Value"] = prop_values[data_def["Key"]] unless prop_values.nil? or prop_values[data_def["Key"]].nil?
+      property["description"] = data_def["Description"]
+      property["value"] = prop_values[data_def["Key"]] unless prop_values.nil? or prop_values[data_def["Key"]].nil?
       self.properties << property
     end
     

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_reply.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_reply.rb
@@ -7,7 +7,7 @@ class RestReply < StickShift::Model
     self.type = type
     self.data = data
     self.messages = []
-    self.version = $requested_api_version
+    self.version = $requested_api_version.to_s
     self.supported_api_versions = BaseController::SUPPORTED_API_VERSIONS
   end
   


### PR DESCRIPTION
Version 1.1 returns framework cartridge and related properties when listing cartridges for an app (.../applications/<id>/cartridges). Version 1.0 returns the model that Jboss tools expects.

Builds upon cartridge metadata which was added in 47d1b813a1a74228c9c95734043487d681f799d4.
