### PR TITLE
Fix mysql-5.1 snapshot for scalable apps

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/db
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/db
@@ -132,7 +132,7 @@ function stop_database_as_user {
 function get_db_host_as_user {
     _set_db_env
     if is_db_on_dbgear; then
-        ssh_dbgear 'echo $_db_host' 2>/dev/null
+        ssh_dbgear "cartridge_type=$cartridge_type; source /etc/openshift/node.conf; source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util; source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/db; _set_db_env; echo \$_db_host" 2> /dev/null
         return 0
     fi
 

--- a/cartridges/openshift-origin-cartridge-mysql-5.1/info/bin/dump.sh
+++ b/cartridges/openshift-origin-cartridge-mysql-5.1/info/bin/dump.sh
@@ -9,6 +9,7 @@ done
 
 source /etc/openshift/node.conf
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
+source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/db
 CART_INFO_DIR=${CARTRIDGE_BASE_PATH}/$cartridge_type/info
 source ${CART_INFO_DIR}/lib/util
 


### PR DESCRIPTION
Populate mysql_db_host with the correct value for both scalable
and non-scalable contexts. Fix the following bug:

https://bugzilla.redhat.com/show_bug.cgi?id=866416
