### PR TITLE
Mongo safety check during deletion of app gears.

### DIFF
--- a/stickshift/controller/lib/stickshift-controller/lib/stickshift/mongo_data_store.rb
+++ b/stickshift/controller/lib/stickshift-controller/lib/stickshift/mongo_data_store.rb
@@ -517,9 +517,9 @@ COND
         end
         query = { "_id" => user_id, "apps.name" => id, "$where" => condition }
         
-        #if destroyed_gears && !destroyed_gears.empty?
-        #  query["apps.group_instances.gears.uuid"] = { "$all" => destroyed_gears }
-        #end
+        if destroyed_gears && !destroyed_gears.empty?
+          query["apps.group_instances.gears.uuid"] = { "$in" => destroyed_gears }
+        end
 
         hash = find_and_modify( user_collection, { :query => query,
                :update => updates })


### PR DESCRIPTION
 If 2 requests are deleting the same gear, this check will ensure that one will succeed and the other will throw an error as expected.
