### PR TITLE
Replace hard-coded cartridge types with categories

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent-0.1/info/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent-0.1/info/manifest.yml
@@ -6,6 +6,7 @@ License: ""
 License-Url: https://mms.10gen.com/links/terms-of-service
 Vendor: 10gen.com
 Categories:
+  - embedded
   - cartridge
   - database-support
 Website: https://mms.10gen.com/

--- a/cartridges/openshift-origin-cartridge-cron-1.4/info/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-cron-1.4/info/manifest.yml
@@ -8,6 +8,7 @@ License-Url: http://www.apache.org/licenses/LICENSE-2.0.txt
 Vendor:
 Categories:
   - cartridge
+  - embedded
 Website: "http://openshift.redhat.com/"
 Help-Topics:
   "Getting Started Guide": https://openshift.redhat.com/community/blogs/getting-started-with-cron-jobs-on-openshift

--- a/cartridges/openshift-origin-cartridge-haproxy-1.4/info/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-haproxy-1.4/info/manifest.yml
@@ -10,6 +10,7 @@ Categories:
   - web_proxy
   - git_host
   - scales
+  - embedded
 Website:
 Help-Topics:
 Cart-Data:

--- a/cartridges/openshift-origin-cartridge-jenkins-client-1.4/info/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jenkins-client-1.4/info/manifest.yml
@@ -7,6 +7,7 @@ Vendor:
 Categories:
   - cartridge
   - ci_builder
+  - embedded
 Cart-Data:
   - Key: "job_url"
     Type: cart_data

--- a/cartridges/openshift-origin-cartridge-mongodb-2.2/info/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mongodb-2.2/info/manifest.yml
@@ -9,6 +9,7 @@ Categories:
   - cartridge
   - database
   - nosql
+  - embedded
 Website: http://www.10gen.com
 Help-Topics:
   - "Building with MongoDB" : https://openshift.redhat.com/community/developers/mongodb

--- a/cartridges/openshift-origin-cartridge-mysql-5.1/info/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mysql-5.1/info/manifest.yml
@@ -8,6 +8,7 @@ License: ASL 2.0
 Categories:
   - cartridge
   - database
+  - embedded
 Website: http://www.mysql.com
 Help-Topics:
   - "Building with MySQL" : http://docs.redhat.com/docs/en-US/OpenShift/2.0/html/User_Guide/sect-User_Guide-Working_With_Database_Cartridges.html

--- a/cartridges/openshift-origin-cartridge-phpmyadmin-3.4/info/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin-3.4/info/manifest.yml
@@ -5,6 +5,8 @@ Version: 1.1.0
 License: ASL 2.0
 Vendor:
 Website: "http://www.phpmyadmin.net/"
+Categories:
+  - embedded
 Cart-Data:
   - Key: "username"
     Type: cart_data

--- a/cartridges/openshift-origin-cartridge-postgresql-8.4/info/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-postgresql-8.4/info/manifest.yml
@@ -7,6 +7,7 @@ Vendor:
 Categories:
   - cartridge
   - database
+  - embedded
 License: ASL 2.0
 Website: http://www.postgresql.org
 Help-Topics:

--- a/cartridges/openshift-origin-cartridge-switchyard-0.6/info/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-switchyard-0.6/info/manifest.yml
@@ -6,6 +6,7 @@ License: ASL 2.0
 Vendor: 
 Categories:
   - cartridge
+  - embedded
 Cart-Data:
   - Key: "module_path"
     Type: cart_data

--- a/controller/app/models/cartridge_cache.rb
+++ b/controller/app/models/cartridge_cache.rb
@@ -23,21 +23,9 @@ class CartridgeCache
     get_cached("all_cartridges", :expires_in => 1.day) {OpenShift::ApplicationContainerProxy.find_one().get_available_cartridges}
   end
 
-  FRAMEWORK_CART_NAMES = [#RHEL6 cartridges
-                          "python-2.6", "jenkins-1.4", "ruby-1.8", "ruby-1.9",
-                          "diy-0.1", "php-5.3", "jbossas-7", "jbosseap-6.0", "jbossews-1.0",
-                          "jbossews-2.0", "perl-5.10", "nodejs-0.6", "zend-5.6",
-                         ]
   def self.cartridge_names(cart_type=nil)
-    cart_names = cartridges.map{|c| c.name}
-
-    if cart_type == 'standalone'
-      return cart_names & FRAMEWORK_CART_NAMES
-    elsif cart_type == 'embedded'
-      return (cart_names - FRAMEWORK_CART_NAMES)
-    else
-      return cart_names
-    end
+    cart_type = "web_framework" if cart_type == "standalone"
+    cartridges.select{|c| cart_type.nil? or c.categories.include? cart_type}.map{|c| c.name}
   end
 
   def self.find_cartridge(capability)


### PR DESCRIPTION
Currently, the type of a cartridge ("standalone" or "embedded") is
hard-coded using the FRAMEWORK_CART_NAMES constant.  Prior to this commit,
this constant has been kept in CartridgeCache.cartridge_names, along with
the logic to filter queries by cartridge type.

This commit removes FRAMEWORK_CART_NAMES and changes
CartridgeCache.cartridge_names to use the cartridge's categories to filter
results.  If cartridge_names is passed 'standalone', it now selects
cartridges that are included in the 'web_framework' category.  (Already,
all 'standalone' cartridges are marked with the 'web_framework' category.)
If it is passed nil, it selects all cartridges.  Thus the method should
behave the same as it did previously in existing usage.

This change is necessary in order to facilitate the creation of custom
standalone cartridges.  Without this change, cartridge authors would need
to modify FRAMEWORK_CART_NAMES, in the OpenShift code.  With this change,
cartridge authors need merely add 'web_framework' to the list of categories
in the manifest.yml files of standalone cartridges.
