### PR TITLE
Consistently silence pushd and popd in hooks

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract/info/bin/deploy_git_dir.sh
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract/info/bin/deploy_git_dir.sh
@@ -39,7 +39,7 @@ function extract_submodules {
     rm -rf ${submodule_tmp_dir}
 }
 
-pushd ${src_dir}
+pushd ${src_dir} > /dev/null
 full_src_dir=`pwd`
 
 # archive and copy the main module
@@ -49,4 +49,4 @@ git archive --format=tar HEAD | (cd ${dest_dir} && tar --warning=no-timestamp -x
 # the submoules
 [ -f ${dest_dir}/.gitmodules ] && extract_submodules
 
-popd
+popd > /dev/null

--- a/cartridges/openshift-origin-cartridge-nodejs-0.6/info/bin/build.sh
+++ b/cartridges/openshift-origin-cartridge-nodejs-0.6/info/bin/build.sh
@@ -31,10 +31,10 @@ function is_node_module_installed() {
     if [ -n "$module_name" ]; then
         pushd "$cartridge_dir" > /dev/null
         if [ -d $m ] ; then
-            popd
+            popd > /dev/null
             return 0
         fi
-        popd
+        popd > /dev/null
     fi
 
     return 1


### PR DESCRIPTION
Consistently redirect the output of pushd and popd to /dev/null in
cartridge scripts.
