### PR TITLE
Added js_required helper

### DIFF
--- a/console/app/helpers/console/layout_helper.rb
+++ b/console/app/helpers/console/layout_helper.rb
@@ -48,7 +48,15 @@ module Console::LayoutHelper
     flash.each do |key, value|
       (value.kind_of?(Array) ? value : [value]).each do |value|
         next if value.blank?
-        tags << content_tag(flash_element_for(key), value, :class => alert_class_for(key))
+        # This will allow us to pass flash messages only intended for noscript tags
+        if key =~ /^noscript/
+          matches = key.to_s.match(/^noscript(?:(?:_)?(.*))?/)
+          key = (matches[1].empty? ? "notice" : matches[1]).to_sym
+          tag = content_tag(flash_element_for(key), value, :class => alert_class_for(key))
+          tags << content_tag(:noscript, tag)
+        else
+          tags << content_tag(flash_element_for(key), value, :class => alert_class_for(key))
+        end
       end
     end
     content_tag(:div, tags.join.html_safe, :id => 'flash') unless tags.empty?
@@ -273,5 +281,9 @@ module Console::LayoutHelper
       ['Wisconsin', 'WI'],
       ['Wyoming', 'WY']
     ]
+  end
+
+  def js_required(msg = "to use this page")
+    flash[:noscript_warning] = ["You need JavaScript enabled",msg].join(" ").squeeze(" ").strip
   end
 end


### PR DESCRIPTION
This adds a helper that alerts users that javascript is required for some pages.
This is currently needed by the signup page because the captchas need JS
