### PR TITLE
US2614 changes [test]

### DIFF
--- a/stickshift/controller/lib/stickshift-controller/app/models/cloud_user.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/cloud_user.rb
@@ -1,7 +1,7 @@
  class CloudUser < StickShift::UserModel
-  #TODO: vip and gear_usage_records no longer used, remove from the model
   attr_accessor :login, :uuid, :system_ssh_keys, :env_vars, :ssh_keys, :domains, :max_gears, :consumed_gears, :applications, 
-                :auth_method, :save_jobs, :usage_records, :gear_usage_records, :capabilities, :parent_user_login, :plan_id, :usage_account_id, :vip
+                :auth_method, :save_jobs, :usage_records, :gear_usage_records, :capabilities, :parent_user_login, 
+                :plan_id, :usage_account_id, :pending_plan_id, :pending_plan_uptime
   primary_key :login
   exclude_attributes :applications, :auth_method, :save_jobs, :usage_records
   require_update_attributes :system_ssh_keys, :env_vars, :ssh_keys, :domains

--- a/stickshift/controller/lib/stickshift-controller/lib/stickshift/mongo_data_store.rb
+++ b/stickshift/controller/lib/stickshift-controller/lib/stickshift/mongo_data_store.rb
@@ -71,8 +71,8 @@ module StickShift
         if opts[:with_usage]
           query["usage_records.0"] = {"$exists" => true}
         end
-        if opts[:with_pending_plan]
-          query["pending_plan_id"] = {"$ne" => nil}
+        if opts[:with_plan]
+          query["$or"] = [{"pending_plan_id" => {"$ne" => nil}}, {"plan_id" => {"$ne" => nil}}]
         end
       end
       mcursor = user_collection.find(query, {:fields => []})
@@ -420,8 +420,8 @@ module StickShift
           if opts[:with_usage]
             query["usage_records.0"] = {"$exists" => true}
           end
-          if opts[:with_pending_plan]
-            query["pending_plan_id"] = {"$ne" => nil}
+          if opts[:with_plan]
+            query["$or"] = [{"pending_plan_id" => {"$ne" => nil}}, {"plan_id" => {"$ne" => nil}}]
           end
         end
         mcursor = user_collection.find(query)

--- a/stickshift/controller/lib/stickshift-controller/lib/stickshift/mongo_data_store.rb
+++ b/stickshift/controller/lib/stickshift-controller/lib/stickshift/mongo_data_store.rb
@@ -71,6 +71,9 @@ module StickShift
         if opts[:with_usage]
           query["usage_records.0"] = {"$exists" => true}
         end
+        if opts[:with_pending_plan]
+          query["pending_plan_id"] = {"$ne" => nil}
+        end
       end
       mcursor = user_collection.find(query, {:fields => []})
       ret = []
@@ -416,6 +419,9 @@ module StickShift
           end
           if opts[:with_usage]
             query["usage_records.0"] = {"$exists" => true}
+          end
+          if opts[:with_pending_plan]
+            query["pending_plan_id"] = {"$ne" => nil}
           end
         end
         mcursor = user_collection.find(query)


### PR DESCRIPTION
- Added 'pending_plan_id', 'pending_plan_uptime' fields to CloudUser model
- Removed 'vip' field from CloudUser model
- find_all() can take ':with_pending_plan' option to list all users with pending plan.
