### PR TITLE
Bug 877222 - Handle more failure scenarios from quickstart jsons

### DIFF
--- a/console/app/controllers/applications_controller.rb
+++ b/console/app/controllers/applications_controller.rb
@@ -119,7 +119,6 @@ class ApplicationsController < ConsoleController
     @application = (@application_type >> Application.new(:as => current_user)).assign_attributes(app_params)
 
     begin
-      logger.debug @application_type.inspect
       @cartridges, @missing_cartridges = @application_type.matching_cartridges
       flash.now[:error] = "No cartridges are defined for this type - all applications require at least one web cartridge" unless @cartridges.present?
     rescue ApplicationType::CartridgeSpecInvalid

--- a/console/app/models/quickstart.rb
+++ b/console/app/models/quickstart.rb
@@ -17,6 +17,10 @@ class Quickstart < RestApi::Base
   alias_attribute :display_name, :name
   alias_attribute :description, :summary
 
+  def name
+    entity_decoded(super)
+  end
+
   def priority
     super.to_i rescue 0
   end
@@ -33,20 +37,8 @@ class Quickstart < RestApi::Base
     @updated ||= Time.at(attributes[:updated].to_i)
   end
 
-  def cartridges
-    @cartridges ||= begin
-      s = (attributes[:cartridges] || '')
-      if s.is_a? Array
-        s
-      else
-        s = s.strip
-        if s[0] == '['
-          ActiveSupport::JSON.decode(s) rescue []
-        else
-          s.split(',').map(&:strip)
-        end
-      end
-    end
+  def cartridges_spec
+    entity_decoded(cartridges)
   end
   alias_method :cartridge_specs, :cartridges
 

--- a/console/app/models/quickstart.rb
+++ b/console/app/models/quickstart.rb
@@ -38,9 +38,8 @@ class Quickstart < RestApi::Base
   end
 
   def cartridges_spec
-    entity_decoded(cartridges)
+    entity_decoded(attributes[:cartridges])
   end
-  alias_method :cartridge_specs, :cartridges
 
   def scalable
     true
@@ -48,7 +47,7 @@ class Quickstart < RestApi::Base
   alias_method :scalable?, :scalable
 
   def >>(application)
-    application.cartridges = cartridges
+    #application.cartridges = cartridges
     application.initial_git_url = initial_git_url
     application
   end

--- a/console/app/models/rest_api/base.rb
+++ b/console/app/models/rest_api/base.rb
@@ -648,6 +648,18 @@ module RestApi
         end
       end
 
+      #
+      # Drupal 6 doesn't correctly encode JSON, and some non-HTML content needs to be
+      # decoded.
+      #
+      def entity_decoded(s)
+        if s && (s.include?('&#') || s.include?('&quot;'))
+          CGI.unescapeHTML(s)
+        else
+          s
+        end
+      end
+
       def connection(refresh = false)
         @connection = nil if refresh
         @connection ||= self.class.connection({:as => as})

--- a/console/app/views/application_types/show.html.haml
+++ b/console/app/views/application_types/show.html.haml
@@ -90,7 +90,7 @@
           %span branch 'master'
         - else
           %h3
-            - if @application_type.initial_git_url
+            - if @application_type.initial_git_url.present?
               #{link_to @application_type.initial_git_url, @application_type.initial_git_url, :target => "_blank"}
               -# if @application_type.initial_git_branch
                 (branch '#{@application_type.initial_git_branch}')
@@ -139,7 +139,7 @@
           %h3
             = map_to_sentence(@cartridges) do |(name, carts)|
               - if carts.length > 1
-                = select_tag 'application[cartridges][]', options_for_select(carts.sort.map{ |c| [c.display_name, c.name] }), :title => "Choose a cartridge that matches '#{name}'"
+                = select_tag 'application[cartridges][]', options_for_select(carts.sort.map{ |c| [c.display_name, c.name] }, [carts.map(&:name) & @application.cartridge_names].first ), :title => "Choose a cartridge that matches '#{name}'"
               - elsif carts.length == 1
                 = hidden_field_tag 'application[cartridges][]', [carts.first.name]
                 = carts.first.display_name

--- a/console/test/functional/application_types_controller_test.rb
+++ b/console/test/functional/application_types_controller_test.rb
@@ -81,7 +81,7 @@ class ApplicationTypesControllerTest < ActionController::TestCase
 
   test "should show type page for quickstart" do
     with_unique_user
-    type = ApplicationType.all.select{ |t| t.quickstart? }.sample(1).first
+    type = ApplicationType.all.select(&:quickstart?).sample(1).first
     omit("No quickstarts registered on this server") if type.nil?
 
     get :show, :id => type.id
@@ -90,10 +90,19 @@ class ApplicationTypesControllerTest < ActionController::TestCase
 
   test "should show type page for application template" do
     with_unique_user
-    type = ApplicationType.all.select{ |t| t.template? }.sample(1).first
+    type = ApplicationType.all.select(&:template?).sample(1).first
     omit("No templates registered on this server") if type.nil?
 
     get :show, :id => type.id
+    assert_standard_show_type(type)
+  end
+
+  test "should handle invalid quickstart page" do
+    with_unique_user
+    type = Quickstart.new(:id => 'test', :name => '', :cartridges => '[{')
+    Quickstart.expects(:find).returns(type)
+
+    get :show, :id => 'quickstart!test'
     assert_standard_show_type(type)
   end
 

--- a/console/test/functional/applications_controller_test.rb
+++ b/console/test/functional/applications_controller_test.rb
@@ -75,9 +75,8 @@ class ApplicationsControllerTest < ActionController::TestCase
   test "should assign errors when advanced form" do
     with_domain
     app_params = get_post_form
-    app_params[:application_type] = 'custom'
     app_params[:name] = ''
