### PR TITLE
Compare retcode as an int rather than string

### DIFF
--- a/controller/test/cucumber/step_definitions/cartridge-jenkins_steps.rb
+++ b/controller/test/cucumber/step_definitions/cartridge-jenkins_steps.rb
@@ -98,7 +98,7 @@ Then /^the application will be updated$/ do
     path = "/var/lib/openshift/#{app_uuid}/app-root/repo/#{@app.name}/index.html"
     $logger.debug "jenkins built application path = #{path}"
     `grep 'Jenkins Builder Testing' "#{path}"`
-    $?.to_s.should be == "0"
+    $?.to_i.should be == 0
 end
 
 Then /^I deconfigure the diy application with jenkins enabled$/ do


### PR DESCRIPTION
The Process::Status#to_s method has changed in Ruby 1.9 to
return a string representing the process. The test needs to
compare the exitcode to 0 as an integer rather than testing
the pretty-formatted string process identifier.
