### PR TITLE
[test] Move cartridge type logic from cache to controller

### DIFF
--- a/controller/app/models/cartridge_cache.rb
+++ b/controller/app/models/cartridge_cache.rb
@@ -23,21 +23,8 @@ class CartridgeCache
     get_cached("all_cartridges", :expires_in => 1.day) {OpenShift::ApplicationContainerProxy.find_one().get_available_cartridges}
   end
 
-  FRAMEWORK_CART_NAMES = [#RHEL6 cartridges
-                          "python-2.6", "jenkins-1.4", "ruby-1.8", "ruby-1.9",
-                          "diy-0.1", "php-5.3", "jbossas-7", "jbosseap-6.0", "jbossews-1.0",
-                          "perl-5.10", "nodejs-0.6", "zend-5.6",
-                         ]
   def self.cartridge_names(cart_type=nil)
-    cart_names = cartridges.map{|c| c.name}
-
-    if cart_type == 'standalone'
-      return cart_names & FRAMEWORK_CART_NAMES
-    elsif cart_type == 'embedded'
-      return (cart_names - FRAMEWORK_CART_NAMES)
-    else
-      return cart_names
-    end
+    cartridges.select{|c| c.type == cart_type || cart_type.nil?}.map{|c| c.name}
   end
 
   def self.find_cartridge(capability)


### PR DESCRIPTION
Currently, the type of a cartridge ("standalone" or "embedded") is
hardcoded using the FRAMEWORK_CART_NAMES constant.  Prior to this commit,
this constant has been kept in CartridgeCache.cartridge_names, along with
the logic to filter queries by cartridge type.

This commit makes the following changes:

• FRAMEWORK_CART_NAMES is moved to the OpenShift::Cartridge class.

• OpenShift::Cartridge now has a .type property.

• OpenShift::Cartridge.from_descriptor now checks for "Cart-Type" in the
  descriptor.  If "Cart-Type" is specified, the new object's .type is
  assigned the specified value.  Otherwise, the old logic is used: If
  the cartridge is listed in FRAMEWORK_CART_NAMES, then .type is set to
  'standalone' and otherwise it is set to 'embedded'.

• OpenShift::Cartridge.to_descriptor similarly handles the .type property.

• CartridgeCache.cartridge_names now uses the cartridge's .type property
  to filter results.

This change is necessary in order to facilitate the creation of custom
standalone cartridges.  Without this change, cartridge authors would need
to modify FRAMEWORK_CART_NAMES, in the OpenShift code.  With this
change, cartridge authors need merely add "Cart-Type: standalone" to
their manifest.yml files.

The previous test failed on an issue with rhc snapshot restore, which the following pull request should fix:

https://github.com/openshift/rhc/pull/262
