### PR TITLE
US2683 and proxy bug

### DIFF
--- a/stickshift/abstract/abstract/info/bin/snapshot.sh
+++ b/stickshift/abstract/abstract/info/bin/snapshot.sh
@@ -23,6 +23,7 @@ echo "Creating and sending tar.gz" 1>&2
 /bin/tar --ignore-failed-read -czf - \
         --exclude=./$OPENSHIFT_GEAR_UUID/.tmp \
         --exclude=./$OPENSHIFT_GEAR_UUID/.ssh \
+        --exclude=./$OPENSHIFT_GEAR_UUID/.sandbox \
         --exclude=./$OPENSHIFT_GEAR_UUID/$OPENSHIFT_GEAR_NAME/${OPENSHIFT_GEAR_NAME}_ctl.sh \
         --exclude=./$OPENSHIFT_GEAR_UUID/$OPENSHIFT_GEAR_NAME/conf.d/stickshift.conf \
         --exclude=./$OPENSHIFT_GEAR_UUID/$OPENSHIFT_GEAR_NAME/run/httpd.pid \

--- a/stickshift/node/lib/stickshift-node/model/unix_user.rb
+++ b/stickshift/node/lib/stickshift-node/model/unix_user.rb
@@ -373,6 +373,7 @@ module StickShift
     #   # Creates:
     #   # ~
     #   # ~/.tmp/
+    #   # ~/.sandbox
     #   # ~/.env/
     #   # APP_UUID, GEAR_UUID, APP_NAME, APP_DNS, HOMEDIR, DATA_DIR, GEAR_DIR, \
     #   #   GEAR_DNS, GEAR_NAME, GEAR_CTL_SCRIPT, PATH, REPO_DIR, TMP_DIR
@@ -392,7 +393,11 @@ module StickShift
       # Required for polyinstantiated tmp dirs to work
       FileUtils.mkdir_p tmp_dir
       FileUtils.chmod(0o0000, tmp_dir)
-            
+
+      sandbox_dir = File.join(homedir, ".sandbox")
+      FileUtils.mkdir_p sandbox_dir
+      FileUtils.chmod(0o0000, sandbox_dir)
+
       env_dir = File.join(homedir, ".env")
       FileUtils.mkdir_p(env_dir)
       FileUtils.chmod(0o0750, env_dir)

--- a/stickshift/port-proxy/bin/stickshift-proxy-cfg
+++ b/stickshift/port-proxy/bin/stickshift-proxy-cfg
@@ -18,6 +18,10 @@ is_running() {
     service stickshift-proxy status &>/dev/null
 }
 
+restart() {
+    service stickshift-proxy restart &>/dev/null
+}
+
 reload() {
     service stickshift-proxy reload &>/dev/null
 }
@@ -36,8 +40,11 @@ getaddr() {
 rollcfg() {
     if ! is_running
     then
-        echo "Error: Stickshift-proxy was not running."
-        return 1
+        if ! restart
+        then
+            echo "Error: Proxy has failed"
+            exit 1
+        fi
     fi
 
     


### PR DESCRIPTION
Add the sandbox polyinstantiation directory.

Proxy control now assumes you want the daemon running when its called to configure.
