### PR TITLE
Fix for Bug 852268

### DIFF
--- a/stickshift/abstract/abstract/info/bin/post_receive_app.sh
+++ b/stickshift/abstract/abstract/info/bin/post_receive_app.sh
@@ -46,6 +46,7 @@ then
         # Start the app
         if hot_deploy_marker_is_present; then
             echo "App will not be started due to presence of hot_deploy marker"
+            set_app_state started
         else
             start_app.sh
         fi

--- a/stickshift/controller/test/cucumber/step_definitions/runtime_steps.rb
+++ b/stickshift/controller/test/cucumber/step_definitions/runtime_steps.rb
@@ -448,6 +448,11 @@ Then /^the tracked application cartridge PIDs should( not)? be changed$/ do |neg
     raise "Expected PID differences, but found none. Old PIDs: #{@current_cart_pids.inspect},"\
       " new PIDs: #{new_cart_pids.inspect}"
   end
+
+  # verify BZ852268 fix
+  state_file = File.join($home_root, @gear.uuid, 'app-root', 'runtime', '.state')
+  state = File.read(state_file).chomp
+  assert_equal 'started', state
 end
 
 Then /^the web console for the ([^ ]+)\-([\d\.]+) cartridge at ([^ ]+) is( not)? accessible$/ do |cart_type, version, uri, negate|


### PR DESCRIPTION
- set state to 'started' after hot deploy of code
  - update hot_deploy marker tests to check for state
