### PR TITLE
Fix for bugz 856487 - Can't add mongodb-2.0 for ruby1.9 app successfully.

### DIFF
--- a/cartridges/mongodb-2.0/info/bin/mongodb_ctl.sh
+++ b/cartridges/mongodb-2.0/info/bin/mongodb_ctl.sh
@@ -14,6 +14,11 @@ do
     . $f
 done
 
+#  FIXME: Temporary fix for bugz 856487 - Can't add mongodb-2.0 to a ruby1.9 app
+#         This needs to be removed once we change how we hande sclized versions
+#         of packages.
+unset LD_LIBRARY_PATH
+
 export STOPTIMEOUT=10
 
 if whoami | grep -q root

--- a/cartridges/mongodb-2.0/info/bin/mongodb_dump.sh
+++ b/cartridges/mongodb-2.0/info/bin/mongodb_dump.sh
@@ -6,6 +6,11 @@ do
     . $f
 done
 
+#  FIXME: Temporary fix for bugz 856487 - Can't add mongodb-2.0 to a ruby1.9 app
+#         This needs to be removed once we change how we hande sclized versions
+#         of packages.
+unset LD_LIBRARY_PATH
+
 source /etc/stickshift/stickshift-node.conf
 CART_INFO_DIR=${CARTRIDGE_BASE_PATH}/embedded/mongodb-2.0/info
 source ${CART_INFO_DIR}/lib/util

--- a/cartridges/mongodb-2.0/info/bin/mongodb_restore.sh
+++ b/cartridges/mongodb-2.0/info/bin/mongodb_restore.sh
@@ -6,6 +6,11 @@ do
     . $f
 done
 
+#  FIXME: Temporary fix for bugz 856487 - Can't add mongodb-2.0 to a ruby1.9 app
+#         This needs to be removed once we change how we hande sclized versions
+#         of packages.
+unset LD_LIBRARY_PATH
+
 source /etc/stickshift/stickshift-node.conf
 CART_INFO_DIR=${CARTRIDGE_BASE_PATH}/embedded/mongodb-2.0/info
 source ${CART_INFO_DIR}/lib/util


### PR DESCRIPTION
Fix for bugz 856487 - Can't add mongodb-2.0 for ruby1.9 app successfully.
