### PR TITLE
BZ 841157

### DIFF
--- a/cartridges/jenkins-1.4/info/bin/update_namespace.sh
+++ b/cartridges/jenkins-1.4/info/bin/update_namespace.sh
@@ -48,4 +48,4 @@ then
     sed -i "s/-${old_namespace}.${CLOUD_DOMAIN}/-${new_namespace}.${CLOUD_DOMAIN}/g" $APP_HOME/app-root/data/hudson.tasks.Mailer.xml
 fi
 
-add_env_var "JENKINS_URL=https://${application}-${new_namespace}.${CLOUD_DOMAIN}/"
+force_add_env_var "JENKINS_URL=https://${application}-${new_namespace}.${CLOUD_DOMAIN}/"

--- a/gearchanger/mcollective/agent/src/stickshift.ddl
+++ b/gearchanger/mcollective/agent/src/stickshift.ddl
@@ -22,7 +22,7 @@ action "cartridge_do", :description => "run a cartridge action" do
         :prompt         => "Action",
         :description    => "Cartridge hook to run",
         :type           => :string,
-        :validation     => '^(app-create|app-destroy|env-var-add|env-var-remove|broker-auth-key-add|broker-auth-key-remove|authorized-ssh-key-add|authorized-ssh-key-remove|app-state-show|cartridge-list|configure|deconfigure|update-namespace|tidy|deploy-httpd-proxy|remove-httpd-proxy|move|pre-move|post-move|info|post-install|post-remove|pre-install|reload|restart|start|status|stop|force-stop|add-alias|remove-alias|threaddump|expose-port|conceal-port|show-port|system-messages|connector-execute|get-quota|set-quota)$',
+        :validation     => '^(app-create|app-destroy|env-var-add|force-env-var-add|env-var-remove|broker-auth-key-add|broker-auth-key-remove|authorized-ssh-key-add|authorized-ssh-key-remove|app-state-show|cartridge-list|configure|deconfigure|update-namespace|tidy|deploy-httpd-proxy|remove-httpd-proxy|move|pre-move|post-move|info|post-install|post-remove|pre-install|reload|restart|start|status|stop|force-stop|add-alias|remove-alias|threaddump|expose-port|conceal-port|show-port|system-messages|connector-execute|get-quota|set-quota)$',
         :optional       => false,
         :maxlength      => 64
 

--- a/gearchanger/mcollective/agent/src/stickshift.rb
+++ b/gearchanger/mcollective/agent/src/stickshift.rb
@@ -170,6 +170,26 @@ module MCollective
           return 0, output
         end
       end
+      
+      def ss_force_env_var_add(cmd, args)
+        Log.instance.info "COMMAND: #{cmd}"
+
+        uuid = args['--with-container-uuid']
+        app_uuid = args['--with-app-uuid']
+        key = args['--with-key']
+        value = args['--with-value']
+        
+        output = ""
+        begin
+          container = StickShift::ApplicationContainer.new(uuid, uuid)
+          container.user.force_add_env_var(key, value)
+        rescue Exception => e
+          Log.instance.info e.message
+          return -1, e.message
+        else
+          return 0, output
+        end
+      end
 
       def ss_env_var_remove(cmd, args)
         Log.instance.info "COMMAND: #{cmd}"
@@ -291,6 +311,8 @@ module MCollective
           rc, output = ss_broker_auth_key_remove(cmd, args)
         when "env-var-add" 
           rc, output = ss_env_var_add(cmd, args)
+        when "force-env-var-add" 
+          rc, output = ss_force_env_var_add(cmd, args)
         when "env-var-remove" 
           rc, output = ss_env_var_remove(cmd, args)
         when "cartridge-list"

--- a/gearchanger/mcollective/plugin/lib/gearchanger-mcollective-plugin/gearchanger/mcollective_application_container_proxy.rb
+++ b/gearchanger/mcollective/plugin/lib/gearchanger-mcollective-plugin/gearchanger/mcollective_application_container_proxy.rb
@@ -239,6 +239,16 @@ module GearChanger
         parse_result(result)
       end
       
