### PR TITLE
BZ847976 - Fixing Jenkins integration

### DIFF
--- a/plugins/auth/mongo/lib/openshift-origin-auth-mongo/lib/openshift/mongo_auth_service.rb
+++ b/plugins/auth/mongo/lib/openshift-origin-auth-mongo/lib/openshift/mongo_auth_service.rb
@@ -46,9 +46,9 @@ module OpenShift
     end
     
     def authenticate(request, login, password)
-      params = request.request_parameters()
-      if params['broker_auth_key'] && params['broker_auth_iv']
-        validate_broker_key(params['broker_auth_iv'], params['broker_auth_key'])
+      if request.headers['User-Agent'] == "OpenShift"
+        # password == iv, login == key
+        return validate_broker_key(password, login)
       else
         raise OpenShift::AccessDeniedException if login.nil? || login.empty? || password.nil? || password.empty?
         encoded_password = Digest::MD5.hexdigest(Digest::MD5.hexdigest(password) + @salt)

--- a/plugins/auth/remote-user/lib/openshift-origin-auth-remote-user/lib/openshift/remote_user_auth_service.rb
+++ b/plugins/auth/remote-user/lib/openshift-origin-auth-remote-user/lib/openshift/remote_user_auth_service.rb
@@ -15,9 +15,9 @@ module OpenShift
     # trusted.  REMOTE_USER must only be set if the web server has verified the
     # password.
     def authenticate(request, login=nil, password=nil)
-      params = request.request_parameters()
-      if params['broker_auth_key'] && params['broker_auth_iv']
-        return validate_broker_key(params['broker_auth_iv'], params['broker_auth_key'])
+      if request.headers['User-Agent'] == "OpenShift"
+        # password == iv, login == key
+        return validate_broker_key(password, login)
       else
         authenticated_user = request.env[@trusted_header]
         raise OpenShift::AccessDeniedException if authenticated_user.nil?

--- a/plugins/auth/remote-user/openshift-origin-auth-remote-user-ldap.conf.sample
+++ b/plugins/auth/remote-user/openshift-origin-auth-remote-user-ldap.conf.sample
@@ -11,7 +11,7 @@ LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
     require valid-user
 
     # The node->broker auth is handled in the Ruby code
-    BrowserMatch Stickshift passthrough
+    BrowserMatch OpenShift passthrough
     Allow from env=passthrough
 
     Order Deny,Allow

--- a/plugins/auth/remote-user/openshift-origin-auth-remote-user.conf.sample
+++ b/plugins/auth/remote-user/openshift-origin-auth-remote-user.conf.sample
@@ -9,7 +9,7 @@ LoadModule authz_user_module modules/mod_authz_user.so
     require valid-user
 
     # The node->broker auth is handled in the Ruby code
-    BrowserMatch Openshift passthrough
+    BrowserMatch OpenShift passthrough
     Allow from env=passthrough
 
     Order Deny,Allow


### PR DESCRIPTION
The Base controller handles extracting the broker_auth_key and broker_auth_iv
parameters or headers and puts them in the login and password variables.

We should probably move more of the shared auth logic into
openshift-controller's AuthService library.
