### PR TITLE
Attempt to stop processes with TERM then KILL

### DIFF
--- a/stickshift/node/lib/stickshift-node/model/unix_user.rb
+++ b/stickshift/node/lib/stickshift-node/model/unix_user.rb
@@ -555,11 +555,12 @@ module StickShift
         raise ArgumentError, "Supplied ID must be a user name or uid."
       end
 
-      sig="KILL"
+      sig="TERM"
       10.times do |i|
         out,err,rc = shellCmd(%{/usr/bin/killall -s '#{sig}' -u '#{id}' 2> /dev/null})
         break unless rc == 0
         sleep 0.5
+        sig="KILL"
       end
     end
 


### PR DESCRIPTION
Enhancement for BZ 848639: The force kill was leaving SystemV IPC entities around
