### PR TITLE
BZ 869862: Fix race conditions between tests with the same type of application

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/util
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/util
@@ -378,7 +378,7 @@ function get_framework_ctl_script() {
 # Tell whether cart is the only cart on a gear
 #
 function only_cart_on_gear() {
-    ret=$(ls $APP_HOME/ | grep -ve "app-root\|git" | grep -v $1 | wc -l)
+    ret=$(ls ${APP_HOME:-$OPENSHIFT_HOMEDIR}/ | grep -ve "app-root\|git" | grep -v $1 | wc -l)
     return $ret
 }
 

--- a/cartridges/openshift-origin-cartridge-mongodb-2.2/info/hooks/configure
+++ b/cartridges/openshift-origin-cartridge-mongodb-2.2/info/hooks/configure
@@ -140,6 +140,7 @@ else
     client_result 'Connection URL: mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/'
     client_result ""
     client_result "You can manage your new MongoDB by also embedding rockmongo-1.1"
+    client_result "The rockmongo username and password will be the same as the MongoDB credentials above."
 fi
 
 cart_props "connection_url=mongodb://$mongodb_ip:$mongodb_port/"

--- a/cartridges/openshift-origin-cartridge-mysql-5.1/info/hooks/configure
+++ b/cartridges/openshift-origin-cartridge-mysql-5.1/info/hooks/configure
@@ -137,6 +137,8 @@ else
     client_result 'Connection URL: mysql://$OPENSHIFT_MYSQL_DB_HOST:$OPENSHIFT_MYSQL_DB_PORT/'
     client_result ""
     client_result "You can manage your new MySQL database by also embedding phpmyadmin-3.4."
+    client_result "The phpmyadmin username and password will be the same as the MySQL credentials above."
+
 fi
 
 cart_props "connection_url=mysql://$mysql_ip:$mysql_port/"

--- a/node-util/bin/oo-admin-ctl-gears
+++ b/node-util/bin/oo-admin-ctl-gears
@@ -259,6 +259,7 @@ case "$1" in
             export uuid=$(basename $gear)
             export OPENSHIFT_HOMEDIR=$APP_HOME
             setup_user_vars
+            [ -e "${CARTRIDGE_BASE_PATH}/$name" ] || continue
             output=`run_as_user "${CARTRIDGE_BASE_PATH}/$name/info/bin/app_ctl.sh status" 2>&1`
             RETVAL=$?
 

--- a/node-util/bin/oo-idler
+++ b/node-util/bin/oo-idler
@@ -101,6 +101,7 @@ fi
 
 if [ -z "$uuid" ] || ! [ -d "/var/lib/openshift/$uuid" ]
 then
+    echo "Unknown gear UUID: $uuid"
     print_help
 fi
 


### PR DESCRIPTION
Tests which use the same type of application (commonly, PHP) are likely to step on each other and exhibit race conditions.  The algorithm being used to find the correct application will always return the application with the lowest numbered randomly generated domain name rather than the one which was created for any specific test.

This leads to, for example, race conditions where one test is trying to perform an action (ex: restart, tidy) on an application that hasn't even finished configuring yet (BZ 869862).

It was determined that every test which looks for an application of a specific type also creates and destroys the application it expects to find.  Applications are expected to be associated with the test that's running them.

The way cucumber tests run, no global (ex: app or apps) survive from scenario to scenario; so the applications are associated to the process ID of the test which created them.
