### PR TITLE
Bug fix to federate to app server control script + add hot deploy instructions

### DIFF
--- a/cartridges/haproxy-1.4/info/bin/app_ctl.sh
+++ b/cartridges/haproxy-1.4/info/bin/app_ctl.sh
@@ -206,7 +206,7 @@ function status() {
 # Operate on the app server control script first.
 CART_INFO_DIR=$(dirname "$0")
 APP_CTL_PATH=$(echo "$PATH" | sed "s#${CART_INFO_DIR}/:##")
-PATH=$APP_CTL_PATH app_ctl.sh "$@"
+[[ "$CARTRIDGE_TYPE" =~ haproxy* ]]  ||  PATH=$APP_CTL_PATH app_ctl.sh "$@"
 
 # And then on the haproxy and haproxy_ctld.
 case "$1" in

--- a/cartridges/haproxy-1.4/info/bin/app_ctl.sh
+++ b/cartridges/haproxy-1.4/info/bin/app_ctl.sh
@@ -198,6 +198,17 @@ function status() {
     print_user_running_processes `id -u`
 }
 
+
+#
+# main():
+#
+
+# Operate on the app server control script first.
+CART_INFO_DIR=$(dirname "$0")
+APP_CTL_PATH=$(echo "$PATH" | sed "s#${CART_INFO_DIR}/:##")
+PATH=$APP_CTL_PATH app_ctl.sh "$@"
+
+# And then on the haproxy and haproxy_ctld.
 case "$1" in
     start)               start       ;;
     graceful-stop|stop)  stop        ;;
@@ -207,3 +218,4 @@ case "$1" in
     force-stop)          force_stop  ;;
     status)              status      ;;
 esac
+

--- a/cartridges/ruby-1.8/template/.openshift/markers/README
+++ b/cartridges/ruby-1.8/template/.openshift/markers/README
@@ -6,3 +6,8 @@ Adding marker files to this directory will have the following effects:
 force_clean_build - Previous output from bundle install --deployment will be 
      removed and all gems will be reinstalled according to the current 
      Gemfile/Gemfile.lock.
+
+hot_deploy - Will prevent the apache process from being restarted during
+    build/deployment. Note that mod_passenger will respawn the Rack worker
+    processes if any code has been modified.
+

--- a/cartridges/ruby-1.9/template/.openshift/markers/README
+++ b/cartridges/ruby-1.9/template/.openshift/markers/README
@@ -6,3 +6,8 @@ Adding marker files to this directory will have the following effects:
 force_clean_build - Previous output from bundle install --deployment will be
      removed and all gems will be reinstalled according to the current
      Gemfile/Gemfile.lock.
+
+hot_deploy - Will prevent the apache process from being restarted during
+    build/deployment. Note that mod_passenger will respawn the Rack worker
+    processes if any code has been modified.
+


### PR DESCRIPTION
Need to also federate start/stop/restart requests to the app server control script.
and fix bugz 847605 - add hot_deploy instructions to README for ruby-1.8 and ruby-1.9
