### PR TITLE
Fix for bugz 845164 - don't start haproxy if stopped and connections are executed as part of gear move

### DIFF
--- a/cartridges/haproxy-1.4/info/bin/app_ctl.sh
+++ b/cartridges/haproxy-1.4/info/bin/app_ctl.sh
@@ -154,7 +154,7 @@ function restart() {
 
 function reload() {
     if ! isrunning; then
-       _start_haproxy_service
+       [ "$1" != "--config" ]  &&  _start_haproxy_service
     else
        echo "`date`: Reloading HAProxy service " 1>&2
        _reload_service
@@ -182,7 +182,7 @@ case "$1" in
     start)               start       ;;
     graceful-stop|stop)  stop        ;;
     restart)             restart     ;;
-    graceful|reload)     reload      ;;
+    graceful|reload)     reload "$@" ;;
     force-stop)          force_stop  ;;
     status)              status      ;;
 esac

--- a/cartridges/haproxy-1.4/info/connection-hooks/set-gear-endpoints
+++ b/cartridges/haproxy-1.4/info/connection-hooks/set-gear-endpoints
@@ -121,4 +121,4 @@ done
 
 uuid=$3
 setup_user_vars
-run_as_user "app_ctl.sh reload"
+run_as_user "app_ctl.sh reload --config"

--- a/cartridges/haproxy-1.4/info/connection-hooks/set-proxy
+++ b/cartridges/haproxy-1.4/info/connection-hooks/set-proxy
@@ -89,7 +89,7 @@ rm -f /tmp/haproxy.cfg.$$
 uuid=$3
 setup_user_vars
 # echo "$0: reloading haproxy for application $1 - uuid $uuid ... "
-run_as_user "app_ctl.sh reload"
+run_as_user "app_ctl.sh reload --config"
 appctl_exitcode=$?
 
 # Pass the appropriate exit code back.


### PR DESCRIPTION
Fix for bugz 845164 - don't start haproxy if stopped and its just a config change via execute connections.
