### PR TITLE
added cgroups setup

### DIFF
--- a/stickshift/node/conf/stickshift-node.conf
+++ b/stickshift/node/conf/stickshift-node.conf
@@ -21,3 +21,5 @@ PUBLIC_HOSTNAME='localhost.localdomain'                      # The public hostna
 # PUBLIC_HOSTNAME_OVERRIDE='localhost.localdomain'           # Override public hostname of this node instead of auto-detecting
 # EXTERNAL_ETH_DEV='eth0'                                    # Specify the internet facing public ethernet device
 # INTERNAL_ETH_DEV='eth1'                                    # Specify the internal cluster facing ethernet device
+# Add observer to configure user containment (cgroups, tc etc)
+STICKSHIFT_NODE_PLUGINS="stickshift-node/plugins/unix_user_observer"

--- a/stickshift/node/lib/stickshift-node/plugins/unix_user_observer.rb
+++ b/stickshift/node/lib/stickshift-node/plugins/unix_user_observer.rb
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2011 Red Hat, Inc. All rights reserved
+
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.  You should have
+# received a copy of the GNU General Public License along with this program;
+# if not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+# Fifth Floor, Boston, MA 02110-1301, USA. Any Red Hat trademarks that are
+# incorporated in the source code or documentation are not subject to the GNU
+# General Public License and may only be used or replicated with the express
+# permission of Red Hat, Inc.
+
+require 'rubygems'
+require 'singleton'
+require 'stickshift-node/config'
+require 'stickshift-node/model/unix_user'
+require 'stickshift-node/utils/shell_exec'
+
+module StickShift
+  class UnixUserObserver
+    include StickShift::Utils::ShellExec
+    include Object::Singleton
+
+    def update(*args)
+      method = args.first
+      args = args.drop(1)
+      send(method, *args)
+    end
+
+    def before_unix_user_create(user)
+    end
+
+    def after_unix_user_create(user)
+      out,err,rc = shellCmd("service cgconfig status > /dev/null 2>&1")
+      if rc == 0
+        out,err,rc = shellCmd("service libra-cgroups startuser #{user.name} > /dev/null")
+        raise StickShift::UserCreationException.new("Unable to setup cgroups for #{user.name}") unless rc == 0
+      end
+
+      out,err,rc = shellCmd("service libra-tc status > /dev/null 2>&1")
+      if rc == 0
+        shellCmd("service libra-tc startuser #{user.name} > /dev/null")
+        raise StickShift::UserCreationException.new("Unable to setup tc for #{user.name}") unless rc == 0
+      end
+    end
+
+    def before_initialize_homedir(user)
+    end
+
+    def after_initialize_homedir(user)
+      cmd = "/bin/sh #{File.join('/usr/libexec/stickshift/lib', "express/setup_pam_fs_limits.sh")} #{user.name} #{user.quota_blocks ? user.quota_blocks : ''} #{user.quota_files ? user.quota_files : ''}"
+      out,err,rc = shellCmd(cmd)
+      raise StickShift::UserCreationException.new("Unable to setup pam/fs limits for #{user.name}") unless rc == 0
+    end
+
+
+    def before_unix_user_destroy(user)
+      out,err,rc = shellCmd("service libra-tc status #{user.name} > /dev/null 2>&1")
+      if rc == 0
+        shellCmd("service libra-tc stopuser #{user.name} > /dev/null")
+      end
+
+      out,err,rc = shellCmd("service cgconfig status > /dev/null")
+      if rc == 0
+        shellCmd("service libra-cgroups stopuser #{user.name} > /dev/null")
+      end
+
+      last_access_dir = StickShift::Config.instance.get("LAST_ACCESS_DIR")
+      shellCmd("rm -f #{last_access_dir}/#{user.name} > /dev/null")
+
+      cmd = "/bin/sh #{File.join("/usr/libexec/stickshift/lib", "express/teardown_pam_fs_limits.sh")} #{user.name}"
+      shellCmd(cmd)
+    end
+
+    def before_initialize_stickshift_proxy(user)
+    end
+
+    def after_initialize_stickshift_proxy(user)
+    end
+
+    def after_unix_user_destroy(user)
+    end
+
+    def before_add_ssh_key(user,key)
+    end
+
+    def after_add_ssh_key(user,key)
+      ssh_dir = File.join(user.homedir, ".ssh")
+      cmd = "restorecon -R #{ssh_dir}"
+      shellCmd(cmd)
+    end
+
+    def before_remove_ssh_key(user,key)
+    end
+
+    def after_remove_ssh_key(user,key)
+    end
+  end
+
+  StickShift::UnixUser.add_observer(UnixUserObserver.instance)
+end

