### PR TITLE
BZ 843354: Don't generate passwords that start with "-".

### DIFF
--- a/stickshift/abstract/abstract/info/lib/util
+++ b/stickshift/abstract/abstract/info/lib/util
@@ -305,7 +305,7 @@ function load_resource_limits_conf {
 }
 
 function generate_password {
-    head -n 500 /dev/urandom|tr -dc "a-np-zA-NP-Z1-9-_"|fold -w 12 | head -n1
+    head -n 500 /dev/urandom|tr -dc "a-np-zA-NP-Z1-9-_"|fold -w 12 | grep -v '^-' | head -n1
 }
 
 function error {


### PR DESCRIPTION
The mongo command treats a password starting with "-" as a new command line option rather than an argument to the --password option.
