### PR TITLE
Cleanup deprecated env vars during db deconfigure.

### DIFF
--- a/cartridges/openshift-origin-cartridge-mongodb-2.2/info/hooks/deconfigure
+++ b/cartridges/openshift-origin-cartridge-mongodb-2.2/info/hooks/deconfigure
@@ -61,6 +61,11 @@ confirm_pid_gone "${MONGODB_DIR}/pid/mongodb.pid"
 #
 /bin/rm -f $APP_HOME/.env/OPENSHIFT_MONGODB_DB_*
 
+# Remove deprecated env vars
+if [ -f $APP_HOME/.env/TYPELESS_TRANSLATED_VARS ]; then
+    sed -i '/OPENSHIFT_NOSQL_DB_*/d' $APP_HOME/.env/TYPELESS_TRANSLATED_VARS
+fi
+
 # For non-embedded (dedicated) mongo gear, destroy the gear.
 if only_cart_on_gear $cartridge_type; then
     # Remove apache vhost configuration.

--- a/cartridges/openshift-origin-cartridge-mysql-5.1/info/hooks/deconfigure
+++ b/cartridges/openshift-origin-cartridge-mysql-5.1/info/hooks/deconfigure
@@ -63,6 +63,11 @@ confirm_pid_gone "${MYSQL_DIR}/pid/mysql.pid"
 #
 /bin/rm -f $APP_HOME/.env/OPENSHIFT_MYSQL_DB*
 
+# Remove deprecated env vars
+if [ -f $APP_HOME/.env/TYPELESS_TRANSLATED_VARS ]; then
+    sed -i '/OPENSHIFT_DB_*/d' $APP_HOME/.env/TYPELESS_TRANSLATED_VARS
+fi
+
 # For non-embedded (dedicated) mysql gear, destroy the gear.
 if only_cart_on_gear $cartridge_type; then
     # Remove apache vhost configuration.

--- a/cartridges/openshift-origin-cartridge-postgresql-8.4/info/hooks/deconfigure
+++ b/cartridges/openshift-origin-cartridge-postgresql-8.4/info/hooks/deconfigure
@@ -69,6 +69,11 @@ confirm_pid_gone "${CART_INSTANCE_DIR}/pid/postgres.pid"
 #
 /bin/rm -f $APP_HOME/.env/OPENSHIFT_POSTGRESQL_DB_*
 
+# Remove deprecated env vars
+if [ -f $APP_HOME/.env/TYPELESS_TRANSLATED_VARS ]; then
+    sed -i '/OPENSHIFT_DB_*/d' $APP_HOME/.env/TYPELESS_TRANSLATED_VARS
+fi
+
 # For non-embedded (dedicated) postgresql gear, destroy the gear.
 if only_cart_on_gear $cartridge_type; then
     # Remove apache vhost configuration.


### PR DESCRIPTION
Removes old env vars from translation file when db is deconfigured.
