### PR TITLE
Remove non working example from default server.js

### DIFF
--- a/cartridges/nodejs-0.6/template/node_modules/read.me
+++ b/cartridges/nodejs-0.6/template/node_modules/read.me
@@ -3,6 +3,5 @@ This directory allows you to package any Node modules (that your application
 depends on) along with your application.
 
 If you just wish to install module(s) from the npm registry (npmjs.org), you
-can specify the module name(s) and optionally version in your application's
-dependency list file (../deplist.txt).
-
+can specify the module name(s) and optionally version in the package.json file,
+in the dependencies array.

--- a/cartridges/nodejs-0.6/template/server.js
+++ b/cartridges/nodejs-0.6/template/server.js
@@ -21,12 +21,6 @@ app.get('/health', function(req, res){
     res.send('1');
 });
 
-// Handler for GET /asciimo
-app.get('/asciimo', function(req, res){
-    var link="https://a248.e.akamai.net/assets.github.com/img/d84f00f173afcf3bc81b4fad855e39838b23d8ff/687474703a2f2f696d6775722e636f6d2f6b6d626a422e706e67";
-    res.send("<html><body><img src='" + link + "'></body></html>");
-});
-
 // Handler for GET /
 app.get('/', function(req, res){
     res.send(zcache['index.html'], {'Content-Type': 'text/html'});


### PR DESCRIPTION
The url seems to no longer work, and I suspect that referencing a
specific akamai.net caching server is too fragile to be kept, since
this may change anytime
