### PR TITLE
Minor improvements to package quality

### DIFF
--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -166,7 +166,6 @@ chcon -R -t httpd_var_run_t %{brokerdir}/httpd/run
 /sbin/restorecon -v '%{_localstatedir}/log/openshift/user_action.log'
 
 %postun
-/usr/sbin/semodule -e passenger -r openshift-origin-common
 /sbin/fixfiles -R rubygem-passenger restore
 /sbin/fixfiles -R mod_passenger restore
 /sbin/restorecon -R -v /var/run

--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -99,9 +99,9 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(0640,apache,apache,0750)
-%attr(0666,-,-) %{brokerdir}/log/production.log
-%attr(0666,-,-) %{brokerdir}/log/development.log
-%attr(0666,-,-) %{_localstatedir}/log/openshift/user_action.log
+%attr(0644,-,-) %ghost %{brokerdir}/log/production.log
+%attr(0644,-,-) %ghost %{brokerdir}/log/development.log
+%attr(0644,-,-) %{_localstatedir}/log/openshift/user_action.log
 %attr(0750,-,-) %{brokerdir}/script
 %attr(0750,-,-) %{brokerdir}/tmp
 %attr(0750,-,-) %{brokerdir}/tmp/cache
@@ -161,7 +161,7 @@ chcon -R -t httpd_var_run_t %{brokerdir}/httpd/run
 /sbin/fixfiles -R rubygem-passenger restore
 /sbin/fixfiles -R mod_passenger restore
 /sbin/restorecon -R -v /var/run
-/sbin/restorecon -rv /usr/lib/ruby/gems/1.8/gems/passenger-*
+/sbin/restorecon -rv %{_datarootdir}/rubygems/gems/passenger-*
 /sbin/restorecon -rv %{brokerdir}/tmp
 /sbin/restorecon -v '%{_localstatedir}/log/openshift/user_action.log'
 


### PR DESCRIPTION
This will require at least rubygem-passenger 3.0.17 (in Fedora/EPEL).  Previously the restorecon call in %postun would just fail.
