### PR TITLE
Fix nameserver cache model

### DIFF
--- a/controller/lib/openshift-origin-controller/app/models/name_server_cache.rb
+++ b/controller/lib/openshift-origin-controller/app/models/name_server_cache.rb
@@ -25,7 +25,7 @@ class NameServerCache
 
   def self.get_name_servers
     dns = Dnsruby::DNS.new()
-    resources = dns.getresources("rhcloud.com", Dnsruby::Types.NS)
+    resources = dns.getresources(Rails.application.config.openshift[:domain_suffix], Dnsruby::Types.NS)
     @nameservers = []
     resources.each do |resource|
       @nameservers.push(resource.domainname.to_s)


### PR DESCRIPTION
Use domain_suffix from config instead of rhcloud.com so that its generic for hosted/onprem/origin
