### PR TITLE
Enable hot deployment support for Ruby cartridges

### DIFF
--- a/cartridges/ruby-1.8/info/bin/post_deploy.sh
+++ b/cartridges/ruby-1.8/info/bin/post_deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+source "/etc/stickshift/stickshift-node.conf"
+source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
+
+for f in ~/.env/*
+do
+  . $f
+done
+
+# Hot deployment support
+if hot_deploy_marker_is_present; then
+  echo "Hot deploy marker is present. Touching Passenger restart.txt to trigger redeployment."
+  touch ${OPENSHIFT_REPO_DIR}tmp/restart.txt
+fi
+
+user_post_deploy.sh

--- a/cartridges/ruby-1.8/info/configuration/jenkins_job_template.xml
+++ b/cartridges/ruby-1.8/info/configuration/jenkins_job_template.xml
@@ -62,7 +62,7 @@
   <builders>
     <hudson.tasks.Shell>
       <command>
-alias rsync="rsync --delete-after -az -e '$GIT_SSH'"      
+source /usr/libexec/stickshift/cartridges/abstract/info/lib/jenkins_util
 
 # Build/update libs and run user pre_build and build
 . ci_build.sh
@@ -74,7 +74,7 @@ then
   # Note: Adding .openshift/markers/force_clean_build at the root of the repo will trigger a clean rebundle
   if [ -f .openshift/markers/force_clean_build ] &amp;&amp; ! [ -d .bundle ] &amp;&amp; ! git show master~1:.bundle > /dev/null 2>&amp;1
   then
-    rsync --include '.bundle/***' --include 'vendor/***' --exclude '*' UPSTREAM_SSH:~/UPSTREAM_APP_NAME/repo/ .
+    jenkins_rsync --include '.bundle/***' --include 'vendor/***' --exclude '*' UPSTREAM_SSH:~/UPSTREAM_APP_NAME/repo/ .
   fi
 
   echo 'Bundling RubyGems based on Gemfile/Gemfile.lock to vendor/bundle'
@@ -85,14 +85,14 @@ fi
 # Deploy new build
 
 # Stop app
-$GIT_SSH UPSTREAM_SSH 'ctl_all stop'
+jenkins_stop_app UPSTREAM_SSH
 
 # Push content back to application
-rsync ~/$WORKSPACE/ UPSTREAM_SSH:~/UPSTREAM_APP_NAME/repo/
+jenkins_rsync ~/$WORKSPACE/ UPSTREAM_SSH:~/UPSTREAM_APP_NAME/repo/
 
 # Configure / start app
 $GIT_SSH UPSTREAM_SSH deploy.sh
-$GIT_SSH UPSTREAM_SSH 'ctl_all start'
+jenkins_start_app UPSTREAM_SSH
 $GIT_SSH UPSTREAM_SSH post_deploy.sh
       </command>
     </hudson.tasks.Shell>

--- a/cartridges/ruby-1.9/info/bin/post_deploy.sh
+++ b/cartridges/ruby-1.9/info/bin/post_deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+source "/etc/stickshift/stickshift-node.conf"
+source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
+
+for f in ~/.env/*
+do
+  . $f
+done
+
+# Hot deployment support
+if hot_deploy_marker_is_present; then
+  echo "Hot deploy marker is present. Touching Passenger restart.txt to trigger redeployment."
+  touch ${OPENSHIFT_REPO_DIR}tmp/restart.txt
+fi
+
+/usr/bin/scl enable ruby193 "user_post_deploy.sh"

--- a/cartridges/ruby-1.9/info/configuration/jenkins_job_template.xml
+++ b/cartridges/ruby-1.9/info/configuration/jenkins_job_template.xml
@@ -62,7 +62,7 @@
   <builders>
     <hudson.tasks.Shell>
       <command>
-alias rsync="rsync --delete-after -az -e '$GIT_SSH'"
+source /usr/libexec/stickshift/cartridges/abstract/info/lib/jenkins_util
 
 # Build/update libs and run user pre_build and build
 . ci_build.sh
@@ -74,7 +74,7 @@ then
   # Note: Adding .openshift/markers/force_clean_build at the root of the repo will trigger a clean rebundle
   if [ -f .openshift/markers/force_clean_build ] &amp;&amp; ! [ -d .bundle ] &amp;&amp; ! git show master~1:.bundle > /dev/null 2>&amp;1
   then
-    rsync --include '.bundle/***' --include 'vendor/***' --exclude '*' UPSTREAM_SSH:~/UPSTREAM_APP_NAME/repo/ .
+    jenkins_rsync --include '.bundle/***' --include 'vendor/***' --exclude '*' UPSTREAM_SSH:~/UPSTREAM_APP_NAME/repo/ .
   fi
 
   echo 'Bundling RubyGems based on Gemfile/Gemfile.lock to vendor/bundle'
@@ -85,14 +85,14 @@ fi
 # Deploy new build
 
 # Stop app
-$GIT_SSH UPSTREAM_SSH 'ctl_all stop'
+jenkins_stop_app UPSTREAM_SSH
 
 # Push content back to application
-rsync ~/$WORKSPACE/ UPSTREAM_SSH:~/UPSTREAM_APP_NAME/repo/
+jenkins_rsync ~/$WORKSPACE/ UPSTREAM_SSH:~/UPSTREAM_APP_NAME/repo/
 
 # Configure / start app
 $GIT_SSH UPSTREAM_SSH deploy.sh
-$GIT_SSH UPSTREAM_SSH 'ctl_all start'
+jenkins_start_app UPSTREAM_SSH
 $GIT_SSH UPSTREAM_SSH post_deploy.sh
       </command>
     </hudson.tasks.Shell>

--- a/stickshift/controller/test/cucumber/cartridge-runtime-extended-ruby.feature
+++ b/stickshift/controller/test/cucumber/cartridge-runtime-extended-ruby.feature
@@ -14,6 +14,8 @@ Feature: Cartridge Runtime Extended Checks (Ruby)
     Then a <proc_name> process will not be running
 
   Scenarios: Code push scenarios
-    | type         | proc_name | hot_deploy_status | pid_changed   |
-    | ruby-1.8     | httpd     | is not enabled    | should be     |
-    | ruby-1.9     | httpd     | is not enabled    | should be     |
+    | type         | proc_name        | hot_deploy_status | pid_changed   |
+    | ruby-1.8     | PassengerWatchd  | is not enabled    | should be     |
+    | ruby-1.9     | PassengerWatchd  | is not enabled    | should be     |
+    | ruby-1.8     | PassengerWatchd  | is enabled        | should not be |
+    | ruby-1.9     | PassengerWatchd  | is enabled        | should not be |


### PR DESCRIPTION
Support the hot_deploy marker in the ruby-1.8 and ruby-1.9 cartridges.
