### PR TITLE
Fix 'Obsoletes' for jbosseap6, port-proxy, mongodb-2.2, and diy

### DIFF
--- a/cartridges/openshift-origin-cartridge-diy-0.1/openshift-origin-cartridge-diy-0.1.spec
+++ b/cartridges/openshift-origin-cartridge-diy-0.1/openshift-origin-cartridge-diy-0.1.spec
@@ -17,7 +17,7 @@ BuildRequires: git
 Requires: openshift-origin-cartridge-abstract
 Requires: rubygem(openshift-origin-node)
 Requires: httpd
-Obsoletes: cartridge-cron-1.4
+Obsoletes: cartridge-diy-0.1
 
 %description
 Provides diy support to OpenShift

--- a/cartridges/openshift-origin-cartridge-jbosseap-6.0/openshift-origin-cartridge-jbosseap-6.0.spec
+++ b/cartridges/openshift-origin-cartridge-jbosseap-6.0/openshift-origin-cartridge-jbosseap-6.0.spec
@@ -34,6 +34,7 @@ Requires: jboss-eap6-index
 Requires: lsof
 Requires: java-1.7.0-openjdk
 Requires: java-1.7.0-openjdk-devel
+Obsoletes: cartridge-jbosseap-6.0
 
 %if 0%{?rhel}
 Requires: maven3

--- a/cartridges/openshift-origin-cartridge-mongodb-2.2/openshift-origin-cartridge-mongodb-2.2.spec
+++ b/cartridges/openshift-origin-cartridge-mongodb-2.2/openshift-origin-cartridge-mongodb-2.2.spec
@@ -16,13 +16,14 @@ BuildArch: noarch
 
 BuildRequires: git
 
-Obsoletes: openshift-origin-cartridge-mongodb-2.0
-
 Requires: openshift-origin-cartridge-abstract
 Requires: mongodb-server
 Requires: mongodb-devel
 Requires: libmongodb
 Requires: mongodb
+
+Obsoletes: openshift-origin-cartridge-mongodb-2.0
+Obsoletes: cartridge-mongodb-2.0
 Obsoletes: cartridge-mongodb-2.2
 
 %description

--- a/port-proxy/openshift-origin-port-proxy.spec
+++ b/port-proxy/openshift-origin-port-proxy.spec
@@ -13,7 +13,7 @@ Requires:      haproxy
 
 # OpenShift Origin node configuration and /etc/openshift
 Requires:      rubygem(openshift-origin-node)
-Obsoletes:     stickshift-proxy
+Obsoletes:     stickshift-port-proxy
 
 
 %if 0%{?fedora} >= 16 || 0%{?rhel} >= 7


### PR DESCRIPTION
Fixes for 2.0.19 RPM upgrade
