### PR TITLE
BZ866854 - Removing abstract cartridge dep from broker spec

### DIFF
--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -32,7 +32,6 @@ Requires:  rubygem(json)
 Requires:  rubygem(openshift-origin-controller)
 Requires:  rubygem(passenger)
 Requires:  rubygem(rcov)
-Requires:  openshift-origin-cartridge-abstract
 Requires:  rubygem-passenger-native
 Requires:  rubygem-passenger-native-libs
 %if %{with_systemd}


### PR DESCRIPTION
I created a broker environment and forcefully removed the openshift-origin-cartridge-abstract.  Afterwards I restarted the broker and everything appeared to still be working.  I'm going to verify with Krishna when he comes in but I suspect this dependency isn't needed.
