### PR TITLE
added a rake task for restarting Origin services

### DIFF
--- a/build/Rakefile
+++ b/build/Rakefile
@@ -179,6 +179,13 @@ end
 task :devnode => [:build, :install_node] do
 end
 
+task :restart_services do
+  ["httpd","sshd","qpidd","mcollective","stickshift-broker","stickshift-proxy"].each do |service|
+    system "sudo chkconfig #{service} on" 
+    system "sudo service #{service} restart"
+  end
+end
+
 task :livecd do
   mkdir_p remix_dir
   remix_ks = "openshift-origin-remix.ks"


### PR DESCRIPTION
This is a new rake task that restarts Origin services and will be used in the scripts to build/launch/sync/update Origin instances.
