### PR TITLE
Add missing license to port proxy

### DIFF
--- a/stickshift/port-proxy/LICENSE
+++ b/stickshift/port-proxy/LICENSE
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Doing Fedora package review, it was brought up that we are missing the license file for this.

https://bugzilla.redhat.com/show_bug.cgi?id=854764
