### PR TITLE
Calculate date duration in a 1.9 compatible way

### DIFF
--- a/node-util/bin/oo-app-idle
+++ b/node-util/bin/oo-app-idle
@@ -36,7 +36,7 @@ if File.exists?(file_path)
     last_access_time = file.read
     d1 = DateTime.strptime(last_access_time, "%d/%b/%Y:%H:%M:%S %Z")
     d2 = DateTime.now
-    hours,minutes,seconds,frac = Date.day_fraction_to_time(d2 - d1)
+    hours = ((d2 - d1) * 24).to_i
     if hours >= IDLE_FOR
       exit 0
     else


### PR DESCRIPTION
The Date.day_fraction_to_time method is gone in Ruby 1.9.3. Replace
date duration computation with a new calculation.
