### PR TITLE
BZ 843326: Set HTTPS if https was used at the front-end.

### DIFF
--- a/cartridges/haproxy-1.4/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/haproxy-1.4/info/configuration/etc/conf/httpd.conf
@@ -217,6 +217,10 @@ Alias /error/ "/var/www/error/"
 </IfModule>
 </IfModule>
 
+<IfModule mod_setenvif.c>
+    SetEnvIf X-Forwarded-Proto https HTTPS=1
+</IfModule>
+
 BrowserMatch "Mozilla/2" nokeepalive
 BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
 BrowserMatch "RealPlayer 4\.0" force-response-1.0

--- a/cartridges/haproxy-1.4/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/haproxy-1.4/info/configuration/etc/conf/httpd_nolog.conf
@@ -217,6 +217,10 @@ Alias /error/ "/var/www/error/"
 </IfModule>
 </IfModule>
 
+<IfModule mod_setenvif.c>
+    SetEnvIf X-Forwarded-Proto https HTTPS=1
+</IfModule>
+
 BrowserMatch "Mozilla/2" nokeepalive
 BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
 BrowserMatch "RealPlayer 4\.0" force-response-1.0

--- a/cartridges/perl-5.10/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/perl-5.10/info/configuration/etc/conf/httpd.conf
@@ -217,6 +217,10 @@ Alias /error/ "/var/www/error/"
 </IfModule>
 </IfModule>
 
+<IfModule mod_setenvif.c>
+    SetEnvIf X-Forwarded-Proto https HTTPS=1
+</IfModule>
+
 BrowserMatch "Mozilla/2" nokeepalive
 BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
 BrowserMatch "RealPlayer 4\.0" force-response-1.0

--- a/cartridges/perl-5.10/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/perl-5.10/info/configuration/etc/conf/httpd_nolog.conf
@@ -217,6 +217,10 @@ Alias /error/ "/var/www/error/"
 </IfModule>
 </IfModule>
 
+<IfModule mod_setenvif.c>
+    SetEnvIf X-Forwarded-Proto https HTTPS=1
+</IfModule>
+
 BrowserMatch "Mozilla/2" nokeepalive
 BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
 BrowserMatch "RealPlayer 4\.0" force-response-1.0

--- a/cartridges/php-5.3/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/php-5.3/info/configuration/etc/conf/httpd.conf
@@ -217,6 +217,10 @@ Alias /error/ "/var/www/error/"
 </IfModule>
 </IfModule>
 
+<IfModule mod_setenvif.c>
+    SetEnvIf X-Forwarded-Proto https HTTPS=1
+</IfModule>
+
 BrowserMatch "Mozilla/2" nokeepalive
 BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
 BrowserMatch "RealPlayer 4\.0" force-response-1.0

--- a/cartridges/php-5.3/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/php-5.3/info/configuration/etc/conf/httpd_nolog.conf
@@ -217,6 +217,10 @@ Alias /error/ "/var/www/error/"
 </IfModule>
 </IfModule>
 
+<IfModule mod_setenvif.c>
+    SetEnvIf X-Forwarded-Proto https HTTPS=1
+</IfModule>
+
 BrowserMatch "Mozilla/2" nokeepalive
 BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
 BrowserMatch "RealPlayer 4\.0" force-response-1.0

--- a/cartridges/phpmyadmin-3.4/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/phpmyadmin-3.4/info/configuration/etc/conf/httpd.conf
@@ -217,6 +217,10 @@ Alias /error/ "/var/www/error/"
 </IfModule>
 </IfModule>
 
+<IfModule mod_setenvif.c>
+    SetEnvIf X-Forwarded-Proto https HTTPS=1
+</IfModule>
+
 BrowserMatch "Mozilla/2" nokeepalive
 BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
 BrowserMatch "RealPlayer 4\.0" force-response-1.0

