### PR TITLE
US2555 changes

### DIFF
--- a/gearchanger/mcollective/plugin/lib/gearchanger-mcollective-plugin/gearchanger/mcollective_application_container_proxy.rb
+++ b/gearchanger/mcollective/plugin/lib/gearchanger-mcollective-plugin/gearchanger/mcollective_application_container_proxy.rb
@@ -13,7 +13,6 @@ module GearChanger
       end
       
       def self.valid_gear_sizes_impl(user)
-        default_gear_sizes = []
         capability_gear_sizes = []
         capability_gear_sizes = user.capabilities['gear_sizes'] if user.capabilities.has_key?('gear_sizes')
 

--- a/stickshift/broker/test/helpers/rest/api_models_v1.rb
+++ b/stickshift/broker/test/helpers/rest/api_models_v1.rb
@@ -154,13 +154,14 @@ class BaseApi_V1 < BaseObj_V1
 end
 
 class RestUser_V1 < BaseObj_V1
-  attr_accessor :login, :consumed_gears, :max_gears, :plan_id, :links                                                                         
+  attr_accessor :login, :consumed_gears, :max_gears, :plan_id, :usage_account_id, :links 
                                                                                                        
   def initialize
     self.login = nil
     self.consumed_gears = 0
     self.max_gears = 3
     self.plan_id = nil
