### PR TITLE
Fix workaround in bugz 869874 - move ~/node_modules to ~/.node_modules

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs-0.6/info/hooks/configure
+++ b/cartridges/openshift-origin-cartridge-nodejs-0.6/info/hooks/configure
@@ -54,6 +54,7 @@ mkdir node_modules
 npmgl="$CART_INFO_DIR/configuration/npm_global_module_list"
 module_list=$(perl -ne 'print if /^\s*[^#\s]/' "$npmgl" | tr '\n' ' ')
 npm link $module_list > /dev/null 2>&1
+mv node_modules .node_modules
 popd > /dev/null
 
 #

--- a/controller/lib/openshift-origin-controller/app/controllers/base_controller.rb
+++ b/controller/lib/openshift-origin-controller/app/controllers/base_controller.rb
@@ -70,12 +70,12 @@ class BaseController < ActionController::Base
         subuser_name = request.headers["X-Impersonate-User"]
 
         if @parent_user.nil?
-          Rails.logger.debug "#{@login} tried to impersinate user but #{@login} user does not exist"
+          Rails.logger.debug "#{@login} tried to impersonate user but #{@login} user does not exist"
           raise OpenShift::AccessDeniedException.new "Insufficient privileges to access user #{subuser_name}"
         end
 
         if @parent_user.capabilities.nil? || !@parent_user.capabilities["subaccounts"] == true
-          Rails.logger.debug "#{@parent_user.login} tried to impersinate user but does not have require capability."
+          Rails.logger.debug "#{@parent_user.login} tried to impersonate user but does not have require capability."
           raise OpenShift::AccessDeniedException.new "Insufficient privileges to access user #{subuser_name}"
         end
 


### PR DESCRIPTION
Cleanup typo in messages
Remove need of workaround in fix for bugz 869874 - move ~/node_modules to ~/.node_modules
