### PR TITLE
Fix for BZ 874881.

### DIFF
--- a/cartridges/openshift-origin-cartridge-postgresql-8.4/openshift-origin-cartridge-postgresql-8.4.spec
+++ b/cartridges/openshift-origin-cartridge-postgresql-8.4/openshift-origin-cartridge-postgresql-8.4.spec
@@ -35,7 +35,10 @@ Requires: php-pear-MDB2-Driver-pgsql
 Requires: php-pgsql
 Requires: postgis
 Requires: python-psycopg2
+%if 0%{?rhel} <= 6 && 0%{?fedora} <=16
 Requires: ruby-postgres
+%endif
+Requires: rubygem-pg
 Requires: rhdb-utils
 Requires: uuid-pgsql
 Obsoletes: cartridge-postgresql-8.4


### PR DESCRIPTION
Always install rubygem-pg and install ruby-postgres for rhel <= 6 or fedora <=16 for backwards
compatibility.
