### PR TITLE
Adds support for logging the entire REST request/response

### DIFF
--- a/console/app/models/rest_api.rb
+++ b/console/app/models/rest_api.rb
@@ -65,7 +65,7 @@ module RestApi
       end
     end
     def debug?
-      @debug || ENV['REST_API_DEBUG']
+      @debug || ENV['REST_API_DEBUG'] || (Rails.configuration.rest_api_debug rescue false)
     end
     def force_http_debug
       unless ActiveResource::Connection.respond_to? :configure_http_with_debug

--- a/console/app/models/rest_api/base.rb
+++ b/console/app/models/rest_api/base.rb
@@ -6,6 +6,24 @@ require 'active_support/concern'
 require 'active_model/dirty'
 require 'active_resource/persistent_connection'
 
+# Alias the request method so we can call the original, but log everything in the new ensure block
+class Net::HTTP
+  alias_method :request_original, :request
+
+  def request(*args)
+    res = request_original(*args)
+  ensure
+    # We need to get the request id from the response.
+    # Our log subscriber will take care of combining them
+    if (rid = (res.to_hash['x-request-id'].first rescue nil))
+      ActiveSupport::Notifications.instrument("request.http") do |payload|
+        payload[:rid] = rid
+        payload[:request] = args.first
+      end
+    end
+  end
+end
+
 class ActiveResource::Connection
   #
   # Changes made in commit https://github.com/rails/rails/commit/51f1f550dab47c6ec3dcdba7b153258e2a0feb69#activeresource/lib/active_resource/base.rb

--- a/console/app/models/rest_api/log_subscriber.rb
+++ b/console/app/models/rest_api/log_subscriber.rb
@@ -1,5 +1,42 @@
 module RestApi
-  class LogSubscriber < ActiveSupport::LogSubscriber
+  module RequestDumper
+    def request_id(request)
+      request.to_hash['x-request-id'].first rescue nil
+    end
+
+    def dump_body(result, color)
+      body = (result.body || "").strip
+      return unless body.size > 0
+
+      msg =  case result.content_type
+             when "application/json"
+               JSON.pretty_generate(sanitize(JSON.parse(body))).lines
+             end
+      without_pid {
+        [*msg].each do |line|
+          logger.debug "#{color(line.chomp,color)}"
+        end
+      }
+    end
+
+    #TODO: This may need to be changed to be recursive
+    def sanitize(hash)
+      keys = %w(password old_password password_confirmation)
+      hash.inject({}){|h,(k,v)| h[k] = (keys.include?(k) ? "<sanitized>" : v); h}
+    end
+
+    def without_pid(&block)
+      old_omit_pid = logger.formatter.omit_pid
+      logger.formatter.omit_pid = true
+      yield
+    ensure
+      logger.formatter.omit_pid = old_omit_pid
+    end
+  end
+
+  class HTTPSubscriber < ActiveSupport::LogSubscriber
+    include RequestDumper
+
     def self.runtime=(value)
       Thread.current["rest_api_call_runtime"] = value
     end
@@ -12,18 +49,57 @@ module RestApi
     end
 
     def request(event)
-      self.class.runtime += event.duration
+      # Do not modify runtime for REST API logging, since this would be a duplicate
+      (self.class.runtime += event.duration) unless event.payload.delete(:rest_api)
       return unless logger.debug?
 
       name = '%s (%.1fms)' % ['OpenShift API', event.duration]
 
       call = "#{color(event.payload.delete(:method), BOLD, true)} #{event.payload.delete(:request_uri)}"
 
-      result = event.payload[:result]
-      query = {:code => result.code}.map{ |k,v| "#{k}: #{color(v, BOLD, true)}" }.join(', ') if result
+      msg = "  #{color(name, BLUE, true)} #{call} "
 
-      debug "  #{color(name, BLUE, true)} #{call} [ #{query} ]"
+      result = event.payload[:result]
+
+      if result
+        query = {:code => result.code}
+        if(rid = request_id(result))
+          query[:rid] = rid[0,8]
+        end
+        query = query.map{ |k,v| "#{k}: #{color(v, BOLD, true)}" }.join(', ')
+        msg << "[ #{query} ] "
+      end
+
+      debug msg
+    end
+  end
+
+  class RestSubscriber < HTTPSubscriber
+    def request(event)
+      event.payload[:rest_api] = true
+      if (request = event.payload[:request])
+        rid = event.payload[:rid]
+        stored_requests[rid] = request unless request.body.blank?
+      else
+        result = event.payload[:result]
+        rid = request_id(result)
+        request = stored_requests.delete(rid)
+        return unless RestApi.site.host == URI.parse(event.payload[:request_uri]).hostname
+        # TODO: Need to make sure this doesn't mess with any of the duration/runtime stuff
+        super(event)
+        without_pid {
+          if(request)
+            dump_body(request,YELLOW)
+            logger.debug("-" * 10)
+          end
+          dump_body(result,CYAN)
+        }
+      end
+    end
+
+    protected
+    def stored_requests
+      @@stored_requests ||= {}
     end
   end
 end
