### PR TITLE
fixing tests and specifying parseconfig gem version

### DIFF
--- a/stickshift/broker/Gemfile
+++ b/stickshift/broker/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 gem 'rails', '~> 3.0.13'
 gem 'json'
-gem 'parseconfig'
+gem 'parseconfig', '0.5.2'
 gem 'mongo'
 gem 'xml-simple'
 gem 'rack'
@@ -43,4 +43,3 @@ group :development, :test do
   gem 'cucumber'
   gem 'rcov'
 end
-

--- a/stickshift/controller/test/cucumber/cartridge-runtime-extended-nodejs.feature
+++ b/stickshift/controller/test/cucumber/cartridge-runtime-extended-nodejs.feature
@@ -1,4 +1,5 @@
 @runtime
+@not-origin
 Feature: Cartridge Runtime Extended Checks (Node)
 
   @runtime_extended2

--- a/stickshift/controller/test/cucumber/cartridge-runtime-extended-python.feature
+++ b/stickshift/controller/test/cucumber/cartridge-runtime-extended-python.feature
@@ -15,4 +15,4 @@ Feature: Cartridge Runtime Extended Checks (Python)
 
   Scenarios: Code push scenarios
     | type         | proc_name | hot_deploy_status | pid_changed   |
-    | nodejs-0.6   | node      | is not enabled    | should be     |
+    | python-2.6   | httpd      | is not enabled    | should be     |

--- a/stickshift/node/stickshift-node.gemspec
+++ b/stickshift/node/stickshift-node.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.executables = Dir[bin_dir].map {|binary| File.basename(binary)}
   s.require_paths = ["lib"]
   s.add_dependency("json")
-  s.add_dependency("parseconfig")
+  s.add_dependency("parseconfig", "0.5.2")
   s.add_dependency("stickshift-common")
 
   s.add_development_dependency('rspec')


### PR DESCRIPTION
- fixing test typo 
- adding @not-origin to nodejs test
- specifying parseconfig gem version to get rid of warnings
