### PR TITLE
F17 related fixes to stickshift-port-proxy

### DIFF
--- a/stickshift/abstract/abstract/info/lib/network
+++ b/stickshift/abstract/abstract/info/lib/network
@@ -116,12 +116,8 @@ function uuid_to_portrange {
 
 function proxy_cmd {
   # Run proxy commands if one exists; otherwise, this is a stub.
-  if chkconfig --list stickshift-proxy >/dev/null 2>&1 
-  then
-    stickshift-proxy-cfg "${@}"
-    return $?
-  fi
-  return 0
+  stickshift-proxy-cfg "${@}"
+  return $?
 }
 
 function find_next_proxy_port {

--- a/stickshift/node/lib/stickshift-node/model/unix_user.rb
+++ b/stickshift/node/lib/stickshift-node/model/unix_user.rb
@@ -558,13 +558,9 @@ module StickShift
 
       proxy_port_range = (proxy_port_begin ... (proxy_port_begin + ports_per_user))
 
-      cmd = %{/sbin/chkconfig --list stickshift-proxy}
-      out,err,rc = shellCmd(cmd)
-      if rc == 0
-        cmd = %{stickshift-proxy-cfg setproxy}
-        proxy_port_range.each { |i| cmd << " #{i} delete" }
-        out, err, rc = shellCmd(cmd)
-      end
+      cmd = %{stickshift-proxy-cfg setproxy}
+      proxy_port_range.each { |i| cmd << " #{i} delete" }
+      out, err, rc = shellCmd(cmd)
 
       notify_observers(:after_initialize_stickshift_proxy)
       return rc == 0


### PR DESCRIPTION
The chkconfig test no longer works on F17 and was no longer needed once port-proxy moved to Crankcase
