### PR TITLE
Fix for bugz  852486 - rubygem-stickshift-node is running restorecon against /var/lib/stickshift

### DIFF
--- a/stickshift/node/stickshift-node.spec
+++ b/stickshift/node/stickshift-node.spec
@@ -100,7 +100,6 @@ rm -rf %{buildroot}
 
 %post
 echo "/usr/bin/ss-trap-user" >> /etc/shells
-restorecon -r %{_var}/lib/stickshift
 
 # copying this file in the post hook so that this file can be replaced by rhc-node
 # copy this file only if it doesn't already exist


### PR DESCRIPTION
One more fix for bugz  852486 - rubygem-stickshift-node is running restorecon against /var/lib/stickshift
