### PR TITLE
US1896

### DIFF
--- a/stickshift/broker/lib/tasks/test_suites.rake
+++ b/stickshift/broker/lib/tasks/test_suites.rake
@@ -10,4 +10,27 @@ namespace :test do
       'test/integration/**/*_test.rb'
     ]
   end
+
+  Rake::TestTask.new :ss_unit1 => ['test:prepare'] do |t|
+    t.libs << 'test'
+    t.test_files = FileList[
+      'test/unit/cloud_user_test.rb',
+      'test/unit/legacy_request_test.rb',
+      'test/unit/mongo_data_store_test.rb'
+    ]
+  end
+
+  Rake::TestTask.new :ss_unit2 => ['test:prepare'] do |t|
+    t.libs << 'test'
+    t.test_files = FileList[
+      'test/unit/rest_api_test.rb'
+    ]
+  end
+
+  Rake::TestTask.new :ss_unit_ext1 => ['test:prepare'] do |t|
+    t.libs << 'test'
+    t.test_files = FileList[
+      'test/unit/rest_api_nolinks_test.rb'
+    ]
+  end
 end

--- a/stickshift/broker/test/helpers/rest/api_common.rb
+++ b/stickshift/broker/test/helpers/rest/api_common.rb
@@ -1,3 +1,5 @@
+$nolinks = false
+
 class BaseObj
   def self.to_obj(hash)
     obj = self.new
@@ -9,6 +11,7 @@ class BaseObj
     return nil unless hash
 
     self.instance_variables.each do |var|
+      next if $nolinks && (var[1..-1] == 'links')
       raise_ex("Object does NOT contain required variable '#{var[1..-1]}'") unless hash.include?(var[1..-1])
     end
     hash.each do |key,value|
@@ -24,7 +27,7 @@ class RestApi < BaseObj
   def initialize(uri=nil, method="GET")
     self.uri = uri
     self.method = method
-    self.request = {}
+    self.request = { 'nolinks' => $nolinks }
     self.request_timeout = 120  # 120 secs
 
     self.response = nil
@@ -47,4 +50,3 @@ def gen_uuid
     file.gets.strip.gsub("-","")
   end
 end
-

--- a/stickshift/broker/test/helpers/rest/api_models_v1.rb
+++ b/stickshift/broker/test/helpers/rest/api_models_v1.rb
@@ -129,7 +129,7 @@ class BaseObj_V1 < BaseObj
       self.links.keys.each do |lname|
         raise_ex("Link '#{lname}' missing") unless obj.links[lname]
         self.links[lname].compare(obj.links[lname])
-      end if self.links.keys
+      end if self.links && self.links.keys
     end
   end
 end
@@ -149,7 +149,7 @@ class BaseApi_V1 < BaseObj_V1
          "LIST_CARTRIDGES" => Link_V1.new("GET", "cartridges"),
          "LIST_TEMPLATES" => Link_V1.new("GET", "application_templates"),
          "LIST_ESTIMATES" => Link_V1.new("GET", "estimates")
-    }
+    } unless $nolinks
   end
 end
 
@@ -169,7 +169,7 @@ class RestUser_V1 < BaseObj_V1
         Param_V1.new("type", "string", ["ssh-rsa", "ssh-dss"]),                            
         Param_V1.new("content", "string"),      
       ])                                                                                              
-    } 
+    } unless $nolinks 
   end
 
   def compare(obj)
@@ -201,7 +201,7 @@ class RestCartridge_V1 < BaseObj_V1
           Param_V1.new("event", "string", "reload")                                            
         ]),
         "DELETE" => Link_V1.new("DELETE", "/cartridges/#{name}")
-      }
+      } unless $nolinks
     end
   end
 
@@ -217,7 +217,7 @@ class RestEstimates_V1 < BaseObj_V1
     self.links = {
       "GET_ESTIMATE" => Link_V1.new("GET", "estimates/application",
         [ Param_V1.new("descriptor", "string") ])
-    }
+    } unless $nolinks
   end
 end
 
@@ -259,7 +259,7 @@ class RestDomain_V1 < BaseObj_V1
         [ Param_V1.new("id", "string") ]),
       "DELETE" => Link_V1.new("DELETE", "domains/#{id}", nil,
         [ OptionalParam_V1.new("force", "boolean", [true, false], false) ])
-    }
+    } unless $nolinks
   end
 end
 
