### PR TITLE
Fix for bugz 852518 - Failed move due to httpd.pid file being empty.

### DIFF
--- a/cartridges/phpmyadmin-3.4/info/bin/phpmyadmin_ctl.sh
+++ b/cartridges/phpmyadmin-3.4/info/bin/phpmyadmin_ctl.sh
@@ -35,6 +35,8 @@ case "$1" in
     ;;
 
     graceful-stop|stop)
+        # Don't exit on errors on stop.
+        set +e
         if [ -f ${OPENSHIFT_PHPMYADMIN_GEAR_DIR}run/httpd.pid ]
         then
             src_user_hook pre_stop_phpmyadmin-3.4


### PR DESCRIPTION
Fix for bugz 852518 - Failed move due to httpd.pid file being empty.
