### PR TITLE
Fix for Bug 874445

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract/info/hooks/deploy-httpd-proxy
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract/info/hooks/deploy-httpd-proxy
@@ -69,7 +69,7 @@ fi
 
 if $idle
 then
-  rhc-idler -u $uuid
+  oo-idler -u $uuid
 fi
 
 restart_httpd_graceful

--- a/cartridges/openshift-origin-cartridge-abstract/abstract/info/hooks/move
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract/info/hooks/move
@@ -67,7 +67,7 @@ fi
 
 if $idle
 then
-  nohup rhc-idler -u $uuid &> /dev/null &
+  nohup oo-idler -u $uuid &> /dev/null &
 else
   restart_httpd_graceful
 fi

--- a/cartridges/openshift-origin-cartridge-haproxy-1.4/info/hooks/move
+++ b/cartridges/openshift-origin-cartridge-haproxy-1.4/info/hooks/move
@@ -71,7 +71,7 @@ fi
 
 if $idle
 then
-  rhc-idler -u $uuid
+  oo-idler -u $uuid
 fi
 
 restart_httpd_graceful

--- a/cartridges/openshift-origin-cartridge-mysql-5.1/info/hooks/deploy-httpd-proxy
+++ b/cartridges/openshift-origin-cartridge-mysql-5.1/info/hooks/deploy-httpd-proxy
@@ -66,7 +66,7 @@ fi
 
 if $idle
 then
-  rhc-idler -u $uuid
+  oo-idler -u $uuid
 fi
 
 restart_httpd_graceful

--- a/node-util/bin/oo-idler
+++ b/node-util/bin/oo-idler
@@ -111,8 +111,10 @@ source /usr/libexec/openshift/cartridges/abstract/info/lib/util
 source /etc/openshift/node.conf
 source "/var/lib/openshift/${uuid}/.env/OPENSHIFT_HOMEDIR"
 
-if `is_idled "$uuid"` || `is_stopped "$uuid"` ; then
-    exit 0 # app is already idled or stopped, nothing to do
+# If moving an idled scaled application the haproxy cartridge will report to be
+#   already "idled" but the associate httpd conf is not
+if `is_stopped "$uuid"` ; then
+    exit 0 # app is already stopped, nothing to do
 fi
 
 HTTP_DIR=`dirname "/etc/httpd/conf.d/openshift/${uuid}"*/00000_default.conf`


### PR DESCRIPTION
Cleanup missed command rename
Remove guard in oo-idler, scaled apps need to run idler code for all cartridges
