### PR TITLE
[test] Set ENV["RAILS_ENV"] in boot.rb

### DIFF
--- a/broker/config/boot.rb
+++ b/broker/config/boot.rb
@@ -1,5 +1,13 @@
 require 'rubygems'
 
+unless ENV["RAILS_ENV"] == "test"
+  if File.exist?('/etc/openshift/development')
+    ENV["RAILS_ENV"] = "development"
+  else
+    ENV["RAILS_ENV"] = "production"
+  end
+end
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 

--- a/broker/config/environment.rb
+++ b/broker/config/environment.rb
@@ -1,12 +1,3 @@
-require 'openshift-origin-common'
-unless ENV["RAILS_ENV"] == "test"
-  if File.exist?(File.join(OpenShift::Config::CONF_DIR, 'development'))
-    ENV["RAILS_ENV"] = "development"
-  else
-    ENV["RAILS_ENV"] = "production"
-  end
-end
-
 # Load the rails application
 require File.expand_path('../application', __FILE__)
 


### PR DESCRIPTION
Instead of setting ENV["RAILS_ENV"] in environment.rb, do so in boot.rb.

When starting the broker normally or using script/rails, environment.rb
is read after Rails has been loaded and has set ENV["RAILS_ENV"] to the
default 'development', so Rails.env.development? returns true even when
the broker is configured to use the production environment.  In the case
of oo-accept-broker, the application is started in such a way that
environment.rb is never loaded, so the development configuration is
always read even when the production configuration should be.

This commit fixes BZ871753 "[US2985][On-Premise]oo-accept-broker will
report failed for mongodb service checking even if mongodb is running."
oo-accept-broker was reading the setting for the MongoDB hostname from
the development configuration file instead of the production
configuration file, which caused the test to fail.
