### PR TITLE
BZ 845332: Fix systemd race condition with stickshift-proxy

### DIFF
--- a/stickshift/abstract/abstract/info/lib/network
+++ b/stickshift/abstract/abstract/info/lib/network
@@ -118,7 +118,7 @@ function proxy_cmd {
   # Run proxy commands if one exists; otherwise, this is a stub.
   if chkconfig --list stickshift-proxy >/dev/null 2>&1 
   then
-    service stickshift-proxy "${@}"
+    stickshift-proxy-cfg "${@}"
     return $?
   fi
   return 0

--- a/stickshift/node/lib/stickshift-node/model/unix_user.rb
+++ b/stickshift/node/lib/stickshift-node/model/unix_user.rb
@@ -522,7 +522,7 @@ module StickShift
       cmd = %{/sbin/chkconfig --list stickshift-proxy}
       out,err,rc = shellCmd(cmd)
       if rc == 0
-        cmd = %{/sbin/service stickshift-proxy setproxy}
+        cmd = %{stickshift-proxy-cfg setproxy}
         proxy_port_range.each { |i| cmd << " #{i} delete" }
         out, err, rc = shellCmd(cmd)
       end

--- a/stickshift/port-proxy/bin/stickshift-proxy-cfg
+++ b/stickshift/port-proxy/bin/stickshift-proxy-cfg
@@ -1,0 +1,181 @@
+#!/bin/bash
+
+#
+# Modify the stickshift-proxy configuration.
+#
+
+
+source /etc/stickshift/stickshift-node.conf
+
+cfgfile=/var/lib/stickshift/.stickshift-proxy.d/stickshift-proxy.cfg
+
+
+### 
+# System service routines; systemctl may require modifications
+# but please retain compatability with RHEL 6 init scripts.
+###
+is_running() {
+    service stickshift-proxy status &>/dev/null
+}
+
+reload() {
+    service stickshift-proxy reload &>/dev/null
+}
+
+getpid() {
+    cat /var/run/stickshift-proxy.pid 
+}
+###
+
+
+getaddr() {
+    # External due to using DNS for gear->gear
+    ip -4 addr show dev ${EXTERNAL_ETH_DEV:-eth0} scope global | sed -r -n '/inet/ { s/^.*inet ([0-9\.]+).*/\1/; p }' | head -1
+}
+
+rollcfg() {
+    if ! is_running
+    then
+        echo "Error: Stickshift-proxy was not running."
+        return 1
+    fi
+
+    
+    if ! haproxy -c -q -f $cfgfile
+    then
+        echo "Error: Proxy configuration is corrupt."
+        return 1
+    fi
+
+    oldpid=$(getpid)
+    
+    if ! reload
+    then
+        echo "stickshift-proxy failed to start"
+        return 1
+    fi
+
+    # Wait for the old PID to terminate
+    if [ "$oldpid" ]
+    then
+        while ps $oldpid &>/dev/null
+        do
+            usleep 500000
+        done
+    fi
+
+    return 0
+}
+
+
+lockwrap() {
+    lockfile ${cfgfile}.lock
+    oldsum=$( md5sum $cfgfile | awk '{ print $1 }' )
+    "$@"
+    retcode=$?
+    if [ $retcode != 0 ]; then
+        echo "Error: Failed to update proxy."
+    else
+        newsum=$( md5sum $cfgfile | awk '{ print $1 }' )
+        if [ $oldsum != $newsum ]; then
+            rollcfg
+            retcode=$?
+        fi
+    fi
+    rm -f ${cfgfile}.lock
+    return $retcode
+}
+
+setproxy() {
+    # Set a proxy entry (either add or delete)
+    proxport="$1"
+    target="$2"
+
+    if ! [ "$proxport" -ge 16384 -a "$proxport" -le 65535 ]; then
+        echo "Proxy port must be an integer between 16384 and 65535"
+        return 1
+    fi
+
+    if [ "$target" == "delete" -o "$target" == "del" ]; then
+        sed -i -e '/^listen '"$proxport"':/,/^# End '"$proxport"':/ d' $cfgfile
+        return $?
+    fi
+
+    ipbytes=( $(echo "$target" | cut -f 1 -d : | sed -e 's/\./ /g') )
+    if [ ${#ipbytes[@]} -ne 4 ]; then
+        echo "Dest addr must be a valid IPv4 address."
+        return 1
+    fi
+
+    for byt in "${ipbytes[@]}"; do
+        if ! [ "$byt" -ge 0 -a "$byt" -le 255 ]; then
+            echo "Dest addr must be a valid IP address."
+            return 1
+        fi
+    done
+
+    port=$(echo $target | cut -f 2 -d :)
+    if ! [ "$port" -ge 1 -a "$port" -le 65535 ]; then
+        echo "Dest port must be an integer between 16384 and 65535"
+        return 1
+    fi
+
+    if grep -q "^listen $proxport:$target" $cfgfile; then
+        return 0
+    fi
+
+    baddr=$(getaddr)
+
+    sed -i -e '/^listen '"$proxport"':/,/^# End '"$proxport"':/ d' $cfgfile
+
+    cat <<EOF >> $cfgfile
+listen $proxport:$target
+    mode tcp
+    bind $baddr:$proxport
+    server $proxport $target
+# End $proxport:$target
+EOF
+
+    return $?
+}
+
+setproxies() {
+    while [ "$1" ]; do
+        setproxy "$1" "$2"
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed at $1 $2"
+            return 1
+        fi
+        shift; shift
+    done
+    return 0
+}
+
+
+showproxies() {
+    sedexp=""
+    for proxport in "$@"; do
+        sedexp="${sedexp};"'s/^listen \('"$proxport"'\):\(.*\)$/\1 \2/'
+    done
+    sedexp="${sedexp}; T; p"
+    sed -n -e "${sedexp}" $cfgfile
+    return 0
+}
+
+case "$1" in
+    getaddr)
+        getaddr
+        ;;
+    setproxy)
+        shift
+        lockwrap setproxies "$@"
+        ;;
+    showproxy)
+        shift
+        lockwrap showproxies "$@"
+        ;;
+    *)
+        echo "Usage: $0 {getaddr|setproxy [proxport] [ip:port]|showproxy [proxport]}"
+        exit 2
+        ;;
+esac

