### PR TITLE
Fix for bugz 846108 - passenger_status fails

### DIFF
--- a/cartridges/ruby-1.9/cartridge-ruby-1.9.spec
+++ b/cartridges/ruby-1.9/cartridge-ruby-1.9.spec
@@ -93,6 +93,8 @@ Requires:  ruby193-rubygem-tzinfo
 Requires:  ruby193-rubygem-uglifier
 Requires:  ruby193-rubygem-xml-simple
 Requires:  ruby193-runtime
+Requires:  ruby193-rubygem-daemon_controller
+Requires:  ruby193-rubygem-fastthread
 Requires:  ruby193-rubygem-passenger
 Requires:  ruby193-rubygem-passenger-devel
 Requires:  ruby193-rubygem-passenger-native


### PR DESCRIPTION
Fix for bugz 846108 - passenger_status fails due to missing gems. Add missing gems to spec.
