### PR TITLE
fixing stickshift port proxy for fedora

### DIFF
--- a/stickshift/port-proxy/stickshift-port-proxy.spec
+++ b/stickshift/port-proxy/stickshift-port-proxy.spec
@@ -37,6 +37,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %if %{with_systemd}
 mkdir -p %{buildroot}%{_unitdir}
+mkdir -p %{buildroot}%{_sysconfdir}/sysconfig/stickshift-proxy
 %else
 mkdir -p %{buildroot}%{_initddir}
 %endif


### PR DESCRIPTION
[merge] need to create directory for installing stickshift proxy service for fedora
