### PR TITLE
Changed the information given to the end user in the UI, the end user wi...

### DIFF
--- a/cartridges/openshift-origin-cartridge-jenkins-1.4/info/hooks/configure
+++ b/cartridges/openshift-origin-cartridge-jenkins-1.4/info/hooks/configure
@@ -186,8 +186,8 @@ client_result ""
 client_result "Note:  You can change your password at: https://${application}-${namespace}.${CLOUD_DOMAIN}/me/configure"
 client_result ""
 
-cart_props "username=system_builder"
-cart_props "password=$system_builder_password"
+cart_props "username=admin"
+cart_props "password=$admin_password"
 
 add_env_var "JENKINS_URL=https://${application}-${namespace}.${CLOUD_DOMAIN}/"
 add_env_var "JENKINS_USERNAME=system_builder"


### PR DESCRIPTION
I changed the account information given at the end of a successful app create. Originally system_builder username and password were given as per the cart.props displayed. In the same output we also gave the user "admin" username and password information. This patch will resolve the confusion. 

https://github.com/openshift/rhc/pull/271

[test] 
