### PR TITLE
@import of _input-prepend-append no longer needed

### DIFF
--- a/console/app/assets/stylesheets/common.css.scss
+++ b/console/app/assets/stylesheets/common.css.scss
@@ -37,7 +37,7 @@
 @import "code";
 //@import "bootstrap/forms";
 @import "forms";
-@import "input-prepend-append";
+//@import "input-prepend-append";
 @import "bootstrap/tables";
 
 // Components: common


### PR DESCRIPTION
Though the input-prepend-append style is still used, on app creation page, with the update to the latest _forms version there were some conflicts with the new input-append and input-prepend rules. Thus I pull out the ones still needed to support input-prepend-append and moved to _core
