### PR TITLE
Allow quickstart match format to support OR construct

### DIFF
--- a/console/app/models/cartridge_type.rb
+++ b/console/app/models/cartridge_type.rb
@@ -102,14 +102,11 @@ class CartridgeType < RestApi::Base
 
   def self.matches(s, opts=nil)
     every = all(opts)
-    s = s[0..-2] if s.is_a?(String) && s.ends_with?('*')
-    Array(every.find{ |t| t.name == s} || every.select do |t|
-      if s.is_a? String
-        t.name.starts_with? s
-      else
-        s.match(t.name)
-      end
-    end)
+    s.split('|').map{ |s| s.gsub('*','') }.map do |s|
+      Array(every.find{ |t| t.name == s } || every.select do |t| 
+        t.name.include?(s) 
+      end)
+    end.flatten.uniq
   end
 
   cache_find_method :every

--- a/console/app/models/quickstart.rb
+++ b/console/app/models/quickstart.rb
@@ -48,6 +48,7 @@ class Quickstart < RestApi::Base
       end
     end
   end
+  alias_method :cartridge_specs, :cartridges
 
   def scalable
     true

--- a/console/test/integration/rest_api/cartridge_type_test.rb
+++ b/console/test/integration/rest_api/cartridge_type_test.rb
@@ -121,7 +121,17 @@ class RestApiCartridgeTypeTest < ActiveSupport::TestCase
   # depending on that behavior.  If this behavior is moved to a new
   # route then we can remove this.
   test 'application template names returned by server' do
-    assert template = ApplicationTemplate.first(:from => :wordpress)
+    template = ApplicationTemplate.first(:from => :wordpress)
+    omit("No templates defined on this server") unless template
     assert_equal 'WordPress', template.display_name
+  end
+
+  test 'match cartridges' do
+    assert_equal [], CartridgeType.cached.matches('bra').map(&:name)
+    assert_equal ['ruby-1.9','ruby-1.8'], CartridgeType.cached.matches('ruby').map(&:name)
+    assert_equal ['ruby-1.9','ruby-1.8'], CartridgeType.cached.matches('ruby*').map(&:name)
+    assert_equal ['ruby-1.9','ruby-1.8'], CartridgeType.cached.matches('*uby*').map(&:name)
+    assert_equal ['zend-5.6','php-5.3'], CartridgeType.cached.matches('zend-|php-').map(&:name)
+    assert_equal ['php-5.3','zend-5.6'], CartridgeType.cached.matches('php-|zend-').map(&:name)
   end
 end


### PR DESCRIPTION
Extend the match spec to support OR construct 'php-|zend-' returns both PHP and Zend