+     def force_add_env_var(app, gear, key, value)
+        args = Hash.new
+        args['--with-app-uuid'] = app.uuid
+        args['--with-container-uuid'] = gear.uuid
+        args['--with-key'] = key
+        args['--with-value'] = value
+        result = execute_direct(@@C_CONTROLLER, 'env-var-add', args)
+        parse_result(result)
+      end
+      
       def remove_env_var(app, gear, key)
         args = Hash.new
         args['--with-app-uuid'] = app.uuid
@@ -1080,6 +1090,9 @@ module GearChanger
                   key = line['ENV_VAR_REMOVE: '.length..-1].chomp
                   result.cart_commands.push({:command => "ENV_VAR_REMOVE", :args => [key]})
                 end
+              elsif line =~ /^FORCE_ENV_VAR_ADD: /
+                env_var = line['FORCE_ENV_VAR_ADD: '.length..-1].chomp.split('=')
+                result.cart_commands.push({:command => "FORCE_ENV_VAR_ADD", :args => [env_var[0], env_var[1]]})
               elsif line =~ /^BROKER_AUTH_KEY_(ADD|REMOVE): /
                 if line =~ /^BROKER_AUTH_KEY_ADD: /
                   result.cart_commands.push({:command => "BROKER_KEY_ADD", :args => []})

--- a/gearchanger/mcollective/plugin/lib/gearchanger-mcollective-plugin/gearchanger/mcollective_application_container_proxy.rb
+++ b/gearchanger/mcollective/plugin/lib/gearchanger-mcollective-plugin/gearchanger/mcollective_application_container_proxy.rb
@@ -59,10 +59,6 @@ module GearChanger
         MCollectiveApplicationContainerProxy.new(current_server)
       end
 
-      def self.get_blacklisted_in_impl
-        []
-      end
-
       def self.blacklisted_in_impl?(name)
         false
       end
@@ -76,56 +72,7 @@ module GearChanger
         cart_data = JSON.parse(result.resultIO.string)
         cart_data.map! {|c| StickShift::Cartridge.new.from_descriptor(YAML.load(c))}
       end
-
-      # Returns an array with following information
-      # [Filesystem, blocks_used, blocks_soft_limit, blocks_hard_limit, inodes_used,
-      #  inodes_soft_limit, inodes_hard_limit]
-      def get_quota(uuid)
-        args = Hash.new
-        args['--uuid'] = uuid
-        reply = execute_direct(@@C_CONTROLLER, 'get-quota', args, false)
-
-        output = nil
-        exitcode = 0
-        if reply.length > 0
-          mcoll_result = reply[0]
-          if (mcoll_result && (defined? mcoll_result.results) && !mcoll_result.results[:data].nil?)
-            output = mcoll_result.results[:data][:output]
-            exitcode = mcoll_result.results[:data][:exitcode]
-            raise StickShift::NodeException.new("Failed to get quota for user: #{output}", 143) unless exitcode == 0
-          else
-            raise StickShift::NodeException.new("Node execution failure (error getting result from node).  If the problem persists please contact Red Hat support.", 143)
-          end
-        else
-          raise StickShift::NodeException.new("Node execution failure (error getting result from node).  If the problem persists please contact Red Hat support.", 143)
-        end
-        output
-      end
       
-      # Set blocks hard limit and inodes ihard limit for uuid
-      def set_quota(uuid, blocks, inodes)
-        args = Hash.new
-        args['--uuid']   = uuid
-        args['--blocks'] = blocks
-        args['--inodes'] = inodes
-        reply = execute_direct(@@C_CONTROLLER, 'set-quota', args, false)
-
-        output = nil
-        exitcode = 0
-        if reply.length > 0
-          mcoll_result = reply[0]
-          if (mcoll_result && (defined? mcoll_result.results) && !mcoll_result.results[:data].nil?)
-            output = mcoll_result.results[:data][:output]
-            exitcode = mcoll_result.results[:data][:exitcode]
-            raise StickShift::NodeException.new("Failed to set quota for user: #{output}", 143) unless exitcode == 0
-          else
-            raise StickShift::NodeException.new("Node execution failure (error getting result from node).  If the problem persists please contact Red Hat support.", 143)
-          end
-        else
-          raise StickShift::NodeException.new("Node execution failure (error getting result from node).  If the problem persists please contact Red Hat support.", 143)
-        end
-      end
-
       def reserve_uid(district_uuid=nil)
         reserved_uid = nil
         if Rails.configuration.gearchanger[:districts][:enabled]
