### PR TITLE
fix wrong error message in cart_list REST action

### DIFF
--- a/controller/app/controllers/legacy_broker_controller.rb
+++ b/controller/app/controllers/legacy_broker_controller.rb
@@ -195,7 +195,7 @@ class LegacyBrokerController < ApplicationController
     cart_type = @req.cart_type                                                                                                                                                                                                                                    
     unless cart_type
       log_action('nil', 'nil', 'nil', "LEGACY_CART_LIST", true, "Cartridge type not specified", get_extra_log_args)
-      @reply.resultIO << "Invalid cartridge types: #{cart_type} specified"
+      @reply.resultIO << "Cartridge type not specified"
       @reply.exitcode = 109
       render :json => @reply, :status => :bad_request
       return


### PR DESCRIPTION
if cart_type is empty, the error message should not use the variable
