### PR TITLE
Use the agreed on newer broker tags for jenkins and jenkins-client

### DIFF
--- a/cartridges/jenkins-1.4/info/manifest.yml
+++ b/cartridges/jenkins-1.4/info/manifest.yml
@@ -7,7 +7,7 @@ Vendor:
 Categories:
   - cartridge
   - web_framework
-  - builds
+  - ci
 Website: http://www.jenkins-ci.org
 Help-Topics:
   "Developer Center": https://openshift.redhat.com/community/developers

--- a/cartridges/jenkins-client-1.4/info/manifest.yml
+++ b/cartridges/jenkins-client-1.4/info/manifest.yml
@@ -7,7 +7,7 @@ Vendor:
 Categories:
   - cartridge
   - web_framework
-  - builds
+  - ci_builder
 Cart-Data:
   - Key: "job_url"
     Type: cart_data


### PR DESCRIPTION
This change is necessary in order to fully pull tags from the broker - right now Jenkins is using :builds which has a different meaning than what the site expects.
