### PR TITLE
Reduce php.ini serialize_precision value

### DIFF
--- a/cartridges/php-5.3/info/configuration/etc/conf/php.ini
+++ b/cartridges/php-5.3/info/configuration/etc/conf/php.ini
@@ -318,7 +318,7 @@ unserialize_callback_func =
 ; When floats & doubles are serialized store serialize_precision significant
 ; digits after the floating point. The default value ensures that when floats
 ; are decoded with unserialize, the data will remain the same.
-serialize_precision = 100
+serialize_precision = 17
 
 ; This directive allows you to enable and disable warnings which PHP will issue
 ; if you pass a value by reference at function call time. Passing values by


### PR DESCRIPTION
The float/double precision is 14 anyway (see precision = 14), so we
don't need to serialize 100 digits. Let's just use the default value
(which is 17 digits from PHP 5.3.6).