@@ -276,7 +276,7 @@ class RestKey_V1 < BaseObj_V1
         Param_V1.new("type", "string", ["ssh-rsa", "ssh-dss"]),
         Param_V1.new("content", "string") ]),
       "DELETE" => Link_V1.new("DELETE", "user/keys/#{name}")
-    }
+    } unless $nolinks
   end
 end
 
@@ -333,7 +333,7 @@ class RestApplication_V1 < BaseObj_V1
       "ADD_CARTRIDGE" => Link_V1.new("POST", "domains/#{domain_id}/applications/#{name}/cartridges",
         [ Param_V1.new("cartridge", "string") ]),
       "LIST_CARTRIDGES" => Link_V1.new("GET", "domains/#{domain_id}/applications/#{name}/cartridges")
-    }
+    } unless $nolinks
   end
 end
 

--- a/stickshift/broker/test/helpers/rest/api_v1.rb
+++ b/stickshift/broker/test/helpers/rest/api_v1.rb
@@ -101,7 +101,7 @@ estimates_list_get_v1.response = RestEstimates_V1.new
 estimates_list_get_v1.response_type = "estimates" 
 
 estimates_app_get_v1 = RestApi_V1.new("/estimates/application")
-estimates_app_get_v1.request = { 'id' => 'application', 'descriptor' => "--- \nName: TestApp1\nRequires: \n- php-5.3\n" }
+estimates_app_get_v1.request.merge!({ 'id' => 'application', 'descriptor' => "--- \nName: TestApp1\nRequires: \n- php-5.3\n" })
 estimates_app_get_v1.response = RestApplicationEstimate_V1.new
 estimates_app_get_v1.response_type = "application_estimates"
  
@@ -110,7 +110,7 @@ template_list_get_v1.response_type = "application_templates"
 
 domain_add_post_v1 = RestApi_V1.new("/domains", "POST")
 dom_id = gen_uuid[0..9]
-domain_add_post_v1.request = { 'id' => dom_id }
+domain_add_post_v1.request['id'] = dom_id
 domain_add_post_v1.response = RestDomain_V1.new(dom_id)
 domain_add_post_v1.response_type = "domain"
 domain_add_post_v1.response_status = "created"
@@ -124,13 +124,13 @@ domain_get_v1.response_type = "domain"
 
 domain_put_v1 = RestApi_V1.new("/domains/#{dom_id}", "PUT")
 dom_id = gen_uuid[0..9]
-domain_put_v1.request = { 'id' =>  dom_id }
+domain_put_v1.request['id'] = dom_id
 domain_put_v1.response = RestDomain_V1.new(dom_id)
 domain_put_v1.response_type = "domain"
 
 keys_post_v1 = RestApi_V1.new("/user/keys", "POST")
 kname, ktype, content = 'key1', 'ssh-rsa', 'abcdef'
-keys_post_v1.request = { 'name' => kname, 'type' => ktype, 'content' => content }
+keys_post_v1.request.merge!({ 'name' => kname, 'type' => ktype, 'content' => content })
 keys_post_v1.response = RestKey_V1.new(kname, content, ktype)
 keys_post_v1.response_type = "key"
 keys_post_v1.response_status = "created"
@@ -145,13 +145,13 @@ keys_get_v1.response_type = "key"
 
 keys_put_v1 = RestApi_V1.new("/user/keys/#{kname}", "PUT")
 nktype, ncontent = 'ssh-dss', '12345'
-keys_put_v1.request = { 'content' => ncontent, 'type' => nktype }
+keys_put_v1.request.merge!({ 'content' => ncontent, 'type' => nktype })
 keys_put_v1.response = RestKey_V1.new(kname, ncontent, nktype) 
 keys_put_v1.response_type = "key"
 
 app_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications", "POST")
 app_name, app_type, app_scale, app_timeout = 'app1', 'php-5.3', true, 180
-app_post_v1.request = { 'name' => app_name, 'cartridge' => app_type, 'scale' => app_scale }
+app_post_v1.request.merge!({ 'name' => app_name, 'cartridge' => app_type, 'scale' => app_scale })
 app_post_v1.request_timeout = app_timeout
 app_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_post_v1.response_type = 'application'
@@ -169,60 +169,60 @@ app_descriptor_get_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_na
 app_descriptor_get_v1.response_type = 'descriptor'
 
 app_start_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/events", "POST")
-app_start_post_v1.request = { 'event' => 'start' }
+app_start_post_v1.request['event'] = 'start'
 app_start_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_start_post_v1.response_type = "application"
 
 app_restart_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/events", "POST")
