### PR TITLE
Cleanup deprecated env vars from uservars

### DIFF
--- a/cartridges/openshift-origin-cartridge-mongodb-2.2/info/hooks/pre-destroy
+++ b/cartridges/openshift-origin-cartridge-mongodb-2.2/info/hooks/pre-destroy
@@ -29,6 +29,13 @@ done
 source /etc/openshift/node.conf
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
+# Remove deprecated env vars that were left behind for backwards compatibility
+for v in "OPENSHIFT_NOSQL_DB_GEAR_DNS" "OPENSHIFT_NOSQL_DB_GEAR_UUID" "OPENSHIFT_NOSQL_DB_HOST" \
+         "OPENSHIFT_NOSQL_DB_PASSWORD" "OPENSHIFT_NOSQL_DB_PORT"      "OPENSHIFT_NOSQL_DB_URL" \
+         "OPENSHIFT_NOSQL_DB_USERNAME";
+do
+    app_remove_env_var $v
+done
 
 for v in "OPENSHIFT_MONGODB_DB_GEAR_DNS" "OPENSHIFT_MONGODB_DB_GEAR_UUID" "OPENSHIFT_MONGODB_DB_HOST" \
          "OPENSHIFT_MONGODB_DB_PASSWORD" "OPENSHIFT_MONGODB_DB_PORT"      "OPENSHIFT_MONGODB_DB_URL" \

--- a/cartridges/openshift-origin-cartridge-mysql-5.1/info/hooks/pre-destroy
+++ b/cartridges/openshift-origin-cartridge-mysql-5.1/info/hooks/pre-destroy
@@ -29,6 +29,14 @@ done
 source /etc/openshift/node.conf
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
+# Remove deprecated env vars that were left behind for backwards compatibility
+for v in "OPENSHIFT_DB_GEAR_DNS" "OPENSHIFT_DB_GEAR_UUID" "OPENSHIFT_DB_HOST" \
+         "OPENSHIFT_DB_PASSWORD" "OPENSHIFT_DB_PORT"      "OPENSHIFT_DB_SOCKET" \
+         "OPENSHIFT_DB_URL"      "OPENSHIFT_DB_USERNAME";
+do
+    app_remove_env_var $v
+done
+
 for v in "OPENSHIFT_MYSQL_DB_GEAR_DNS" "OPENSHIFT_MYSQL_DB_GEAR_UUID" "OPENSHIFT_MYSQL_DB_HOST" \
          "OPENSHIFT_MYSQL_DB_PASSWORD" "OPENSHIFT_MYSQL_DB_PORT"      "OPENSHIFT_MYSQL_DB_SOCKET" \
          "OPENSHIFT_MYSQL_DB_URL"      "OPENSHIFT_MYSQL_DB_USERNAME";

--- a/cartridges/openshift-origin-cartridge-postgresql-8.4/info/hooks/pre-destroy
+++ b/cartridges/openshift-origin-cartridge-postgresql-8.4/info/hooks/pre-destroy
@@ -29,6 +29,14 @@ done
 source /etc/openshift/node.conf
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
+# Remove deprecated env vars that were left behind for backwards compatibility
+for v in "OPENSHIFT_DB_GEAR_UUID" "OPENSHIFT_DB_GEAR_DNS" "OPENSHIFT_DB_USERNAME" \
+         "OPENSHIFT_DB_PASSWORD"  "OPENSHIFT_DB_HOST"     "OPENSHIFT_DB_PORT" \
+         "OPENSHIFT_DB_URL"       "OPENSHIFT_DB_SOCKET"
+do
+    app_remove_env_var $v
+done
+
 for v in "OPENSHIFT_POSTGRESQL_DB_GEAR_UUID" "OPENSHIFT_POSTGRESQL_DB_GEAR_DNS" "OPENSHIFT_POSTGRESQL_DB_USERNAME" \
          "OPENSHIFT_POSTGRESQL_DB_PASSWORD"  "OPENSHIFT_POSTGRESQL_DB_HOST"     "OPENSHIFT_POSTGRESQL_DB_PORT" \
          "OPENSHIFT_POSTGRESQL_DB_URL"       "OPENSHIFT_POSTGRESQL_DB_SOCKET"


### PR DESCRIPTION
Fix to cleanup old env vars after migration on removing db from a scalable app.