-    post(:create, {:application => app_params, :advanced => true})
+    post(:create, {:application => app_params, :application_type => 'custom', :advanced => true})
 
     assert_template 'application_types/show'
     assert app = assigns(:application)
@@ -100,14 +99,16 @@ class ApplicationsControllerTest < ActionController::TestCase
   test "should assign errors when advanced form with carts" do
     with_domain
     app_params = get_post_form
-    app_params[:application_type] = {
+    app_type = {
       :id => 'custom',
-      :cartridges => ['ruby-1.9'],
+      :cartridges => ['ruby-'],
       :initial_git_url => 'http://foo.com',
       :initial_git_branch => 'bar',
     }
     app_params[:name] = ''
-    post(:create, {:application => app_params, :advanced => true})
+    app_params[:cartridges] = ['ruby-1.8']
+    app_params[:scale] = 'true'
+    post(:create, {:application => app_params, :application_type => app_type, :advanced => true})
 
     assert_template 'application_types/show'
     assert app = assigns(:application)
@@ -116,9 +117,10 @@ class ApplicationsControllerTest < ActionController::TestCase
     assert_equal 1, app.errors[:name].length
 
     assert_select '.alert.alert-error', /Application name is required/i
-    assert_select "select[name='application[scale]']"
+    assert_select "select[name='application[scale]'] > option[selected]", 'Scale with web traffic'
     assert_select "input[name='application[initial_git_url]'][value=http://foo.com]"
     #assert_select "input[name='application[initial_git_branch]'][value=bar]"
+    assert_select "select[name='application[cartridges][]'] > option[selected]", 'Ruby 1.8'
   end
 
   test "should assign errors on long name" do

--- a/console/test/integration/rest_api/cartridge_type_test.rb
+++ b/console/test/integration/rest_api/cartridge_type_test.rb
@@ -13,7 +13,7 @@ class RestApiCartridgeTypeTest < ActiveSupport::TestCase
           description: #{t.description}
           tags:        #{t.tags.inspect}
           version:     #{t.version}
-          cartridges:  #{t.respond_to?(:cartridges) ? t.cartridges.join(', ') : 'n/a'}
+          cartridges:  #{t.respond_to?(:cartridges) ? t.cartridges.inspect : 'n/a'}
           priority:    #{t.priority}
         #{log_extra(t)}
       TYPE
@@ -113,6 +113,12 @@ class RestApiCartridgeTypeTest < ActiveSupport::TestCase
 
     assert php < jenkins
     assert ruby < jenkins
+  end
+
+  test 'matching cartridges types' do
+    found, missing = ApplicationType.matching_cartridges('php-')
+    assert_equal ['php-5.3'], found['php-'].map(&:name), found.inspect
+    assert missing.empty?
   end
 
   # Currently /application_templates/<string>.json can return an array

--- a/console/test/unit/rest_api_test.rb
+++ b/console/test/unit/rest_api_test.rb
@@ -1474,11 +1474,25 @@ class RestApiTest < ActiveSupport::TestCase
   end
 
   def test_quickstart
-   assert_equal [:test], Quickstart.new(:tags => ['test']).tags
-   assert_equal ['php-5.3'], Quickstart.new(:cartridges => ['php-5.3']).cartridges
+    assert_equal [:test], Quickstart.new(:tags => ['test']).tags
 
-   assert_equal ['php-5.3'], Quickstart.new(:cartridges => ['php-5.3'].to_json).cartridges
-   assert_equal [], Quickstart.new(:cartridges => "[{'php-5.3'}]").cartridges
+    assert_equal 'php-5.3', Quickstart.new(:cartridges => 'php-5.3').cartridges_spec
+    assert_equal '"', Quickstart.new(:cartridges => '&quot;').cartridges_spec
+    assert_equal '"', Quickstart.new(:cartridges => '&quot;').cartridges_spec
+
+    assert_equal '"', Quickstart.new(:name => '&quot;').display_name
+  end
+
+  def test_application_type_cartridge_specs
+    assert_equal ['php-5.3'], ApplicationType.new(:cartridges_spec => 'php-5.3').cartridge_specs
+    assert_equal ['php-5.3'], ApplicationType.new(:cartridges => ['php-5.3']).cartridge_specs
+    assert_equal ['php-5.3'], ApplicationType.new(:cartridges => 'php-5.3').cartridge_specs
+    assert_equal ['php-5.3'], ApplicationType.new(:cartridges_spec => ['php-5.3'].to_json).cartridge_specs
+    assert_equal [], ApplicationType.new(:cartridges_spec => nil).cartridge_specs
+    assert_equal [], ApplicationType.new(:cartridges_spec => []).cartridge_specs
+    assert_equal [], ApplicationType.new(:cartridges_spec => '').cartridge_specs
+    assert_raise(ApplicationType::CartridgeSpecInvalid){ ApplicationType.new(:cartridges_spec => "[{").cartridge_specs }
+    assert_raise(ApplicationType::CartridgeSpecInvalid){ ApplicationType.new(:cartridges_spec => '[{name:"php"}]').cartridge_specs }
   end
 
   def test_quickstart_search
@@ -1512,7 +1526,7 @@ class RestApiTest < ActiveSupport::TestCase
     assert_equal "Wordpress 3.4", q.name
     assert_equal "12069", q.id
     assert q.website
-    assert_equal ['php-5.3', 'mysql-5.1'], q.cartridges
+    assert_equal 'php-5.3, mysql-5.1', q.cartridges_spec
     assert q.initial_git_url
     assert q.tags.include?(:blog)
     assert q.updated > 1.year.ago


### PR DESCRIPTION
Also make it much clearer what data is being copied, make ApplicationType own responsibility for processing cartridge specs
