### PR TITLE
remove %prep steps that add gem pre-processing since we're using a .tar.gz

### DIFF
--- a/common/rubygem-openshift-origin-common.spec
+++ b/common/rubygem-openshift-origin-common.spec
@@ -44,12 +44,7 @@ This contains the Cloud Development Common packaged as a ruby site library
 documentation files.
 
 %prep
-%{?scl:scl enable %scl "}
-#gem unpack %{SOURCE0}
-#%setup -q -D -T -n  %{gem_name}-%{version}
-%setup -q -D -n  %{gem_name}-%{version}
-#gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
-%{?scl:"}
+%setup -q
 
 %build
 mkdir -p ./%{gem_dir}


### PR DESCRIPTION
[merge]
