### PR TITLE
US3050: Increase SELinux configuration to allow for 15k gears

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/network
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/network
@@ -7,6 +7,11 @@ LI_CONTROLLER_LIB_NETWORK=true
 function address() {
     # uid=$1
     # final=$2
+    if [ $uid -lt 0 -o $uid -gt 262143 ]
+    then
+        echo "The UID is outside our working range: $uid" 1>&2
+        exit 5
+    fi
     printf "0x%08x\n" "$((0x7f000000 + $(($1<<7)) + $2))"
 }
 

--- a/node/lib/openshift-origin-node/model/unix_user.rb
+++ b/node/lib/openshift-origin-node/model/unix_user.rb
@@ -716,6 +716,10 @@ module OpenShift
     # @param [Integer] The user ID
     # @return [String] The SELinux MCS label
     def get_mcs_label(uid)
+      if ((uid.to_i < 0) || (uid.to_i>523776))
+        raise ArgumentError, "Supplied UID must be between 0 and 523776."
+      end
+
       setsize=1023
       tier=setsize
       ord=uid.to_i

--- a/node/misc/bin/oo-get-mcs-level
+++ b/node/misc/bin/oo-get-mcs-level
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function usage() {
-    echo "Usage: $0 [uid]"  >&2
+    echo "Usage: $0 [uid: 1-523776]"  >&2
     exit 1
 }
 
@@ -24,5 +24,6 @@ function get_mcs_level() {
 
 
 trap usage ERR
-test "$1" -gt 0 &>/dev/null
+test "$1" -ge 1 &>/dev/null
+test "$1" -le 523776 &>/dev/null
 get_mcs_level "$1"

--- a/pam_openshift/oo-namespace-init
+++ b/pam_openshift/oo-namespace-init
@@ -8,6 +8,8 @@
 
 function get_mcs_level() {
     # UID=$1
+    [ "$1" -lt 1 ] && return
+    [ "$1" -gt 523776 ] && return
 
     SETSIZE=1023
     TIER=$SETSIZE

--- a/pam_openshift/pam_openshift.c
+++ b/pam_openshift/pam_openshift.c
@@ -154,6 +154,9 @@ pam_sm_setcred(pam_handle_t *pamh UNUSED, int flags UNUSED,
 }
 
 static void get_mcs_level(int uid, security_context_t *scon) {
+        if ((uid < 1) || (uid >523776)) {
+          return;
+        }
 	int SETSIZE = 1023;
 	int TIER = SETSIZE;
 


### PR DESCRIPTION
The limits of our MCS label and IP address generation functions were set as boundaries.
MCS Labels: 0 <= UID <= 523776
IP Addrs: 0 <= UID <= 262143

The IPTables and SELinux node generators were adjusted for the new node count and an updated table was created for devenv.

The bulk of work for US3050 is test scripts and testing.
