### PR TITLE
Move lifecycle tests for php and ruby to libra_check

### DIFF
--- a/stickshift/controller/test/cucumber/cartridge-lifecycle-php.feature
+++ b/stickshift/controller/test/cucumber/cartridge-lifecycle-php.feature
@@ -1,5 +1,5 @@
-@runtime_verify
-@runtime_verify1
+@runtime
+@runtime2
 Feature: Cartridge Lifecycle PHP Verification Tests
   Scenario Outline: Application Creation
     Given the libra client tools

--- a/stickshift/controller/test/cucumber/cartridge-lifecycle-ruby.feature
+++ b/stickshift/controller/test/cucumber/cartridge-lifecycle-ruby.feature
@@ -1,5 +1,5 @@
-@runtime_verify
-@runtime_verify3
+@runtime
+@runtime1
 Feature: Cartridge Lifecycle Ruby Verification Tests
   Scenario Outline: Application Creation
     Given the libra client tools


### PR DESCRIPTION
All long running lifecycle tests are now in runtime_extended job