-app_restart_post_v1.request = { 'event' => 'restart' }
+app_restart_post_v1.request['event'] = 'restart'
 app_restart_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_restart_post_v1.response_type = "application"
 
 app_stop_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/events", "POST")
-app_stop_post_v1.request = { 'event' => 'stop' }
+app_stop_post_v1.request['event'] = 'stop'
 app_stop_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_stop_post_v1.response_type = "application"
 
 app_force_stop_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/events", "POST")
-app_force_stop_post_v1.request = { 'event' => 'force-stop' }
+app_force_stop_post_v1.request['event'] = 'force-stop'
 app_force_stop_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_force_stop_post_v1.response_type = "application"
 
 app_add_alias_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/events", "POST")
 app_alias = 'myApp'
-app_add_alias_post_v1.request = { 'event' => 'add-alias' , 'alias' => app_alias }
+app_add_alias_post_v1.request.merge!({ 'event' => 'add-alias' , 'alias' => app_alias })
 app_add_alias_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_add_alias_post_v1.response_type = "application"
 
 app_remove_alias_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/events", "POST")
-app_remove_alias_post_v1.request = { 'event' => 'remove-alias' , 'alias' => app_alias }
+app_remove_alias_post_v1.request.merge!({ 'event' => 'remove-alias' , 'alias' => app_alias })
 app_remove_alias_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_remove_alias_post_v1.response_type = "application"
 
 app_scale_up_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/events", "POST")
-app_scale_up_post_v1.request = { 'event' => 'scale-up' }
+app_scale_up_post_v1.request['event'] = 'scale-up'
 app_scale_up_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_scale_up_post_v1.response_type = "application"
 
 app_scale_down_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/events", "POST")
-app_scale_down_post_v1.request = { 'event' => 'scale-down' }
+app_scale_down_post_v1.request['event'] = 'scale-down'
 app_scale_down_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_scale_down_post_v1.response_type = "application"
 
 app_add_cart_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/cartridges", "POST")
 embed_cart = 'mysql-5.1'
-app_add_cart_post_v1.request = { 'name' => embed_cart, 'colocate_with' => nil }
+app_add_cart_post_v1.request.merge!({ 'name' => embed_cart, 'colocate_with' => nil })
 app_add_cart_post_v1.response = RestCartridge_V1.new('embedded', embed_cart)
 app_add_cart_post_v1.response_type = "cartridge"
 app_add_cart_post_v1.response_status = "created"
 
 app_expose_port_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/events", "POST")
-app_expose_port_post_v1.request = { 'event' => 'expose-port' }
+app_expose_port_post_v1.request['event'] = 'expose-port'
 app_expose_port_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_expose_port_post_v1.response_type = "application"
 
 app_show_port_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/events", "POST")
-app_show_port_post_v1.request = { 'event' => 'show-port' }
+app_show_port_post_v1.request['event'] = 'show-port'
 app_show_port_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_show_port_post_v1.response_type = "application"
 
@@ -233,7 +233,7 @@ app_gear_groups_get_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_n
 app_gear_groups_get_v1.response_type = 'gear_groups'
 
 app_conceal_port_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/events", "POST")
-app_conceal_port_post_v1.request = { 'event' => 'conceal-port' }
+app_conceal_port_post_v1.request['event'] = 'conceal-port'
 app_conceal_port_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_conceal_port_post_v1.response_type = "application"
 
@@ -246,22 +246,22 @@ app_cart_get_v1.response = RestCartridge_V1.new('embedded', embed_cart)
 app_cart_get_v1.response_type = "cartridge"
 
 app_cart_start_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/cartridges/#{embed_cart}/events", "POST")
-app_cart_start_post_v1.request = { "event" => 'start' }
+app_cart_start_post_v1.request['event'] = 'start'
 app_cart_start_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_cart_start_post_v1.response_type = "application"
 
 app_cart_restart_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/cartridges/#{embed_cart}/events", "POST")
-app_cart_restart_post_v1.request = { "event" => 'restart' }
+app_cart_restart_post_v1.request['event'] = 'restart'
 app_cart_restart_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_cart_restart_post_v1.response_type = "application"
 
 app_cart_reload_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/cartridges/#{embed_cart}/events", "POST")
-app_cart_reload_post_v1.request = { "event" => 'reload' }
+app_cart_reload_post_v1.request['event'] = 'reload'
 app_cart_reload_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_cart_reload_post_v1.response_type = "application"
 
 app_cart_stop_post_v1 = RestApi_V1.new("/domains/#{dom_id}/applications/#{app_name}/cartridges/#{embed_cart}/events", "POST")
