### PR TITLE
fix requirement in the spec and gemspec of uplift bind plugin

### DIFF
--- a/plugins/dns/bind/openshift-origin-dns-bind.gemspec
+++ b/plugins/dns/bind/openshift-origin-dns-bind.gemspec
@@ -26,11 +26,8 @@ Gem::Specification.new do |s|
   s.files       += %w(README.md Rakefile Gemfile rubygem-openshift-origin-dns-bind.spec openshift-origin-dns-bind.gemspec LICENSE COPYRIGHT)
   s.require_paths = ["lib"]
 
-  s.add_dependency('openshift-origin-controller')
-  s.add_dependency('json')  
+  s.add_dependency('openshift-origin-common')
   s.add_dependency('dnsruby')
   s.add_development_dependency('rake', '>= 0.8.7', '<= 0.9.6')  
-  s.add_development_dependency('rspec')
   s.add_development_dependency('bundler')
-  s.add_development_dependency('mocha')
 end

--- a/plugins/dns/bind/rubygem-openshift-origin-dns-bind.spec
+++ b/plugins/dns/bind/rubygem-openshift-origin-dns-bind.spec
@@ -21,7 +21,6 @@ Requires:      ruby(release)
 Requires:      %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
 %endif
 Requires:      %{?scl:%scl_prefix}rubygems
-Requires:      %{?scl:%scl_prefix}rubygem(json)
 Requires:      %{?scl:%scl_prefix}rubygem(dnsruby)
 Requires:      rubygem(openshift-origin-common)
 Requires:      bind


### PR DESCRIPTION
plugin do not use json, no mention of rspec or mocha in the code
or rakefile, and that's the stickshift-common gem that's used
