### PR TITLE
[test] Sanity check CLOUD_USER value

### DIFF
--- a/node/lib/openshift-origin-node/model/unix_user.rb
+++ b/node/lib/openshift-origin-node/model/unix_user.rb
@@ -46,6 +46,10 @@ module OpenShift
 
       @config = OpenShift::Config.new
 
+      # CLOUD_NAME will be interpolated into shell variable names, so it
+      # must only contain characters that are valid in variable names.
+      raise "CLOUD_NAME has an invalid value" unless @config.get("CLOUD_NAME").match /^[a-zA-Z][a-zA-Z0-9_]*$/
+
       @container_uuid = container_uuid
       @application_uuid = application_uuid
       @uuid = container_uuid


### PR DESCRIPTION
The OpenShift::UnixUser class interpolates the value of CLOUD_USER in
/etc/openshift/node.conf into the name of a shell environment variable.
Therefore, if CLOUD_USER contains symbols that may not appear in a shell
variable name, we will get mysterious errors.

This patch adds a check in the initializer for OpenShift::UnixUser to
verify that CLOUD_USER contains only valid symbols.
