### PR TITLE
  Fixes for bugz 840030 - Apache blocks access to /icons

### DIFF
--- a/cartridges/haproxy-1.4/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/haproxy-1.4/info/configuration/etc/conf/httpd.conf
@@ -99,14 +99,14 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
 # BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
 # BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 

--- a/cartridges/haproxy-1.4/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/haproxy-1.4/info/configuration/etc/conf/httpd_nolog.conf
@@ -99,14 +99,14 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 #CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
 # BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
 # BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 

--- a/cartridges/perl-5.10/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/perl-5.10/info/configuration/etc/conf/httpd.conf
@@ -99,14 +99,14 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
 #BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
 #BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 

--- a/cartridges/perl-5.10/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/perl-5.10/info/configuration/etc/conf/httpd_nolog.conf
@@ -98,15 +98,15 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 #CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 PassEnv OPENSHIFT_GEAR_CTL_SCRIPT OPENSHIFT_GEAR_TYPE OPENSHIFT_APP_TYPE OPENSHIFT_INTERNAL_IP OPENSHIFT_RUN_DIR OPENSHIFT_GEAR_DIR OPENSHIFT_APP_DIR OPENSHIFT_GEAR_UUID OPENSHIFT_APP_UUID OPENSHIFT_INTERNAL_PORT OPENSHIFT_TMP_DIR OPENSHIFT_GEAR_DNS OPENSHIFT_APP_DNS OPENSHIFT_DATA_DIR OPENSHIFT_LOG_DIR PATH OPENSHIFT_GEAR_NAME OPENSHIFT_APP_NAME OPENSHIFT_HOMEDIR OPENSHIFT_REPO_DIR OPENSHIFT_DB_USERNAME OPENSHIFT_DB_PASSWORD OPENSHIFT_DB_TYPE OPENSHIFT_DB_HOST OPENSHIFT_DB_PORT OPENSHIFT_DB_SOCKET OPENSHIFT_DB_URL OPENSHIFT_DB_CTL_SCRIPT OPENSHIFT_NOSQL_DB_USERNAME OPENSHIFT_NOSQL_DB_PASSWORD OPENSHIFT_NOSQL_DB_TYPE OPENSHIFT_NOSQL_DB_HOST OPENSHIFT_NOSQL_DB_PORT OPENSHIFT_NOSQL_DB_URL OPENSHIFT_NOSQL_DB_CTL_SCRIPT 
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
 #BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
 #BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 

--- a/cartridges/php-5.3/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/php-5.3/info/configuration/etc/conf/httpd.conf
@@ -99,14 +99,14 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
 # BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
 # BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 

--- a/cartridges/php-5.3/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/php-5.3/info/configuration/etc/conf/httpd_nolog.conf
@@ -99,14 +99,14 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 #CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
 # BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
 # BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 

--- a/cartridges/phpmyadmin-3.4/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/phpmyadmin-3.4/info/configuration/etc/conf/httpd.conf
@@ -99,14 +99,14 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
 #BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
 #BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 

--- a/cartridges/phpmyadmin-3.4/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/phpmyadmin-3.4/info/configuration/etc/conf/httpd_nolog.conf
@@ -99,14 +99,14 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 #CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
 #BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
 #BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 

--- a/cartridges/python-2.6/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/python-2.6/info/configuration/etc/conf/httpd.conf
@@ -99,14 +99,14 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
 #BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
 #BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 

--- a/cartridges/python-2.6/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/python-2.6/info/configuration/etc/conf/httpd_nolog.conf
@@ -99,14 +99,14 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 #CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
 #BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
 #BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 

--- a/cartridges/ruby-1.8/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/ruby-1.8/info/configuration/etc/conf/httpd.conf
@@ -99,14 +99,14 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
 #BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
 #BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 

--- a/cartridges/ruby-1.8/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/ruby-1.8/info/configuration/etc/conf/httpd_nolog.conf
@@ -99,14 +99,14 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 #CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
 #BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
 #BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 

--- a/cartridges/ruby-1.9/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/ruby-1.9/info/configuration/etc/conf/httpd.conf
@@ -99,14 +99,14 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
 #BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
 #BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 

--- a/cartridges/ruby-1.9/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/ruby-1.9/info/configuration/etc/conf/httpd_nolog.conf
@@ -99,14 +99,14 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 #CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
 #BZ785050 IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
 #BZ785050 AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 

--- a/stickshift/broker/httpd/httpd.conf
+++ b/stickshift/broker/httpd/httpd.conf
@@ -41,7 +41,7 @@ LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule mime_module modules/mod_mime.so
 #LoadModule dav_module modules/mod_dav.so
 LoadModule status_module modules/mod_status.so
-LoadModule autoindex_module modules/mod_autoindex.so
+# BZ840030 (addendum to BZ785050): LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule info_module modules/mod_info.so
 #LoadModule dav_fs_module modules/mod_dav_fs.so
 #LoadModule vhost_alias_module modules/mod_vhost_alias.so
