### PR TITLE
Fix bug 860536 - gears info will not record into gear-registry.db 

### DIFF
--- a/stickshift/controller/lib/stickshift-controller/app/models/application.rb
+++ b/stickshift/controller/lib/stickshift-controller/app/models/application.rb
@@ -142,8 +142,6 @@ GroupOverrides:
 Connections:
   auto-scale:
     Components: [\"proxy/haproxy-1.4\", \"web/#{framework}\"]
-  local-proxy:
-     Components: [\"proxy/haproxy-1.4\", \"proxy/#{framework}\"]
   proxy-web:
      Components: [\"proxy/#{framework}\", \"web/#{framework}\"]
 Configure-Order: [\"proxy/#{framework}\", \"proxy/haproxy-1.4\"]


### PR DESCRIPTION
Fix bug 860536 - gears info will not record into gear-registry.db and failed to redirect connection to gears when access the scalable app dns