-app_cart_stop_post_v1.request = { "event" => 'stop' }
+app_cart_stop_post_v1.request['event'] = 'stop'
 app_cart_stop_post_v1.response = RestApplication_V1.new(app_name, app_type, dom_id, app_scale)
 app_cart_stop_post_v1.response_type = "application"
 

--- a/stickshift/broker/test/unit/rest_api_nolinks_test.rb
+++ b/stickshift/broker/test/unit/rest_api_nolinks_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+require 'helpers/rest/api_common'
+#set nolinks before loading rest api models
+$nolinks = true
+require 'helpers/rest/api'
+require 'json'
+
+class RestApiNolinksTest < ActiveSupport::TestCase
+  test "rest api nolinks" do
+    register_user if registration_required?
+    REST_CALLS.each do |rest_version|
+      rest_version.each do |rest_api|
+#        puts "#{rest_api.method}  #{rest_api.uri}  #{rest_api.request}"
+        response = http_call(rest_api)
+#        puts "RSP => #{response}"
+        if response.to_s.length != 0
+          response_json = JSON.parse(response)
+          rest_api.compare(response_json)
+        end
+      end
+    end
+  end
+end

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/app_events_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/app_events_controller.rb
@@ -109,7 +109,7 @@ class AppEventsController < BaseController
     log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "#{event.sub('-', '_').upcase}_APPLICATION", true, "Application event '#{event}' successful")
         
     application = Application.find(@cloud_user, id)
-    app = RestApplication.new(application, get_url)
+    app = RestApplication.new(application, get_url, nolinks)
     @reply = RestReply.new(:ok, "application", app)
     message = Message.new("INFO", msg)
     @reply.messages.push(message)

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/application_templates_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/application_templates_controller.rb
@@ -4,7 +4,7 @@ class ApplicationTemplatesController < BaseController
   
   def index
     log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "LIST_TEMPLATES", true, "Showing all templates")
-    templates = ApplicationTemplate.find_all.map{|t| RestApplicationTemplate.new(t, get_url)}
+    templates = ApplicationTemplate.find_all.map{|t| RestApplicationTemplate.new(t, get_url, nolinks)}
     @reply = RestReply.new(:ok, "application_templates", templates)
     respond_with @reply, :status => @reply.status
   end
@@ -14,11 +14,11 @@ class ApplicationTemplatesController < BaseController
     template = ApplicationTemplate.find(id_or_tag)
     unless template.nil?
       log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "SHOW_TEMPLATE", true, "Showing template for '#{id_or_tag}'")
-      @reply = RestReply.new(:ok, "application_template", RestApplicationTemplate.new(template, get_url))
+      @reply = RestReply.new(:ok, "application_template", RestApplicationTemplate.new(template, get_url, nolinks))
       respond_with @reply, :status => @reply.status
     else
       log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "LIST_TEMPLATES", true, "Showing template for '#{id_or_tag}'")
-      templates = ApplicationTemplate.find_all(id_or_tag).map{|t| RestApplicationTemplate.new(t, get_url)}
+      templates = ApplicationTemplate.find_all(id_or_tag).map{|t| RestApplicationTemplate.new(t, get_url, nolinks)}
       @reply = RestReply.new(:ok, "application_templates", templates)
       respond_with @reply, :status => @reply.status
     end

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/applications_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/applications_controller.rb
@@ -20,7 +20,7 @@ class ApplicationsController < BaseController
     if not applications.nil? 
       applications.each do |application|
         if application.domain.uuid = domain.uuid
-          app = RestApplication.new(application, get_url)
+          app = RestApplication.new(application, get_url, nolinks)
           apps.push(app)
         end
       end
@@ -54,7 +54,7 @@ class ApplicationsController < BaseController
       respond_with @reply, :status => @reply.status
     else
       log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "SHOW_APPLICATION", true, "Application '#{id}' found")
-      app = RestApplication.new(application, get_url)
+      app = RestApplication.new(application, get_url, nolinks)
       @reply = RestReply.new(:ok, "application", app)
       respond_with @reply, :status => @reply.status
     end
@@ -180,7 +180,7 @@ class ApplicationsController < BaseController
 
       log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "ADD_APPLICATION", true, "Created application #{application.name}")
 
