### PR TITLE
Application types now inherit a scalability check from their parents

### DIFF
--- a/console/app/models/application_template.rb
+++ b/console/app/models/application_template.rb
@@ -74,6 +74,10 @@ class ApplicationTemplate < RestApi::Base
     @included_cartridges ||= descriptor['Requires'].map{|cart_id| CartridgeType.find(cart_id)}
   end
 
+  def scalable
+    false
+  end
+
   #def attribute(s)
   #  return get_metadata(s) if [:description, :website, :version, :git_url, :git_project_url].include?(s.to_sym)
   #  attr = {:name => 'Name', :provides => 'Requires'}[s.to_sym]
@@ -102,7 +106,7 @@ class ApplicationTemplate < RestApi::Base
   def to_application_type
     attrs = { :id => name, :name => display_name }
 
-    [:tags, :description, :website, :version, :template, :provides].each do |m|
+    [:tags, :description, :website, :version, :template, :provides, :scalable].each do |m|
       attrs[m] = send(m)
     end
 

--- a/console/app/models/application_type.rb
+++ b/console/app/models/application_type.rb
@@ -16,6 +16,7 @@ class ApplicationType
   attr_accessor :help_topics
   attr_accessor :priority
   attr_accessor :template
+  attr_accessor :scalable
 
   alias_attribute :categories, :tags
   alias_attribute :display_name, :name
@@ -39,10 +40,6 @@ class ApplicationType
 
   def priority
     @priority || 0
-  end
-
-  def scalable?
-    @scalable ||= CartridgeType.cached.find(self.id).attributes.has_key?('scaling_info')
   end
 
   class << self

--- a/console/app/models/cartridge_type.rb
+++ b/console/app/models/cartridge_type.rb
@@ -82,6 +82,10 @@ class CartridgeType < RestApi::Base
     true
   end
 
+  def scalable
+    self.attributes['supported_scales_to'] > 1
+  end
+
   def <=>(other)
     return 0 if name == other.name
     c = self.class.tag_compare(tags, other.tags)
@@ -92,10 +96,10 @@ class CartridgeType < RestApi::Base
   end
 
   def to_application_type
-    attrs = {:id => name, :name => display_name}
+    attrs = { :id => name, :name => display_name}
     [:version, :license, :license_url,
      :tags, :description, :website,
-     :help_topics, :priority].each do |m|
+     :help_topics, :priority, :scalable].each do |m|
       attrs[m] = send(m)
     end
     ApplicationType.new attrs

--- a/console/app/views/application_types/_application_type_config.html.haml
+++ b/console/app/views/application_types/_application_type_config.html.haml
@@ -25,7 +25,7 @@
         - unless application_type.template.nil?
           - application_type.template.included_cartridges.map(&:display_name).each do |cart_name|
             %li= cart_name
-        - if application_type.template.nil?
+        - if application_type.scalable
           %li{:title => 'By default, an application is created as a single instance. To set up you application for scalability, select it here. Note that scalability requires the use of one extra gear.'}
             - if advanced and (max_gears - gears_used) >= 2
               = form.select :scale, [['Runs one instance of your app',false],['Runs as a scalable application',true]]


### PR DESCRIPTION
DO NOT MERGE YET. Waiting for a fix from the broker team that has cartridges mis-reporting their capacity for scalability.
