### PR TITLE
allow ruby versions > 1.8

### DIFF
--- a/uplift/bind/uplift-bind-plugin.spec
+++ b/uplift/bind/uplift-bind-plugin.spec
@@ -12,7 +12,7 @@ License:        ASL 2.0
 URL:            http://openshift.redhat.com
 Source0:        rubygem-%{gemname}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-Requires:       ruby(abi) = 1.8
+Requires:       ruby(abi) >= 1.8
 Requires:       rubygems
 Requires:       rubygem(stickshift-common)
 Requires:       rubygem(json)
@@ -62,7 +62,7 @@ cp -r doc/* %{buildroot}%{_docdir}/%{name}-%{version}/
 
 # Compile SELinux policy
 mkdir -p %{buildroot}/usr/share/selinux/packages/rubygem-uplift-bind-plugin
-cp %{buildroot}/usr/lib/ruby/gems/1.8/gems/uplift-bind-plugin-*/doc/examples/dhcpnamedforward.* %{buildroot}/usr/share/selinux/packages/rubygem-uplift-bind-plugin/
+cp %{buildroot}%{gemdir}/gems/uplift-bind-plugin-*/doc/examples/dhcpnamedforward.* %{buildroot}/usr/share/selinux/packages/rubygem-uplift-bind-plugin/
 
 %post
 


### PR DESCRIPTION
This change to the spec file allows ruby versions > 1.8.

It increases the acceptable ruby(abi) to >= 1.8
It replaces a hard-coded file path for a copy with one that contains automatic variables. This allows the file copy to work without error regardless of the version of ruby used.
