### PR TITLE
Fix for Bug 895878

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/util
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/util
@@ -28,8 +28,6 @@ function post_start_app () {
 	            echo "!!!!!!!!"
 	        fi
 	
-          orig_app_state=`get_app_state`
-
 	        set_app_state building
 	
 	        # Do any cleanup before the next build
@@ -42,8 +40,6 @@ function post_start_app () {
 	
 	        # Deploy new build, run internal deploy steps, then user deploy
 	        deploy.sh
-
-          set_app_state "$orig_app_state"
 	        
 	        hot_deploy_added=false
 	        
@@ -254,11 +250,7 @@ function get_attached_databases {
 #
 # Returns 0 on success
 function start_app {
-    _state=`get_app_state`
-    _locks=$(ls ${APP_HOME:-$OPENSHIFT_HOMEDIR}/*/run/stop_lock 2>/dev/null |grep -ve 'app-root|git' |wc -l)
-    if [ "$_locks" -eq 0 ] && [ idle != "$_state" ]; then
-        set_app_state started
-    fi
+    set_app_state started
 
     for db in $(get_local_databases)
     do

--- a/node-util/bin/oo-restorer
+++ b/node-util/bin/oo-restorer
@@ -53,9 +53,10 @@ framework_carts=$(get_installed_framework_carts)
 primary_framework_cart=${framework_carts[0]}
 
 stop_lock_file="${OPENSHIFT_HOMEDIR}/${primary_framework_cart}/run/stop_lock"
-if [ -f "$stop_lock_file" ]
+state=`cat $OPENSHIFT_HOMEDIR/app-root/runtime/.state`
+if [ -f "$stop_lock_file" -o 'idled' = "$state" ]
 then
-    rm "$stop_lock_file"
+    rm -f "$stop_lock_file"
 else
     # Do not restore non-idled application. Browser may cause 20+ retries when restoring application.
     exit 0
@@ -65,7 +66,7 @@ fi
 runuser --shell /bin/sh "$uuid" -c "echo started >$OPENSHIFT_HOMEDIR/app-root/runtime/.state"
 
 # timeout take from oo-admin-ctl-gears
-/usr/bin/timeout -s USR1 30s /usr/sbin/oo-admin-ctl-gears startgear "${uuid}"
+/usr/bin/timeout -s USR1 120s /usr/sbin/oo-admin-ctl-gears startgear "${uuid}"
 
 HTTP_DIR=`dirname "/etc/httpd/conf.d/openshift/${uuid}"*/00000_default.conf`
 


### PR DESCRIPTION
- rhc app start... failed to un-idle application. Regression from
  https://github.com/openshift/origin-server/commit/6ec9581a05058daeb83edcbb717edf4dff141096
  Reverted here.
  - oo-restorer updated to be more robust
