### PR TITLE
US 2552: Stop requiring deconfigure to be called with app destroy

### DIFF
--- a/cartridges/diy-0.1/info/hooks/configure
+++ b/cartridges/diy-0.1/info/hooks/configure
@@ -33,7 +33,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # Repo
 if [ ! -d $git_url ]; then

--- a/cartridges/diy-0.1/info/hooks/deconfigure
+++ b/cartridges/diy-0.1/info/hooks/deconfigure
@@ -28,7 +28,7 @@ source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
 setup_deconfigure "$1" $2 $3
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -47,7 +47,6 @@ else
     enable_cgroups
 fi
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/cartridges/haproxy-1.4/info/hooks/configure
+++ b/cartridges/haproxy-1.4/info/hooks/configure
@@ -33,7 +33,6 @@ function setup_haproxy_as_a_service() {
 
     setup_configure "$1" $2 $3 $4
     check_cartridge_dir_doesnt_exist
-    unobfuscate_app_home $uuid $namespace $application
 
     # Source the original application name if any.
     source_if_exists "$APP_HOME/.env/OPENSHIFT_APP_NAME"

--- a/cartridges/haproxy-1.4/info/hooks/deconfigure
+++ b/cartridges/haproxy-1.4/info/hooks/deconfigure
@@ -73,7 +73,7 @@ if [ "$application" != "$OPENSHIFT_APP_NAME" ]; then
    rm -rf "/etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${OPENSHIFT_APP_NAME}.conf" "/etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${OPENSHIFT_APP_NAME}"
 fi
 
-remove_ssh_key
+$CART_INFO_DIR/hooks/pre-destroy "$@"
 
 # Got here if its haproxy embedded and got removed - so start up all apps with
 # the new path (IE: without haproxy)

--- a/cartridges/haproxy-1.4/info/hooks/move
+++ b/cartridges/haproxy-1.4/info/hooks/move
@@ -36,7 +36,6 @@ setup_basic_vars
 
 CART_INFO_DIR=$CARTRIDGE_BASE_PATH/$cartridge_type/info
 
-unobfuscate_app_home $uuid $namespace $application
 
 observe_setup_app_home
 observe_setup_app_and_git_dirs

--- a/cartridges/haproxy-1.4/info/hooks/pre-destroy
+++ b/cartridges/haproxy-1.4/info/hooks/pre-destroy
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Destroys haproxy instance
+CART_NAME="haproxy"
+CART_VERSION="1.4"
+
+
+function print_help {
+    echo "Usage: $0 app-name namespace uuid"
+
+    echo "$0 $@" | logger -p local0.notice -t stickshift_haproxy_deconfigure
+    exit 1
+}
+
+while getopts 'd' OPTION
+do
+    case $OPTION in
+        d) set -x
+        ;;
+        ?) print_help
+        ;;
+    esac
+done
+
+[ $# -eq 3 ] || print_help
+
+cartridge_type="$CART_NAME-$CART_VERSION"
+source /etc/stickshift/stickshift-node.conf
+source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
+
+setup_embedded_deconfigure "$1" $2 $3
+
+remove_ssh_key

--- a/cartridges/jenkins-1.4/info/hooks/configure
+++ b/cartridges/jenkins-1.4/info/hooks/configure
@@ -86,7 +86,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 check_cartridge_dir_doesnt_exist
 
-unobfuscate_app_home $uuid $namespace $application
 
 #
 # Setup the base of the application

--- a/cartridges/jenkins-1.4/info/hooks/deconfigure
+++ b/cartridges/jenkins-1.4/info/hooks/deconfigure
@@ -29,7 +29,7 @@ source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 setup_deconfigure "$1" $2 $3
 
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -58,15 +58,10 @@ else
     enable_cgroups
 fi
 
-remove_ssh_key
-
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache
 #
 rm_httpd_proxy $uuid $namespace $application
 
-remove_env_var "JENKINS_URL"
-remove_env_var "JENKINS_USERNAME"
-remove_env_var "JENKINS_PASSWORD"
+$CART_INFO_DIR/hooks/pre-destroy "$@"

--- a/cartridges/jenkins-1.4/info/hooks/pre-destroy
+++ b/cartridges/jenkins-1.4/info/hooks/pre-destroy
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+function print_help {
+    echo "Usage: $0 app-name namespace uuid"
+
+    echo "$0 $@" | logger -p local0.notice -t stickshift_jenkins_deconfigure
+    exit 1
+}
+
+while getopts 'd' OPTION
+do
+    case $OPTION in
+        d) set -x
+        ;;
+        ?) print_help
+        ;;
+    esac
+done
+
+[ $# -eq 3 ] || print_help
+
+cartridge_type="jenkins-1.4"
+source "/etc/stickshift/stickshift-node.conf"
+source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
+
+setup_deconfigure "$1" $2 $3
+
+
+remove_ssh_key
+
+remove_env_var "JENKINS_URL"
+remove_env_var "JENKINS_USERNAME"
+remove_env_var "JENKINS_PASSWORD"

--- a/cartridges/jenkins-client-1.4/info/hooks/pre-destroy
+++ b/cartridges/jenkins-client-1.4/info/hooks/pre-destroy
@@ -1,0 +1,1 @@
+deconfigure

--- a/cartridges/mongodb-2.0/info/hooks/configure
+++ b/cartridges/mongodb-2.0/info/hooks/configure
@@ -17,7 +17,6 @@ function prepare_gear_for_standalone_mongodb() {
 
     setup_configure "$1" $2 $3 $4
     check_cartridge_dir_doesnt_exist
-    unobfuscate_app_home $uuid $namespace $application
 
     # Source the original application name if any.
     source_if_exists "$APP_HOME/.env/OPENSHIFT_APP_NAME"

--- a/cartridges/mongodb-2.0/info/hooks/deconfigure
+++ b/cartridges/mongodb-2.0/info/hooks/deconfigure
@@ -46,7 +46,7 @@ source_if_exists "$APP_HOME/.env/OPENSHIFT_GEAR_TYPE"
 
 # For non-embedded (dedicated) mongo gear, destroy the git repo and stop app.
 if [ "mongodb-2.0" = "$OPENSHIFT_GEAR_TYPE" ]; then
-   remove_all_proxy_ports $uuid
+   $CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
    # Destroy git repo and stop app.
    destroy_git_repo $application $uuid
@@ -69,7 +69,6 @@ runcon -l s0-s0:c0.c1023 rm -rf "$MONGODB_DIR" "$MONGODB_DIR/${application}_mong
 if [ "mongodb-2.0" = "$OPENSHIFT_GEAR_TYPE" ]; then
     # Blow away the directories.
     rm_app_dir
-    rm_unobfuscated_app_home $namespace $application
 
     # Remove apache vhost configuration.
     rm_httpd_proxy $uuid $namespace $application

--- a/cartridges/mongodb-2.0/info/hooks/move
+++ b/cartridges/mongodb-2.0/info/hooks/move
@@ -43,7 +43,6 @@ IP=$OPENSHIFT_INTERNAL_IP
 . $APP_HOME/.env/OPENSHIFT_APP_NAME
 if [ ! -d "$GEAR_BASE_DIR/$uuid/$OPENSHIFT_APP_NAME" ]; then
     #  This gear is dedicated to running mongo - configure it as such.
-    unobfuscate_app_home $uuid $namespace $application
     export CART_INFO_DIR
     import_env_vars
     $CART_INFO_DIR/bin/deploy_httpd_proxy.sh $application $namespace $uuid $IP

--- a/cartridges/mongodb-2.0/info/hooks/remove-httpd-proxy
+++ b/cartridges/mongodb-2.0/info/hooks/remove-httpd-proxy
@@ -38,6 +38,5 @@ APP_HOME="$GEAR_BASE_DIR/$uuid"
 # Only do this for an "standalone" mongodb gear.
 [ "$OPENSHIFT_GEAR_TYPE" = "mongodb-2.0" ]  ||  return 0
 
-rm_unobfuscated_app_home $namespace $application
 
 rm -rf "/etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application}.conf" "/etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application}"

--- a/cartridges/mysql-5.1/info/hooks/configure
+++ b/cartridges/mysql-5.1/info/hooks/configure
@@ -17,7 +17,6 @@ function setup_mysql_as_a_service() {
 
     setup_configure "$1" $2 $3 $4
     check_cartridge_dir_doesnt_exist
-    unobfuscate_app_home $uuid $namespace $application
 
     # Source the original application name if any.
     source_if_exists "$APP_HOME/.env/OPENSHIFT_APP_NAME"

--- a/cartridges/mysql-5.1/info/hooks/deconfigure
+++ b/cartridges/mysql-5.1/info/hooks/deconfigure
@@ -47,7 +47,7 @@ source_if_exists "$APP_HOME/.env/OPENSHIFT_DB_TYPE"
 # For non-embedded (dedicated) mysql gear, destroy the git repo and stop app.
 APPLICATION_DIR=`readlink -fn "$APP_DIR"`
 if [ "$MYSQL_DIR" -ef  "$APPLICATION_DIR" ]; then
-   remove_all_proxy_ports $uuid
+   $CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
    # Destroy git repo and stop app.
    destroy_git_repo $application $uuid
@@ -69,7 +69,6 @@ fi
 if [ "$MYSQL_DIR" -ef  "$APPLICATION_DIR" ]; then
     # Blow away the directories.
     rm_app_dir
-    rm_unobfuscated_app_home $namespace $application
 
     # Remove apache vhost configuration.
     rm_httpd_proxy $uuid $namespace $application

--- a/cartridges/mysql-5.1/info/hooks/move
+++ b/cartridges/mysql-5.1/info/hooks/move
@@ -44,7 +44,6 @@ fi
 . $APP_HOME/.env/OPENSHIFT_APP_NAME
 if [ ! -d "$GEAR_BASE_DIR/$uuid/$OPENSHIFT_APP_NAME" ]; then
     #  This gear is dedicated to running mysql - configure it as such.
-    unobfuscate_app_home $uuid $namespace $application
     export CART_INFO_DIR
     import_env_vars
     $CART_INFO_DIR/bin/deploy_httpd_proxy.sh $application $namespace $uuid $IP

--- a/cartridges/mysql-5.1/info/hooks/remove-httpd-proxy
+++ b/cartridges/mysql-5.1/info/hooks/remove-httpd-proxy
@@ -39,6 +39,5 @@ APP_HOME="$GEAR_BASE_DIR/$uuid"
 # Only do this for an "standalone" mysql gear.
 [ "$OPENSHIFT_GEAR_TYPE" = "mysql-5.1" ]  || exit 0
 
-rm_unobfuscated_app_home $namespace $application
 
 rm -rf "/etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application}.conf" "/etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application}"

--- a/cartridges/nodejs-0.6/info/hooks/configure
+++ b/cartridges/nodejs-0.6/info/hooks/configure
@@ -30,7 +30,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # Repo
 if [ ! -d $git_url ]; then

--- a/cartridges/nodejs-0.6/info/hooks/deconfigure
+++ b/cartridges/nodejs-0.6/info/hooks/deconfigure
@@ -35,7 +35,7 @@ source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 # Deconfigure app.
 setup_deconfigure "$1" $2 $3
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -59,7 +59,6 @@ else
     enable_cgroups
 fi
 
-rm_unobfuscated_app_home $namespace $application
 
 # And finally, remove virtualhost definition added to Apache.
 rm_httpd_proxy $uuid $namespace $application

--- a/cartridges/perl-5.10/info/hooks/configure
+++ b/cartridges/perl-5.10/info/hooks/configure
@@ -33,7 +33,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # Repo
 if [ ! -d $git_url ]; then

--- a/cartridges/perl-5.10/info/hooks/deconfigure
+++ b/cartridges/perl-5.10/info/hooks/deconfigure
@@ -30,7 +30,7 @@ setup_deconfigure "$1" $2 $3
 
 PERLCART_INSTANCE_DIR=$(get_cartridge_instance_dir "$cartridge_type")
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -54,7 +54,6 @@ else
     enable_cgroups
 fi
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/cartridges/php-5.3/info/hooks/configure
+++ b/cartridges/php-5.3/info/hooks/configure
@@ -32,7 +32,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # Repo
 if [ ! -d $git_url ]; then

--- a/cartridges/php-5.3/info/hooks/deconfigure
+++ b/cartridges/php-5.3/info/hooks/deconfigure
@@ -30,7 +30,7 @@ setup_deconfigure "$1" $2 $3
 
 PHPCART_INSTANCE_DIR=$(get_cartridge_instance_dir "$cartridge_type")
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -54,7 +54,6 @@ else
     enable_cgroups
 fi
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/cartridges/python-2.6/info/hooks/configure
+++ b/cartridges/python-2.6/info/hooks/configure
@@ -32,7 +32,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # Repo
 if [ ! -d $git_url ]; then

--- a/cartridges/python-2.6/info/hooks/deconfigure
+++ b/cartridges/python-2.6/info/hooks/deconfigure
@@ -28,7 +28,7 @@ source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
 setup_deconfigure "$1" $2 $3
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -53,7 +53,6 @@ else
     enable_cgroups
 fi
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/cartridges/ruby-1.8/info/hooks/configure
+++ b/cartridges/ruby-1.8/info/hooks/configure
@@ -32,7 +32,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # Repo
 if [ ! -d $git_url ]; then

--- a/cartridges/ruby-1.8/info/hooks/deconfigure
+++ b/cartridges/ruby-1.8/info/hooks/deconfigure
@@ -28,7 +28,7 @@ source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
 setup_deconfigure "$1" $2 $3
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -53,7 +53,6 @@ else
     enable_cgroups
 fi
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/cartridges/ruby-1.9/info/hooks/configure
+++ b/cartridges/ruby-1.9/info/hooks/configure
@@ -32,7 +32,6 @@ setup_configure "$1" $2 $3 $4
 disable_cgroups
 
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # Repo
 if [ ! -d $git_url ]; then

--- a/cartridges/ruby-1.9/info/hooks/deconfigure
+++ b/cartridges/ruby-1.9/info/hooks/deconfigure
@@ -28,7 +28,7 @@ source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
 setup_deconfigure "$1" $2 $3
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 if [ ! -d "$APP_HOME/app-root" ]
 then
@@ -53,7 +53,6 @@ else
     enable_cgroups
 fi
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/gearchanger/mcollective/agent/src/stickshift.rb
+++ b/gearchanger/mcollective/agent/src/stickshift.rb
@@ -53,17 +53,22 @@ module MCollective
       def ss_app_destroy(cmd, args)
         Log.instance.info "COMMAND: #{cmd}"
         app_uuid = args['--with-app-uuid']
-        uuid = args['--with-container-uuid']
-        
+        app_name = args['--with-app-name']
+        gear_uuid = args['--with-container-uuid']
+        gear_name = args['--with-container-name']
+        namespace = args['--with-namespace']
         output = ""
         begin
-          container = StickShift::ApplicationContainer.new(app_uuid, uuid)
-          container.destroy
+          container = StickShift::ApplicationContainer.new(app_uuid, gear_uuid, nil, app_name, gear_name, 
+                                                           namespace, nil, nil)
+          out, err, rc = container.destroy
         rescue Exception => e
           Log.instance.info e.message
           return -1, e.message
         else
-          return 0, output
+          output << out
+          output << err
+          return rc, output
         end
       end
 

--- a/gearchanger/mcollective/plugin/lib/gearchanger-mcollective-plugin/gearchanger/mcollective_application_container_proxy.rb
+++ b/gearchanger/mcollective/plugin/lib/gearchanger-mcollective-plugin/gearchanger/mcollective_application_container_proxy.rb
@@ -144,7 +144,10 @@ module GearChanger
       def destroy(app, gear, keep_uid=false, uid=nil)
         args = Hash.new
         args['--with-app-uuid'] = app.uuid
+        args['--with-app-name'] = app.name
         args['--with-container-uuid'] = gear.uuid
+        args['--with-container-name'] = gear.name
+        args['--with-namespace'] = app.domain.namespace
         result = execute_direct(@@C_CONTROLLER, 'app-destroy', args)
         result_io = parse_result(result)
         

--- a/stickshift/abstract/abstract-jboss/info/hooks/configure
+++ b/stickshift/abstract/abstract-jboss/info/hooks/configure
@@ -104,7 +104,6 @@ setup_configure "$1" $2 $3 $4
 
 disable_cgroups
 check_cartridge_dir_doesnt_exist
-unobfuscate_app_home $uuid $namespace $application
 
 # The root of the application jboss contents
 JBOSS_INSTANCE_DIR=$(get_cartridge_instance_dir "$jboss_version")

--- a/stickshift/abstract/abstract-jboss/info/hooks/deconfigure
+++ b/stickshift/abstract/abstract-jboss/info/hooks/deconfigure
@@ -33,7 +33,7 @@ setup_deconfigure "$1" $2 $3
 
 JBOSS_INSTANCE_DIR=$(get_cartridge_instance_dir "$cartridge_type")
 
-remove_all_proxy_ports $uuid
+$CART_INFO_DIR/hooks/conceal-port "$application" "$namespace" "$uuid"
 
 M2_DIR="$APP_HOME/.m2" # maven dir
 JAVA_PREFS_DIR="$APP_HOME/.java" # Java preferences dir
@@ -64,7 +64,6 @@ runcon -l s0-s0:c0.c1023 rm -rf "$M2_DIR"
 # remove the Java preferences dir
 runcon -l s0-s0:c0.c1023 rm -rf "$JAVA_PREFS_DIR"
 
-rm_unobfuscated_app_home $namespace $application
 
 #
 # Remove virtualhost definition for apache

--- a/stickshift/abstract/abstract/info/hooks/move
+++ b/stickshift/abstract/abstract/info/hooks/move
@@ -38,8 +38,6 @@ cartridge_type=$OPENSHIFT_GEAR_TYPE
 
 CART_INFO_DIR=$CARTRIDGE_BASE_PATH/$OPENSHIFT_GEAR_TYPE/info
 
-unobfuscate_app_home $uuid $namespace $application
-
 observe_setup_app_home
 observe_setup_app_and_git_dirs
 observe_setup_cart_instance_dir

--- a/stickshift/abstract/abstract/info/hooks/remove-httpd-proxy
+++ b/stickshift/abstract/abstract/info/hooks/remove-httpd-proxy
@@ -32,6 +32,4 @@ namespace=`basename $2`
 application="$1"
 uuid=$3
 
-rm_unobfuscated_app_home $namespace $application
-
 rm -rf "/etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application}.conf" "/etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application}"

--- a/stickshift/abstract/abstract/info/lib/network
+++ b/stickshift/abstract/abstract/info/lib/network
@@ -184,15 +184,3 @@ function show_proxy_port {
   echo "Failed to find proxy."
   return 1
 }
-
-function remove_all_proxy_ports {
-  uuid=$1
-
-  setproxy=()
-  for proxy_port in $(uuid_to_portset $uuid)
-  do
-    setproxy=("${setproxy[@]}" "$proxy_port" "delete")
-  done
-  proxy_cmd setproxy "${setproxy[@]}"
-  return 0
-}

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -405,6 +405,8 @@ function setup_deconfigure {
     source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/network
     source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/apache
 
+    CART_INFO_DIR=$CARTRIDGE_BASE_PATH/$cartridge_type/info
+
     namespace=`basename $2`
     application="$1"
     uuid=$3
@@ -559,37 +561,6 @@ function print_user_running_processes {
     echo ""
     ps -FCvx -U ${myuserid}
     echo ""
-}
-
-function rm_unobfuscated_app_home {
-    # Check if unobfuscate is set in /etc/stickshift/stickshift-node.conf
-    # If it is set, remove symlink
-
-    namespace=$1
-    appname=$2
-
-    if [ $CREATE_APP_SYMLINKS -eq 1 ]
-    then
-        rm -f "${GEAR_BASE_DIR}/${appname}-${namespace}"
-    fi
-}
-
-function unobfuscate_app_home {
-    # Check if unobfuscate is set in /etc/stickshift/stickshift-node.conf
-    # If it is set, symlink /var/lib/stickshift/uuid to /var/lib/stickshift/appname-namespace
-    # This will allow easier debugging.
-
-    uuid=$1
-    namespace=$2
-    appname=$3
-
-    if [ $CREATE_APP_SYMLINKS -eq 1 ]
-    then
-        if [ ! -f "${GEAR_BASE_DIR}/$appname-$namespace" ] && [ ! -d "${GEAR_BASE_DIR}/$appname-$namespace" ]
-        then
-            /bin/ln -sf "${GEAR_BASE_DIR}/${uuid}" "${GEAR_BASE_DIR}/${appname}-${namespace}"
-        fi
-    fi
 }
 
 function send_stopped_status {

--- a/stickshift/controller/test/cucumber/step_definitions/node_steps.rb
+++ b/stickshift/controller/test/cucumber/step_definitions/node_steps.rb
@@ -10,9 +10,9 @@ require 'dnsruby'
 # Controller cartridge command paths
 $cartridge_root = '/usr/libexec/stickshift/cartridges'
 $controller_config_path = "ss-app-create"
-$controller_config_format = "#{$controller_config_path} -c '%s' --with-namespace '%s' --with-app-name '%s'"
+$controller_config_format = "#{$controller_config_path} -c '%s' -a '%s' --with-namespace '%s' --with-app-name '%s'"
 $controller_deconfig_path = "ss-app-destroy"
-$controller_deconfig_format = "#{$controller_deconfig_path} -c '%s'"
+$controller_deconfig_format = "#{$controller_deconfig_path} -c '%s' -a '%s' --with-namespace '%s' --with-app-name '%s'"
 $home_root = "/var/lib/stickshift"
 
 # --------------------------------------------------------------------------
@@ -58,7 +58,7 @@ Given /^a new gear with namespace "([^\"]*)" and app name "([^\"]*)"$/ do |names
     'appnames' => [ name ],
   }
 
-  command = $controller_config_format % [acctname, namespace, name]
+  command = $controller_config_format % [acctname, acctname, namespace, name]
   run command
 
   # get and store the account UID's by name
@@ -78,7 +78,7 @@ Given /^a new guest account$/ do
     'appnames' => [ appname ],
   }
 
-  command = $controller_config_format % [acctname, namespace, appname]
+  command = $controller_config_format % [acctname, acctname, namespace, appname]
   run command
 
   # get and store the account UID's by name
@@ -103,7 +103,7 @@ When /^I create a guest account$/ do
     'appnames' => [ appname ],
   }
 
-  command = $controller_config_format % [acctname, namespace, appname]
+  command = $controller_config_format % [acctname, acctname, namespace, appname]
   run command
 
   # get and store the account UID's by name
@@ -113,7 +113,10 @@ end
 When /^I delete the guest account$/ do
   # call /usr/libexec/stickshift/cartridges  @table.hashes.each do |row|
   
-  command = $controller_deconfig_format % [@account['accountname']]
+  command = $controller_deconfig_format % [@account['accountname'],
+                                           @account['accountname'],
+                                           @account['namespace'],
+                                           @account['appnames'][0]]
   run command
 
 end

--- a/stickshift/node/bin/ss-app-destroy
+++ b/stickshift/node/bin/ss-app-destroy
@@ -24,15 +24,22 @@ ss-app-destroy: Deletes an application container.
 
 == Usage
 
-ss-app-destroy --with-container-uuid UUID --with-app-uuid APP_UUID
+ss-app-destroy --with-container-uuid UUID \\
+               --with-container-name NAME \\
+               --with-app-uuid APP_UUID \\
+               --with-app-name APP_NAME \\
+               --with-namespace NAMESPACE
 
-Options:
--h|--help:
-   Prints this message
-
-APP_UUID: Unique identifier for the application
-UUID: Unique identifier for the application
-NAME: The name of the application to create
+== List of arguments
+  -a|--with-app-uuid        app_uuid    Unique application identifier (required)
+  -c|--with-container-uuid  gear_uuid   Unique identifier for the gear(required)
+    |--with-app-name        name        Name of the application (required)
+    |--with-namespace       namespace   Namespace of the application (required)
+    |--with-container-name  gear_name   Name of the gear
+  -n|--dry-run                          Don't make changes, just do a dry run.
+  -q|--porcelain                        TODO: what does this do?
+  -d|--debug                            Enable debug mode
+  -h|--help                             Print this message
 
 USAGE
 end
@@ -42,8 +49,10 @@ require 'stickshift-node'
 opts = GetoptLong.new(
     ["--with-app-uuid",       "-a", GetoptLong::REQUIRED_ARGUMENT],
     ["--with-container-uuid", "-c", GetoptLong::REQUIRED_ARGUMENT],
+    ["--with-app-name",             GetoptLong::REQUIRED_ARGUMENT],
+    ["--with-namespace",            GetoptLong::REQUIRED_ARGUMENT],
+    ["--with-container-name",       GetoptLong::OPTIONAL_ARGUMENT],
     ["--dry-run",             "-n", GetoptLong::NO_ARGUMENT],
-    ["--with-app-name",             GetoptLong::OPTIONAL_ARGUMENT],
     ["--porcelain",           "-q", GetoptLong::NO_ARGUMENT],
     ["--debug",               "-d", GetoptLong::NO_ARGUMENT],
     ["--help",                "-?", GetoptLong::NO_ARGUMENT]
@@ -63,22 +72,28 @@ if args["--help"]
 end
 
 app_uuid = args['--with-app-uuid']
-uuid = args['--with-container-uuid']
+app_name = args['--with-app-name']
+container_uuid = args['--with-container-uuid']
+container_name = args['--with-container-name'] || args['--with-app-name']
+namespace = args['--with-namespace']
 $dry_run = true if args['--dry-run']
 $ss_debug = true if args['--debug']
 $porcelin = args['--porcelain'] ? true : false
 
-unless uuid
+unless container_uuid
   usage
   exit -100
 end
 
 begin
-  container = StickShift::ApplicationContainer.new(app_uuid,uuid)
-  container.destroy
+  container = StickShift::ApplicationContainer.new(app_uuid, container_uuid, nil, app_name,
+                                                   container_name, namespace, nil, nil)
+  out, err, rc = container.destroy
 rescue Exception => e
   $stderr.puts(e.message)
   exit -1
 else
-  exit 0
+  $stdout.puts(out) if out != ""
+  $stderr.puts(err) if err != ""
+  exit rc
 end

--- a/stickshift/node/lib/stickshift-node/model/application_container.rb
+++ b/stickshift/node/lib/stickshift-node/model/application_container.rb
@@ -17,15 +17,19 @@
 require 'rubygems'
 require 'stickshift-node/config'
 require 'stickshift-node/model/unix_user'
+require 'stickshift-node/utils/shell_exec'
 require 'stickshift-common'
 
 module StickShift
   # == Application Container
   class ApplicationContainer < Model
+    include StickShift::Utils::ShellExec
     attr_reader :uuid, :application_uuid, :user
 
     def initialize(application_uuid, container_uuid, user_uid = nil,
         app_name = nil, container_name = nil, namespace = nil, quota_blocks = nil, quota_files = nil)
+      @config = StickShift::Config.instance
+
       @uuid = container_uuid
       @application_uuid = application_uuid
       @user = UnixUser.new(application_uuid, container_uuid, user_uid,
@@ -46,8 +50,49 @@ module StickShift
     # Destroy gear - model/unix_user.rb
     def destroy
       notify_observers(:before_container_destroy)
+
+      hook_timeout=30
+
+      output = ""
+      errout = ""
+      retcode = 0
+
+      hooks={}
+      ["pre", "post"].each do |hooktype|
+        if @user.homedir.nil?
+          hooks[hooktype]=[]
+        else
+          hooks[hooktype] = Dir.entries(@user.homedir).map { |cart|
+            [ File.join(@config.get("CARTRIDGE_BASE_PATH"),cart,"info","hooks","#{hooktype}-destroy"),
+              File.join(@config.get("CARTRIDGE_BASE_PATH"),"embedded",cart,"info","hooks","#{hooktype}-destroy"),
+            ].select { |hook| File.exists? hook }[0]
+          }.select { |hook|
+            not hook.nil?
+          }.map { |hook|
+            "#{hook} #{@user.container_name} #{@user.namespace} #{@user.container_uuid}"
+          }
+        end
+      end
+
+      hooks["pre"].each do | cmd |
+        out,err,rc = shellCmd(cmd, "/", true, 0, hook_timeout)
+        errout << err if not err.nil?
+        output << out if not out.nil?
+        retcode = 121 if rc != 0
+      end
+
       @user.destroy
-      notify_observers(:after_container_destroy)      
+
+      hooks["post"].each do | cmd |
+        out,err,rc = shellCmd(cmd, "/", true, 0, hook_timeout)
+        errout << err if not err.nil?
+        output << out if not out.nil?
+        retcode = 121 if rc != 0
+      end
+
+      notify_observers(:after_container_destroy)
+
+      return output, errout, retcode
     end
 
     # Public: Fetch application state from gear.


### PR DESCRIPTION
Add pre and post destroy calls on gear destruction and move unobfuscate and stickshift-proxy out of cartridge hooks and into node.

There will be a corresponding pull request in li which must be tested together with this pull request.
