### PR TITLE
Additional F17 fixes

### DIFF
--- a/broker-util/oo-setup-broker
+++ b/broker-util/oo-setup-broker
@@ -89,6 +89,17 @@ def restart_mongo
   start_mongo
 end
 
+def enable_se_booleans(bool_list)
+  bool_list.delete_if{ |bool| `getsebool #{bool}`.match(/--> on/) }
+  semanage_commands = bool_list.map { |bool| "boolean -m --on #{bool}" }.join("\n")
+
+run <<-EOOF
+/usr/sbin/semanage -i - <<_EOF
+#{semanage_commands}
+_EOF
+EOOF
+end
+
 def usage
   puts <<USAGE
 == Synopsis
@@ -241,6 +252,9 @@ else
 fi
 EOF
 
+$log.info "...opening qpid port for other nodes"
+run "/usr/sbin/lokkit -p 5672:tcp"
+
 if not File.exist?("/etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf")
   FileUtils.mv "/etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf.example", "/etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf"
 end
@@ -355,11 +369,7 @@ find_and_replace("/etc/mongodb.conf", /^auth = .*$/, "auth = true")
 
 $log.info "Configuring BIND DNS server"
 $log.info "...installing DNS server related SELinux policies (This might take a while)"
-run <<-EOOF
-/usr/sbin/semanage -i - <<_EOF
-boolean -m --on named_write_master_zones
-_EOF
-EOOF
+enable_se_booleans(["named_write_master_zones"])
 
 unless File.exist?('/etc/rndc.key')
   $log.info  "...generating rndc.key file"
@@ -396,6 +406,10 @@ $log.info "...register broker with local dns server"
 run "service named restart"
 run "/usr/sbin/oo-register-dns -h broker -n #{ext_address.strip} --domain #{node_domain}" 
 run "service named stop"
+
+$log.info "...open named port"
+run "/usr/sbin/lokkit -p 53:tcp"
+run "/usr/sbin/lokkit -p 53:udp"
 
 $log.info "Updating broker hostname in apache"
 find_and_replace( "/etc/httpd/conf.d/000000_openshift_origin_broker_proxy.conf", /  ServerName.*$/, "  ServerName broker.#{node_domain}" )
@@ -435,8 +449,9 @@ EOF
 
 $log.info "Fixing console SELinux and file permission"
 run "chown -R apache:apache /var/www/openshift/console"
-run "chcon -R system_u:object_r:httpd_log_t:s0 /var/www/openshift/console/log"
-run "chcon -R system_u:object_r:httpd_tmp_t:s0 /var/www/openshift/console/tmp"
+
+$log.info "Enabling console SELinux booleans"
+enable_se_booleans(["httpd_can_network_connect", "httpd_can_network_relay", "httpd_read_user_content", "httpd_enable_homedirs", "httpd_execmem"])
 
 $log.info "Updating sshd configuration to enable OpenShift git push"
 insert_if_not_exist("/etc/ssh/sshd_config", "AcceptEnv GIT_SSH", "\nAcceptEnv GIT_SSH\n")

