### PR TITLE
Don't follow redirects for health checks

### DIFF
--- a/controller/test/cucumber/step_definitions/runtime_url_steps.rb
+++ b/controller/test/cucumber/step_definitions/runtime_url_steps.rb
@@ -34,9 +34,8 @@ When /^I run the health\-check for the ([^ ]+) cartridge$/ do | type |
       "health"
   end
 
-  # Use curl to hit the app, causing restorer to turn it back
-  # on and redirect.  Curl then follows that redirect.
-  command = "/usr/bin/curl -L -k -H 'Host: #{host}' -s http://localhost/#{url}"
+  # Use curl to hit the app, causing restorer to turn it back on.
+  command = "/usr/bin/curl -k -H 'Host: #{host}' -s http://localhost/#{url}"
   output = run_stdout command
   output.chomp!
 


### PR DESCRIPTION
Prevent redirect loops when checking health of restored apps.
