### PR TITLE
Fix broken cartridge hook symlinks

### DIFF
--- a/cartridges/jbosseap-6.0/cartridge-jbosseap-6.0.spec
+++ b/cartridges/jbosseap-6.0/cartridge-jbosseap-6.0.spec
@@ -70,7 +70,6 @@ ln -s %{cartridgedir}/../abstract/info/hooks/restart %{buildroot}%{cartridgedir}
 ln -s %{cartridgedir}/../abstract/info/hooks/start %{buildroot}%{cartridgedir}/info/hooks/start
 ln -s %{cartridgedir}/../abstract/info/hooks/stop %{buildroot}%{cartridgedir}/info/hooks/stop
 ln -s %{cartridgedir}/../abstract/info/hooks/update-namespace %{buildroot}%{cartridgedir}/info/hooks/update-namespace
-ln -s %{cartridgedir}/../abstract/info/hooks/preconfigure %{buildroot}%{cartridgedir}/info/hooks/preconfigure
 ln -s %{cartridgedir}/../abstract/info/hooks/deploy-httpd-proxy %{buildroot}%{cartridgedir}/info/hooks/deploy-httpd-proxy
 ln -s %{cartridgedir}/../abstract/info/hooks/remove-httpd-proxy %{buildroot}%{cartridgedir}/info/hooks/remove-httpd-proxy
 ln -s %{cartridgedir}/../abstract/info/hooks/force-stop %{buildroot}%{cartridgedir}/info/hooks/force-stop

--- a/cartridges/phpmyadmin-3.4/cartridge-phpmyadmin-3.4.spec
+++ b/cartridges/phpmyadmin-3.4/cartridge-phpmyadmin-3.4.spec
@@ -29,7 +29,7 @@ rm -rf $RPM_BUILD_ROOT
 rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}%{cartridgedir}/info/connection-hooks/
-ln -s %{cartridgedir}/../abstract/info/connection-hooks/set-db-connection-info %{buildroot}%{cartridgedir}/info/connection-hooks/set-db-connection-info
+ln -s %{cartridgedir}/../../abstract/info/connection-hooks/set-db-connection-info %{buildroot}%{cartridgedir}/info/connection-hooks/set-db-connection-info
 mkdir -p %{buildroot}/%{_sysconfdir}/stickshift/cartridges
 ln -s %{cartridgedir}/info/configuration/ %{buildroot}/%{_sysconfdir}/stickshift/cartridges/%{name}
 cp -r info %{buildroot}%{cartridgedir}/


### PR DESCRIPTION
Correct a couple of broken symlinks referring to abstract cart hooks.

Resolves the following bug:
- https://bugzilla.redhat.com/show_bug.cgi?id=845933
