### PR TITLE
Removing the node profile enforcement from the ss-admin-ctl scripts

### DIFF
--- a/stickshift/broker-util/ss-admin-ctl-district
+++ b/stickshift/broker-util/ss-admin-ctl-district
@@ -81,11 +81,6 @@ bypass   = args['--bypass']
 name     = args['--name']
 node_profile = args['--node_profile']
   
-if node_profile && !(node_profile =~ /\A(jumbo|exlarge|large|medium|micro|small)\z/)
-  puts "Node profile must be one of: (small(default)|jumbo|exlarge|medium|large|micro)"
-  exit 1
-end
-
 if command && !(command =~ /\A(add-node|remove-node|deactivate-node|activate-node|add-capacity|remove-capacity|create|destroy)\z/)
   puts "Command must be one of: (add-node|remove-node|deactivate-node|activate-node|add-capacity|remove-capacity|create|destroy)"
   exit 1

--- a/stickshift/broker-util/ss-admin-ctl-user
+++ b/stickshift/broker-util/ss-admin-ctl-user
@@ -318,19 +318,11 @@ unless account_to_remove.nil?
 end
 
 unless gear_size_to_add.nil?
-    if !(gear_size_to_add =~ /\A(jumbo|exlarge|large|medium|micro|small|c9)\z/)
-        puts "Gear size must be one of: (small|jumbo|exlarge|medium|large|micro|c9)"
-        exit 1
-    end
     add_gear_size(user, gear_size_to_add)
     changed_user = true
 end
 
 unless gear_size_to_remove.nil?
-    if !(gear_size_to_remove =~ /\A(jumbo|exlarge|large|medium|micro|small|c9)\z/)
-        puts "Gear size must be one of: (small|jumbo|exlarge|medium|large|micro|c9)"
-        exit 1
-    end
     remove_gear_size(user, gear_size_to_remove)
     changed_user = true
 end


### PR DESCRIPTION
On the dev list we discussed having a registry that would allow the tools to
emit useful error messages in case an invalid node profile is passed in.

http://lists.openshift.redhat.com/openshift-archives/dev/2012-September/msg00021.html
