### PR TITLE
broker spec fixes for systemd

### DIFF
--- a/stickshift/broker/systemd/stickshift-broker.env
+++ b/stickshift/broker/systemd/stickshift-broker.env
@@ -1,0 +1,7 @@
+# Configuration file for the stickshift-broker service.
+
+#
+# To pass additional options (for instance, -D definitions) to the
+# httpd binary at startup, set OPTIONS here.
+#
+OPTIONS="-C 'Include /var/www/stickshift/broker/httpd/broker.conf' -f /var/www/stickshift/broker/httpd/httpd.conf"

--- a/stickshift/broker/systemd/stickshift-broker.service
+++ b/stickshift/broker/systemd/stickshift-broker.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=The StickShift Broker
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=forking
+PIDFile=/var/www/stickshift/broker/httpd/run/httpd.pid
+EnvironmentFile=/etc/sysconfig/stickshift-broker
+ExecStart=/usr/sbin/httpd $OPTIONS -k start
+ExecReload=/usr/sbin/httpd $OPTIONS -t
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStop=/usr/sbin/httpd $OPTIONS -k stop
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Changes needed to use systemd for Fedora >= 16 and RHEL >= 7
