### PR TITLE
Set up .ssh directory during gear move

### DIFF
--- a/cartridges/haproxy-1.4/info/hooks/configure
+++ b/cartridges/haproxy-1.4/info/hooks/configure
@@ -67,7 +67,6 @@ function setup_haproxy_as_a_service() {
     secure_app_dir
     secure_cart_instance_dir
     secure_conf_dirs
-    observe_setup_app_and_git_dirs
     observe_setup_cart_instance_dir
 
     #
@@ -79,7 +78,6 @@ function setup_haproxy_as_a_service() {
     create_standard_repo_dir_env_var
     create_standard_path_env_var
 
-    observe_setup_env_uservars_dir
 
     export IP2=`embedded_find_open_ip $uid "$APP_HOME/"`
     echo "export OPENSHIFT_HAPROXY_STATUS_IP='$IP2'" > "$APP_HOME/.env/OPENSHIFT_HAPROXY_STATUS_IP"

--- a/cartridges/haproxy-1.4/info/hooks/move
+++ b/cartridges/haproxy-1.4/info/hooks/move
@@ -35,12 +35,11 @@ fi
 setup_basic_vars
 
 CART_INFO_DIR=$CARTRIDGE_BASE_PATH/$cartridge_type/info
+HAPROXY_DIR=$(get_cartridge_instance_dir "$cartridge_type")
 
 
-observe_setup_app_home
-observe_setup_app_and_git_dirs
-observe_setup_env_uservars_dir
 observe_setup_cart_instance_dir
+observe_setup_var_lib_dir "$HAPROXY_DIR/.ssh/"
 
 #
 # Find an open localhost IP


### PR DESCRIPTION
Ensure that observe_setup_var_lib_dir is invoked against the .ssh directory
of the cartridge during a gear move. The call is made explicitly in the
configure hook, and must be invoked in the same way during a gear move
operation.

Clean up some old calls to observe_\* functions which are inapplicable to
a catridge such as HAProxy which does not own the APP_ROOT.
