### PR TITLE
Bug 867264 - Not able to create jenkins app

### DIFF
--- a/console/app/controllers/building_controller.rb
+++ b/console/app/controllers/building_controller.rb
@@ -29,7 +29,7 @@ class BuildingController < ConsoleController
       framework = CartridgeType.cached.all.find{ |c| c.tags.include? :ci }
       @jenkins_server = Application.new(
         :name => params[:application][:name],
-        :cartridge => framework,
+        :cartridge => framework.name,
         :domain => @domain,
         :as => current_user)
 

--- a/console/test/functional/building_controller_test.rb
+++ b/console/test/functional/building_controller_test.rb
@@ -183,6 +183,10 @@ class BuildingControllerTest < ActionController::TestCase
 
     post :create, args.merge({:application => {:name => 'jenkins2'}})
 
+    body = mock_body_for{ |r| /applications.json/ =~ r.path }
+    assert_equal 'jenkins-1.4', body['cartridge']
+    assert_equal 'jenkins2', body['name']
+
     assert_response :success
     assert_template :new
     assert flash[:info_pre].include? 'App remote message'

--- a/console/test/support/rest_api.rb
+++ b/console/test/support/rest_api.rb
@@ -150,6 +150,14 @@ class ActiveSupport::TestCase
     use_app(:scalable_app) { Application.new({:name => "scaled", :cartridge => 'ruby-1.8', :scale => true, :as => new_named_user('user_with_scaled_app')}) }
   end
 
+  def mock_body_for(&block)
+    req = ActiveResource::HttpMock.requests.find &block
+    assert req, "No mock request was found for this block"
+    body = req.body
+    body = ActiveSupport::JSON.decode(req.body) if req.headers['Content-Type'].include?('application/json')
+    body
+  end
+
   def auth_headers
    h = {}
    h['Cookie'] = "rh_sso=#{@user.ticket}" if @user.ticket


### PR DESCRIPTION
When I did the refactoring I didn't correctly validate that the mock response
posted the right values, so tests passed but jenkins app creation failed. 
Should have been passing the cartridge name instead of the entire cart
object.

[merge] after tests pass