-      app = RestApplication.new(application, get_url)
+      app = RestApplication.new(application, get_url, nolinks)
       @reply = RestReply.new( :created, "application", app)
       message = Message.new(:info, "Application #{application.name} was created.")
       @reply.messages.push(message)

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/base_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/base_controller.rb
@@ -28,7 +28,7 @@ class BaseController < ActionController::Base
       "LIST_CARTRIDGES" => Link.new("List cartridges", "GET", URI::join(get_url, "cartridges")),
       "LIST_TEMPLATES" => Link.new("List application templates", "GET", URI::join(get_url, "application_templates")),
       "LIST_ESTIMATES" => Link.new("List available estimates", "GET" , URI::join(get_url, "estimates"))
-    }
+    } unless nolinks
     
     @reply = RestReply.new(:ok, "links", links)
     respond_with @reply, :status => @reply.status
@@ -117,7 +117,16 @@ class BaseController < ActionController::Base
     #Rails.logger.debug "Request URL: #{url.to_s}"
     return url.to_s
   end
-  
+
+  def nolinks
+    ignore_links = params[:nolinks]
+    if ignore_links
+      ignore_links.downcase!
+      return ["true", "1"].include?(ignore_links)
+    end
+    return false
+  end
+ 
   def check_version
     accept_header = request.headers['Accept']
     mime_types = accept_header.split(%r{,\s*})

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/cartridges_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/cartridges_controller.rb
@@ -21,9 +21,9 @@ class CartridgesController < BaseController
       end
       carts.each do |cart|
         if $requested_api_version >= 1.1
-          cartridge = RestCartridge11.new(cart_type, cart, nil, get_url)
+          cartridge = RestCartridge11.new(cart_type, cart, nil, get_url, nolinks)
         else
-          cartridge = RestCartridge10.new(cart_type, cart, nil, get_url)
+          cartridge = RestCartridge10.new(cart_type, cart, nil, get_url, nolinks)
         end
         cartridges.push(cartridge)
       end
@@ -37,9 +37,9 @@ class CartridgesController < BaseController
       end
       carts.each do |cart|
 	if $requested_api_version >= 1.1
-          cartridge = RestCartridge11.new(cart_type, cart, nil, get_url)
+          cartridge = RestCartridge11.new(cart_type, cart, nil, get_url, nolinks)
         else
-          cartridge = RestCartridge10.new(cart_type, cart, nil, get_url)
+          cartridge = RestCartridge10.new(cart_type, cart, nil, get_url, nolinks)
         end
         cartridges.push(cartridge)
       end

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/domains_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/domains_controller.rb
@@ -7,7 +7,7 @@ class DomainsController < BaseController
     Rails.logger.debug "Getting domains for user #{@cloud_user.login}"
     Rails.logger.debug @cloud_user.domains
     @cloud_user.domains.each do |domain|
-      domains.push(RestDomain.new(domain, get_url))
+      domains.push(RestDomain.new(domain, get_url, nolinks))
     end
     log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "LIST_DOMAINS")
     @reply = RestReply.new(:ok, "domains", domains)
@@ -22,7 +22,7 @@ class DomainsController < BaseController
     if domain and domain.hasAccess?(@cloud_user)
       #Rails.logger.debug "Found domain #{id}"
       log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "SHOW_DOMAIN", true, "Found domain #{id}")
-      domain = RestDomain.new(domain, get_url)
+      domain = RestDomain.new(domain, get_url, nolinks)
       @reply = RestReply.new(:ok, "domain", domain)
       respond_with @reply, :status => @reply.status
     else
@@ -100,7 +100,7 @@ class DomainsController < BaseController
     end
 
     log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "ADD_DOMAIN", true, "Created domain with namespace #{namespace}")
-    domain = RestDomain.new(domain, get_url)
+    domain = RestDomain.new(domain, get_url, nolinks)
     @reply = RestReply.new(:created, "domain", domain)
     respond_with @reply, :status => @reply.status
   end
@@ -215,7 +215,7 @@ class DomainsController < BaseController
     return
     end
     @cloud_user = CloudUser.find(@login)
-    domain = RestDomain.new(domain, get_url)
+    domain = RestDomain.new(domain, get_url, nolinks)
     @reply = RestReply.new(:ok, "domain", domain)
 
     log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "UPDATE_DOMAIN", true, "Updated domain #{id} to #{new_namespace}")

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/emb_cart_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/emb_cart_controller.rb
@@ -19,15 +19,15 @@ class EmbCartController < BaseController
     end
     cartridges = Array.new
     if $requested_api_version >= 1.1