@@ -234,6 +181,7 @@ module GearChanger
       end
 
       def add_env_var(app, gear, key, value)
+        Rails.logger.debug "!!!!!!!!!! mc add_env_var #{key} #{value}"
         args = Hash.new
         args['--with-app-uuid'] = app.uuid
         args['--with-container-uuid'] = gear.uuid
@@ -243,13 +191,14 @@ module GearChanger
         parse_result(result)
       end
       
-     def force_add_env_var(app, gear, key, value)
+      def force_add_env_var(app, gear, key, value)
+        Rails.logger.debug "!!!!!!!!!! mc force_add_env_var #{key} #{value}"
         args = Hash.new
         args['--with-app-uuid'] = app.uuid
         args['--with-container-uuid'] = gear.uuid
         args['--with-key'] = key
         args['--with-value'] = value
-        result = execute_direct(@@C_CONTROLLER, 'env-var-add', args)
+        result = execute_direct(@@C_CONTROLLER, 'force-env-var-add', args)
         parse_result(result)
       end
       
@@ -479,6 +428,17 @@ module GearChanger
         args['--with-key'] = key
         args['--with-value'] = value
         job = RemoteJob.new('stickshift-node', 'env-var-add', args)
+        job
+      end
+      
+     def get_force_env_var_add_job(app, gear, key, value)
+       Rails.logger.debug "!!!!!!!!!!!! mc get_force_env_var_add_job #{key} #{value}"
+        args = Hash.new
+        args['--with-app-uuid'] = app.uuid
+        args['--with-container-uuid'] = gear.uuid
+        args['--with-key'] = key
+        args['--with-value'] = value
+        job = RemoteJob.new('stickshift-node', 'force-env-var-add', args)
         job
       end
       
@@ -743,6 +703,7 @@ module GearChanger
                 end
               end
             end
+            # deconfigure destination
             # destroy destination
             log_debug "DEBUG: Moving failed.  Rolling back gear '#{gear.name}' in '#{app.name}' with destroy on '#{destination_container.id}'"
             reply.append destination_container.destroy(app, gear, keep_uid)
@@ -792,6 +753,21 @@ module GearChanger
         reply = ResultIO.new
         log_debug "DEBUG: Deconfiguring old app '#{app.name}' on #{source_container.id} after move"
         begin
+          gi = app.group_instance_map[gear.group_instance_name]
+          # gi.component_instances.each do |ci_name|
+          app.configure_order.reverse.each do |ci_name|
+            next if not gi.component_instances.include? ci_name
+            cinst = app.comp_instance_map[ci_name]
+            cart = cinst.parent_cart_name
+            next if cart==app.name
+            begin
+              if framework_carts.include? cart or app.scalable
+                reply.append source_container.run_cartridge_command(cart, app, gear, "deconfigure", nil, false) if not cart.include? "jenkins"
+              end
+            rescue Exception => e
+              log_debug "DEBUG: The application '#{app.name}' with gear uuid '#{gear.uuid}' is now moved to '#{destination_container.id}' but not completely deconfigured from '#{source_container.id}'"
+            end
+          end
           reply.append source_container.destroy(app, gear, keep_uid, orig_uid)
         rescue Exception => e
           log_debug "DEBUG: The application '#{app.name}' with gear uuid '#{gear.uuid}' is now moved to '#{destination_container.id}' but not completely deconfigured from '#{source_container.id}'"
@@ -1061,6 +1037,7 @@ module GearChanger
         
         if output && !output.empty?
           output.each_line do |line|
+            Rails.logger.debug "!!!!! mc parse_result " + line
             if line =~ /^CLIENT_(MESSAGE|RESULT|DEBUG|ERROR): /
               if line =~ /^CLIENT_MESSAGE: /
                 result.messageIO << line['CLIENT_MESSAGE: '.length..-1]

