### PR TITLE
[test] oo-accept-broker: RHEL6 compatibility

### DIFF
--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -508,7 +508,8 @@ function check_auth_mongo() {
         fi
 
         # check service enabled
-	if (service mongod status 2>/dev/null | grep enabled 2>&1 >/dev/null)
+	if (service mongod status 2>/dev/null | grep enabled 2>&1 >/dev/null \
+            || chkconfig --list 2>/dev/null | grep '^mongod.*2:on.*3:on.*4:on.*5:on' 2>&1 >/dev/null)
         then
 	    verbose "LOCAL: mongod service enabled"
         else
@@ -516,7 +517,7 @@ function check_auth_mongo() {
         fi
 
         # check service started
-	if (service mongod status 2>/dev/null | grep 'active (running)' 2>&1 >/dev/null)
+	if (service mongod status 2>/dev/null | grep 'running' 2>&1 >/dev/null)
         then
 	    verbose "LOCAL: mongod service running"
         else


### PR DESCRIPTION
oo-accept-broker is written for Fedora, which uses systemd.  In
particular, check_auth_mongo is written with the assumption that the
service command will print systemd-style output.  These assumptions
break on RHEL6 where the service command prints sysvinit-style output.

This commit adds compatibility so that oo-accept-broker should parse the
output of the service command correctly on both recent Fedora and RHEL6.
