### PR TITLE
BZ 884865: Do not attempt to install extensions already on the system.

### DIFF
--- a/cartridges/openshift-origin-cartridge-php-5.3/info/bin/build.sh
+++ b/cartridges/openshift-origin-cartridge-php-5.3/info/bin/build.sh
@@ -25,8 +25,11 @@ then
         if pear list "$f" > /dev/null
         then
             pear upgrade "$f"
-        else
+        elif ! ( php -c "${OPENSHIFT_PHP_DIR}"/conf -m | grep -q \^`basename "$f"`\$ )
+        then
             pear install --alldeps "$f"
+        else
+            echo "Extension already installed in the system: $f"
         fi
     done
 fi

--- a/cartridges/openshift-origin-cartridge-php-5.3/info/bin/build.sh
+++ b/cartridges/openshift-origin-cartridge-php-5.3/info/bin/build.sh
@@ -25,7 +25,7 @@ then
         if pear list "$f" > /dev/null
         then
             pear upgrade "$f"
-        elif ! ( php -c "${OPENSHIFT_PHP_DIR}"/conf -m | grep -q \^`basename "$f"`\$ )
+        elif ! ( php -c "${OPENSHIFT_PHP_DIR}"/conf -m | grep -i -q \^`basename "$f"`\$ )
         then
             pear install --alldeps "$f"
         else


### PR DESCRIPTION
PHP PECL extensions are a mess.  Many have compilation issues and most have installation issues.  OpenShift Hosted service frequently has to just install PHP extensions on the system to make them available.

If an extension is found on the system; then do not attempt to install it even if there's a better version available from upstream.
