### PR TITLE
 Fix for bugz 862078 -  django import errors on  slave gears

### DIFF
--- a/cartridges/python-2.6/info/bin/deploy.sh
+++ b/cartridges/python-2.6/info/bin/deploy.sh
@@ -18,6 +18,10 @@ start_dbs
 if [ -d ${OPENSHIFT_GEAR_DIR}virtenv ]
 then 
     pushd ${OPENSHIFT_GEAR_DIR}virtenv > /dev/null
+    # FIXME: Fix next line to use $virtenv when typeless gears merge is done.
+    z_virtenv_dir=~/python-2.6/virtenv
+    /bin/rm -f lib64
+    virtualenv --system-site-packages "$z_virtenv_dir"
     . ./bin/activate
     popd > /dev/null
 fi


### PR DESCRIPTION
 Fix for bugz 862078 - Getting "ImportError: No module named django.core.management" error on slave gears
