### PR TITLE
Do not return a unclear error message if json_data is not set

### DIFF
--- a/controller/app/controllers/legacy_broker_controller.rb
+++ b/controller/app/controllers/legacy_broker_controller.rb
@@ -384,7 +384,7 @@ class LegacyBrokerController < ApplicationController
   def validate_request
     @reply = ResultIO.new
     begin
-      @req = LegacyRequest.new.from_json(params['json_data'])
+      @req = LegacyRequest.new.from_json(params['json_data'] || '{}')
       if @req.invalid?
         log_action('nil','nil', 'nil', "LEGACY_BROKER", false, "Validation error: #{@req.errors.first[1][:message]}")
         @reply.resultIO << @req.errors.first[1][:message]


### PR DESCRIPTION
Test with :
   curl -d ''  http://127.0.0.1:8080/broker/cartlist

While this should return a error message, the current code return
a ruby traceback, which is not helpful to understand what is going on.
