### PR TITLE
Prefix options are not preserved during save

### DIFF
--- a/console/app/models/rest_api/base.rb
+++ b/console/app/models/rest_api/base.rb
@@ -621,6 +621,15 @@ module RestApi
         end
       end
 
+      def load_attributes_from_response(response)
+        if (response_code_allows_body?(response.code) &&
+            (response['Content-Length'].nil? || response['Content-Length'] != "0") &&
+            !response.body.nil? && response.body.strip.size > 0)
+          load(prefix_options.merge(self.class.format.decode(response.body)), true)
+          @persisted = true
+        end
+      end
+
       def connection(refresh = false)
         @connection = nil if refresh
         @connection ||= self.class.connection({:as => as})

--- a/console/test/integration/rest_api/application_test.rb
+++ b/console/test/integration/rest_api/application_test.rb
@@ -56,7 +56,7 @@ class RestApiApplicationTest < ActiveSupport::TestCase
     assert_equal 1, cart.current_scale
     assert_equal 1, cart.scales_from
     assert_equal 1, cart.scales_to
-    # assert cart.scales?
+    assert !cart.scales?
   end
 
   def test_retrieve_gear_groups

--- a/console/test/integration/rest_api/cartridge_test.rb
+++ b/console/test/integration/rest_api/cartridge_test.rb
@@ -24,12 +24,16 @@ class RestApiCartridgeTest < ActiveSupport::TestCase
 
     name = cart.name
 
+    prefix = cart.prefix_options.dup
+
     cart.scales_from = base
     cart.scales_to = base
     assert cart.save, "Unable to set scales_from/to to #{base}: #{cart.errors.full_messages}"
 
     assert_equal base, cart.scales_from
     assert_equal base, cart.scales_to
+
+    assert_equal prefix, cart.prefix_options
 
     cart.reload 
 


### PR DESCRIPTION
After .save resources can't be reloaded or saved a second time

[merge] after tests pass