--- a/gearchanger/mcollective/plugin/lib/gearchanger-mcollective-plugin/gearchanger/mcollective_application_container_proxy.rb
+++ b/gearchanger/mcollective/plugin/lib/gearchanger-mcollective-plugin/gearchanger/mcollective_application_container_proxy.rb
@@ -181,7 +181,6 @@ module GearChanger
       end
 
       def add_env_var(app, gear, key, value)
-        Rails.logger.debug "!!!!!!!!!! mc add_env_var #{key} #{value}"
         args = Hash.new
         args['--with-app-uuid'] = app.uuid
         args['--with-container-uuid'] = gear.uuid
@@ -192,7 +191,6 @@ module GearChanger
       end
       
       def force_add_env_var(app, gear, key, value)
-        Rails.logger.debug "!!!!!!!!!! mc force_add_env_var #{key} #{value}"
         args = Hash.new
         args['--with-app-uuid'] = app.uuid
         args['--with-container-uuid'] = gear.uuid
@@ -432,7 +430,6 @@ module GearChanger
       end
       
      def get_force_env_var_add_job(app, gear, key, value)
-       Rails.logger.debug "!!!!!!!!!!!! mc get_force_env_var_add_job #{key} #{value}"
         args = Hash.new
         args['--with-app-uuid'] = app.uuid
         args['--with-container-uuid'] = gear.uuid
@@ -1037,7 +1034,6 @@ module GearChanger
         
         if output && !output.empty?
           output.each_line do |line|
-            Rails.logger.debug "!!!!! mc parse_result " + line
             if line =~ /^CLIENT_(MESSAGE|RESULT|DEBUG|ERROR): /
               if line =~ /^CLIENT_MESSAGE: /
                 result.messageIO << line['CLIENT_MESSAGE: '.length..-1]

--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -354,6 +354,10 @@ function add_env_var {
     echo "ENV_VAR_ADD: $1"
 }
 
+function force_add_env_var {
+    echo "FORCE_ENV_VAR_ADD: $1"
+}
+
 function remove_env_var {
     echo "ENV_VAR_REMOVE: $1"
 }

