### PR TITLE
Fix tests to work with remote-user auth

### DIFF
--- a/broker/test/helpers/rest/api.rb
+++ b/broker/test/helpers/rest/api.rb
@@ -13,7 +13,13 @@ $credentials = Base64.encode64("#{$user}:#{$password}")
 $default_timeout = 120 # 120 secs
 
 def register_user
-  cmd = "oo-register-user -l admin -p admin --username #{$user} --userpass #{$password}"
+  if File.exists?("/etc/openshift/plugins.d/openshift-origin-auth-mongo.conf")
+    cmd = "oo-register-user -l admin -p admin --username #{$user} --userpass #{$password}"
+  elsif File.exists?("/etc/openshift/plugins.d/openshift-origin-auth-remote-user.conf")
+    cmd = "/usr/bin/htpasswd -b /etc/openshift/htpasswd #{$user} #{$password}"
+  else
+    raise "No authentication plug-in is configured."
+  end
   pid, stdin, stdout, stderr = nil, nil, nil, nil
 
   with_clean_env {

--- a/controller/test/cucumber/support/00_setup_helper.rb
+++ b/controller/test/cucumber/support/00_setup_helper.rb
@@ -25,7 +25,11 @@ $selinux_type = "openshift_initrc_t"
 
 # User registration flag and script
 $registration_required = true
-$user_register_script_format = "/usr/bin/oo-register-user -l admin -p admin --username %s --userpass %s"
+if File.exists?("/etc/openshift/plugins.d/openshift-origin-auth-mongo.conf")
+  $user_register_script_format = "/usr/bin/oo-register-user -l admin -p admin --username %s --userpass %s"
+elsif File.exists?("/etc/openshift/plugins.d/openshift-origin-auth-remote-user.conf")
+  $user_register_script_format = "/usr/bin/htpasswd -b /etc/openshift/htpasswd %s %s"
+end
 
 # Alternatie domain suffix for use in alias commands
 $alias_domain = "foobar.com"


### PR DESCRIPTION
Check which authentication plug-in is enabled, and use oo-register-user
if the mongo auth plug-in is enabled and else htpasswd if the
remote-user plug-in is enabled.
