### PR TITLE
BZ 838365: Protect force-stop against user resource limits

### DIFF
--- a/stickshift/abstract/abstract/info/hooks/force-stop
+++ b/stickshift/abstract/abstract/info/hooks/force-stop
@@ -35,14 +35,16 @@ setup_basic_hook "$1" $2 $3
 # Stop application
 #
 
+# Do not exit on errors past this point; force kill no matter what else happens.
+set +e
+
 set_app_state stopped
 for i in {1..10}
 do
-    if /bin/ps -U "$uuid" -o pid | /bin/grep -v PID | xargs kill -9 2> /dev/null
+    if killall -s KILL -u "$uuid" 2> /dev/null
     then
         sleep .5
     else
         break
     fi
 done
-

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -719,9 +719,14 @@ function set_app_state {
 
 function set_cartridge_state {
   _state=`get_cartridge_state "$1"`
+
   if [ ! \( "idle" = "$_state" -a "stopped" = "$2" \) ]; then
     _state_file="$1/.state"
-    run_as_user "echo \"$2\" >$_state_file"
+    rm -f "$_state_file"
+    echo "$2" > "$_state_file"
+    chown --reference="$1" "$_state_file"
+    chcon --reference="$1" "$_state_file"
+    chmod 640 "$_state_file"
   fi  
 }
 


### PR DESCRIPTION
Have the force-stop task attempt to kill user processes even if it can't set the app state.  And set the app state using root rather than the UID in case the UID is resource starved (ex: out of processes).
