### PR TITLE
[TO STAGE] A nil error is displayed when quickstarts are shown with type length == 1

### DIFF
--- a/console/app/helpers/console/model_helper.rb
+++ b/console/app/helpers/console/model_helper.rb
@@ -96,7 +96,7 @@ module Console::ModelHelper
           [tag, types]
         end
       end
-    end.compact!
+    end.compact
     [groups, other]
   end
 

--- a/console/test/unit/helpers/model_helper_test.rb
+++ b/console/test/unit/helpers/model_helper_test.rb
@@ -58,4 +58,19 @@ class Console::ModelHelperTest < ActionView::TestCase
       },
       scale_to_options(stub(:supported_scales_from => 1, :supported_scales_to => -1), 6, 5))
   end
+
+  Tagged = Struct.new(:tags)
+
+  def test_in_groups_by_tag
+    t1 = Tagged.new([:ruby, :php])
+    t2 = Tagged.new([:ruby])
+
+    groups, others = in_groups_by_tag([t1], [:ruby])
+    assert_equal [t1], others
+    assert groups.empty?
+
+    groups, others = in_groups_by_tag([t1, t2], [:ruby])
+    assert_equal [[:ruby, [t1, t2]]], groups
+    assert others.empty?
+  end
 end


### PR DESCRIPTION
Blocks us from enabling community quickstarts in prod.  Waiting for fix to get into master.