@@ -99,49 +99,49 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 CustomLog logs/access_log combined
 ServerSignature On
-Alias /icons/ "/var/www/icons/"
+# BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
-IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
-AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
+# BZ840030 (addendum to BZ785050): <Directory "/var/www/icons">
+# BZ840030 (addendum to BZ785050):     Options Indexes MultiViews FollowSymLinks
+# BZ840030 (addendum to BZ785050):     AllowOverride None
+# BZ840030 (addendum to BZ785050):     Order allow,deny
+# BZ840030 (addendum to BZ785050):     Allow from all
+# BZ840030 (addendum to BZ785050): </Directory>
+# BZ840030 (addendum to BZ785050): IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
+# BZ840030 (addendum to BZ785050): AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
 
-AddIconByType (TXT,/icons/text.gif) text/*
-AddIconByType (IMG,/icons/image2.gif) image/*
-AddIconByType (SND,/icons/sound2.gif) audio/*
-AddIconByType (VID,/icons/movie.gif) video/*
+# BZ840030 (addendum to BZ785050): AddIconByType (TXT,/icons/text.gif) text/*
+# BZ840030 (addendum to BZ785050): AddIconByType (IMG,/icons/image2.gif) image/*
+# BZ840030 (addendum to BZ785050): AddIconByType (SND,/icons/sound2.gif) audio/*
+# BZ840030 (addendum to BZ785050): AddIconByType (VID,/icons/movie.gif) video/*
 
-AddIcon /icons/binary.gif .bin .exe
-AddIcon /icons/binhex.gif .hqx
-AddIcon /icons/tar.gif .tar
-AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
-AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
-AddIcon /icons/a.gif .ps .ai .eps
-AddIcon /icons/layout.gif .html .shtml .htm .pdf
-AddIcon /icons/text.gif .txt
-AddIcon /icons/c.gif .c
-AddIcon /icons/p.gif .pl .py
-AddIcon /icons/f.gif .for
-AddIcon /icons/dvi.gif .dvi
-AddIcon /icons/uuencoded.gif .uu
-AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
-AddIcon /icons/tex.gif .tex
-AddIcon /icons/bomb.gif core
+# BZ840030 (addendum to BZ785050): AddIcon /icons/binary.gif .bin .exe
+# BZ840030 (addendum to BZ785050): AddIcon /icons/binhex.gif .hqx
+# BZ840030 (addendum to BZ785050): AddIcon /icons/tar.gif .tar
+# BZ840030 (addendum to BZ785050): AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
+# BZ840030 (addendum to BZ785050): AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
+# BZ840030 (addendum to BZ785050): AddIcon /icons/a.gif .ps .ai .eps
+# BZ840030 (addendum to BZ785050): AddIcon /icons/layout.gif .html .shtml .htm .pdf
+# BZ840030 (addendum to BZ785050): AddIcon /icons/text.gif .txt
+# BZ840030 (addendum to BZ785050): AddIcon /icons/c.gif .c
+# BZ840030 (addendum to BZ785050): AddIcon /icons/p.gif .pl .py
+# BZ840030 (addendum to BZ785050): AddIcon /icons/f.gif .for
+# BZ840030 (addendum to BZ785050): AddIcon /icons/dvi.gif .dvi
+# BZ840030 (addendum to BZ785050): AddIcon /icons/uuencoded.gif .uu
+# BZ840030 (addendum to BZ785050): AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
+# BZ840030 (addendum to BZ785050): AddIcon /icons/tex.gif .tex
+# BZ840030 (addendum to BZ785050): AddIcon /icons/bomb.gif core
 
-AddIcon /icons/back.gif ..
-AddIcon /icons/hand.right.gif README
-AddIcon /icons/folder.gif ^^DIRECTORY^^
-AddIcon /icons/blank.gif ^^BLANKICON^^
+# BZ840030 (addendum to BZ785050): AddIcon /icons/back.gif ..
+# BZ840030 (addendum to BZ785050): AddIcon /icons/hand.right.gif README
+# BZ840030 (addendum to BZ785050): AddIcon /icons/folder.gif ^^DIRECTORY^^
+# BZ840030 (addendum to BZ785050): AddIcon /icons/blank.gif ^^BLANKICON^^
 
-DefaultIcon /icons/unknown.gif
+# BZ840030 (addendum to BZ785050): DefaultIcon /icons/unknown.gif
 
-ReadmeName README.html
-HeaderName HEADER.html
-IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
+# BZ840030 (addendum to BZ785050): ReadmeName README.html
+# BZ840030 (addendum to BZ785050): HeaderName HEADER.html
+# BZ840030 (addendum to BZ785050): IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
 AddLanguage ca .ca
 AddLanguage cs .cz .cs
 AddLanguage da .dk


### PR DESCRIPTION
```
Fixes for bugz 840030 - Apache blocks access to /icons. Remove these as
mod_autoindex has now been turned OFF (see bugz 785050 for more details).
```
