### PR TITLE
Use correct alias method during gear post-move

### DIFF
--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -609,7 +609,7 @@ module OpenShift
           unless keep_uid
             unless app.aliases.nil?
               app.aliases.each do |server_alias|
-                reply.append destination_container.send(:run_cartridge_command, app.framework, app, app.gear, "add-alias", server_alias, false)
+                reply.append destination_container.add_alias(app, app.gear, server_alias)
               end
             end
           end


### PR DESCRIPTION
Use the new add_alias function during post-move rather than
sending direct messages to the cartridges.

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=884589
