### PR TITLE
fixed single quotes to doubble in oo-admin-ctl-gears GEAR_GECOS subst

### DIFF
--- a/node-util/bin/oo-admin-ctl-gears
+++ b/node-util/bin/oo-admin-ctl-gears
@@ -277,7 +277,7 @@ case "$1" in
   status)
     echo "Checking OpenShift Services: "
 
-    for gear in $(grep ':${GEAR_GECOS}:' /etc/passwd | cut -d: -f6)
+    for gear in $(grep ":${GEAR_GECOS}:" /etc/passwd | cut -d: -f6)
     do
         for cartridge in $(ls -d $gear/* |grep -E -v 'app-root|git')
         do


### PR DESCRIPTION
Replaced single quotes around a variable substitution with double quotes so the variable would resolve.
