### PR TITLE
US 2552: Stop requiring deconfigure to be called with app destroy

### DIFF
--- a/cartridges/diy-0.1/info/hooks/configure
+++ b/cartridges/diy-0.1/info/hooks/configure
@@ -33,7 +33,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # Repo
 if [ ! -d $git_url ]; then

--- a/cartridges/diy-0.1/info/hooks/deconfigure
+++ b/cartridges/diy-0.1/info/hooks/deconfigure
@@ -28,7 +28,7 @@ source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
 setup_deconfigure "$1" $2 $3
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -47,7 +47,6 @@ else
     enable_cgroups
 fi
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/cartridges/haproxy-1.4/info/hooks/configure
+++ b/cartridges/haproxy-1.4/info/hooks/configure
@@ -33,7 +33,6 @@ function setup_haproxy_as_a_service() {
 
     setup_configure "$1" $2 $3 $4
     check_cartridge_dir_doesnt_exist
-    unobfuscate_app_home $uuid $namespace $application
 
     # Source the original application name if any.
     source_if_exists "$APP_HOME/.env/OPENSHIFT_APP_NAME"

--- a/cartridges/haproxy-1.4/info/hooks/move
+++ b/cartridges/haproxy-1.4/info/hooks/move
@@ -36,7 +36,6 @@ setup_basic_vars
 
 CART_INFO_DIR=$CARTRIDGE_BASE_PATH/$cartridge_type/info
 
-unobfuscate_app_home $uuid $namespace $application
 
 observe_setup_app_home
 observe_setup_app_and_git_dirs

--- a/cartridges/jenkins-1.4/info/hooks/configure
+++ b/cartridges/jenkins-1.4/info/hooks/configure
@@ -86,7 +86,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 check_cartridge_dir_doesnt_exist
 
-unobfuscate_app_home $uuid $namespace $application
 
 #
 # Setup the base of the application

--- a/cartridges/jenkins-1.4/info/hooks/deconfigure
+++ b/cartridges/jenkins-1.4/info/hooks/deconfigure
@@ -29,7 +29,7 @@ source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 setup_deconfigure "$1" $2 $3
 
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -60,7 +60,6 @@ fi
 
 remove_ssh_key
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/cartridges/mongodb-2.0/info/hooks/configure
+++ b/cartridges/mongodb-2.0/info/hooks/configure
@@ -17,7 +17,6 @@ function prepare_gear_for_standalone_mongodb() {
 
     setup_configure "$1" $2 $3 $4
     check_cartridge_dir_doesnt_exist
-    unobfuscate_app_home $uuid $namespace $application
 
     # Source the original application name if any.
     source_if_exists "$APP_HOME/.env/OPENSHIFT_APP_NAME"

--- a/cartridges/mongodb-2.0/info/hooks/deconfigure
+++ b/cartridges/mongodb-2.0/info/hooks/deconfigure
@@ -46,7 +46,7 @@ source_if_exists "$APP_HOME/.env/OPENSHIFT_GEAR_TYPE"
 
 # For non-embedded (dedicated) mongo gear, destroy the git repo and stop app.
 if [ "mongodb-2.0" = "$OPENSHIFT_GEAR_TYPE" ]; then
-   remove_all_proxy_ports $uuid
+   $CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
    # Destroy git repo and stop app.
    destroy_git_repo $application $uuid
@@ -69,7 +69,6 @@ runcon -l s0-s0:c0.c1023 rm -rf "$MONGODB_DIR" "$MONGODB_DIR/${application}_mong
 if [ "mongodb-2.0" = "$OPENSHIFT_GEAR_TYPE" ]; then
     # Blow away the directories.
     rm_app_dir
-    rm_unobfuscated_app_home $namespace $application
 
     # Remove apache vhost configuration.
     rm_httpd_proxy $uuid $namespace $application

--- a/cartridges/mongodb-2.0/info/hooks/move
+++ b/cartridges/mongodb-2.0/info/hooks/move
@@ -43,7 +43,6 @@ IP=$OPENSHIFT_INTERNAL_IP
 . $APP_HOME/.env/OPENSHIFT_APP_NAME
 if [ ! -d "$GEAR_BASE_DIR/$uuid/$OPENSHIFT_APP_NAME" ]; then
     #  This gear is dedicated to running mongo - configure it as such.
-    unobfuscate_app_home $uuid $namespace $application
     export CART_INFO_DIR
     import_env_vars
     $CART_INFO_DIR/bin/deploy_httpd_proxy.sh $application $namespace $uuid $IP

--- a/cartridges/mongodb-2.0/info/hooks/remove-httpd-proxy
+++ b/cartridges/mongodb-2.0/info/hooks/remove-httpd-proxy
@@ -38,6 +38,5 @@ APP_HOME="$GEAR_BASE_DIR/$uuid"
 # Only do this for an "standalone" mongodb gear.
 [ "$OPENSHIFT_GEAR_TYPE" = "mongodb-2.0" ]  ||  return 0
 
-rm_unobfuscated_app_home $namespace $application
 
 rm -rf "/etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application}.conf" "/etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application}"

--- a/cartridges/mysql-5.1/info/hooks/configure
+++ b/cartridges/mysql-5.1/info/hooks/configure
@@ -17,7 +17,6 @@ function setup_mysql_as_a_service() {
 
     setup_configure "$1" $2 $3 $4
     check_cartridge_dir_doesnt_exist
-    unobfuscate_app_home $uuid $namespace $application
 
     # Source the original application name if any.
     source_if_exists "$APP_HOME/.env/OPENSHIFT_APP_NAME"

--- a/cartridges/mysql-5.1/info/hooks/deconfigure
+++ b/cartridges/mysql-5.1/info/hooks/deconfigure
@@ -47,7 +47,7 @@ source_if_exists "$APP_HOME/.env/OPENSHIFT_DB_TYPE"
 # For non-embedded (dedicated) mysql gear, destroy the git repo and stop app.
 APPLICATION_DIR=`readlink -fn "$APP_DIR"`
 if [ "$MYSQL_DIR" -ef  "$APPLICATION_DIR" ]; then
-   remove_all_proxy_ports $uuid
+   $CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
    # Destroy git repo and stop app.
    destroy_git_repo $application $uuid
@@ -69,7 +69,6 @@ fi
 if [ "$MYSQL_DIR" -ef  "$APPLICATION_DIR" ]; then
     # Blow away the directories.
     rm_app_dir
-    rm_unobfuscated_app_home $namespace $application
 
     # Remove apache vhost configuration.
     rm_httpd_proxy $uuid $namespace $application

--- a/cartridges/mysql-5.1/info/hooks/move
+++ b/cartridges/mysql-5.1/info/hooks/move
@@ -44,7 +44,6 @@ fi
 . $APP_HOME/.env/OPENSHIFT_APP_NAME
 if [ ! -d "$GEAR_BASE_DIR/$uuid/$OPENSHIFT_APP_NAME" ]; then
     #  This gear is dedicated to running mysql - configure it as such.
-    unobfuscate_app_home $uuid $namespace $application
     export CART_INFO_DIR
     import_env_vars
     $CART_INFO_DIR/bin/deploy_httpd_proxy.sh $application $namespace $uuid $IP

--- a/cartridges/mysql-5.1/info/hooks/remove-httpd-proxy
+++ b/cartridges/mysql-5.1/info/hooks/remove-httpd-proxy
@@ -39,6 +39,5 @@ APP_HOME="$GEAR_BASE_DIR/$uuid"
 # Only do this for an "standalone" mysql gear.
 [ "$OPENSHIFT_GEAR_TYPE" = "mysql-5.1" ]  || exit 0
 
-rm_unobfuscated_app_home $namespace $application
 
 rm -rf "/etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application}.conf" "/etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application}"

--- a/cartridges/nodejs-0.6/info/hooks/configure
+++ b/cartridges/nodejs-0.6/info/hooks/configure
@@ -30,7 +30,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # Repo
 if [ ! -d $git_url ]; then

--- a/cartridges/nodejs-0.6/info/hooks/deconfigure
+++ b/cartridges/nodejs-0.6/info/hooks/deconfigure
@@ -35,7 +35,7 @@ source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 # Deconfigure app.
 setup_deconfigure "$1" $2 $3
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -59,7 +59,6 @@ else
     enable_cgroups
 fi
 
-rm_unobfuscated_app_home $namespace $application
 
 # And finally, remove virtualhost definition added to Apache.
 rm_httpd_proxy $uuid $namespace $application

--- a/cartridges/perl-5.10/info/hooks/configure
+++ b/cartridges/perl-5.10/info/hooks/configure
@@ -33,7 +33,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # Repo
 if [ ! -d $git_url ]; then

--- a/cartridges/perl-5.10/info/hooks/deconfigure
+++ b/cartridges/perl-5.10/info/hooks/deconfigure
@@ -30,7 +30,7 @@ setup_deconfigure "$1" $2 $3
 
 PERLCART_INSTANCE_DIR=$(get_cartridge_instance_dir "$cartridge_type")
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -54,7 +54,6 @@ else
     enable_cgroups
 fi
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/cartridges/php-5.3/info/hooks/configure
+++ b/cartridges/php-5.3/info/hooks/configure
@@ -32,7 +32,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # Repo
 if [ ! -d $git_url ]; then

--- a/cartridges/php-5.3/info/hooks/deconfigure
+++ b/cartridges/php-5.3/info/hooks/deconfigure
@@ -30,7 +30,7 @@ setup_deconfigure "$1" $2 $3
 
 PHPCART_INSTANCE_DIR=$(get_cartridge_instance_dir "$cartridge_type")
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -54,7 +54,6 @@ else
     enable_cgroups
 fi
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/cartridges/python-2.6/info/hooks/configure
+++ b/cartridges/python-2.6/info/hooks/configure
@@ -32,7 +32,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # Repo
 if [ ! -d $git_url ]; then

--- a/cartridges/python-2.6/info/hooks/deconfigure
+++ b/cartridges/python-2.6/info/hooks/deconfigure
@@ -28,7 +28,7 @@ source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
 setup_deconfigure "$1" $2 $3
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -53,7 +53,6 @@ else
     enable_cgroups
 fi
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/cartridges/ruby-1.8/info/hooks/configure
+++ b/cartridges/ruby-1.8/info/hooks/configure
@@ -32,7 +32,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # Repo
 if [ ! -d $git_url ]; then

--- a/cartridges/ruby-1.8/info/hooks/deconfigure
+++ b/cartridges/ruby-1.8/info/hooks/deconfigure
@@ -28,7 +28,7 @@ source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
 setup_deconfigure "$1" $2 $3
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -53,7 +53,6 @@ else
     enable_cgroups
 fi
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/cartridges/ruby-1.9/info/hooks/configure
+++ b/cartridges/ruby-1.9/info/hooks/configure
@@ -32,7 +32,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # Repo
 if [ ! -d $git_url ]; then

--- a/cartridges/ruby-1.9/info/hooks/deconfigure
+++ b/cartridges/ruby-1.9/info/hooks/deconfigure
@@ -28,7 +28,7 @@ source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
 setup_deconfigure "$1" $2 $3
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -53,7 +53,6 @@ else
     enable_cgroups
 fi
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/stickshift/abstract/abstract-jboss/info/hooks/configure
+++ b/stickshift/abstract/abstract-jboss/info/hooks/configure
@@ -104,7 +104,6 @@ setup_configure "$1" $2 $3 $4
 
 disable_cgroups
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # The root of the application jboss contents
 JBOSS_INSTANCE_DIR=$(get_cartridge_instance_dir "$jboss_version")

--- a/stickshift/abstract/abstract-jboss/info/hooks/deconfigure
+++ b/stickshift/abstract/abstract-jboss/info/hooks/deconfigure
@@ -33,7 +33,7 @@ setup_deconfigure "$1" $2 $3
 
 JBOSS_INSTANCE_DIR=$(get_cartridge_instance_dir "$cartridge_type")
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 M2_DIR="$APP_HOME/.m2" # maven dir
 JAVA_PREFS_DIR="$APP_HOME/.java" # Java preferences dir
@@ -64,7 +64,6 @@ runcon -l s0-s0:c0.c1023 rm -rf "$M2_DIR"
 # remove the Java preferences dir
 runcon -l s0-s0:c0.c1023 rm -rf "$JAVA_PREFS_DIR"
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/stickshift/abstract/abstract/info/hooks/move
+++ b/stickshift/abstract/abstract/info/hooks/move
@@ -38,8 +38,6 @@ cartridge_type=$OPENSHIFT_GEAR_TYPE
 
 CART_INFO_DIR=$CARTRIDGE_BASE_PATH/$OPENSHIFT_GEAR_TYPE/info
 
-unobfuscate_app_home $uuid $namespace $application
-
 observe_setup_app_home
 observe_setup_app_and_git_dirs
 observe_setup_cart_instance_dir

--- a/stickshift/abstract/abstract/info/hooks/remove-httpd-proxy
+++ b/stickshift/abstract/abstract/info/hooks/remove-httpd-proxy
@@ -32,6 +32,4 @@ namespace=`basename $2`
 application="$1"
 uuid=$3
 
-rm_unobfuscated_app_home $namespace $application
-
 rm -rf "/etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application}.conf" "/etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application}"

--- a/stickshift/abstract/abstract/info/lib/network
+++ b/stickshift/abstract/abstract/info/lib/network
@@ -184,15 +184,3 @@ function show_proxy_port {
   echo "Failed to find proxy."
   return 1
 }
-
-function remove_all_proxy_ports {
-  uuid=$1
-
-  setproxy=()
-  for proxy_port in $(uuid_to_portset $uuid)
-  do
-    setproxy=("${setproxy[@]}" "$proxy_port" "delete")
-  done
-  proxy_cmd setproxy "${setproxy[@]}"
-  return 0
-}

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -405,6 +405,8 @@ function setup_deconfigure {
     source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/network
     source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/apache
 
+    CART_INFO_DIR=$CARTRIDGE_BASE_PATH/$cartridge_type/info
+
     namespace=`basename $2`
     application="$1"
     uuid=$3
@@ -559,37 +561,6 @@ function print_user_running_processes {
     echo ""
     ps -FCvx -U ${myuserid}
     echo ""
-}
-
-function rm_unobfuscated_app_home {
-    # Check if unobfuscate is set in /etc/stickshift/stickshift-node.conf
-    # If it is set, remove symlink
-
-    namespace=$1
-    appname=$2
-
-    if [ $CREATE_APP_SYMLINKS -eq 1 ]
-    then
-        rm -f "${GEAR_BASE_DIR}/${appname}-${namespace}"
-    fi
-}
-
-function unobfuscate_app_home {
-    # Check if unobfuscate is set in /etc/stickshift/stickshift-node.conf
-    # If it is set, symlink /var/lib/stickshift/uuid to /var/lib/stickshift/appname-namespace
-    # This will allow easier debugging.
-
-    uuid=$1
-    namespace=$2
-    appname=$3
-
-    if [ $CREATE_APP_SYMLINKS -eq 1 ]
-    then
-        if [ ! -f "${GEAR_BASE_DIR}/$appname-$namespace" ] && [ ! -d "${GEAR_BASE_DIR}/$appname-$namespace" ]
-        then
-            /bin/ln -sf "${GEAR_BASE_DIR}/${uuid}" "${GEAR_BASE_DIR}/${appname}-${namespace}"
-        fi
-    fi
 }
 
 function send_stopped_status {

--- a/stickshift/node/lib/stickshift-node/model/unix_user.rb
+++ b/stickshift/node/lib/stickshift-node/model/unix_user.rb
@@ -117,6 +117,7 @@ module StickShift
       end
       notify_observers(:after_unix_user_create)
       initialize_homedir(basedir, @homedir, @config.get("CARTRIDGE_BASE_PATH"))
+      initialize_stickshift_proxy
     end
     
     # Public: Destroys a gear stopping all processes and removing all files
@@ -137,15 +138,21 @@ module StickShift
             "ERROR: unable to destroy user account #{@uuid}"
             ) if @uid.nil? || @homedir.nil? || @uuid.nil?
       notify_observers(:before_unix_user_destroy)
+
+      initialize_stickshift_proxy
       
-      cmd = %{/bin/ps -U '#{@uuid}' -o pid | \
-              /bin/grep -v PID | \
-              xargs kill -9 2> /dev/null}
+      cmd = %{/usr/bin/killall -s KILL -u '#{@uuid}' 2> /dev/null}
       (1..10).each do |i|
         out,err,rc = shellCmd(cmd)
         break unless rc == 0
+        sleep 0.5
       end
       
+      unobfuscated = File.join(@homedir,"..","#{@container_name}-#{namespace}")
+      if File.exists? unobfuscated
+        FileUtils.rm_f(unobfuscated)
+      end
+
       FileUtils.rm_rf(@homedir)
 
       basedir = @config.get("GEAR_BASE_DIR")
@@ -370,6 +377,13 @@ module StickShift
       @homedir = homedir
       notify_observers(:before_initialize_homedir)
       homedir = homedir.end_with?('/') ? homedir : homedir + '/'
+
+      if @config.get("CREATE_APP_SYMLINKS").to_i == 1
+        unobfuscated = File.join(@homedir,"..","#{@container_name}-#{namespace}")
+        if not File.exists? unobfuscated
+          FileUtils.ln_s File.basename(@homedir), unobfuscated, :force=>true
+        end
+      end
       
       tmp_dir = File.join(homedir, ".tmp")
       # Required for polyinstantiated tmp dirs to work
@@ -463,6 +477,55 @@ module StickShift
           return i
         end
       end
+    end
+
+    # Private: Initialize Stickshift Port Proxy for this gear
+    #
+    # The port proxy range is determined by configuration and must
+    # produce identical results to the abstract cartridge provided
+    # range.
+    #
+    # Examples:
+    # initialize_stickshift_proxy
+    #    => true
+    #    service stickshift_proxy setproxy 35000 delete 35001 delete etc...
+    #
+    # Returns:
+    #    true   - port proxy could be initialized properly
+    #    false  - port proxy could not be initialized properly
+    def initialize_stickshift_proxy
+      notify_observers(:before_initialize_stickshift_proxy)
+
+      port_begin = (@config.get("PORT_BEGIN") || "35531").to_i
+      ports_per_user = (@config.get("PORTS_PER_USER") || "5").to_i
+
+      # Note, due to a mismatch between dev and prod this is
+      # intentionally not GEAR_MIN_UID and the range must
+      # wrap back around on itself.
+      uid_begin = (@config.get("UID_BEGIN") || "500").to_i
+
+      wrap_uid = ((65536 - port_begin)/ports_per_user)+uid_begin
+
+      if @uid >= wrap_uid
+        tuid = @uid - wrap_uid + uid_begin
+      else
+        tuid = @uid
+      end
+
+      proxy_port_begin = (tuid-uid_begin) * ports_per_user + port_begin
+
+      proxy_port_range = (proxy_port_begin ... (proxy_port_begin + ports_per_user))
+
+      cmd = %{/sbin/chkconfig --list stickshift-proxy}
+      out,err,rc = shellCmd(cmd)
+      if rc == 0
+        cmd = %{/sbin/service stickshift-proxy setproxy}
+        proxy_port_range.each { |i| cmd << " #{i} delete" }
+        out, err, rc = shellCmd(cmd)
+      end
+
+      notify_observers(:after_initialize_stickshift_proxy)
+      return rc == 0
     end
   end
 end

--- a/stickshift/node/lib/stickshift-node/utils/shell_exec.rb
+++ b/stickshift/node/lib/stickshift-node/utils/shell_exec.rb
@@ -15,7 +15,7 @@
 #++
 
 require 'rubygems'
-require 'open3'
+require 'open4'
 
 module StickShift::Utils
   class ShellExecutionException < Exception
@@ -46,23 +46,31 @@ module StickShift::Utils::ShellExec
   #   # => ["/etc/passwd\n","", 0]
   #
   # Returns An Array with [stdout, stderr, return_code]
-  def self.shellCmd(cmd, pwd = ".", ignore_err = true, expected_rc = 0)
+  def self.shellCmd(cmd, pwd = ".", ignore_err = true, expected_rc = 0, timeout = 3600)
     out = err = rc = nil         
     begin
-      rc_file = "/var/tmp/#{Process.pid}.#{rand}"
-      m_cmd = "cd #{pwd}; #{cmd}; echo $? > #{rc_file}"
-      stdin, stdout, stderr = Open3.popen3(m_cmd){ | stdin, stdout, stderr,
-                                                    thr |
+      # Using Open4 spawn with cwd isn't thread safe
+      m_cmd = "cd #{pwd} && ( #{cmd} )"
+      pid, stdin, stdout, stderr = Open4.popen4ext(true, m_cmd)
+      begin
         stdin.close
-        out = stdout.read
-        err = stderr.read          
+        Timeout::timeout(timeout) do
+          out = stdout.read
+          err = stderr.read
+        end
+      rescue Timeout::Error
+        pstree = Hash.new{|a,b| a[b]=[b]}
+        pppids = Hash[*`ps -e -opid,ppid --no-headers`.map{|p| p.to_i}]
+        pppids.each do |l_pid, l_ppid|
+          pstree[l_ppid] << pstree[l_pid]
+        end
+        Process.kill("KILL", *(pstree[pid].flatten))
+        raise StickShift::Utils::ShellExecutionException.new("command timed out")
+      ensure
         stdout.close
         stderr.close  
-      }
-      f_rc_file = File.open(rc_file,"r")
-      rc = f_rc_file.read.to_i
-      f_rc_file.close
-      `rm -f #{rc_file}`
+        rc = Process::waitpid2(pid)[1].exitstatus
+      end
     rescue Exception => e
       raise StickShift::Utils::ShellExecutionException.new(e.message
                                                     ) unless ignore_err


### PR DESCRIPTION
Add pre and post destroy calls on gear destruction and move unobfuscate and stickshift-proxy out of cartridge hooks and into node.

This is a mid-project update to keep from diverging too far from upstream.