--- a/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/util
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/util
@@ -218,7 +218,7 @@ function get_installed_framework_carts {
 
 # Get list of installed databases
 function get_installed_databases {
-    (cd $OPENSHIFT_HOMEDIR; ls -d {mongodb-2.2,mysql-5.1,postgresql-8.4} 2>/dev/null)
+    (cd $OPENSHIFT_HOMEDIR; ls -d {mongodb-2.2,mysql-5.1,postgresql-8.4,postgres-9.1} 2>/dev/null)
 }
 
 function get_local_databases {

--- a/cartridges/openshift-origin-cartridge-php-5.3/openshift-origin-cartridge-php-5.3.spec
+++ b/cartridges/openshift-origin-cartridge-php-5.3/openshift-origin-cartridge-php-5.3.spec
@@ -17,7 +17,7 @@ BuildRequires: git
 Requires: openshift-origin-cartridge-abstract
 Requires: rubygem(openshift-origin-node)
 Requires: php >= 5.3.2
-Requires: php < 5.4.0
+Requires: php
 Requires: mod_bw
 Requires: rubygem-builder
 Requires: php-devel

--- a/cartridges/openshift-origin-cartridge-postgresql-8.4/openshift-origin-cartridge-postgresql-8.4.spec
+++ b/cartridges/openshift-origin-cartridge-postgresql-8.4/openshift-origin-cartridge-postgresql-8.4.spec
@@ -17,7 +17,7 @@ BuildArch: noarch
 BuildRequires: git
 Requires: openshift-origin-cartridge-abstract
 Requires: rubygem(openshift-origin-node)
-Requires: postgresql
+Requires: postgresql < 9
 Requires: postgresql-server
 Requires: postgresql-libs
 Requires: postgresql-devel

--- a/controller/app/models/cartridge_cache.rb
+++ b/controller/app/models/cartridge_cache.rb
@@ -23,9 +23,10 @@ class CartridgeCache
     get_cached("all_cartridges", :expires_in => 1.day) {OpenShift::ApplicationContainerProxy.find_one().get_available_cartridges}
   end
 
-  FRAMEWORK_CART_NAMES = ["python-2.6", "jenkins-1.4", "ruby-1.8", "ruby-1.9",
+  FRAMEWORK_CART_NAMES = [#RHEL6 cartridges
+                          "python-2.6", "jenkins-1.4", "ruby-1.8", "ruby-1.9",
                           "diy-0.1", "php-5.3", "jbossas-7", "jbosseap-6.0", "jbossews-1.0",
-                          "perl-5.10", "nodejs-0.6", "zend-5.6"
+                          "perl-5.10", "nodejs-0.6", "zend-5.6",
                          ]
   def self.cartridge_names(cart_type=nil)
     cart_names = cartridges.map{|c| c.name}

--- a/node-util/bin/oo-setup-node
+++ b/node-util/bin/oo-setup-node
@@ -58,7 +58,16 @@ def run(cmd)
   return status.to_i
 end
 
+def enable_se_booleans(bool_list)
+  bool_list.delete_if{ |bool| `getsebool #{bool}`.match(/--> on/) }
+  semanage_commands = bool_list.map { |bool| "boolean -m --on #{bool}" }.join("\n")
 
+run <<-EOOF
+/usr/sbin/semanage -i - <<_EOF
+#{semanage_commands}
+_EOF
+EOOF
+end
 
 def usage
   puts <<USAGE
@@ -212,7 +221,7 @@ else
     f.write "PREFIX=#{ext_prefix}\n"
     f.write "GATEWAY=#{ext_gw}\n"
 end
-  f.write "DNS1=127.0.0.1\n"
+  f.write "DNS1=#{broker_ip}\n"
   dns_address.each_index do |idx|
     f.write "DNS#{idx+2}=#{dns_address[idx]}\n"
   end
@@ -246,23 +255,77 @@ end
 run "/sbin/chkconfig network on"
 
 $log.info "Setting node SELinux booleans\n"
-run("/usr/sbin/setsebool -P httpd_run_stickshift 1 &>/dev/null || :")
-run("/usr/sbin/setsebool -P httpd_run_openshift 1 &>/dev/null || :")
-run("/usr/sbin/setsebool -P httpd_verify_dns 1 &>/dev/null || :")
-run("/usr/sbin/setsebool -P allow_polyinstantiation 1 &>/dev/null || :")
+enable_se_booleans(["httpd_run_stickshift", "httpd_verify_dns", "allow_polyinstantiation"])
+
+$log.info "Updating node configuration"
+find_and_replace("/etc/openshift/node.conf", /^PUBLIC_IP=.*$/, "PUBLIC_IP=#{ext_address}")
+find_and_replace("/etc/openshift/node.conf", /^CLOUD_DOMAIN=.*$/, "CLOUD_DOMAIN=#{node_domain}")
+find_and_replace("/etc/openshift/node.conf", /^PUBLIC_HOSTNAME=.*$/, "PUBLIC_HOSTNAME=#{node_hostname}.#{node_domain}")
+find_and_replace("/etc/openshift/node.conf", /^(# )?EXTERNAL_ETH_DEV=.*$/, "EXTERNAL_ETH_DEV=#{ext_eth_device}")
+find_and_replace("/etc/openshift/node.conf", /^(# )?INTERNAL_ETH_DEV=.*$/, "INTERNAL_ETH_DEV=#{int_eth_device}")
+find_and_replace("/etc/openshift/node.conf", /^BROKER_HOST=.*$/, "BROKER_HOST=\"#{broker_ip}\"")
+
 
 $log.info "Opening required ports\n"
 run "/usr/sbin/lokkit --service=ssh"
 run "/usr/sbin/lokkit --service=http"
 run "/usr/sbin/lokkit --service=https"
+run "/usr/sbin/lokkit -p 8000:tcp"
+run "/usr/sbin/lokkit -p 8443:tcp"
 
 $log.info "Setting up m-collective to use qpid"
-find_and_replace("/etc/mcollective/client.cfg", /^plugin\.qpid\.host=.*$/, "plugin.qpid.host=#{broker_ip}")
-find_and_replace("/etc/mcollective/server.cfg", /^plugin\.qpid\.host=.*$/, "plugin.qpid.host=#{broker_ip}")
+$log.info "...configuring mcollective client to use qpid"
+File.open("/etc/mcollective/client.cfg","w") do |f|
+  f.write <<-EOF
+topicprefix = /topic/
+main_collective = mcollective
+collectives = mcollective
+libdir = /usr/libexec/mcollective
+loglevel = debug
+logfile = /var/log/mcollective-client.log
+
+# Plugins
+securityprovider = psk
+plugin.psk = unset
+connector = qpid
+plugin.qpid.host=broker.#{node_domain}
+plugin.qpid.secure=false
+plugin.qpid.timeout=5
+
+# Facts
+factsource = yaml
+plugin.yaml = /etc/mcollective/facts.yaml
+EOF
+end
+
+$log.info "...configuring mcollective server to use qpid"
+File.open("/etc/mcollective/server.cfg", "w") do |f|
+  f.write <<-EOF
+topicprefix = /topic/
+main_collective = mcollective
+collectives = mcollective
+libdir = /usr/libexec/mcollective
+logfile = /var/log/mcollective.log
+loglevel = debug
+daemonize = 1 
+direct_addressing = n
+
+# Plugins
+securityprovider = psk
+plugin.psk = unset
+connector = qpid
+plugin.qpid.host=broker.#{node_domain}
+plugin.qpid.secure=false
+plugin.qpid.timeout=5
+
+# Facts
+factsource = yaml
+plugin.yaml = /etc/mcollective/facts.yaml
+EOF
+end
 
 $log.info "Generating mcollective facts"
 run "/etc/cron.minutely/openshift-facts"
-run "/usr/libexec/mcollective/update_yaml.rb /etc/mcollective/facts.yaml"
 
 oo_device=%x[/bin/df -P /var/lib/openshift | tail -1].split[0]
 oo_mount=%x[/bin/df -P /var/lib/openshift | tail -1 | tr -s ' '].split[5]
@@ -303,14 +366,6 @@ run "/sbin/chkconfig cgred on"
   run "/sbin/chkconfig --add openshift-cgroups"
   run "/sbin/chkconfig openshift-cgroups on"
 #end
-
-$log.info "Updating node configuration"
-find_and_replace("/etc/openshift/node.conf", /^PUBLIC_IP=.*$/, "PUBLIC_IP=#{ext_address}")
-find_and_replace("/etc/openshift/node.conf", /^CLOUD_DOMAIN=.*$/, "CLOUD_DOMAIN=#{node_domain}")
-find_and_replace("/etc/openshift/node.conf", /^PUBLIC_HOSTNAME=.*$/, "PUBLIC_HOSTNAME=#{node_hostname}.#{node_domain}")
-find_and_replace("/etc/openshift/node.conf", /^(# )?EXTERNAL_ETH_DEV=.*$/, "EXTERNAL_ETH_DEV=#{ext_eth_device}")
-find_and_replace("/etc/openshift/node.conf", /^(# )?INTERNAL_ETH_DEV=.*$/, "INTERNAL_ETH_DEV=#{int_eth_device}")
-find_and_replace("/etc/openshift/node.conf", /^BROKER_HOST=.*$/, "BROKER_HOST=\"#{broker_ip}\"")
 
 $log.info "Restore SELinux default security contexts."
 run "/sbin/restorecon /var/lib/openshift || :"

--- a/openshift-console/openshift-console.spec
+++ b/openshift-console/openshift-console.spec
@@ -156,24 +156,9 @@ fi
 /sbin/service openshift-console condrestart || :
 %endif
 
-#selinux updated
-semanage -i - <<_EOF
-boolean -m --on httpd_can_network_connect
-boolean -m --on httpd_can_network_relay
-boolean -m --on httpd_read_user_content
-boolean -m --on httpd_enable_homedirs
-boolean -m --on httpd_execmem
-fcontext -a -t httpd_var_run_t '%{consoledir}/httpd/run(/.*)?'
-fcontext -a -t httpd_log_t '%{consoledir}/httpd/logs(/.*)?'
-_EOF
-
-chcon -R -t httpd_log_t %{consoledir}/httpd/logs
-chcon -R -t httpd_tmp_t %{consoledir}/httpd/run
-chcon -R -t httpd_var_run_t %{consoledir}/httpd/run
 /sbin/fixfiles -R %{?scl:%scl_prefix}rubygem-passenger restore
 /sbin/fixfiles -R %{?scl:%scl_prefix}mod_passenger restore
 /sbin/restorecon -R -v /var/run
-#/sbin/restorecon -rv %{gemdir}/passenger*
 %changelog
 * Wed Oct 31 2012 Adam Miller <admiller@redhat.com> 0.0.3-1
 - Bug 871705 - renaming a sample conf file for consistency

--- a/plugins/msg-node/mcollective/facts/openshift-facts
+++ b/plugins/msg-node/mcollective/facts/openshift-facts
@@ -1,2 +1,2 @@
 #!/bin/bash
-oo-exec-ruby "/usr/libexec/mcollective/update_yaml.rb /etc/mcollective/facts.yaml" &> /dev/null
+oo-exec-ruby /usr/libexec/mcollective/update_yaml.rb /etc/mcollective/facts.yaml &> /dev/null


### PR DESCRIPTION
- oo-setup-broker fixes: Open dns ports for access to DNS server from outside the VM
- Updates abstract cartridges to set proper order for php-5.4 and postgres-9.1 cartridges
- Updated broker to add fedora 17 cartridges
- Fixed facts cron job