+    self.usage_account_id = nil
     self.links = {                                                                                         
       "LIST_KEYS" => Link_V1.new("GET", "user/keys"),                     
       "ADD_KEY" => Link_V1.new("POST", "user/keys", [                  

--- a/stickshift/broker/test/unit/mongo_data_store_test.rb
+++ b/stickshift/broker/test/unit/mongo_data_store_test.rb
@@ -295,8 +295,7 @@ class MongoDataStoreTest < ActiveSupport::TestCase
       "env_vars" => {},
       "ssh_keys" => {},
       "max_gears" => 3,
-      "consumed_gears" => 0,
-      "vip" => false
+      "consumed_gears" => 0
     }
     cloud_user
   end

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/applications_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/applications_controller.rb
@@ -79,11 +79,7 @@ class ApplicationsController < BaseController
     
     template_id = params[:template]
     node_profile = params[:gear_profile]
-    if not node_profile 
-      node_profile = "small"
-    else
-      node_profile.downcase!
-    end
+    node_profile.downcase! if node_profile
 
     if app_name.nil? or app_name.empty?
       log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "ADD_APPLICATION", false, "Application name is required and cannot be blank")

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/base_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/base_controller.rb
@@ -169,4 +169,12 @@ class BaseController < ActionController::Base
     end
   end
 
+  def throw_error(status, msg, error_code, field=nil)
+    @reply = RestReply.new(status)
+    @reply.messages.push(message = Message.new(:error, msg, error_code, field))
+    respond_with(@reply) do |format|
+      format.xml { render :xml => @reply, :status => @reply.status }
+      format.json { render :json => @reply, :status => @reply.status }
+    end
+  end
 end

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/legacy_broker_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/legacy_broker_controller.rb
@@ -205,7 +205,6 @@ class LegacyBrokerController < ApplicationController
   end
   
   def cartridge_post
-    @req.node_profile ||= "small"
     raise StickShift::UserException.new("Invalid user", 99) if @cloud_user.nil?
     
     case @req.action

--- a/stickshift/controller/lib/stickshift-controller/app/models/application.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/application.rb
@@ -53,7 +53,7 @@ class Application < StickShift::Cartridge
   def initialize(user=nil, app_name=nil, uuid=nil, node_profile=nil, framework=nil, template=nil, will_scale=false, domain=nil)
     self.user = user
     self.domain = domain
-    self.node_profile = node_profile || DEFAULT_NODE_PROFILE
+    self.node_profile = node_profile
     self.creation_time = DateTime::now().strftime
     self.uuid = uuid || StickShift::Model.gen_uuid
     self.scalable = will_scale
@@ -259,6 +259,7 @@ Configure-Order: [\"proxy/#{framework}\", \"proxy/haproxy-1.4\"]
     super(user.login)
     self.ngears = 0
     self.usage_records = nil
+    self.destroyed_gears = []
   end
   
   # Deletes the application object from the datastore
@@ -274,6 +275,7 @@ Configure-Order: [\"proxy/#{framework}\", \"proxy/haproxy-1.4\"]
     self.class.notify_observers(:before_application_create, {:application => self, :reply => result_io})
     gears_created = []
     begin
+      self.node_profile = DEFAULT_NODE_PROFILE unless self.node_profile
       elaborate_descriptor
       if self.scalable
         raise StickShift::UserException.new("Scalable app cannot be of type #{UNSCALABLE_FRAMEWORKS.join(' ')}", "108", result_io) if UNSCALABLE_FRAMEWORKS.include? framework

--- a/stickshift/controller/lib/stickshift-controller/app/models/cloud_user.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/cloud_user.rb
@@ -1,5 +1,7 @@
  class CloudUser < StickShift::UserModel
-  attr_accessor :login, :uuid, :system_ssh_keys, :env_vars, :ssh_keys, :domains, :max_gears, :consumed_gears, :applications, :auth_method, :save_jobs, :usage_records, :capabilities, :parent_user_login, :plan_id
+  #TODO: vip no longer used, remove from the model
+  attr_accessor :login, :uuid, :system_ssh_keys, :env_vars, :ssh_keys, :domains, :max_gears, :consumed_gears, :applications, 
+                :auth_method, :save_jobs, :usage_records, :capabilities, :parent_user_login, :plan_id, :usage_account_id, :vip
   primary_key :login
   exclude_attributes :applications, :auth_method, :save_jobs, :usage_records
   require_update_attributes :system_ssh_keys, :env_vars, :ssh_keys, :domains
@@ -25,7 +27,8 @@
     end if val
   end
 
-  def initialize(login=nil, ssh=nil, ssh_type=nil, key_name=nil, capabilities=nil, parent_login=nil)
+  def initialize(login=nil, ssh=nil, ssh_type=nil, key_name=nil, capabilities=nil, 
+                 parent_login=nil)
     super()
     if not ssh.nil?
       ssh_type = "ssh-rsa" if ssh_type.to_s.strip.length == 0
@@ -38,7 +41,6 @@
     self.login = login
     self.domains = []
     self.max_gears = Rails.configuration.ss[:default_max_gears]
-    self.plan_id = :freeshift
     self.capabilities = capabilities || {}
     self.parent_user_login = parent_login
 

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_user.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_user.rb
@@ -1,11 +1,12 @@
 class RestUser < StickShift::Model
-  attr_accessor :login, :consumed_gears, :max_gears, :plan_id, :links
+  attr_accessor :login, :consumed_gears, :max_gears, :plan_id, :usage_account_id, :links
   
   def initialize(cloud_user, url)
     self.login = cloud_user.login
     self.consumed_gears = cloud_user.consumed_gears
     self.max_gears = cloud_user.max_gears
     self.plan_id = cloud_user.plan_id
+    self.usage_account_id = cloud_user.usage_account_id
     @links = {
       "LIST_KEYS" => Link.new("Get SSH keys", "GET", URI::join(url, "user/keys")),
       "ADD_KEY" => Link.new("Add new SSH key", "POST", URI::join(url, "user/keys"), [

--- a/stickshift/controller/lib/stickshift-controller/lib/stickshift/mongo_data_store.rb
+++ b/stickshift/controller/lib/stickshift-controller/lib/stickshift/mongo_data_store.rb
@@ -544,7 +544,7 @@ COND
         query = { "_id" => user_id, "apps.name" => id, "$where" => condition }
         
         if destroyed_gears && !destroyed_gears.empty?
-          query["apps.group_instances.gears.uuid"] = { "$in" => destroyed_gears }
+          query["apps.group_instances.gears.uuid"] = { "$all" => destroyed_gears }
         end
 
         hash = find_and_modify( user_collection, { :query => query,


### PR DESCRIPTION
Mongo deleted_gears fix

Remove 'vip' from mongo datastore test case

Remove unused variable in valid_gaer_sizes_impl()

Add 'usage_tracker_id' field to cloud_user model

Add usage_tracker_id field to rest_user model

Add usage_tracker_id to cloud user model

Application node_profile will be obtained from User capabilities

Helper method to throw errors in case of REST api failures

plan_id cleanup
- Rename usage_tracker_id to usage_account_id
- Don't persist usage_account_id, plan_id if not set
