### PR TITLE
BZ877125 - File attributes on open shift-cgroups init script are inco

### DIFF
--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -146,7 +146,7 @@ rm -rf %{buildroot}
 %attr(0755,-,-) %{appdir}
 
 #%if 0%{?fedora}%{?rhel} <= 6
-%attr(0755,-,0)	/etc/rc.d/init.d/openshift-cgroups
+%attr(0755,-,-)	/etc/rc.d/init.d/openshift-cgroups
 #%else
 #%attr(0750,-,-) /etc/systemd/system
 #%endif


### PR DESCRIPTION
[merge] after tests