-      cartridges.push(RestCartridge11.new("standalone", application.framework, application, get_url))
+      cartridges.push(RestCartridge11.new("standalone", application.framework, application, get_url, nolinks))
     end
 
     unless application.embedded.nil?
       application.embedded.each_key do |key|
         if $requested_api_version >= 1.1
-          cartridge = RestCartridge11.new("embedded", key, application, get_url)
+          cartridge = RestCartridge11.new("embedded", key, application, get_url, nolinks)
         else
-          cartridge = RestCartridge10.new("embedded", key, application, get_url)
+          cartridge = RestCartridge10.new("embedded", key, application, get_url, nolinks)
         end
         cartridges.push(cartridge)
       end
@@ -59,9 +59,9 @@ class EmbCartController < BaseController
           log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "SHOW_APP_CARTRIDGE", true, "Showing cartridge #{id} for application #{application_id} under domain #{domain_id}")
 
           if $requested_api_version >= 1.1
-            cartridge = RestCartridge11.new("embedded", key, application, get_url)
+            cartridge = RestCartridge11.new("embedded", key, application, get_url, nolinks)
           else
-            cartridge = RestCartridge10.new("embedded", key, application, get_url)
+            cartridge = RestCartridge10.new("embedded", key, application, get_url, nolinks)
           end
           @reply = RestReply.new(:ok, "cartridge", cartridge)
           respond_with @reply, :status => @reply.status
@@ -175,9 +175,9 @@ class EmbCartController < BaseController
         if key == name
           log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "EMBED_CARTRIDGE", true, "Embedded cartridge #{name} in application #{id}")
           if $requested_api_version >= 1.1
-            cartridge = RestCartridge11.new("embedded", key, application, get_url)
+            cartridge = RestCartridge11.new("embedded", key, application, get_url, nolinks)
           else
-            cartridge = RestCartridge10.new("embedded", key, application, get_url)
+            cartridge = RestCartridge10.new("embedded", key, application, get_url, nolinks)
           end
           @reply = RestReply.new(:created, "cartridge", cartridge)
           message = Message.new(:info, "Added #{name} to application #{id}")
@@ -243,7 +243,7 @@ class EmbCartController < BaseController
       
     log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "REMOVE_CARTRIDGE", true, "Cartridge #{cartridge} removed from application #{id}")
     application = Application.find(@cloud_user, id)
-    app = RestApplication.new(application, get_url)
+    app = RestApplication.new(application, get_url, nolinks)
     @reply = RestReply.new(:ok, "application", app)
     message = Message.new(:info, "Removed #{cartridge} from application #{id}")
     @reply.messages.push(message)

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/emb_cart_events_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/emb_cart_events_controller.rb
@@ -59,7 +59,7 @@ class EmbCartEventsController < BaseController
     
     log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "CARTRIDGE_EVENT", true, "Added event #{event} on cartridge #{cartridge} for application #{id}")
     application = Application.find(@cloud_user, id)
-    app = RestApplication.new(application, get_url)
+    app = RestApplication.new(application, get_url, nolinks)
     @reply = RestReply.new(:ok, "application", app)
     message = Message.new(:info, "Added #{event} on #{cartridge} for application #{id}")
     @reply.messages.push(message)

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/estimates_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/estimates_controller.rb
@@ -5,7 +5,7 @@ class EstimatesController < BaseController
   # GET /estimates
   def index
     log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "LIST_ESTIMATES")
-    @reply = RestReply.new(:ok, "estimates", RestEstimates.new(get_url))
+    @reply = RestReply.new(:ok, "estimates", RestEstimates.new(get_url, nolinks))
     respond_with @reply, :status => @reply.status
   end
 

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/keys_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/keys_controller.rb
@@ -7,7 +7,7 @@ class KeysController < BaseController
     ssh_keys = Array.new
     unless @cloud_user.ssh_keys.nil? 
       @cloud_user.ssh_keys.each do |name, key|
-        ssh_key = RestKey.new(name, key["key"], key["type"], get_url)
+        ssh_key = RestKey.new(name, key["key"], key["type"], get_url, nolinks)
         ssh_keys.push(ssh_key)
       end
     end
@@ -23,7 +23,7 @@ class KeysController < BaseController
       @cloud_user.ssh_keys.each do |key_name, key|
         if key_name == id
           log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "SHOW_KEY", true, "Found SSH key '#{id}'")
