### PR TITLE
[test] Drop msg-broker Requires: on qpid packages

### DIFF
--- a/plugins/msg-broker/mcollective/rubygem-openshift-origin-msg-broker-mcollective.spec
+++ b/plugins/msg-broker/mcollective/rubygem-openshift-origin-msg-broker-mcollective.spec
@@ -15,9 +15,6 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       ruby(abi) = 1.8
 Requires:       rubygems
 Requires:       mcollective-client
-Requires:       qpid-cpp-client
-Requires:       ruby-qpid-qmf
-#Requires:       qpid-tools
 Requires:       rubygem(openshift-origin-common)
 Requires:       rubygem(json)
 Requires:       selinux-policy-targeted


### PR DESCRIPTION
rubygem-openshift-origin-msg-broker-mcollective should not depend on qpid-cpp-client or ruby-qpid-qmf because a different messaging service, such as ActiveMQ, may be used.
