### PR TITLE
Fix bugz 851427 and 851494

### DIFF
--- a/cartridges/haproxy-1.4/info/bin/deploy.sh
+++ b/cartridges/haproxy-1.4/info/bin/deploy.sh
@@ -11,6 +11,10 @@ source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
 ${CARTRIDGE_BASE_PATH}/abstract/info/bin/deploy.sh
 
+#  For auto-scaling disabled, ensure the haproxy control daemon is stopped.
+disable_as="${OPENSHIFT_REPO_DIR}/.openshift/markers/disable_auto_scaling"
+[ -f "$disable_as" ]  &&  haproxy_ctld_daemon stop > /dev/null 2>&1
+
 # Sync to the other gears
 ${CARTRIDGE_BASE_PATH}/${OPENSHIFT_GEAR_TYPE}/info/bin/sync_gears.sh
 

--- a/cartridges/haproxy-1.4/info/bin/haproxy_ctld
+++ b/cartridges/haproxy-1.4/info/bin/haproxy_ctld
@@ -133,7 +133,7 @@ class Haproxy
           raise ShouldRetry, e.to_s
         end
 
-        @gear_count = self.stats['express'].count - 3
+        @gear_count = self.stats['express'].count - 4
         @sessions = self.stats['express']['BACKEND'].scur.to_i
         if @gear_count == 0
           raise ShouldRetry, "Failed to get information from haproxy"


### PR DESCRIPTION
Fix bug with count - with the local gear serving, we need to adjust the counts.
Fix bugz 851427 - quickstart : missing openshift module when deploying dancer example
Fix for bugz 851494 - Gears will be down if disable auto scaling and hot deploy are both triggered