-          @reply = RestReply.new(:ok, "key", RestKey.new(key_name, key["key"], key["type"], get_url))
+          @reply = RestReply.new(:ok, "key", RestKey.new(key_name, key["key"], key["type"], get_url, nolinks))
           respond_with @reply, :status => @reply.status
         return
         end
@@ -90,7 +90,7 @@ class KeysController < BaseController
     begin
       @cloud_user.add_ssh_key(name, content, type)
       @cloud_user.save
-      ssh_key = RestKey.new(name, @cloud_user.ssh_keys[name]["key"], @cloud_user.ssh_keys[name]["type"], get_url)
+      ssh_key = RestKey.new(name, @cloud_user.ssh_keys[name]["key"], @cloud_user.ssh_keys[name]["type"], get_url, nolinks)
       log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "ADD_KEY", true, "Created SSH key #{name}")
       @reply = RestReply.new(:created, "key", ssh_key)
       @reply.messages.push(Message.new(:info, "Created SSH key #{name} for user #{@login}"))
@@ -147,7 +147,7 @@ class KeysController < BaseController
     begin
       @cloud_user.update_ssh_key(content, type, id)
       @cloud_user.save
-      ssh_key = RestKey.new(id, @cloud_user.ssh_keys[id]["key"], @cloud_user.ssh_keys[id]["type"], get_url)
+      ssh_key = RestKey.new(id, @cloud_user.ssh_keys[id]["key"], @cloud_user.ssh_keys[id]["type"], get_url, nolinks)
       log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "UPDATE_KEY", true, "Updated SSH key #{id}")
       @reply = RestReply.new(:ok, "key", ssh_key)
       @reply.messages.push(Message.new(:info, "Updated SSH key with name #{id} for user #{@login}"))

--- a/stickshift/controller/lib/stickshift-controller/app/controllers/user_controller.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/controllers/user_controller.rb
@@ -13,7 +13,7 @@ class UserController < BaseController
     end
     
     log_action(@request_id, @cloud_user.uuid, @cloud_user.login, "SHOW_USER")
-    @reply = RestReply.new(:ok, "user", RestUser.new(@cloud_user, get_url))
+    @reply = RestReply.new(:ok, "user", RestUser.new(@cloud_user, get_url, nolinks))
     respond_with @reply, :status => @reply.status
   end
 end

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_application.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_application.rb
@@ -2,7 +2,7 @@ class RestApplication < StickShift::Model
   attr_accessor :framework, :creation_time, :uuid, :embedded, :aliases, :name, :gear_count, :links, :domain_id, :git_url, :app_url, :ssh_url, :gear_profile, :scalable, :health_check_path, :scale_min, :scale_max
   include LegacyBrokerHelper
   
-  def initialize(app, url)
+  def initialize(app, url, nolinks=false)
     self.framework = app.framework
     self.name = app.name
     self.creation_time = app.creation_time
@@ -84,7 +84,7 @@ class RestApplication < StickShift::Model
         Param.new("cartridge", "string", "framework-type, e.g.: mongodb-2.0", carts)
       ]),
       "LIST_CARTRIDGES" => Link.new("List embedded cartridges", "GET", URI::join(url, "domains/#{@domain_id}/applications/#{@name}/cartridges"))
-    }
+    } unless nolinks
   end
   
   def to_xml(options={})

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_application_template.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_application_template.rb
@@ -1,7 +1,7 @@
 class RestApplicationTemplate < StickShift::Model
   attr_accessor :uuid, :display_name, :descriptor_yaml, :git_url, :tags, :gear_cost, :metadata, :links
   
-  def initialize(template, url)
+  def initialize(template, url, nolinks=false)
     @uuid, @display_name, @descriptor_yaml, @git_url, @tags, @gear_cost, @metadata =
      template.uuid, template.display_name, template.descriptor_yaml, template.git_url, template.tags,
         template.gear_cost, template.metadata
@@ -10,7 +10,7 @@ class RestApplicationTemplate < StickShift::Model
       "GET_TEMPLATE" => Link.new("Get specific template", "GET", URI::join(url, "application_templates/#{@uuid}")),
       "LIST_TEMPLATES" => Link.new("Get specific template", "GET", URI::join(url, "application_templates")),
       "LIST_TEMPLATES_BY_TAG" => Link.new("Get specific template", "GET", URI::join(url, "application_templates/TAG"))
-    }
+    } unless nolinks
   end
   
   def to_xml(options={})

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_cartridge10.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_cartridge10.rb
@@ -1,7 +1,7 @@
 class RestCartridge10 < StickShift::Model
   attr_accessor :type, :name, :links, :properties
   
