### PR TITLE
Add php-process to the PHP cartridge.

### DIFF
--- a/cartridges/php-5.3/cartridge-php-5.3.spec
+++ b/cartridges/php-5.3/cartridge-php-5.3.spec
@@ -34,6 +34,7 @@ Requires: php-pecl-apc
 Requires: php-mcrypt
 Requires: php-soap
 Requires: php-bcmath
+Requires: php-process
 
 %description
 Provides php support to OpenShift


### PR DESCRIPTION
Some apps depend on being able to spawn daemons, and in PHP this
is done by requiring the POSIX extension (which is contained in
php-process on RHEL). One such example is Facebook's Phabricator
code review apps, which depends on the ability to launch daemons
in order for SCM repositories to be tracked properly.