--- a/stickshift/port-proxy/init-scripts/stickshift-proxy
+++ b/stickshift/port-proxy/init-scripts/stickshift-proxy
@@ -24,156 +24,13 @@ prog=haproxy
 lockfile=/var/lock/subsys/stickshift-proxy
 pidfile=/var/run/stickshift-proxy.pid
 cfgfile=/var/lib/stickshift/.stickshift-proxy.d/stickshift-proxy.cfg
-source /etc/stickshift/stickshift-node.conf
-
-getaddr() {
-    if ! [ "$INTERNAL_ETH_DEV" ] ; then
-      INTERNAL_ETH_DEV=eth0
-    fi
-    ip -4 addr show dev $INTERNAL_ETH_DEV scope global | sed -r -n '/inet/ { s/^.*inet ([0-9\.]+).*/\1/; p }' | head -1
-}
-
-fixaddr() {
-    # Fix internal ip address in case it was changed by the cloud provider
-    baddr=$(getaddr)
-    sed -i -r -e '/^[^\#]*bind/ { /127\.[0-9\.]+:/ b; s/([0-9\.]+):/'"$baddr"':/ }' $cfgfile
-}
-
-
-rollcfg() {
-  # If proxy is running, roll the configuration and block till done
-    if [ -f $lockfile ]; then
-
-        $exec -c -q -f $cfgfile
-        if [ $? -ne 0 ]; then
-            echo "Error: Proxy configuration is corrupt."
-            return 1
-        fi
-
-        oldpid=$( cat $pidfile )
-
-        if ! [ "$(readlink /proc/$oldpid/exe)" == "$exec" -o "$(readlink /proc/$oldpid/exe)" == "$exec (deleted)" ]; then
-            echo "stickshift-proxy has crashed."
-            return 1
-        fi
-
-        $exec -D -f $cfgfile -p $pidfile -sf "$oldpid"
-        retv=$?
-        if [ $retv != 0 ]; then
-            echo "stickshift-proxy failed to start"
-            return 1
-        fi
-
-        while [ "$(readlink /proc/$oldpid/exe)" == "$exec" -o "$(readlink /proc/$oldpid/exe)" == "$exec (deleted)" ]; do
-            usleep 500000
-        done
-
-        newpid=$( cat $pidfile )
-        if [ $newpid == $oldpid ]; then
-            echo "stickshift-proxy failed to update"
-            return 1
-        fi
-    fi
-    return 0
-}
-
-
-lockwrap() {
-    lockfile ${cfgfile}.lock
-    oldsum=$( md5sum $cfgfile | awk '{ print $1 }' )
-    "$@"
-    retcode=$?
-    if [ $retcode != 0 ]; then
-        echo "Error: Bad proxy configuration."
-    else
-        newsum=$( md5sum $cfgfile | awk '{ print $1 }' )
-        if [ $oldsum != $newsum ]; then
-            rollcfg
-            retcode=$?
-        fi
-    fi
-    rm -f ${cfgfile}.lock
-    return $retcode
-}
-
-setproxy() {
-  # Set a proxy entry (either add or delete)
-    proxport="$1"
-    target="$2"
-
-    if ! [ "$proxport" -ge 16384 -a "$proxport" -le 65535 ]; then
-        echo "Proxy port must be an integer between 16384 and 65535"
-        return 1
-    fi
-
-    if [ "$target" == "delete" -o "$target" == "del" ]; then
-        sed -i -e '/^listen '"$proxport"':/,/^# End '"$proxport"':/ d' $cfgfile
-        return $?
-    fi
-
-    ipbytes=( $(echo "$target" | cut -f 1 -d : | sed -e 's/\./ /g') )
-    if [ ${#ipbytes[@]} -ne 4 ]; then
-        echo "Dest addr must be a valid IP address."
-        return 1
-    fi
-
-    for byt in "${ipbytes[@]}"; do
-        if ! [ "$byt" -ge 0 -a "$byt" -le 255 ]; then
-            echo "Dest addr must be a valid IP address."
-            return 1
-        fi
-    done
-
-    port=$(echo $target | cut -f 2 -d :)
-    if ! [ "$port" -ge 1 -a "$port" -le 65535 ]; then
-        echo "Dest port must be an integer between 16384 and 65535"
-        return 1
-    fi
-
-    if grep -q "^listen $proxport:$target" $cfgfile; then
-        return 0
-    fi
-
-    baddr=$(getaddr)
-
-    sed -i -e '/^listen '"$proxport"':/,/^# End '"$proxport"':/ d' $cfgfile
-
-    cat <<EOF >> $cfgfile
-listen $proxport:$target
-    mode tcp
-    bind $baddr:$proxport
-    server $proxport $target
-# End $proxport:$target
-EOF
-
-    return $?
-}
-
-setproxies() {
-    while [ "$1" ]; do
-        setproxy "$1" "$2"
-        if [ $? -ne 0 ]; then
-            echo "Error: Failed at $1 $2"
-            return 1
-        fi
-        shift; shift
-    done
-    return 0
-}
-
-
-showproxies() {
-    sedexp=""
-    for proxport in "$@"; do
-        sedexp="${sedexp};"'s/^listen \('"$proxport"'\):\(.*\)$/\1 \2/'
-    done
-    sedexp="${sedexp}; T; p"
-    sed -n -e "${sedexp}" $cfgfile
-    return 0
-}
 
 start() {
-    fixaddr
+
+    # Fix internal ip address in case it was changed by the cloud provider
+    baddr=$(stickshift-proxy-cfg getaddr)
+    sed -i -r -e '/^[^\#]*bind/ { /127\.[0-9\.]+:/ b; s/([0-9\.]+):/'"$baddr"':/ }' $cfgfile
+
     if $exec -c -q -f $cfgfile; then
         echo -n $"Starting stickshift-proxy: "
         daemon --pidfile $pidfile $exec -D -f $cfgfile -p $pidfile
@@ -242,15 +99,7 @@ case "$1" in
             restart
         fi
 	;;
-    setproxy)
-        shift
-        lockwrap setproxies "$@"
-        ;;
-    showproxy)
-        shift
-        lockwrap showproxies "$@"
-        ;;
     *)
