### PR TITLE
[TO STAGE] Bug 849950 - web_framework does not belong on jenkins client

### DIFF
--- a/cartridges/jenkins-client-1.4/info/manifest.yml
+++ b/cartridges/jenkins-client-1.4/info/manifest.yml
@@ -6,7 +6,6 @@ License: ASL 2.0
 Vendor: 
 Categories:
   - cartridge
-  - web_framework
   - ci_builder
 Cart-Data:
   - Key: "job_url"


### PR DESCRIPTION
Resolves bad tag on jenkins-client