--- a/stickshift/controller/lib/stickshift-controller/app/models/application.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/application.rb
@@ -1350,10 +1350,12 @@ Configure-Order: [\"proxy/#{framework}\", \"proxy/haproxy-1.4\"]
       when "SYSTEM_SSH_KEY_REMOVE"
         self.user.remove_system_ssh_key(self.name)
       when "ENV_VAR_ADD"
+      Rails.logger.debug "!!!!!!!!!!!! process_cartridge_commands ENV_VAR_ADD"
         key = command_item[:args][0]
         value = command_item[:args][1]
         self.user.add_env_var(key,value)
       when "FORCE_ENV_VAR_ADD"
+Rails.logger.debug "!!!!!!!!!!!! process_cartridge_commands FORCE_ENV_VAR_ADD"
         key = command_item[:args][0]
         value = command_item[:args][1]
         self.user.force_add_env_var(key,value)

--- a/stickshift/controller/lib/stickshift-controller/app/models/application.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/application.rb
@@ -1353,6 +1353,10 @@ Configure-Order: [\"proxy/#{framework}\", \"proxy/haproxy-1.4\"]
         key = command_item[:args][0]
         value = command_item[:args][1]
         self.user.add_env_var(key,value)
+      when "FORCE_ENV_VAR_ADD"
+        key = command_item[:args][0]
+        value = command_item[:args][1]
+        self.user.force_add_env_var(key,value)
       when "ENV_VAR_REMOVE"
         key = command_item[:args][0]
         self.user.remove_env_var(key)

--- a/stickshift/controller/lib/stickshift-controller/app/models/application.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/application.rb
@@ -1350,12 +1350,10 @@ Configure-Order: [\"proxy/#{framework}\", \"proxy/haproxy-1.4\"]
       when "SYSTEM_SSH_KEY_REMOVE"
         self.user.remove_system_ssh_key(self.name)
       when "ENV_VAR_ADD"
-      Rails.logger.debug "!!!!!!!!!!!! process_cartridge_commands ENV_VAR_ADD"
         key = command_item[:args][0]
         value = command_item[:args][1]
         self.user.add_env_var(key,value)
       when "FORCE_ENV_VAR_ADD"
-Rails.logger.debug "!!!!!!!!!!!! process_cartridge_commands FORCE_ENV_VAR_ADD"
         key = command_item[:args][0]
         value = command_item[:args][1]
         self.user.force_add_env_var(key,value)

--- a/stickshift/controller/lib/stickshift-controller/app/models/cloud_user.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/cloud_user.rb
@@ -128,6 +128,14 @@
                 job = gear.env_var_job_add(env_var_key, env_var_value)
                 RemoteJob.add_parallel_job(exec_handle, tag, gear, job)
               end
+           when 'force-env_vars'
+              values.each do |value|
+                env_var_key = value[0]
+                env_var_value = value[1]
+Rails.logger.debug "!!!!!!!!! cloud_user save #{env_var_key} #{env_var_value}"
+                job = gear.force_env_var_job_add(env_var_key, env_var_value)
+                RemoteJob.add_parallel_job(exec_handle, tag, gear, job)
+              end
             when 'broker_auth_keys'
               values.each do |value|
                 app_uuid = value[0]
@@ -295,15 +303,17 @@
   end
  
   def add_env_var(key, value)
+    Rails.logger.debug "!!!!!!!!! cloud_user add_env_var #{key} #{value}"
     self.env_vars = {} unless self.env_vars
     self.env_vars[key] = value
     add_save_job('adds', 'env_vars', [key, value])
   end
   
   def force_add_env_var(key, value)
+    Rails.logger.debug "!!!!!!!!! cloud_user force_add_env_var #{key} #{value}"
     self.env_vars = {} unless self.env_vars
     self.env_vars[key] = value
-    add_save_job('adds', 'env_vars', [key, value])
+    add_save_job('adds', 'force-env_vars', [key, value])
   end
   
   def remove_env_var(key)

--- a/stickshift/controller/lib/stickshift-controller/app/models/cloud_user.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/cloud_user.rb
@@ -132,7 +132,6 @@
               values.each do |value|
                 env_var_key = value[0]
                 env_var_value = value[1]
-Rails.logger.debug "!!!!!!!!! cloud_user save #{env_var_key} #{env_var_value}"
                 job = gear.force_env_var_job_add(env_var_key, env_var_value)
                 RemoteJob.add_parallel_job(exec_handle, tag, gear, job)
               end
@@ -303,14 +302,12 @@ Rails.logger.debug "!!!!!!!!! cloud_user save #{env_var_key} #{env_var_value}"
   end
  
   def add_env_var(key, value)
-    Rails.logger.debug "!!!!!!!!! cloud_user add_env_var #{key} #{value}"
     self.env_vars = {} unless self.env_vars
     self.env_vars[key] = value
     add_save_job('adds', 'env_vars', [key, value])
   end
   
   def force_add_env_var(key, value)
-    Rails.logger.debug "!!!!!!!!! cloud_user force_add_env_var #{key} #{value}"
     self.env_vars = {} unless self.env_vars
     self.env_vars[key] = value
     add_save_job('adds', 'force-env_vars', [key, value])

--- a/stickshift/controller/lib/stickshift-controller/app/models/cloud_user.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/cloud_user.rb
@@ -300,6 +300,12 @@
     add_save_job('adds', 'env_vars', [key, value])
   end
   
+  def force_add_env_var(key, value)
+    self.env_vars = {} unless self.env_vars
+    self.env_vars[key] = value
+    add_save_job('adds', 'env_vars', [key, value])
+  end
+  
   def remove_env_var(key)
     self.env_vars = {} unless self.env_vars
     self.env_vars.delete key

--- a/stickshift/controller/lib/stickshift-controller/app/models/gear.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/gear.rb
@@ -205,6 +205,11 @@ class Gear < StickShift::Model
     job
   end
   
+  def force_env_var_job_add(key, value)
+    job = get_proxy.get_force_env_var_add_job(app, self, key, value)
+    job
+  end
+  
   def ssh_key_job_add(ssh_key, ssh_key_type, ssh_key_comment)
     job = get_proxy.get_add_authorized_ssh_key_job(app, self, ssh_key, ssh_key_type, ssh_key_comment)
     job

--- a/stickshift/controller/lib/stickshift-controller/lib/stickshift/application_container_proxy.rb
+++ b/stickshift/controller/lib/stickshift-controller/lib/stickshift/application_container_proxy.rb
@@ -77,6 +77,9 @@ module StickShift
 
     def add_env_var(app, gear, key, value)
     end
+    
+    def force_add_env_var(app, gear, key, value)
+    end
 
     def remove_env_var(app, gear, key)
     end

--- a/stickshift/node/bin/ss-force-env-var-add
+++ b/stickshift/node/bin/ss-force-env-var-add
@@ -1,0 +1,84 @@
+#!/usr/bin/env ruby
+#--
+# Copyright 2010 Red Hat, Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#    http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+def usage
+    puts <<USAGE
+== Synopsis
+
+ss-force-env-var-add: Adds an environment var to the app. 
+  This command must be run as root.
+
+== Usage
+
+ss-force-env-var-add  --with-app-uuid APP_UUID \\
+                --with-container-uuid UUID \\
+                --with-key KEY \\
+                --with-value VALUE
+
+Options:
+-h|--help:
+   Prints this message
+
+UUID: Unique identifier for the application
+KEY: The env var key
+VALUE: The env var value
+
+USAGE
+end
+
+require 'rubygems'
+require 'stickshift-node'
+require 'stickshift-node/utils/shell_exec'
+opts = GetoptLong.new(
+    ["--with-app-uuid",       "-a", GetoptLong::REQUIRED_ARGUMENT],
+    ["--with-container-uuid", "-c", GetoptLong::REQUIRED_ARGUMENT],
+    ["--with-key",         "-k", GetoptLong::REQUIRED_ARGUMENT],
+    ["--with-value",       "-v", GetoptLong::REQUIRED_ARGUMENT]
+)
+
+args = {}
+begin
+    opts.each{ |k,v| args[k]=v }
+rescue GetoptLong::Error => e
+    usage
+    exit -100
+end
+
+container_uuid = args['--with-container-uuid']
+app_uuid = args['--with-app-uuid']
+key = args['--with-key']
+value = args['--with-value']
+
+if args["--help"]
+  usage
+  exit -1
+end
+
+unless container_uuid and app_uuid and key and value
+  usage
+  exit -100
+end
+
+begin
+  container = StickShift::ApplicationContainer.new(app_uuid, container_uuid)
+  container.user.force_add_env_var(key, value)
+rescue Exception => e
+  $stderr.puts(e.message)
+  exit -1
+else
+  exit 0
+end

--- a/stickshift/node/lib/stickshift-node/model/unix_user.rb
+++ b/stickshift/node/lib/stickshift-node/model/unix_user.rb
@@ -291,6 +291,36 @@ module StickShift
         blk.call(value)
       end
     end
+    
+    # Public: Add an environment variable to a given gear.
+    #
+    # key - The String value of target environment variable.
+    # value - The String value to place inside the environment variable.
+    # prefix_cloud_name - The String value to append in front of key.
+    #
+    # Examples
+    #
+    #  add_env_var('OPENSHIFT_DB_TYPE',
+    #               'mysql-5.3')
+    #  # => 36
+    #
+    # Returns the Integer value for how many bytes got written or raises on 
+    # failure.
+    def force_add_env_var(key, value, prefix_cloud_name = false, &blk)
+      env_dir = File.join(@homedir,'.env/')
+      if prefix_cloud_name
+        key = (@config.get('CLOUD_NAME') || 'SS') + "_#{key}"
+      end
+      filename = File.join(env_dir, key)
+      File.open(filename,
+          File::WRONLY|File::TRUNC|File::CREAT) do |file|
+            file.write "export #{key}='#{value}'"
+        end
+
+      if block_given?
+        blk.call(value)
+      end
+    end
 
     
     # Public: Remove an environment variable from a given gear.


### PR DESCRIPTION
Added force_add_env_var. Need to keep JENKINS_URL the same when additional Jenkins apps are created but also withstand a namespace change. So the namespace change calls force_add_env_var and everything else calls add_env_var which ignores updates to JENKINS\* if the env already exists (i.e. it's a new Jenkins app)
