### PR TITLE
Improve database cartridge runtime test coverage

### DIFF
--- a/stickshift/controller/test/cucumber/cartridge-runtime-extended-db.feature
+++ b/stickshift/controller/test/cucumber/cartridge-runtime-extended-db.feature
@@ -1,0 +1,26 @@
+@runtime
+Feature: Cartridge Runtime Extended Checks (Database)
+
+  @runtime_extended2
+  Scenario Outline: Embed and then unembed database cartridges
+    Given a new <app_type> type application
+    
+    When I embed a <db_cart_type> cartridge into the application
+    Then a <db_proc> process will be running
+    And the embedded <db_cart_type> cartridge directory will exist
+    And the <db_name> configuration file will exist
+    And the <db_name> database will exist
+    And the embedded <db_cart_type> cartridge control script will exist
+    
+    When I remove the <db_cart_type> cartridge from the application
+    Then a <db_proc> process will not be running
+    And the <db_name> database will not exist
+    And the embedded <db_cart_type> cartridge control script will not exist
+    And the <db_name> configuration file will not exist
+    And the embedded <db_cart_type> cartridge directory will not exist
+
+  Scenarios: Embed/Unembed database cartridge scenarios
+    | app_type  | db_cart_type    | db_proc   | db_name     |
+    | php-5.3   | mysql-5.1       | mysqld    | mysql       |
+    | php-5.3   | postgresql-8.4  | postgres  | postgresql  |
+    | php-5.3   | mongodb-2.0     | mongod    | mongodb     |

--- a/stickshift/controller/test/cucumber/step_definitions/runtime_steps.rb
+++ b/stickshift/controller/test/cucumber/step_definitions/runtime_steps.rb
@@ -119,6 +119,20 @@ When /^I (fail to )?embed a ([^ ]+) cartridge into the application$/ do | negate
 end
 
 
+# Un-embeds a cartridge from the current application's gear by 
+# invoking deconfigure on the named cartridge.
+When /^I remove the ([^ ]+) cartridge from the application$/ do | cart_name |
+  record_measure("Runtime Benchmark: Deconfigure #{cart_name} cartridge in cartridge #{@cart.name}") do
+    raise "No embedded cart named #{cart_name} associated with gear #{gear.uuid}" unless @gear.carts.has_key?(cart_name)
+
+    embedded_cart = @gear.carts[cart_name]
+
+    exit_code = embedded_cart.deconfigure
+    assert_equal 0, exit_code
+  end
+end
+
+
 # Verifies the existence of httpd proxy files associated with
 # the current application.
 Then /^the application http proxy file will( not)? exist$/ do | negate |


### PR DESCRIPTION
Add specific coverage for database cartridges which
exercises the embedded cart deconfigure scripts without
destroying the entire application.

There have been bugs in the database cart deconfigure
scripts which are only caught when the db carts are
removed while leaving the app intact.
