### PR TITLE
Bug 869494 - Using :text instead of :string for input selection on scale page when range is large

### DIFF
--- a/console/app/helpers/console/model_helper.rb
+++ b/console/app/helpers/console/model_helper.rb
@@ -49,7 +49,7 @@ module Console::ModelHelper
     if range = scale_range(obj.supported_scales_from, obj.supported_scales_to, max, max_choices)
       {:as => :select, :collection => range, :include_blank => false}
     else
-      {:as => :text}
+      {:as => :string}
     end
   end
   def scale_to_options(obj, max, max_choices=20)
@@ -57,7 +57,7 @@ module Console::ModelHelper
       range << ['All available', -1] if obj.supported_scales_to == -1
       {:as => :select, :collection => range, :include_blank => false}
     else
-      {:as => :text, :hint => 'Use -1 to scale to your current account limits'}
+      {:as => :string, :hint => 'Use -1 to scale to your current account limits'}
     end
   end
 end

--- a/console/test/unit/helpers/model_helper_test.rb
+++ b/console/test/unit/helpers/model_helper_test.rb
@@ -40,7 +40,7 @@ class Console::ModelHelperTest < ActionView::TestCase
       }, 
       scale_from_options(stub(:supported_scales_from => 1, :supported_scales_to => -1), 3))
     assert_equal({
-        :as => :text
+        :as => :string
       }, 
       scale_from_options(stub(:supported_scales_from => 1, :supported_scales_to => -1), 6, 5))
   end
@@ -53,7 +53,7 @@ class Console::ModelHelperTest < ActionView::TestCase
       },
       scale_to_options(stub(:supported_scales_from => 1, :supported_scales_to => -1), 3))
     assert_equal({
-        :as => :text,
+        :as => :string,
         :hint => 'Use -1 to scale to your current account limits',
       },
       scale_to_options(stub(:supported_scales_from => 1, :supported_scales_to => -1), 6, 5))


### PR DESCRIPTION
[merge] if tests pass
