### PR TITLE
Documentation updates

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs-0.6/template/.openshift/markers/README
+++ b/cartridges/openshift-origin-cartridge-nodejs-0.6/template/.openshift/markers/README
@@ -5,8 +5,3 @@ Adding marker files to this directory will have the following effects:
 
 force_clean_build - Will remove any previously installed npm modules and
                     re-install all the required modules from scratch
-                    
-hot_deploy - Will run Node with Supervisor (https://npmjs.org/package/supervisor)
-			 so that changes to javascript files will be reloaded without requiring
-			 a restart of Node. NOTE: Node will be restarted and started with Supervisor
-			 the first time the hot_deploy marker appears

--- a/cartridges/openshift-origin-cartridge-nodejs-0.6/template/README
+++ b/cartridges/openshift-origin-cartridge-nodejs-0.6/template/README
@@ -70,17 +70,6 @@ Note: Among other things, this file contains a list of dependencies
       every time you "git push" to your OpenShift application.
 
 
-Development Mode
-================
-
-When you push your code changes to OpenShift, if you want dynamic reloading
-of your javascript files in "development" mode, you can either use the
-hot_deploy marker or add the following to package.json.
-   "scripts": { "start": "supervisor <relative-path-from-repo-to>/server.js" },
-
-This will run Node with Supervisor - https://npmjs.org/package/supervisor
-
-
 Local Development + Testing
 ===========================
 


### PR DESCRIPTION
Remove references to hot deployment functionality, which is not
currently supported.
