### PR TITLE
Move direct calls to httpd init script to httpd_singular locking script

### DIFF
--- a/cartridges/phpmyadmin-3.4/info/hooks/deconfigure
+++ b/cartridges/phpmyadmin-3.4/info/hooks/deconfigure
@@ -55,5 +55,5 @@ runcon -l s0-s0:c0.c1023 rm -rf "$PHPMYADMIN_DIR"
 #
 rm -f /etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application}/phpmyadmin-3.4.conf || warning "Could not remove phpmyadmin apache definition" 156
 
-/sbin/service httpd configtest 2> /dev/null && /sbin/service httpd graceful 2> /dev/null || warning "Failed to restart master httpd, please contact support" 120
+${CARTRIDGE_BASE_PATH}/abstract/info/bin/httpd_singular graceful 2> /dev/null || warning "Failed to restart master httpd, please contact support" 120
 enable_cgroups

--- a/stickshift/abstract/abstract/info/bin/httpd_singular
+++ b/stickshift/abstract/abstract/info/bin/httpd_singular
@@ -1,0 +1,60 @@
+#!/bin/env ruby
+
+require 'rubygems'
+require 'open4'
+require 'thread'
+
+HTTPD_SYSTEM="/sbin/service httpd"
+HTTPD_CMDS=["graceful", "restart"]
+HTTPD_PRE_CMDS=["configtest"]
+LOCKFILE="/tmp/httpd_singular.lock"
+
+def single_instance(&block)
+  File.open(LOCKFILE, File::CREAT|File::TRUNC|File::RDWR, 0640) do |f|
+    begin
+      f.flock(File::LOCK_EX)
+      block.call
+    ensure
+      f.flock(File::LOCK_UN)
+    end
+  end
+end
+
+ 
+def async_cat(infd, outfd)
+  th = Thread.new(infd, outfd) do
+    outfd.sync=true
+    loop do
+      Thread.current[:buf] = infd.getc
+      break if Thread.current[:buf].nil?
+      outfd.putc Thread.current[:buf]
+    end
+  end
+  return th
+end
+
+if ! HTTPD_CMDS.include?(ARGV[0])
+  warn("Command must be one of: #{HTTPD_CMDS.join(' ')}")
+  exit(false)
+end
+
+
+out=""
+err=""
+rc=0
+single_instance do
+  [HTTPD_PRE_CMDS, ARGV[0]].flatten.each do |cmd|
+    status = Open4.popen4ext(true, "#{HTTPD_SYSTEM} #{cmd}") do |pid, stdin, stdout, stderr|
+      stdin.close
+      thset = []
+      thset << async_cat(stdout, $stdout)
+      thset << async_cat(stderr, $stderr)
+      thset.each do |th|
+        th.join
+      end
+    end
+    if status.exitstatus != 0
+      exit(status.exitstatus)
+    end
+  end
+end

--- a/stickshift/abstract/abstract/info/lib/apache
+++ b/stickshift/abstract/abstract/info/lib/apache
@@ -13,13 +13,11 @@ function rm_httpd_proxy {
     rm -rf /etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application}.conf \
            /etc/httpd/conf.d/stickshift/${uuid}_${namespace}_${application} || \
            echo "Could not remove apache definition" 1>&2
-    /sbin/service httpd configtest 2> /dev/null && \
-    /sbin/service httpd graceful 2> /dev/null || \
+    ${CARTRIDGE_BASE_PATH}/abstract/info/bin/httpd_singular graceful 2> /dev/null || \
     echo "Failed to restart master httpd, please contact support" 1>&2
 }
 
 function restart_httpd_graceful {
-    /sbin/service httpd configtest 2> /dev/null &&\
-    /sbin/service httpd graceful 2> /dev/null || \
+    ${CARTRIDGE_BASE_PATH}/abstract/info/bin/httpd_singular graceful 2> /dev/null || \
     error "Failed to restart master httpd, please contact support" 120
 }


### PR DESCRIPTION
Simultaneous calls to check and reload httpd were causing load spikes in production.  Serialise checking and graceful calls through a lock.