-  def initialize(type, name, app, url)
+  def initialize(type, name, app, url, nolinks=false)
     self.name = name
     self.type = type
     self.properties = {}
@@ -25,7 +25,7 @@ class RestCartridge10 < StickShift::Model
               Param.new("event", "string", "event", "reload")
             ]),
             "DELETE" => Link.new("Delete embedded cartridge", "DELETE", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/cartridges/#{name}"))
-          }
+          } unless nolinks
       end
     end
   end

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_cartridge11.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_cartridge11.rb
@@ -2,7 +2,7 @@ class RestCartridge11 < StickShift::Model
   attr_accessor :type, :name, :version, :license, :license_url, :tags, :website,
   :help_topics, :links, :properties
   
-  def initialize(type, name, app, url)
+  def initialize(type, name, app, url, nolinks=false)
     self.name = name
     self.type = type
   
@@ -40,7 +40,7 @@ class RestCartridge11 < StickShift::Model
       self.properties << property
     end
     
-    if app
+    if app and !nolinks
       domain_id = app.domain.namespace
       app_id = app.name
       if type == "embedded" and not app_id.nil? and not domain_id.nil?

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_domain.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_domain.rb
@@ -2,7 +2,7 @@ class RestDomain < StickShift::Model
   attr_accessor :id, :suffix, :links
   include LegacyBrokerHelper
   
-  def initialize(domain, url)
+  def initialize(domain, url, nolinks=false)
     self.id = domain.namespace
     self.suffix = Rails.application.config.ss[:domain_suffix] 
 
@@ -29,7 +29,7 @@ class RestDomain < StickShift::Model
       "DELETE" => Link.new("Delete domain", "DELETE", URI::join(url, "domains/#{id}"),nil,[
         OptionalParam.new("force", "boolean", "Force delete domain.  i.e. delete any applications under this domain", [true, false], false)
       ])
-    }
+    } unless nolinks
   end
   
   def to_xml(options={})

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_estimates.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_estimates.rb
@@ -1,12 +1,12 @@
 class RestEstimates < StickShift::Model
   attr_accessor :links 
  
-  def initialize(url)
+  def initialize(url, nolinks=false)
     self.links = {
       "GET_ESTIMATE" => Link.new("Get application estimate", "GET", URI::join(url, "estimates/application"), [
         Param.new("descriptor", "string", "application requirements")
       ]) 
-    }
+    } unless nolinks
   end
   
   def to_xml(options={})

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_key.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_key.rb
@@ -1,7 +1,7 @@
 class RestKey < StickShift::Model
   attr_accessor :name, :content, :type, :links
   
-  def initialize(name, content, type, url)
+  def initialize(name, content, type, url, nolinks=false)
     self.name= name
     self.content = content
     self.type = type || "ssh-rsa"
@@ -13,7 +13,7 @@ class RestKey < StickShift::Model
         Param.new("content", "string", "The key portion of an rsa key (excluding ssh-rsa and comment)"),
       ]),
       "DELETE" => Link.new("Delete SSH key", "DELETE", URI::join(url, "user/keys/#{name}"))
-    }
+    } unless nolinks
   end
   
   def to_xml(options={})

--- a/stickshift/controller/lib/stickshift-controller/app/models/rest_user.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/rest_user.rb
@@ -1,7 +1,7 @@
 class RestUser < StickShift::Model
   attr_accessor :login, :consumed_gears, :max_gears, :plan_id, :usage_account_id, :links
   
-  def initialize(cloud_user, url)
+  def initialize(cloud_user, url, nolinks=false)
     self.login = cloud_user.login
     self.consumed_gears = cloud_user.consumed_gears
     self.max_gears = cloud_user.max_gears
@@ -14,7 +14,7 @@ class RestUser < StickShift::Model
         Param.new("type", "string", "Type of Key", ["ssh-rsa", "ssh-dss"]),
         Param.new("content", "string", "The key portion of an rsa key (excluding ssh-rsa and comment)"),
       ])
-    }
+    } unless nolinks
   end
   
   def to_xml(options={})


### PR DESCRIPTION
Added 'nolinks' parameter to suppress link generation in the REST API replies to make the output terse and improve general processing speed

Fix test_rest_api to support 'nolinks' option

Default 'nolinks' to false in REST models

Added unit test for rest api with nolinks option set

Split stickshift rake unit tests
