### PR TITLE
BZ 854764: Changes based on Fedora review

### DIFF
--- a/stickshift/port-proxy/bin/stickshift-proxy-cfg
+++ b/stickshift/port-proxy/bin/stickshift-proxy-cfg
@@ -7,7 +7,8 @@
 
 source /etc/stickshift/stickshift-node.conf
 
-cfgfile=/var/lib/stickshift/.stickshift-proxy.d/stickshift-proxy.cfg
+cfgfile=/etc/stickshift/stickshift-proxy.cfg
+vardir=${GEAR_BASE_DIR}/.stickshift-proxy.d
 
 
 ### 
@@ -125,7 +126,7 @@ rollcfg() {
 
 
 lockwrap() {
-    exec 200>${cfgfile}.lock 201>${cfgfile}.reload.lock
+    exec 200>${vardir}/lock 201>${vardir}/reload-lock
 
     flock 200
     oldsum=$( md5sum $cfgfile | awk '{ print $1 }' )
@@ -140,12 +141,12 @@ lockwrap() {
     fi
 
     if [ $oldsum != $newsum ]; then
-        reqfile=$(mktemp ${cfgfile}.reload.req.XXXXXX)
+        reqfile=$(mktemp ${vardir}/reload-req.XXXXXX)
         flock 201
 
         reloadreq=()
         reloadit=""
-        for f in ${cfgfile}.reload.req.??????
+        for f in ${vardir}/reload-req.??????
         do
             s=$(stat --printf '%s' "$f" )
             if [ $s -eq 0 ]

--- a/stickshift/port-proxy/init-scripts/stickshift-proxy
+++ b/stickshift/port-proxy/init-scripts/stickshift-proxy
@@ -23,7 +23,7 @@ exec=/usr/sbin/haproxy
 prog=haproxy
 lockfile=/var/lock/subsys/stickshift-proxy
 pidfile=/var/run/stickshift-proxy.pid
-cfgfile=/var/lib/stickshift/.stickshift-proxy.d/stickshift-proxy.cfg
+cfgfile=/etc/stickshift/stickshift-proxy.cfg
 
 pre_start() {
     # Fix internal ip address in case it was changed by the cloud provider

--- a/stickshift/port-proxy/stickshift-port-proxy.spec
+++ b/stickshift/port-proxy/stickshift-port-proxy.spec
@@ -13,9 +13,7 @@ Source0:       stickshift-port-proxy-%{version}.tar.gz
 %define with_systemd 0
 %endif
 
-BuildRoot:     %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 Requires:      haproxy
-Requires:      procmail
 %if %{with_systemd}
 BuildRequires: systemd-units
 Requires:  systemd-units
@@ -54,15 +52,7 @@ install -m 755 init-scripts/stickshift-proxy %{buildroot}%{_initddir}
 install -m 644 config/stickshift-proxy.cfg %{buildroot}%{_sysconfdir}/stickshift/
 install -m 755 bin/stickshift-proxy-cfg %{buildroot}%{_bindir}/stickshift-proxy-cfg
 
-%clean
-rm -rf $RPM_BUILD_ROOT
-
 %post
-# Enable proxy and fix if the config file is missing
-if ! [ -f /var/lib/stickshift/.stickshift-proxy.d/stickshift-proxy.cfg ]; then
-   cp /etc/stickshift/stickshift-proxy.cfg /var/lib/stickshift/.stickshift-proxy.d/stickshift-proxy.cfg
-   restorecon /var/lib/stickshift/.stickshift-proxy.d/stickshift-proxy.cfg || :
-fi
 /sbin/restorecon /var/lib/stickshift/.stickshift-proxy.d/ || :
 
 %if %{with_systemd}
@@ -83,14 +73,14 @@ fi
 %files
 %defattr(-,root,root,-)
 %if %{with_systemd}
-%attr(0644,-,-) %{_unitdir}/stickshift-proxy.service
-%attr(0644,-,-) %{_sysconfdir}/sysconfig/stickshift-proxy
+%{_unitdir}/stickshift-proxy.service
+%{_sysconfdir}/sysconfig/stickshift-proxy
 %else
-%attr(0750,-,-) %{_initddir}/stickshift-proxy
+%{_initddir}/stickshift-proxy
 %endif
-%attr(0755,-,-) %{_bindir}/stickshift-proxy-cfg
-%dir %attr(0750,root,root) %{_localstatedir}/lib/stickshift/.stickshift-proxy.d
-%attr(0640,-,-) %config(noreplace) %{_sysconfdir}/stickshift/stickshift-proxy.cfg
+%{_bindir}/stickshift-proxy-cfg
+%dir %attr(0750,-,-) %{_localstatedir}/lib/stickshift/.stickshift-proxy.d
+%config(noreplace) %{_sysconfdir}/stickshift/stickshift-proxy.cfg
 
 %changelog
 * Thu Aug 30 2012 Adam Miller <admiller@redhat.com> 0.2.2-1

--- a/stickshift/port-proxy/systemd/stickshift-proxy.env
+++ b/stickshift/port-proxy/systemd/stickshift-proxy.env
@@ -1,7 +1,7 @@
 # Configuration file for the stickshift-proxy service.
 
 # Set the configuration file location
-STICKSHIFT_PROXY_CONFIG="/var/lib/stickshift/.stickshift-proxy.d/stickshift-proxy.cfg"
+STICKSHIFT_PROXY_CONFIG="/etc/stickshift/stickshift-proxy.cfg"
 
 # To pass additional options to the stickshift-proxy binary at
 # startup, set OPTIONS here.


### PR DESCRIPTION
Move configuration file to /etc; leave lock files and reload requests in... /var/lib/stickshift.
