### PR TITLE
Misc fixes to the broker spec

### DIFF
--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -131,12 +131,6 @@ rm -rf $RPM_BUILD_ROOT
 %doc %{brokerdir}/LICENSE
 
 %post
-/bin/touch %{brokerdir}/log/production.log
-/bin/touch %{brokerdir}/log/development.log
-/bin/touch %{brokerdir}/httpd/logs/error_log
-/bin/touch %{brokerdir}/httpd/logs/access_log
-/bin/touch %{_localstatedir}/log/openshift/user_action.log
-
 %if %{with_systemd}
 systemctl --system daemon-reload
 # if under sysv, hopefully we don't need to reload anything

--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -166,7 +166,6 @@ chcon -R -t httpd_var_run_t %{brokerdir}/httpd/run
 /sbin/restorecon -v '%{_localstatedir}/log/openshift/user_action.log'
 
 %postun
-/usr/sbin/semodule -e passenger -r openshift-origin-common
 /sbin/fixfiles -R rubygem-passenger restore
 /sbin/fixfiles -R mod_passenger restore
 /sbin/restorecon -R -v /var/run

--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -99,9 +99,9 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(0640,apache,apache,0750)
-%attr(0666,-,-) %{brokerdir}/log/production.log
-%attr(0666,-,-) %{brokerdir}/log/development.log
-%attr(0666,-,-) %{_localstatedir}/log/openshift/user_action.log
+%attr(0644,-,-) %ghost %{brokerdir}/log/production.log
+%attr(0644,-,-) %ghost %{brokerdir}/log/development.log
+%attr(0644,-,-) %{_localstatedir}/log/openshift/user_action.log
 %attr(0750,-,-) %{brokerdir}/script
 %attr(0750,-,-) %{brokerdir}/tmp
 %attr(0750,-,-) %{brokerdir}/tmp/cache
@@ -161,7 +161,7 @@ chcon -R -t httpd_var_run_t %{brokerdir}/httpd/run
 /sbin/fixfiles -R rubygem-passenger restore
 /sbin/fixfiles -R mod_passenger restore
 /sbin/restorecon -R -v /var/run
-/sbin/restorecon -rv /usr/lib/ruby/gems/1.8/gems/passenger-*
+/sbin/restorecon -rv %{_datarootdir}/rubygems/gems/passenger-*
 /sbin/restorecon -rv %{brokerdir}/tmp
 /sbin/restorecon -v '%{_localstatedir}/log/openshift/user_action.log'
 


### PR DESCRIPTION
The semanage command shouldn't been needed anymore b/c the policy has been upstreamed

QE verified the restorecon command is still actually needed but I changed the path to match the current latest rubygem-passenger location.  We should eventually track down why fixfiles isn't doing the job completely.

The world writeable logs were an issue that was already fixed in the Fedora specfiles.  I verified the touch commands in %post were no longer needed and actually cause problems now that we label the rails logs as %ghost.
