### PR TITLE
to-master: Fix bugz 851315 - user deploy hook is not called on the local serving gear

### DIFF
--- a/cartridges/haproxy-1.4/info/bin/deploy.sh
+++ b/cartridges/haproxy-1.4/info/bin/deploy.sh
@@ -9,6 +9,8 @@ done
 source /etc/stickshift/stickshift-node.conf
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
+${CARTRIDGE_BASE_PATH}/abstract/info/bin/deploy.sh
+
 # Sync to the other gears
 ${CARTRIDGE_BASE_PATH}/${OPENSHIFT_GEAR_TYPE}/info/bin/sync_gears.sh
 


### PR DESCRIPTION
to master : Fix bugz 851315 - user deploy hook is not called on the local serving gear