--- a/stickshift/node/misc/bin/ss-trap-user
+++ b/stickshift/node/misc/bin/ss-trap-user
@@ -74,7 +74,49 @@ def read_config():
       config[split_line[0]] = value
   return config
 
+#
+# Join the user's cgroup if available
+#
+def join_cgroup():
+    """
+    Determine a user's cgroup and join it if possible
+    """
+
+    username = pwd.getpwuid(os.getuid())[0]
+    pid = os.getpid()
+
+    # this should come from /etc/stickshift/stickshift-node.conf:OPENSHIFT_CGROUP_ROOT
+    cgroup_root = "/cgroup/all/openshift"
+    cgroup_user = os.path.join(cgroup_root, username)
+    cgroup_tasks = os.path.join(cgroup_user, "tasks")
+
+    syslog.syslog("user %s: putting process %d in cgroup %s" % (username, pid, c
+group_root))
+
+    if not os.path.isdir(cgroup_root):
+        # raise an exception
+        return
+
+    if not os.path.isdir(cgroup_user):
+        # raise an exception
+        return
+
+    if not os.path.isfile(cgroup_tasks):
+        # raise an exception
+        return 
+
+    # try:
+    taskfile = open(cgroup_tasks, 'w')
+    taskfile.write(str(pid) + "\n")
+    taskfile.flush()
+    taskfile.close()
+    # except IOError, e:
+    #    write "can't join cgroup" message
+
+
+
 if __name__ == '__main__':
+    join_cgroup()
     read_env_vars()
     config = read_config()
 

