### PR TITLE
Don't write to pearrc during build

### DIFF
--- a/cartridges/php-5.3/info/bin/build.sh
+++ b/cartridges/php-5.3/info/bin/build.sh
@@ -11,7 +11,6 @@ then
     echo ".openshift/markers/force_clean_build found!  Recreating pear libs" 1>&2
     rm -rf "${OPENSHIFT_GEAR_DIR}"/phplib/pear/*
     mkdir -p "${OPENSHIFT_GEAR_DIR}"/phplib/pear/{docs,ext,php,cache,cfg,data,download,temp,tests,www}
-    pear -c ~/.pearrc config-set php_ini "${OPENSHIFT_GEAR_DIR}/conf/php.ini"
 fi
 
 if [ -f ${OPENSHIFT_REPO_DIR}deplist.txt ]


### PR DESCRIPTION
The build is executed in the context of the gear user. The pearrc
file is not writable by the gear user. The build does not modify
the PHP ini setting in the pearrc, and so there's no reason to
attempt to update pearrc to re-set this configuration item.
Attempting to do so will fail, as pearrc is not writable in this
context.

Remove the pearrc PHP ini config update during the build process.

Resolve this bug: https://bugzilla.redhat.com/show_bug.cgi?id=861550