--- a/cartridges/phpmyadmin-3.4/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/phpmyadmin-3.4/info/configuration/etc/conf/httpd_nolog.conf
@@ -217,6 +217,10 @@ Alias /error/ "/var/www/error/"
 </IfModule>
 </IfModule>
 
+<IfModule mod_setenvif.c>
+    SetEnvIf X-Forwarded-Proto https HTTPS=1
+</IfModule>
+
 BrowserMatch "Mozilla/2" nokeepalive
 BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
 BrowserMatch "RealPlayer 4\.0" force-response-1.0

--- a/cartridges/python-2.6/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/python-2.6/info/configuration/etc/conf/httpd.conf
@@ -217,6 +217,10 @@ Alias /error/ "/var/www/error/"
 </IfModule>
 </IfModule>
 
+<IfModule mod_setenvif.c>
+    SetEnvIf X-Forwarded-Proto https HTTPS=1
+</IfModule>
+
 BrowserMatch "Mozilla/2" nokeepalive
 BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
 BrowserMatch "RealPlayer 4\.0" force-response-1.0

--- a/cartridges/python-2.6/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/python-2.6/info/configuration/etc/conf/httpd_nolog.conf
@@ -217,6 +217,10 @@ Alias /error/ "/var/www/error/"
 </IfModule>
 </IfModule>
 
+<IfModule mod_setenvif.c>
+    SetEnvIf X-Forwarded-Proto https HTTPS=1
+</IfModule>
+
 BrowserMatch "Mozilla/2" nokeepalive
 BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
 BrowserMatch "RealPlayer 4\.0" force-response-1.0

--- a/cartridges/ruby-1.8/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/ruby-1.8/info/configuration/etc/conf/httpd.conf
@@ -217,6 +217,10 @@ Alias /error/ "/var/www/error/"
 </IfModule>
 </IfModule>
 
+<IfModule mod_setenvif.c>
+    SetEnvIf X-Forwarded-Proto https HTTPS=1
+</IfModule>
+
 BrowserMatch "Mozilla/2" nokeepalive
 BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
 BrowserMatch "RealPlayer 4\.0" force-response-1.0

--- a/cartridges/ruby-1.8/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/ruby-1.8/info/configuration/etc/conf/httpd_nolog.conf
@@ -217,6 +217,10 @@ Alias /error/ "/var/www/error/"
 </IfModule>
 </IfModule>
 
+<IfModule mod_setenvif.c>
+    SetEnvIf X-Forwarded-Proto https HTTPS=1
+</IfModule>
+
 BrowserMatch "Mozilla/2" nokeepalive
 BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
 BrowserMatch "RealPlayer 4\.0" force-response-1.0

--- a/cartridges/ruby-1.9/info/configuration/etc/conf/httpd.conf
+++ b/cartridges/ruby-1.9/info/configuration/etc/conf/httpd.conf
@@ -217,6 +217,10 @@ Alias /error/ "/var/www/error/"
 </IfModule>
 </IfModule>
 
+<IfModule mod_setenvif.c>
+    SetEnvIf X-Forwarded-Proto https HTTPS=1
+</IfModule>
+
 BrowserMatch "Mozilla/2" nokeepalive
 BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
 BrowserMatch "RealPlayer 4\.0" force-response-1.0

--- a/cartridges/ruby-1.9/info/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/ruby-1.9/info/configuration/etc/conf/httpd_nolog.conf
@@ -217,6 +217,10 @@ Alias /error/ "/var/www/error/"
 </IfModule>
 </IfModule>
 
+<IfModule mod_setenvif.c>
+    SetEnvIf X-Forwarded-Proto https HTTPS=1
+</IfModule>
+
 BrowserMatch "Mozilla/2" nokeepalive
 BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
 BrowserMatch "RealPlayer 4\.0" force-response-1.0


### PR DESCRIPTION
Some frameworks (ex: mod_wsgi) need HTTPS set to notify the app that https was used.
