### PR TITLE
US3036

### DIFF
--- a/broker-util/oo-admin-chk
+++ b/broker-util/oo-admin-chk
@@ -19,6 +19,7 @@
 
 require 'rubygems'
 require 'getoptlong'
+require 'socket'
 
 def usage
     puts <<USAGE
@@ -58,9 +59,61 @@ require "/var/www/openshift/broker/config/environment"
 # Disable analytics for admin scripts
 Rails.configuration.analytics[:enabled] = false
 
-no_error = true
+errors = false
 summary = []
 
+
+# start with validation of the nodes
+
+localhost = %w[127.0.0.1 ::1]
+# get public_hostname of all nodes
+hosts = Hash.new {|h,k| h[k]=[]}
+OpenShift::MCollectiveApplicationContainerProxy.rpc_get_fact("public_hostname") do |s,host|
+  hosts[host] << s
+  begin # test host resolution
+    # public_hostname must resolve as a FQDN, so should be the full name
+    # (the "." at the end blocks adding a search domain)
+    resolved_host = IPSocket.getaddress(host + ".")
+    if localhost.member? resolved_host
+      errors = true
+      summary << "FAIL - PUBLIC_HOSTNAME #{host} for #{s} should be public, not localhost"
+    else
+      puts "OK - PUBLIC_HOSTNAME #{host} for #{s} resolves to #{resolved_host}" if verbose
+    end
+  rescue Exception => e
+    errors = true
+    summary << "FAIL - PUBLIC_HOSTNAME #{host} for #{s} does not resolve as a FQDN (#{e})"
+  end
+end
+
+# get public_ip of all nodes
+ips = Hash.new {|h,k| h[k]=[]}
+OpenShift::MCollectiveApplicationContainerProxy.rpc_get_fact("public_ip") do |s,ip|
+  ips[ip] << s
+  if localhost.member? ip
+    errors = true
+    summary << "FAIL - PUBLIC_IP #{ip} should be public, not localhost"
+  else
+    puts "OK - PUBLIC_IP #{ip} for #{s}" if verbose
+  end
+end
+
+hosts.each do |host,ids|
+  if ids.length > 1
+      errors = true
+      summary << "FAIL - multiple node hosts have public_hostname #{host}: #{ids.join ','}"
+  end
+end
+ips.each do |ip,ids|
+  if ids.length > 1
+      errors = true
+      summary << "FAIL - multiple node hosts have public_ip #{ip}: #{ids.join ','}"
+  end
+end
+
+puts summary.join "\n" if errors && verbose
+
+# now do validation of all gears
 node_hash = OpenShift::ApplicationContainerProxy.get_all_gears
 
 mongo_hash = {}