--- a/stickshift/node/misc/init/os-cgroups
+++ b/stickshift/node/misc/init/os-cgroups
@@ -1,0 +1,470 @@
+#!/bin/sh
+#
+# openshift-cgroups This shell script initializes openshift control groups
+#
+# Author:       Seth Vidal <skvidal@phy.duke.edu>
+#               Mike McGrath <mmcgrath@redhat.com>
+#               Mark lamourine <markllama@redhat.com>
+#
+# chkconfig:    345 6 94
+#
+# description:  Create Openshift user cgroups
+# processname:  NA
+#
+
+# CAVEAT: if the policy is changed, must run these by hand (release ticket)
+
+# source function library
+. /etc/rc.d/init.d/functions
+
+# import openshift cgroups settings
+if [ -f /etc/sysconfig/openshift-cgroups ]
+then
+    . /etc/sysconfig/openshift-cgroups
+fi
+
+lockfile=/var/lock/subsys/openshift-cgroups
+
+if [ -f /etc/stickshift/stickshift-node.conf ]
+then
+    . /etc/stickshift/stickshift-node.conf
+fi
+
+if [ -f /etc/stickshift/resource_limits.conf ]
+then
+    . /etc/stickshift/resource_limits.conf
+fi
+
+RETVAL=0
+GROUP_RETVAL=0
+
+#
+# Set defaults if not provided
+#
+GEAR_GECOS=${GEAR_GECOS:="openshift guest"}
+
+OPENSHIFT_CGROUP_ROOT=${OPENSHIFT_CGROUP_ROOT:="/openshift"}
+OPENSHIFT_CGROUP_SUBSYSTEMS=${OPENSHIFT_CGROUP_SUBSYSTEMS:="cpu,cpuacct,memory,net_cls,freezer"}
+
+CGROUP_RULES_FILE=${CGROUP_RULES_FILE:="/etc/cgrules.conf"}
+
+CPU_VARS="cfs_period_us cfs_quota_us rt_period_us rt_runtime_us shares"
+MEM_VARS="limit_in_bytes memsw_limit_in_bytes soft_limit_in_bytes swappiness"
+
+# Get a user's UID
+function uid() {
+    grep -e "^$1:" /etc/passwd | cut -d: -f3
+}
+
+# get a user's home directory
+function homedir() {
+    grep -e "^$1:" /etc/passwd | cut -d: -f6
+}
+
+# ============================================================================
+#  Functions for setting the net class
+# ============================================================================
+
+#
+# Convert an MCS pair into a cgroup net class id
+#
+function classid() {
+    # major: 1, minor UID
+    printf "0x1%04x" $1
+}
+
+function set_net_cls() {
+    # USERNAME=$1
+    CGPATH=openshift/$1
+    USERID=`uid $1`
+    USERCLASSID=`classid $USERID`
+    #cgset -r net_cls.classid=$USERCLASSID $CGPATH
+    # it turns out that net_cls doesn't REALLY want an MCS
+    cgset -r net_cls.classid=$USERCLASSID $CGPATH
+}
+
+# ==========================================================================
+#  Functions for tuning the user's CPU limits in cgroups
+# ==========================================================================
+CPUVARS="cfs_period_us cfs_quota_us rt_period_us rt_runtime_us shares"
+function set_cpu() {
+    # USERNAME=$1
+    CGPATH=openshift/$1
+
+    for VARNAME in $CPUVARS
+    do
+	# cgroups names can have periods(.)  shell varnames can't
+	SAFENAME=`echo $VARNAME | tr . _`
+	VALUE=`eval echo \\$cpu_$SAFENAME`
+	if [ -n "${VALUE}" ]
+	then
+	    # TODO: get per-app increments
+	    cgset -r "cpu.$VARNAME=$VALUE" $CGPATH
+	fi
+    done
+}
+
+# ==========================================================================
+#  Functions for tuning the user's memory limits in cgroups
+# ==========================================================================
+MEMVARS="limit_in_bytes memsw.limit_in_bytes soft_limit_in_bytes swappiness"
+function set_memory() {
+    # USERNAME=$1
+    CGPATH=openshift/$1
+
+    # for each var get and set the value
+    for VARNAME in $MEMVARS
+    do
+	# cgroups names can have periods(.)  shell varnames can't
+	SAFENAME=`echo $VARNAME | tr . _`
+	VALUE=`eval echo \\$memory_$SAFENAME`
+	if [ -n "${VALUE}" ]
+	then
+	    # TODO: get per-app increments
+	    cgset -r "memory.$VARNAME=$VALUE" $CGPATH
+	fi
+    done
+}
+
+# ==========================================================================
+#  Functions for tuning the user's memory limits in cgroups
+# ==========================================================================
+BLKIOVARS="weight weight_device"
+function set_blkio() {
+    # USERNAME=$1
+    CGPATH=/$1
+
+    # for each var get and set the value
+    for VARNAME in $BLKIOVARS
+    do
+	# cgroups names can have periods(.)  shell varnames can't
+	SAFENAME=`echo $VARNAME | tr . _`
+	VALUE=`eval echo \\$blkio_$SAFENAME`
+	if [ -n "${VALUE}" ]
+	then
+	    # TODO: get per-app increments
+	    # TODO: weight_device should really use the user's home device
+	    #       and set the rest (if any) to 0
+	    # cgset -r "blkio.$VARNAME=$VALUE" $CGPATH
+	    echo nothing >>/dev/null
+	fi
+    done
+}
+
+# List the openshift guest users
+#
+openshift_users() {
+    grep "${GEAR_GECOS}" /etc/passwd | cut -d: -f1
+}
+
+valid_user() {
+    # check if the user name exists and is tagged as a openshift guest user
+    grep ":${GEAR_GECOS}:" /etc/passwd | cut -d: -f1 | grep -e "^$1\$" >/dev/null 2>&1
+}
+
+#
+# Create a new openshift user cgroup
+#
+add_cgroup() {
+    # USERNAME=$1
+    cgcreate -t $1:$1 -g ${OPENSHIFT_CGROUP_SUBSYSTEMS}:${OPENSHIFT_CGROUP_ROOT}/$1
+}
+
+#
+# Delete a openshift user cgroup
+#
+delete_cgroup() {
+    # USERNAME=$1
+    cgdelete ${OPENSHIFT_CGROUP_SUBSYSTEMS}:${OPENSHIFT_CGROUP_ROOT}/$1
+}
+
+
+#
+# check which user cgroups exist
+#
+cgroup_user_subsystems() {
+    # USERNAME=$1
+    lscgroup | grep ":${OPENSHIFT_CGROUP_ROOT}/$1\$" | cut -d: -f1
+}
+
+#
+# Check that a group binding rule exists for a user
+#
+cgroup_rule_exists() {
+    #USERNAME=$1
+    # remove comments, get first field, match exactly, quiet
+    grep -v '^#' ${CGROUP_RULES_FILE} | cut -f1 | grep -q -x $1
+}
+
+
+#
+# Bind the user to the cgroup: update /etc/cgrules.conf and kick cgred
+#
+add_cgroup_rule() {
+    # USERNAME=$1
+    cat <<EOF >>${CGROUP_RULES_FILE}
+$1	$OPENSHIFT_CGROUP_SUBSYSTEMS	$OPENSHIFT_CGROUP_ROOT/$1
+EOF
+}
+
+#
+# Unbind the user from any cgroup
+#
+delete_cgroup_rule() {
+    # USERNAME=$1
+    sed -i -e "/^$1\s/d" ${CGROUP_RULES_FILE}
+}
+
+startuser() {
+    NEWUSER=$1
+
+    echo -n "starting cgroups for $NEWUSER..."
+
+    add_cgroup $NEWUSER
+    if [ $? != 0 ]
+    then
+        RETVAL=$?
+    fi
+
+    set_cpu $NEWUSER
+    set_memory $NEWUSER
+    #set_blkio $NEWUSER
+    set_net_cls $NEWUSER
+
+    # CHECK: don't trust old rules
+    if ( cgroup_rule_exists $NEWUSER )
+    then
+        delete_cgroup_rule $NEWUSER
+    fi
+    add_cgroup_rule $NEWUSER
+    if [ $? != 0 ]
+    then
+        RETVAL=$?
+    fi
+
+    if [ $RETVAL -eq 0 ]
+    then
+        echo_success
+    else
+        GROUP_RETVAL=$(($GROUP_RETVAL+1))
+        echo_failure
+    fi
+    echo
+}
+
+
+start() {
+    echo "Initializing Openshift guest control groups: "
+
+    if !(service cgconfig status >/dev/null)
+    then
+       RETVAL=1
+       GROUP_RETVAL=3
+       echo "cgconfig service not running"
+
+       return $GROUP_RETVAL
+    fi
+
+    # create the root of the openshift user control group
+    add_cgroup # defaults to creating the root group
+    RETVAL=$?
+
+    # This won't scale forever, but works fine in the '100 or so' range
+    for USERNAME in `openshift_users`
+    do
+        startuser $USERNAME
+    done
+
+    # kick the Cgroups rules daemon
+    service cgred reload
+
+    [ $GROUP_RETVAL -eq 0 ] && touch ${lockfile}
+    [ $GROUP_RETVAL -eq 0 ] && success || failure
+
+    echo -n $"Openshift cgroups initialized"
+    echo
+    return $GROUP_RETVAL
+    echo
+    echo "WARNING !!! WARNING !!! WARNING !!!"
+    echo "Cgroups may have just restarted.  It's important to confirm all the openshift apps are actively running."
+    echo "It's suggested you run service openshift restart now"
+    echo "WARNING !!! WARNING !!! WARNING !!!"
+    echo
+}
+
+
+stopuser() {
+    DELUSER=$1
+    echo -n "stopping cgroups for $DELUSER..."
+
+    # kill any processes owned by these users
+    #pkill -u $DELUSER
+    
+    # remove the user's cgroup
+    delete_cgroup $DELUSER
+    if [ $? != 0 ]
+    then
+	RETVAL=$?
+    fi
+    
+    # remove the user's cgroup binding rule
+    delete_cgroup_rule $DELUSER
+    if [ $? != 0 ]
+    then
+	RETVAL=$?
+    fi
+
+    if [ $RETVAL -eq 0 ]
+    then
+        echo_success
+    else
+        GROUP_RETVAL=$(($GROUP_RETVAL+1))
+        echo_failure
+    fi
+}
+
+stop() {
+    echo "Removing Openshift guest control groups: "
+
+    if !(service cgconfig status >/dev/null)
+    then
+       RETVAL=1
+       GROUP_RETVAL=3
+       echo "cgconfig service not running"
+
+       return $GROUP_RETVAL
+    fi
+
+    # This won't scale forever, but works fine in the '100 or so' range
+    for USERNAME in `openshift_users`
+    do
+	stopuser $USERNAME
+    done
+
+    # notify the cgroup rule daemon
+    service cgred reload
+
+    # remove the openshift root cgroup
+    delete_cgroup
+
+    if [ $RETVAL -eq 0 ]
+    then
+        echo_success
+    else
+        GROUP_RETVAL=$(($GROUP_RETVAL+1))
+        echo_failure
+    fi
+
+    [ $GROUP_RETVAL -eq 0 ] && touch ${lockfile}
+    echo -n $"Openshift cgroups uninitialized"
+    echo
+    return $GROUP_RETVAL
+}
+
+restart() {
+    stop
+    start
+}
+
+status() {
+    echo "Checking Openshift Services: "
+
+    lscgroup | grep -e  ":${OPENSHIFT_CGROUP_ROOT}\$" >/dev/null 2>&1
+    if [ $? -ne 0 ]
+    then
+	echo "Openshift cgroups uninitialized"
+	echo
+	return 1
+    else
+	echo "Openshift cgroups initialized"
+    fi
+    
+    if [ -z "$1" ]
+    then
+	USERLIST=`openshift_users`
+    else
+        USERLIST=$1
+    fi
+
+    # check that the /openshift cgroup exists
+
+    # This won't scale forever, but works fine in the '100 or so' range
+    #  would be easy to convert to a 'in `find...`'     jj
+    for USERNAME in $USERLIST
+    do
+	# check that /openshift/<username> exists
+	SUBSYSTEMS=`cgroup_user_subsystems`
+	if ( cgroup_rule_exists $USERNAME )
+        then
+	    RETVAL=0
+            BOUND="BOUND"
+        else
+	    RETVAL=1
+            BOUND="UNBOUND"
+        fi
+
+	echo -n "${USERNAME}: $BOUND	" `echo $SUBSYSTEMS | tr ' ' ,`
+	# check that cgrule exists
+
+        if [ $RETVAL -eq 0 ]
+        then
+            echo_success
+        else
+            GROUP_RETVAL=$(($GROUP_RETVAL+1))
+            echo_failure
+        fi
+	echo
+    done
+    return $GROUP_RETVAL
+}
+
+
+case "$1" in
+  start)
+    start
+    ;;
+
+  stop) 
+    stop
+    ;;
+
+  restart|force-reload|reload)
+    restart
+    ;;
+
+  condrestart)
+    [ -f "$lockfile" ] && restart
+    ;;
+
+  status)
+    status $2
+    ;;
+
+  startuser)
+    if (service cgconfig status >/dev/null)
+    then
+        startuser $2
+        service cgred reload
+    else
+        RETVAL=1
+        echo "cgconfig service not running"
+    fi
+    ;;
+
+  stopuser)
+    if (service cgconfig status >/dev/null)
+    then
+        stopuser $2
+        service cgred reload
+    else
+        RETVAL=1
+        echo "cgconfig service not running"
+    fi
+    ;;
+
+  *)
+    echo $"Usage: $0 {start|stop|status|restart|reload|force-reload|condrestart|startuser <username>|stopuser <username>}"
+    exit 1
+esac
+
+exit $RETVAL


### PR DESCRIPTION
Implement Cgroup containment for Openshift gears.

Updates the rubygem-stickshift-node package.

Adds dependency on the libcgroup package.

This configures all of the cgroup subsystems under a single top group.
When new gears are created they are associated with a single cgroup under that top group.
The cgred rules are updated so that new processes owned by the gear's UNIX account are placed in to the cgroup.
The trap-user script is updated so the first action on login is to place the shell under the gear group.
cgroup settings are enforced from values in /etc/stickshift/resource-limit.conf.
