### PR TITLE
Honor stop_lock during app_ctl stop calls

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/bin/app_ctl_impl.sh
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/bin/app_ctl_impl.sh
@@ -67,7 +67,7 @@ function start_app() {
     fi
 
     _state=`get_app_state`
-    if [ -f $APP_JBOSS/run/stop_lock -o idle = "$_state" ]; then
+    if [ -f $CART_DIR/run/stop_lock -o idle = "$_state" ]; then
         echo "Application is explicitly stopped!  Use 'rhc app start -a ${cartridge_type}' to start back up." 1>&2
     else
         # Check for running app

--- a/cartridges/openshift-origin-cartridge-jenkins-1.4/info/bin/app_ctl.sh
+++ b/cartridges/openshift-origin-cartridge-jenkins-1.4/info/bin/app_ctl.sh
@@ -10,7 +10,7 @@ do
 done
 
 cartridge_type="jenkins-1.4"
-cartridge_dir=$OPENSHIFT_HOMEDIR/$cartridge_dir
+cartridge_dir=$OPENSHIFT_HOMEDIR/$cartridge_type
 
 translate_env_vars
 


### PR DESCRIPTION
Fix references to the stop_lock file, preventing app startup
when the app was explicitly shut down previously.
