### PR TITLE
Fix for bugz 845162 - MySQL cartridge status hook does correctly show true status

### DIFF
--- a/cartridges/mysql-5.1/info/bin/mysql_ctl.sh
+++ b/cartridges/mysql-5.1/info/bin/mysql_ctl.sh
@@ -31,8 +31,9 @@ source ${CART_INFO_DIR}/lib/util
 
 isrunning() {
     if [ -f $MYSQL_DIR/pid/mysql.pid ]; then
-        mysql_pid=`$MYSQL_DIR/pid/mysql.pid 2> /dev/null`
-        if `ps --pid $mysql_pid > /dev/null 2>&1` || `pgrep -x mysqld_safe > /dev/null 2>&1`
+        mysql_pid=`cat $MYSQL_DIR/pid/mysql.pid 2> /dev/null`
+        myid=`id -u`
+        if `ps --pid $mysql_pid > /dev/null 2>&1` || `pgrep -x mysqld_safe -u $myid > /dev/null 2>&1`
         then
             return 0
         fi


### PR DESCRIPTION
Fix for bugz 845162 - MySQL cartridge status hook doesn't correctly show true status if pid file contains an invalid pid.
