### PR TITLE
remove various hardcoded usage of file in /tmp

### DIFF
--- a/broker-util/oo-setup-bind
+++ b/broker-util/oo-setup-bind
@@ -20,8 +20,8 @@ rm -f /var/named/K$node_domain*
 sed "s/example.com/$node_domain/g" < $base_path/doc/examples/example.com.db > /var/named/dynamic/$node_domain.db
 
 
-mkdir -p /tmp/named
-pushd /tmp/named
+NAMED_TMP=$(mktemp -d /tmp/namedXXXXXXX)
+pushd $NAMED_TMP
 
 if ! [ $dont_force_entropy ] ; then
   rngd -r /dev/urandom
@@ -33,10 +33,10 @@ if ! [ $dont_force_entropy ] ; then
   killall rngd
 fi
 
-KEY=$( grep Key: /tmp/named/*.private | cut -d' ' -f 2 )
-mv /tmp/named/K$node_domain.* /var/named
+KEY=$( grep Key: $NAMED_TMP/*.private | cut -d' ' -f 2 )
+mv $NAMED_TMP/K$node_domain.* /var/named
 popd
-rm -rf /tmp/named
+rm -rf $NAMED_TMP
 
 cat <<EOF > /var/named/$node_domain.key
   key $node_domain {

--- a/broker/script/oss-bind-setup.sh
+++ b/broker/script/oss-bind-setup.sh
@@ -30,18 +30,14 @@ service network stop
 # copy files
 mkdir -p /var/named/dynamic
 pushd $li_repo/misc/devenv/var/named
-cp example.com.db.init /tmp/dummy
-sed 's/example/rhcloud/g' </tmp/dummy  >/var/named/rhcloud.com.db.init
-cp example.com.key /tmp/dummy
-sed 's/example/rhcloud/g' </tmp/dummy  >/var/named/rhcloud.com.key
-cp dynamic/example.com.db /tmp/dummy
-sed 's/example/rhcloud/g' </tmp/dummy  >/var/named/dynamic/rhcloud.com.db
+sed 's/example/rhcloud/g' example.com.db.init     >/var/named/rhcloud.com.db.init
+sed 's/example/rhcloud/g' example.com.key         >/var/named/rhcloud.com.key
+sed 's/example/rhcloud/g' dynamic/example.com.db  >/var/named/dynamic/rhcloud.com.db
 #touch /var/named/dynamic/rhcloud.com.db.jnl
 popd
 
 pushd $li_repo/misc/devenv/etc
-cp named.conf /tmp/dummy
-sed 's/example/rhcloud/g' </tmp/dummy  >/etc/named.conf
+sed 's/example/rhcloud/g' named.conf  >/etc/named.conf
 mkdir -p /var/named/data
 touch /var/named/data/named.run
 touch /var/named/data/queries.log
@@ -57,18 +53,15 @@ mkdir -p /etc/dhcp
 for (( i=0; i < ${#ifc[@]}; i++ ))
 do
   cp dhclient-eth0.conf /etc/dhclient-${ifc[$i]}.conf
-  cp dhcp/dhclient-eth0-up-hooks /tmp/dummy
-  sed s/eth0/${ifc[$i]}/g </tmp/dummy  >/etc/dhcp/dhclient-${ifc[$i]}-up-hooks
+  sed s/eth0/${ifc[$i]}/g <dhcp/dhclient-eth0-up-hooks  >/etc/dhcp/dhclient-${ifc[$i]}-up-hooks
   chmod 755 /etc/dhcp/dhclient-${ifc[$i]}-up-hooks
 done
 cp rndc.conf /etc/rndc.conf
 popd
 
-sed /upstream_hints/d </etc/named.conf >/tmp/dummy
-cp /tmp/dummy /etc/named.conf
+sed -i /upstream_hints/d /etc/named.conf
 
 chown -R named:named /var/named
-rm /tmp/dummy
 
 echo "Setup dhcp update hooks"
 cat <<EOF > /etc/dhcp/dhclient.conf


### PR DESCRIPTION
Even if the files are not meant to be distributed or used for now, it
is better to have clean and secure code so people who may look or
copy it do not copy or look at insecure code.
