### PR TITLE
Clean up DB environment variables during pre-destroy

### DIFF
--- a/cartridges/mongodb-2.0/info/hooks/pre-destroy
+++ b/cartridges/mongodb-2.0/info/hooks/pre-destroy
@@ -30,8 +30,9 @@ source /etc/stickshift/stickshift-node.conf
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
 app_remove_env_var OPENSHIFT_NOSQL_DB_GEAR_UUID
-app_remove_env_var OPENSHIFT_GEAR_DNS
 app_remove_env_var OPENSHIFT_NOSQL_DB_CTL_SCRIPT
+app_remove_env_var OPENSHIFT_NOSQL_DB_CTL_ONGEAR_SCRIPT
+app_remove_env_var OPENSHIFT_NOSQL_DB_GEAR_DNS
 app_remove_env_var OPENSHIFT_NOSQL_DB_TYPE
 app_remove_env_var OPENSHIFT_NOSQL_DB_USERNAME
 app_remove_env_var OPENSHIFT_NOSQL_DB_PASSWORD
@@ -42,4 +43,3 @@ app_remove_env_var OPENSHIFT_NOSQL_DB_MONGODB_20_DUMP
 app_remove_env_var OPENSHIFT_NOSQL_DB_MONGODB_20_DUMP_CLEANUP
 app_remove_env_var OPENSHIFT_NOSQL_DB_MONGODB_20_EMBEDDED_TYPE
 app_remove_env_var OPENSHIFT_NOSQL_DB_MONGODB_20_RESTORE
-

--- a/cartridges/postgresql-8.4/info/hooks/pre-destroy
+++ b/cartridges/postgresql-8.4/info/hooks/pre-destroy
@@ -30,8 +30,9 @@ source /etc/stickshift/stickshift-node.conf
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
 app_remove_env_var OPENSHIFT_DB_GEAR_UUID
-app_remove_env_var OPENSHIFT_GEAR_DNS
+app_remove_env_var OPENSHIFT_DB_GEAR_DNS
 app_remove_env_var OPENSHIFT_DB_CTL_SCRIPT
+app_remove_env_var OPENSHIFT_DB_CTL_ONGEAR_SCRIPT
 app_remove_env_var OPENSHIFT_DB_TYPE
 app_remove_env_var OPENSHIFT_DB_USERNAME
 app_remove_env_var OPENSHIFT_DB_PASSWORD
@@ -43,4 +44,3 @@ app_remove_env_var OPENSHIFT_DB_POSTGRESQL_84_DUMP
 app_remove_env_var OPENSHIFT_DB_POSTGRESQL_84_DUMP_CLEANUP
 app_remove_env_var OPENSHIFT_DB_POSTGRESQL_84_EMBEDDED_TYPE
 app_remove_env_var OPENSHIFT_DB_POSTGRESQL_84_RESTORE
-


### PR DESCRIPTION
Remove a few staggling environment variables which weren't
being cleaned up during the pre-destroy hook execution.
