### PR TITLE
Disable Jenkins built-in SSH server by default

### DIFF
--- a/cartridges/jenkins-1.4/info/configuration/jenkins-pre-deploy/org.jenkinsci.main.modules.sshd.SSHD.xml
+++ b/cartridges/jenkins-1.4/info/configuration/jenkins-pre-deploy/org.jenkinsci.main.modules.sshd.SSHD.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<org.jenkinsci.main.modules.sshd.SSHD>
+  <helpRedirect/>
+  <port>-1</port>
+</org.jenkinsci.main.modules.sshd.SSHD>


### PR DESCRIPTION
The built-in Jenkins SSH server does not provide any means to configure
the interface on which it binds.  This makes the Jenkins server volatile
depending on the restrictions of the node security implementation.

Disable the server by default to ensure consistent startup success.  The
feature can be re-enabled by users on-demand if their environment
is permissive of the binding.
