### PR TITLE
Minor fix to the mongo auth service constructor

### DIFF
--- a/swingshift/mongo/lib/swingshift-mongo-plugin/lib/swingshift/mongo_auth_service.rb
+++ b/swingshift/mongo/lib/swingshift-mongo-plugin/lib/swingshift/mongo_auth_service.rb
@@ -5,7 +5,7 @@ require 'date'
 module Swingshift
   class MongoAuthService < StickShift::AuthService
   
-    def initialize
+    def initialize(auth_info = nil)
       super
 
       if @auth_info != nil


### PR DESCRIPTION
The parent class actually sets @auth_info.  I don't like this code right now
but this unbreaks the mongo plugin.  I'll give this a better look shortly.
