### PR TITLE
[test] Make cartridge-abstract depend on make

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/openshift-origin-cartridge-abstract.spec
+++ b/cartridges/openshift-origin-cartridge-abstract/openshift-origin-cartridge-abstract.spec
@@ -13,6 +13,7 @@ BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 BuildArch: noarch
 Requires: git
+Requires: make
 Requires: mod_ssl
 Obsoletes: stickshift-abstract
 


### PR DESCRIPTION
make may be needed in Ruby apps (so that Bundler can compile gems that need it) or DIY apps.
