### PR TITLE
Fix clustering env var references

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/connection-hooks/publish_jboss_cluster
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/connection-hooks/publish_jboss_cluster
@@ -28,9 +28,11 @@ done
 source "/etc/openshift/node.conf"
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
-source "${GEAR_BASE_DIR}/$3/.env/OPENSHIFT_GEAR_DNS"
-
 CART_NS=$(get_cartridge_namespace_from_path)
+
+source ${GEAR_BASE_DIR}/$3/.env/OPENSHIFT_${CART_NS}_CLUSTER_PROXY_PORT
+source ${GEAR_BASE_DIR}/$3/.env/OPENSHIFT_GEAR_DNS
+
 OPENSHIFT_JBOSS_CLUSTER_PROXY_PORT=$(get_env_var_dynamic "OPENSHIFT_${CART_NS}_CLUSTER_PROXY_PORT")
 
 echo ${OPENSHIFT_GEAR_DNS}:${OPENSHIFT_JBOSS_CLUSTER_PROXY_PORT}

--- a/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/connection-hooks/publish_jboss_remoting
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/connection-hooks/publish_jboss_remoting
@@ -28,9 +28,11 @@ done
 source "/etc/openshift/node.conf"
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
-source "${GEAR_BASE_DIR}/$3/.env/OPENSHIFT_GEAR_DNS"
-
 CART_NS=$(get_cartridge_namespace_from_path)
+
+source ${GEAR_BASE_DIR}/$3/.env/OPENSHIFT_${CART_NS}_REMOTING_PORT
+source ${GEAR_BASE_DIR}/$3/.env/OPENSHIFT_GEAR_DNS
+
 OPENSHIFT_JBOSS_REMOTING_PORT=$(get_env_var_dynamic "OPENSHIFT_${CART_NS}_REMOTING_PORT")
 
 echo ${OPENSHIFT_GEAR_DNS}:${OPENSHIFT_JBOSS_REMOTING_PORT}

--- a/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/connection-hooks/set_jboss_cluster
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/connection-hooks/set_jboss_cluster
@@ -23,7 +23,8 @@ done
 if [ -f /var/lib/openshift/$3/.env/OPENSHIFT_${CART_NS}_HAPROXY_CLUSTER ]
 then
   source /var/lib/openshift/$3/.env/OPENSHIFT_${CART_NS}_HAPROXY_CLUSTER
-  echo "export OPENSHIFT_${CART_NS}_CLUSTER=$list,$OPENSHIFT_${CART_NS}_HAPROXY_CLUSTER" > /var/lib/openshift/$3/.env/OPENSHIFT_${CART_NS}_CLUSTER
+  HAPROXY_CLUSTER=$(get_env_var_dynamic "OPENSHIFT_${CART_NS}_HAPROXY_CLUSTER")
+  echo "export OPENSHIFT_${CART_NS}_CLUSTER=$list,$HAPROXY_CLUSTER" > /var/lib/openshift/$3/.env/OPENSHIFT_${CART_NS}_CLUSTER
   rm -f /var/lib/openshift/$3/.env/OPENSHIFT_${CART_NS}_HAPROXY_CLUSTER
 else
   echo "export OPENSHIFT_${CART_NS}_HAPROXY_CLUSTER=$list" > /var/lib/openshift/$3/.env/OPENSHIFT_${CART_NS}_HAPROXY_CLUSTER

--- a/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/connection-hooks/set_jboss_remoting
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/connection-hooks/set_jboss_remoting
@@ -25,7 +25,8 @@ done
 if [ -f /var/lib/openshift/$3/.env/OPENSHIFT_${CART_NS}_HAPROXY_REMOTING ]
 then
   source /var/lib/openshift/$3/.env/OPENSHIFT_${CART_NS}_HAPROXY_REMOTING
-  echo "export OPENSHIFT_${CART_NS}_CLUSTER_REMOTING=$list,$OPENSHIFT_${CART_NS}_HAPROXY_REMOTING" > /var/lib/openshift/$3/.env/OPENSHIFT_${CART_NS}_CLUSTER_REMOTING
+  HAPROXY_REMOTING=$(get_env_var_dynamic "OPENSHIFT_${CART_NS}_HAPROXY_REMOTING")
+  echo "export OPENSHIFT_${CART_NS}_CLUSTER_REMOTING=$list,$HAPROXY_REMOTING" > /var/lib/openshift/$3/.env/OPENSHIFT_${CART_NS}_CLUSTER_REMOTING
   rm -f /var/lib/openshift/$3/.env/OPENSHIFT_${CART_NS}_HAPROXY_REMOTING
 else
   echo "export OPENSHIFT_${CART_NS}_HAPROXY_REMOTING=$list" > /var/lib/openshift/$3/.env/OPENSHIFT_${CART_NS}_HAPROXY_REMOTING


### PR DESCRIPTION
Source env vars dynamically so the correct values are used.

Resolve https://bugzilla.redhat.com/show_bug.cgi?id=867420