@@ -79,7 +132,7 @@ CloudUser.find_all(nil) {|hash|
     msg = "FAIL - user #{user.login} has a mismatch in consumed gears (#{user.consumed_gears}) and actual gears (#{gear_count})!"
     puts msg if verbose
     summary << msg
-    no_error = false
+    errors = true
   else
     puts "OK - user #{user.login} has consumed_gears equal to actual gears (#{gear_count})!" if verbose
   end
@@ -90,7 +143,7 @@ puts "Checking application gears in respective nodes :" if verbose
 mongo_hash.each { |mk,mv|
   print "#{mk}...\t" if verbose
   if not node_hash.has_key? mk
-    no_error = false
+    errors = true
     puts "FAIL" if verbose
     summary << "Gear #{mk} in #{mv} does not exist on any node"
   else
@@ -103,7 +156,7 @@ puts "Checking node gears in application database:" if verbose
 node_hash.each { |nk, nv|
   print "#{nk}...\t" if verbose
   if not mongo_hash.has_key? nk
-    no_error = false
+    errors = true
     puts "FAIL" if verbose
     summary << "Gear #{nk} exists on node #{nv} but does not exist in mongo database"
   else
@@ -111,5 +164,5 @@ node_hash.each { |nk, nv|
   end
 }
 
-puts no_error ? "Success" : "Check failed.\n #{summary.join("\n")}"
-exit (no_error ? 0 : 1)
+puts errors ? "Check failed.\n #{summary.join("\n")}" : "Success"
+exit (errors ? 1 : 0)

--- a/node-util/bin/oo-accept-node
+++ b/node-util/bin/oo-accept-node
@@ -174,8 +174,9 @@ def check_node_public_resolution
     # check that the broker host resolves to an external IP
     begin
       resolved_host = IPSocket.getaddress(broker)
-      localhost.member?(resolved_host) and
-        do_fail("#{$NODE_CONF_FILE}: BROKER_HOST #{broker} should be public address, not localhost") 
+      # on devenv or livecd, BROKER_HOST=localhost is considered legit. Will let that be for now.
+      #localhost.member?(resolved_host) and
+        #do_fail("#{$NODE_CONF_FILE}: BROKER_HOST #{broker} should be public address, not localhost") 
     rescue Exception => e
       do_fail("#{$NODE_CONF_FILE}: BROKER_HOST #{broker} does not resolve (#{e})")
     end

--- a/node-util/bin/oo-accept-node
+++ b/node-util/bin/oo-accept-node
@@ -19,6 +19,7 @@
 
 require 'rubygems'
 require 'optparse'
+require 'socket'
 
 $OPTIONS = {}
 
@@ -38,9 +39,9 @@ $TC_CHECK=false
 $TC_DATA = %x[tc clas show dev eth0].split("\n").grep(/parent/)
 $ALL_QUOTAS = %x[repquota -a].split("\n")
 
-$LIBRA_CONF_DIR="/etc/openshift"
-$NODE_CONF_FILE=File.join($LIBRA_CONF_DIR, "/node.conf")
-$RESOURCE_LIMITS_FILE=File.join($LIBRA_CONF_DIR,"/resource_limits.conf")
+$CONF_DIR="/etc/openshift"
+$NODE_CONF_FILE=File.join($CONF_DIR, "/node.conf")
+$RESOURCE_LIMITS_FILE=File.join($CONF_DIR,"/resource_limits.conf")
 $LIMITS_CONF_DIR="/etc/security/limits.d"
 #
 # Control variables.  Override for testing
@@ -51,7 +52,7 @@ DEFAULT_PACKAGES="rubygem-openshift-origin-node openshift-origin-node-util \
 #                  cartridge-rack-1.1.
 #                  cartridge-wsgi-3.2
 #                  cartridge-php-5.3"
-DEFAULT_SERVICES="mcollective cgconfig cgred httpd"
+DEFAULT_SERVICES="mcollective cgconfig cgred httpd openshift-port-proxy"
 DEFAULT_MINSEM=512
 
 $SEBOOL_LIST="SEBOOL_LIST"
@@ -140,11 +141,19 @@ def load_node_conf
 
     #Source it in bash, grep it in ruby
     source_file($NODE_CONF_FILE)
-    if ENV["GEAR_BASE_DIR"].nil?
-        do_fail("GEAR_BASE_DIR is not set in the node configuration")
-    else
-        $GEAR_BASE_DIR=ENV['GEAR_BASE_DIR']
+
+    # make sure required values are set in the conf file
+    %w[
+      GEAR_BASE_DIR GEAR_SKEL_DIR GEAR_SHELL GEAR_GECOS CLOUD_NAME
+      GEAR_MIN_UID GEAR_MAX_UID CARTRIDGE_BASE_PATH
+      PROXY_MIN_PORT_NUM PROXY_PORTS_PER_GEAR OPENSHIFT_HTTP_CONF_DIR
+      CLOUD_DOMAIN BROKER_HOST PUBLIC_IP PUBLIC_HOSTNAME
+    ].each do |value|
+      next unless ENV[value].nil? || ENV[value].empty?
+      do_fail("SEVERE: in #{$NODE_CONF_FILE}, #{value} not defined")
     end
+
+    $GEAR_BASE_DIR=ENV['GEAR_BASE_DIR']
     do_fail("GEAR_BASE_DIR does not exist or is not a directory: #{$GEAR_BASE_DIR}") unless File.exists? $GEAR_BASE_DIR
     $GEAR_HTTPD_DIR=File.join($GEAR_BASE_DIR,"/.httpd.d")
 
@@ -152,6 +161,47 @@ def load_node_conf
 
     do_fail("No resource limits file: #{$RESOURCE_LIMITS_FILE}") unless File.exists? $RESOURCE_LIMITS_FILE
     source_file($RESOURCE_LIMITS_FILE)
+end
+
+def check_node_public_resolution
+    verbose("checking node public hostname resolution")
+
+    localhost = %w[127.0.0.1 ::1]
+    pubhost = ENV["PUBLIC_HOSTNAME"]
+    pubip = ENV["PUBLIC_IP"]
+    broker = ENV["BROKER_HOST"]
+
+    # check that the broker host resolves to an external IP
+    begin
+      resolved_host = IPSocket.getaddress(broker)
+      localhost.member?(resolved_host) and
+        do_fail("#{$NODE_CONF_FILE}: BROKER_HOST #{broker} should be public address, not localhost") 
+    rescue Exception => e
+      do_fail("#{$NODE_CONF_FILE}: BROKER_HOST #{broker} does not resolve (#{e})")
+    end
+
+    # attempt to resolve the node public hostname
+    begin
+      # must resolve as a FQDN, so should be the full name
+      # (the "." at the end blocks adding a search domain)
+      resolved_host = IPSocket.getaddress(pubhost + ".")
+    rescue Exception => e
+      do_fail("#{$NODE_CONF_FILE}: PUBLIC_HOSTNAME #{pubhost} does not resolve as a FQDN (#{e})")
+      return
+    end
+
+    # make sure public settings resolve correctly to a non-localhost IP
+    do_fail("#{$NODE_CONF_FILE}: PUBLIC_HOSTNAME #{pubhost} should be public, not localhost") if localhost.member? resolved_host
+    do_fail("#{$NODE_CONF_FILE}: PUBLIC_IP #{pubip} should be public, not localhost") if localhost.member? pubip
+
+    # it would be nice to check that the PUBLIC_IP actually ends up at a NIC on this host.
+    # however in settings like EC2, there's no good way to do that.
+    #
+    # but we can check PUBLIC_HOSTNAME resolves to either a NIC on this host or PUBLIC_IP.
+    # in EC2, hostname resolves differently internal vs. external, so will match NIC.
+    # in most places, PUBLIC_HOSTNAME will resolve to PUBLIC_IP
+    my_ips = `ip addr show scope global`.scan(/^\s+inet\s+([\d\.]+)/).flatten.push(pubip).uniq
+    do_fail("#{$NODE_CONF_FILE}: PUBLIC_HOSTNAME #{pubhost} resolves to #{resolved_host}; expected #{my_ips.join '|'}") unless my_ips.member? resolved_host
 end
 
 def check_selinux()
@@ -329,6 +379,7 @@ end
 if __FILE__ == $0
     $STATUS=0
     load_node_conf
+    check_node_public_resolution
     check_selinux
     check_packages
     check_services

--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -10,6 +10,8 @@ CLOUD_DOMAIN="example.com"                                  # Domain suffix to u
 # You may want these, depending on the complexity of your networking:
 # EXTERNAL_ETH_DEV='eth0'                                    # Specify the internet facing public ethernet device
 # INTERNAL_ETH_DEV='eth1'                                    # Specify the internal cluster facing ethernet device
+INSTANCE_ID="localhost"                                      # Set by RH EC2 automation
+
 
 # Generally the following should not be changed:
 GEAR_BASE_DIR="/var/lib/openshift"                         # gear root directory

--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -1,3 +1,17 @@
+# These should not be left at default values, even for a demo.
+# "PUBLIC" networking values are ones that end-users should be able to reach.
+PUBLIC_HOSTNAME="please.set.node.public-hostname.fqdn"       # The node host's public hostname
+PUBLIC_IP="127.0.0.1"                                        # The node host's public IP address
+BROKER_HOST="localhost"                                      # IP or DNS name of broker server for REST API
+
+# Usually (unless in a demo) this should be changed to the domain for your installation:
+CLOUD_DOMAIN="example.com"                                  # Domain suffix to use for applications (Must match broker config)
+
+# You may want these, depending on the complexity of your networking:
+# EXTERNAL_ETH_DEV='eth0'                                    # Specify the internet facing public ethernet device
+# INTERNAL_ETH_DEV='eth1'                                    # Specify the internal cluster facing ethernet device
+
+# Generally the following should not be changed:
 GEAR_BASE_DIR="/var/lib/openshift"                         # gear root directory
 GEAR_SKEL_DIR="/etc/openshift/skel"                        # skel files to use when building a gear
 GEAR_SHELL="/usr/bin/oo-trap-user"                          # shell to use for the gear
@@ -11,14 +25,5 @@ LAST_ACCESS_DIR="/var/lib/openshift/.last_access"          # Location to maintai
 APACHE_ACCESS_LOG="/var/log/httpd/access_log"              # Localion of httpd for node
 PROXY_MIN_PORT_NUM=35531                                    # Lower bound of port numbers used to proxy ports externally
 PROXY_PORTS_PER_GEAR=5                                      # Number of proxy ports available per gear
-CLOUD_DOMAIN="example.com"                                  # Domain suffix to use for applications (Must match broker config)
-BROKER_HOST="localhost"                                     # DNS name of broker server
 CREATE_APP_SYMLINKS=0                                       # If set to 1, creates gear-name symlinks to the UUID directories (debugging only)
-INSTANCE_ID="localhost"
 OPENSHIFT_HTTP_CONF_DIR="/etc/httpd/conf.d/openshift"
-PUBLIC_IP="127.0.0.1"                                        # The public IP address, this will be overridden (see OVERRIDE below)
-PUBLIC_HOSTNAME="localhost.localdomain"                      # The public hostname, this will be overridden (see OVERRIDE below)
-# PUBLIC_IP_OVERRIDE='127.0.0.1'                             # Override public IP of this node instead of auto-detecting
-# PUBLIC_HOSTNAME_OVERRIDE='localhost.localdomain'           # Override public hostname of this node instead of auto-detecting
-# EXTERNAL_ETH_DEV='eth0'                                    # Specify the internet facing public ethernet device
-# INTERNAL_ETH_DEV='eth1'                                    # Specify the internal cluster facing ethernet device


### PR DESCRIPTION
updates to oo-accept-node, oo-admin-chk to detect bad node PUBLIC_\* settings.
- pull changeable node.conf settings to top; remove unused; comment
- add various oo-accept-node checks for node.conf sanity, including PUBLIC_HOSTNAME
- have oo-admin-chk validate the PUBLIC_HOSTNAME and PUBLIC_IP of all nodes and check for dupes
