### PR TITLE
[test] oo-accept-broker: drop sysctl checks

### DIFF
--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -360,18 +360,6 @@ function check_selinux_modules() {
 }
 
 
-function check_kernel_settings() {
-  verbose "checking kernel settings"
-
-  KERNEL_SETTINGS="kernel.sem net.ipv4.ip_local_port_range net.netfilter.nf_conntrack_max"
-
-  for KERNEL_KEY in $KERNEL_SETTINGS
-  do
-      notice current - $(sysctl $KERNEL_KEY)
-      notice config - $(grep -e "^$KERNEL_KEY " /etc/sysctl.conf)
-  done
-}
-
 function check_firewall() {
   verbose "checking firewall settings"
 
@@ -846,7 +834,6 @@ check_ruby_requirements $OSO_RUBY_LIBS
 load_application_values
 #check_selinux_modules
 #check_selinux_booleans
-#check_kernel_settings
 check_firewall
 check_services
 


### PR DESCRIPTION
In oo-accept-broker, we have the check_kernel_settings function which
checks some sysctl settings.  However, we only change these settings on
the node, so these checks to no belong in oo-accept-broker.

The invocation of check_kernel_settings is commented out, so the checks
were never run.  This commit deletes both the commented-out invocation
and the definition of check_kernel_settings.
