### PR TITLE
Set db ctl script var that was no longer getting set due to refactoring.

### DIFF
--- a/cartridges/mysql-5.1/info/hooks/move
+++ b/cartridges/mysql-5.1/info/hooks/move
@@ -61,6 +61,7 @@ fi
 
 # Create simple mysql start / stop script
 ln -sf $CART_INFO_DIR/bin/mysql_ctl.sh $MYSQL_DIR/${application}_mysql_ctl.sh
+OPENSHIFT_DB_CTL_SCRIPT="$MYSQL_DIR/${application}_mysql_ctl.sh"
 
 #
 # Fix permissions

--- a/cartridges/mysql-5.1/info/hooks/post-move
+++ b/cartridges/mysql-5.1/info/hooks/post-move
@@ -40,7 +40,8 @@ IP=$OPENSHIFT_INTERNAL_IP
 . $APP_HOME/.env/OPENSHIFT_DB_PORT
 . $APP_HOME/.env/OPENSHIFT_DB_PASSWORD
 . $APP_HOME/.env/OPENSHIFT_DB_USERNAME
-    
+
+OPENSHIFT_DB_CTL_SCRIPT="$MYSQL_DIR/${application}_mysql_ctl.sh"
 start_db
 
     echo "

--- a/cartridges/mysql-5.1/info/hooks/pre-move
+++ b/cartridges/mysql-5.1/info/hooks/pre-move
@@ -55,6 +55,7 @@ then
     error "Can not move mysql without OPENSHIFT_DB_PASSWORD" 188
 else
 
+OPENSHIFT_DB_CTL_SCRIPT="$MYSQL_DIR/${application}_mysql_ctl.sh"
 start_db
 
     echo "


### PR DESCRIPTION
Set the required variable for start/stop operations.
