### PR TITLE
Minor fix for the kerberos/ldap sample config files

### DIFF
--- a/plugins/auth/remote-user/openshift-origin-auth-remote-user-kerberos.conf.sample
+++ b/plugins/auth/remote-user/openshift-origin-auth-remote-user-kerberos.conf.sample
@@ -21,14 +21,14 @@ LoadModule auth_kerb_module modules/mod_auth_kerb.so
 </Location>
 
 # The following APIs do not require auth:
-<Location /broker/rest/application_templates>
+<Location /broker/rest/application_templates*>
     Allow from all
 </Location>
 
-<Location /broker/rest/cartridges>
+<Location /broker/rest/cartridges*>
     Allow from all
 </Location>
 
-<Location /broker/rest/api>
+<Location /broker/rest/api*>
     Allow from all
 </Location>

--- a/plugins/auth/remote-user/openshift-origin-auth-remote-user-ldap.conf.sample
+++ b/plugins/auth/remote-user/openshift-origin-auth-remote-user-ldap.conf.sample
@@ -20,14 +20,14 @@ LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
 </Location>
 
 # The following APIs do not require auth:
-<Location /broker/rest/application_templates>
+<Location /broker/rest/application_templates*>
     Allow from all
 </Location>
 
-<Location /broker/rest/cartridges>
+<Location /broker/rest/cartridges*>
     Allow from all
 </Location>
 
-<Location /broker/rest/api>
+<Location /broker/rest/api*>
     Allow from all
 </Location>


### PR DESCRIPTION
This is needed so that resources ending in .json, .html, .xml are supported.
This is needed for the web console calls into the broker.