-        echo $"Usage: $0 {start|stop|status|restart|reload|setproxy [proxport] [ip:port]|showproxy [proxport]}"
+        echo $"Usage: $0 {start|stop|status|restart|reload}"
         exit 2
 esac

--- a/stickshift/port-proxy/stickshift-port-proxy.spec
+++ b/stickshift/port-proxy/stickshift-port-proxy.spec
@@ -26,9 +26,11 @@ rm -rf $RPM_BUILD_ROOT
 mkdir -p %{buildroot}%{_initddir}
 mkdir -p %{buildroot}%{_localstatedir}/lib/stickshift/.stickshift-proxy.d
 mkdir -p %{buildroot}%{_sysconfdir}/stickshift
+mkdir -p %{buildroot}%{_bindir}
 
 mv init-scripts/stickshift-proxy %{buildroot}%{_initddir}
 mv config/stickshift-proxy.cfg %{buildroot}%{_sysconfdir}/stickshift/
+install -m 755 bin/stickshift-proxy-cfg %{buildroot}%{_bindir}/stickshift-proxy-cfg
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -54,6 +56,7 @@ fi
 %files
 %defattr(-,root,root,-)
 %attr(0750,-,-) %{_initddir}/stickshift-proxy
+%attr(0755,-,-) %{_bindir}/stickshift-proxy-cfg
 %dir %attr(0750,root,root) %{_localstatedir}/lib/stickshift/.stickshift-proxy.d
 %attr(0640,-,-) %config(noreplace) %{_sysconfdir}/stickshift/stickshift-proxy.cfg
 


### PR DESCRIPTION
On Origin, during the reload phase of proxy reconfiguration; systemd interprets the daemon switch-over as a crash and stops the proxy service. If the init script is called with "reload", then systemd properly tracks the change.

Re-factor the solution to handle configuration in a separate script and call reload to bounce the daemon.

This also makes the stickshift-proxy init script completely normal, and replaceable with a systemd script in the future.

This request must be tested alongside its partner li pull request.