-

--- a/console/app/models/rest_api/railties/controller_runtime.rb
+++ b/console/app/models/rest_api/railties/controller_runtime.rb
@@ -8,14 +8,14 @@ module RestApi
       attr_internal :ra_runtime
 
       def process_action(action, *args)
-        RestApi::LogSubscriber.reset_runtime
+        RestApi::HTTPSubscriber.reset_runtime
         super
       end
 
       def cleanup_view_runtime
-        rt_before_render = RestApi::LogSubscriber.reset_runtime
+        rt_before_render = RestApi::HTTPSubscriber.reset_runtime
         runtime = super
-        rt_after_render = RestApi::LogSubscriber.reset_runtime
+        rt_after_render = RestApi::HTTPSubscriber.reset_runtime
         self.ra_runtime = rt_before_render + rt_after_render
         runtime - rt_after_render
       end

--- a/console/config/initializers/extended_logger.rb
+++ b/console/config/initializers/extended_logger.rb
@@ -10,13 +10,17 @@ if Rails.version[0..3] != '3.0.'
     SEVERITY_TO_COLOR_MAP   = {'DEBUG'=>'0;37', 'INFO'=>'32', 'WARN'=>'33', 'ERROR'=>'31', 'FATAL'=>'31', 'UNKNOWN'=>'37'}
     USE_HUMOROUS_SEVERITIES = true
 
+    attr_accessor :omit_pid
+
     def call(severity, time, progname, msg)
       formatted_severity = sprintf("%-5s","#{severity}")
 
       formatted_time = time.strftime("%Y-%m-%d %H:%M:%S.") << time.usec.to_s[0..2].rjust(3)
       color = SEVERITY_TO_COLOR_MAP[severity]
 
-      "\033[0;37m#{formatted_time}\033[0m [\033[#{color}m#{formatted_severity}\033[0m] #{msg.strip} (pid:#{$$})\n"
+      _msg = "\033[0;37m#{formatted_time}\033[0m [\033[#{color}m#{formatted_severity}\033[0m] #{msg.strip}"
+      _msg << "(pid:#{$$})" unless omit_pid
+      return "#{_msg}\n"
     end
   end
 

--- a/console/config/initializers/rest_api.rb
+++ b/console/config/initializers/rest_api.rb
@@ -2,7 +2,35 @@ require 'rest_api'
 require 'rest_api/log_subscriber'
 require 'rest_api/railties/controller_runtime'
 
-RestApi::LogSubscriber.attach_to :active_resource
+RestApi::HTTPSubscriber.attach_to :active_resource
+
+if RestApi::debug?
+  # Get the log path from the Rails config
+  log_paths = [
+    File.dirname(Rails.configuration.paths['log'].first),
+    File.dirname(Rails.configuration.paths['tmp'].first),
+    Dir.tmpdir
+  ]
+
+  log_path = log_paths.select{|x| File.writable?(x) }.first
+
+  if log_path.nil?
+    Rails.logger.debug "Cannot create logfile for REST API logging, skipping"
+  else
+    path = File.join(log_path,"rest_api.log")
+    # Create our new logger
+    rest_logger = ActiveSupport::TaggedLogging.new(Logger.new(path))
+    Rails.logger.debug "Created REST API logger at #{path}"
+
+    # Use the same formatter as Rails
+    rest_logger.formatter = Formatter.new
+    # Set our logger for the subscriber
+    RestApi::RestSubscriber.logger = rest_logger
+    # Attach our logger to see requests
+    RestApi::RestSubscriber.attach_to :active_resource
+    RestApi::RestSubscriber.attach_to :http
+  end
+end
 
 begin
   info = RestApi.info


### PR DESCRIPTION
To use, either set `config.rest_api_debug = true` in your `environments/*.rb` or launch the console with `REST_API_DEBUG=1 rails server`.

This will log the entire request/response to `#{Rails.root}/log/rest_api.log` (it will fall back to `#{Rails.root}/tmp` or `/tmp`. It uses a separate file so as to not clutter the main log file with hundreds of lines of JSON (and doesn't clutter the REST logging with lots of assets logging and such). 

The main log now includes a shortened version of the `x-request-id` which can be used to correlate requests with the `rest_api.log` or potentially the broker/Apache.

An example can be found here: https://gist.github.com/9a5a4a39fad2b4d7aab0
