### PR TITLE
Fix bugz 852216, 852518 and 853372 - zend /sandbox, failed moves due to invalid httpd.pid files

### DIFF
--- a/cartridges/phpmyadmin-3.4/info/bin/phpmyadmin_ctl.sh
+++ b/cartridges/phpmyadmin-3.4/info/bin/phpmyadmin_ctl.sh
@@ -2,6 +2,7 @@
 
 source "/etc/stickshift/stickshift-node.conf"
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
+source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/apache
 
 # Import Environment Variables
 for f in ~/.env/*
@@ -20,6 +21,8 @@ validate_run_as_user
 export PHPRC="${OPENSHIFT_PHPMYADMIN_GEAR_DIR}conf/php.ini"
 
 CART_CONF_DIR=${CARTRIDGE_BASE_PATH}/embedded/phpmyadmin-3.4/info/configuration/etc/conf
+HTTPD_CFG_FILE=$CART_CONF_DIR/httpd_nolog.conf
+HTTPD_PID_FILE=${OPENSHIFT_PHPMYADMIN_GEAR_DIR}run/httpd.pid
 
 case "$1" in
     start)
@@ -28,8 +31,9 @@ case "$1" in
             echo "Application is explicitly stopped!  Use 'rhc app cartridge start -a ${OPENSHIFT_GEAR_NAME} -c phpmyadmin-3.4' to start back up." 1>&2
             exit 0
         else
+            ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
             src_user_hook pre_start_phpmyadmin-3.4
-            /usr/sbin/httpd -C "Include ${OPENSHIFT_PHPMYADMIN_GEAR_DIR}conf.d/*.conf" -f $CART_CONF_DIR/httpd_nolog.conf -k $1
+            /usr/sbin/httpd -C "Include ${OPENSHIFT_PHPMYADMIN_GEAR_DIR}conf.d/*.conf" -f $HTTPD_CFG_FILE -k $1
             run_user_hook post_start_phpmyadmin-3.4
         fi
     ;;
@@ -37,19 +41,18 @@ case "$1" in
     graceful-stop|stop)
         # Don't exit on errors on stop.
         set +e
-        if [ -f ${OPENSHIFT_PHPMYADMIN_GEAR_DIR}run/httpd.pid ]
-        then
-            src_user_hook pre_stop_phpmyadmin-3.4
-            httpd_pid=`cat ${OPENSHIFT_PHPMYADMIN_GEAR_DIR}run/httpd.pid 2> /dev/null`
-            /usr/sbin/httpd -C "Include ${OPENSHIFT_PHPMYADMIN_GEAR_DIR}conf.d/*.conf" -f $CART_CONF_DIR/httpd_nolog.conf -k $1
-            wait_for_stop $httpd_pid
-            run_user_hook post_stop_phpmyadmin-3.4
-        fi
+        src_user_hook pre_stop_phpmyadmin-3.4
+        httpd_pid=`cat "$HTTPD_PID_FILE" 2> /dev/null`
+        ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
+        /usr/sbin/httpd -C "Include ${OPENSHIFT_PHPMYADMIN_GEAR_DIR}conf.d/*.conf" -f $HTTPD_CFG_FILE -k $1
+        wait_for_stop $httpd_pid
+        run_user_hook post_stop_phpmyadmin-3.4
     ;;
 
     restart|graceful)
+        ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
         src_user_hook pre_start_phpmyadmin-3.4
-        /usr/sbin/httpd -C "Include ${OPENSHIFT_PHPMYADMIN_GEAR_DIR}conf.d/*.conf" -f $CART_CONF_DIR/httpd_nolog.conf -k $1
+        /usr/sbin/httpd -C "Include ${OPENSHIFT_PHPMYADMIN_GEAR_DIR}conf.d/*.conf" -f $HTTPD_CFG_FILE -k $1
         run_user_hook post_start_phpmyadmin-3.4
     ;;
 esac

--- a/stickshift/abstract/abstract-httpd/info/bin/app_ctl_stop.sh
+++ b/stickshift/abstract/abstract-httpd/info/bin/app_ctl_stop.sh
@@ -2,6 +2,7 @@
 
 source "/etc/stickshift/stickshift-node.conf"
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
+source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/apache
 
 # Import Environment Variables
 for f in ~/.env/*
@@ -11,10 +12,16 @@ done
 
 CART_CONF_DIR=${CARTRIDGE_BASE_PATH}/${OPENSHIFT_GEAR_TYPE}/info/configuration/etc/conf
 
+cart_instance_dir=${OPENSHIFT_HOMEDIR}/${CARTRIDGE_TYPE}
+
+HTTPD_CFG_FILE=$CART_CONF_DIR/httpd_nolog.conf
+HTTPD_PID_FILE=$cart_instance_dir/run/httpd.pid
+
 # Stop the app
 src_user_hook pre_stop_${CARTRIDGE_TYPE}
 set_app_state stopped
-httpd_pid=`cat ${OPENSHIFT_RUN_DIR}httpd.pid 2> /dev/null`
-/usr/sbin/httpd -C "Include ${OPENSHIFT_GEAR_DIR}conf.d/*.conf" -f $CART_CONF_DIR/httpd_nolog.conf -k $1
+httpd_pid=`cat "$HTTPD_PID_FILE" 2> /dev/null`
+ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
+/usr/sbin/httpd -C "Include ${OPENSHIFT_GEAR_DIR}conf.d/*.conf" -f $HTTPD_CFG_FILE -k $1
 wait_for_stop $httpd_pid
 run_user_hook post_stop_${CARTRIDGE_TYPE}

--- a/stickshift/abstract/abstract/info/lib/apache
+++ b/stickshift/abstract/abstract/info/lib/apache
@@ -21,3 +21,22 @@ function restart_httpd_graceful {
     ${CARTRIDGE_BASE_PATH}/abstract/info/bin/httpd_singular graceful 2> /dev/null || \
     error "Failed to restart master httpd, please contact support" 120
 }
+
+
+function pid_is_httpd() {
+    ps -p "$1" 2> /dev/null | grep httpd > /dev/null
+}
+
+function killall_matching_httpds() {
+   [ -z "$1" ]  &&  return 1
+   ps -u `id -u` -o pid,command | grep "$1" | grep -v "grep" |    \
+       awk '{ print $1 }' |  xargs kill -9  > /dev/null 2>&1  || :
+}
+
+function ensure_valid_httpd_process() {
+    # $1 == pidfile.
+    # $2 == httpd config file.
+    [ -n "$1" ]  &&  [ -f "$1" ]  &&  pid_is_httpd `cat "$1"`  &&  return 0
+    [ -n "$1" ]  &&  rm -f "$1"
+    killall_matching_httpds "$2"
+}

--- a/stickshift/node/lib/stickshift-node/model/unix_user.rb
+++ b/stickshift/node/lib/stickshift-node/model/unix_user.rb
@@ -378,7 +378,7 @@ module StickShift
     #   # Creates:
     #   # ~
     #   # ~/.tmp/
-    #   # ~/.sandbox
+    #   # ~/.sandbox/$uuid
     #   # ~/.env/
     #   # APP_UUID, GEAR_UUID, APP_NAME, APP_DNS, HOMEDIR, DATA_DIR, GEAR_DIR, \
     #   #   GEAR_DNS, GEAR_NAME, GEAR_CTL_SCRIPT, PATH, REPO_DIR, TMP_DIR
@@ -402,6 +402,10 @@ module StickShift
       sandbox_dir = File.join(homedir, ".sandbox")
       FileUtils.mkdir_p sandbox_dir
       FileUtils.chmod(0o0000, sandbox_dir)
+
+      sandbox_uuid_dir = File.join(sandbox_dir, @uuid)
+      FileUtils.mkdir_p sandbox_uuid_dir
+      FileUtils.chmod(0o1755, sandbox_uuid_dir)
 
       env_dir = File.join(homedir, ".env")
       FileUtils.mkdir_p(env_dir)


### PR DESCRIPTION
Fix for bugz 852216 - zend /sandbox should be root owned if possible.
Fix for bugz 852518 - Failed move due to httpd.pid file being empty.
Fix for bugz 853372 - Failed to move primary cartridge app due to httpd.pid file being empty.
