### PR TITLE
BZ 855990: systemd wrapper script for haproxy

### DIFF
--- a/stickshift/port-proxy/config/stickshift-proxy.cfg
+++ b/stickshift/port-proxy/config/stickshift-proxy.cfg
@@ -12,11 +12,9 @@ global
     log         127.0.0.1 local2
     
     chroot      /var/lib/haproxy
-    pidfile     /var/run/stickshift-proxy.pid
     maxconn     30000
     user        haproxy
     group       haproxy
-    daemon
 
     # turn on stats unix socket
     stats socket /var/lib/haproxy/stickshift-proxy-stats

--- a/stickshift/port-proxy/systemd/stickshift-proxy
+++ b/stickshift/port-proxy/systemd/stickshift-proxy
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+#
+# Wrap haproxy to provide LSB compatible behavior for systemd.
+#
+# The haproxy reload swaps daemon processes which causes systemd
+# to behave as though the service has failed.
+#
+
+[ -f /etc/sysconfig/stickshift-proxy ] && \
+    source /etc/sysconfig/stickshift-proxy
+
+HAPROXY_PID=""
+
+function reload {
+    if [ "$HAPROXY_PID" ]; then
+        /sbin/haproxy -f "$STICKSHIFT_PROXY_CONFIG" $OPTIONS -sf $HAPROXY_PID &
+        HAPROXY_PID=$!
+        echo "$HAPROXY_PID" > /run/stickshift-proxy.pid
+    else
+        exit 127
+    fi
+}
+
+function redeliver {
+    if [ "$HAPROXY_PID" ]; then
+        /bin/kill -s "$1" "$HAPROXY_PID"
+        rv=$?
+        if [ $rv -ne 0 ]; then
+            exit $rv
+        fi
+    else
+        exit 127
+    fi
+}
+
+function cleaner {
+    rm -f /run/stickshift-proxy.pid
+}
+
+
+# Start haproxy
+/usr/bin/stickshift-proxy-cfg fixaddr
+
+/sbin/haproxy -f "$STICKSHIFT_PROXY_CONFIG" $OPTIONS &
+HAPROXY_PID=$!
+echo "$HAPROXY_PID" > /run/stickshift-proxy.pid
+
+trap "cleaner" EXIT
+
+trap "reload" USR2
+
+for sig in HUP INT TERM USR1 TTOU TTIN QUIT PIPE; do
+    trap "redeliver $sig" "$sig"
+done
+
+while true
+do
+    oldpid=$HAPROXY_PID
+    wait $oldpid
+    rv=$?
+    if [ "$oldpid" == "$HAPROXY_PID" ]; then
+        exit $rv
+    fi
+done

--- a/stickshift/port-proxy/systemd/stickshift-proxy.service
+++ b/stickshift/port-proxy/systemd/stickshift-proxy.service
@@ -3,12 +3,8 @@ Description=Stickshift Port Proxy
 After=syslog.target network.target remote-fs.target nss-lookup.target
 
 [Service]
-Type=forking
-PIDFile=/run/stickshift-proxy.pid
-EnvironmentFile=/etc/sysconfig/stickshift-proxy
-ExecStartPre=stickshift-proxy-cfg fixaddr
-ExecStart=@/usr/sbin/haproxy stickshift-proxy -D -f $STICKSHIFT_PROXY_CONFIG -p /run/stickshift-proxy.pid
-ExecReload=@/usr/sbin/haproxy stickshift-proxy -D -f $STICKSHIFT_PROXY_CONFIG -p /run/stickshift-proxy.pid -sf $MAINPID
+ExecStart=/usr/sbin/stickshift-proxy
+ExecReload=/bin/kill -USR2 $MAINPID
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fedora 17 systemd support requres a wrapper which is LSB compliant.
