### PR TITLE
Storing assets in the build/pre_build scripts

### DIFF
--- a/cartridges/ruby-1.9/info/bin/pre_build.sh
+++ b/cartridges/ruby-1.9/info/bin/pre_build.sh
@@ -17,6 +17,12 @@ then
   mv ${OPENSHIFT_REPO_DIR}vendor ${OPENSHIFT_GEAR_DIR}tmp/
 fi
 
+# Store precompiled assets between deploys
+if [ -d ${OPENSHIFT_REPO_DIR}/public/assets ]; then
+  echo 'Saving away previously precompiled assets'
+  mv ${OPENSHIFT_REPO_DIR}/public/assets ${OPENSHIFT_GEAR_DIR}/tmp
+fi
+
 redeploy_repo_dir.sh
 
 /usr/bin/scl enable ruby193 "user_pre_build.sh"


### PR DESCRIPTION
This modification to the scripts stores and retrieves a user's
`public/assets` directory similarly to how their `vendor` folders are
currently handled.

It also attempts to intelligently determine whether `rake` can be run and
whether `assets:compile` is a supported `rake` command.
