### PR TITLE
Fixing some init scripts to make the product release tests happy

### DIFF
--- a/broker/init.d/openshift-broker
+++ b/broker/init.d/openshift-broker
@@ -62,6 +62,14 @@ start() {
 # errant children.
 stop() {
 	echo -n $"Stopping $prog: "
+	if [ -e ${pidfile} ]; then
+	  killproc -p ${pidfile} -d 10 $httpd
+	else
+	  # BZ876937
+	  echo -n "(already stopped)"
+	  success
+	fi
+
 	killproc -p ${pidfile} -d 10 $httpd
 	RETVAL=$?
 	echo

--- a/openshift-console/init.d/openshift-console
+++ b/openshift-console/init.d/openshift-console
@@ -56,7 +56,13 @@ start() {
 # errant children.
 stop() {
 	echo -n $"Stopping $prog: "
-	killproc -p ${pidfile} -d 10 $httpd
+        if [ -e ${pidfile} ]; then
+          killproc -p ${pidfile} -d 10 $httpd
+        else
+          # BZ876937
+          echo -n "(already stopped)"
+          success
+        fi
 	RETVAL=$?
 	echo
 	[ $RETVAL = 0 ] && rm -f ${lockfile} ${pidfile}

--- a/port-proxy/init-scripts/openshift-port-proxy
+++ b/port-proxy/init-scripts/openshift-port-proxy
@@ -41,7 +41,13 @@ start() {
 
 stop() {
     echo -n $"Stopping openshift-port-proxy: "
-    killproc -p $pidfile $prog 
+    if [ -e ${pidfile} ]; then
+      killproc -p $pidfile $prog
+    else
+      # BZ876937
+      echo -n "(already stopped)"
+      success
+    fi
     retval=$?
     echo
     [ $retval -eq 0 ] && rm -f $lockfile


### PR DESCRIPTION
In order to release OpenShift Enterprise all packages must pass the automated standards tests.  They state that running 'stop' on a service script should not report FAILED if the service was already stopped. Previously these service scripts would report the correct exit code were printing the failure message.

Now we wrap the killproc call with a test for the pid.  The killproc call won't work if the pid is missing anyway.

NOTE: It's true that you don't have to look far to see counter examples of this in packages (the openshift-broker and console scripts were based on apache's) but since we are a new product we are expected to adhere to the latest standards.
