### PR TITLE
Add nano and emacs-nox to openshift-origin-node

### DIFF
--- a/build/openshift-origin-node/openshift-origin-node.spec
+++ b/build/openshift-origin-node/openshift-origin-node.spec
@@ -9,6 +9,8 @@ Source0:        openshift-origin-node-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 Requires:       vim
+Requires:       nano
+Requires:       emacs-nox
 Requires:       git
 Requires:       ruby
 Requires:       rubygems


### PR DESCRIPTION
I've encountered two people in the last few days in separate IRC
conversations who have complained about vim being available but not
nano. While we're at it, why not provide emacs-nox?

nano is 437 kB
emacs-nox is 2.3 MB
