### PR TITLE
Fix for Bug 901404

### DIFF
--- a/cartridges/openshift-origin-cartridge-mongodb-2.2/info/bin/dump.sh
+++ b/cartridges/openshift-origin-cartridge-mongodb-2.2/info/bin/dump.sh
@@ -34,7 +34,7 @@ function die() {
 function create_mongodb_snapshot() {
    #  Work in a temporary directory (create and cd to it).
    umask 077
-   dumpdir = $(mktemp -d mongodumpXXXXXXXX)
+   dumpdir=$(mktemp -d /tmp/mongodumpXXXXXXXX)
    [ $? -eq 0 ] || die 0 "ERROR" "Failed to create working directory."
    pushd $dumpdir > /dev/null
 

--- a/cartridges/openshift-origin-cartridge-mongodb-2.2/info/bin/restore.sh
+++ b/cartridges/openshift-origin-cartridge-mongodb-2.2/info/bin/restore.sh
@@ -67,7 +67,7 @@ WARNING: You may have possibly encountered the mongorestore bugs related to
 function restore_from_mongodb_snapshot() {
    #  Work in a temporary directory (create and cd to it).
    umask 077
-   dumpdir = $(mktemp -d mongodumpXXXXXXXX)
+   dumpdir=$(mktemp -d /tmp/mongodumpXXXXXXXX)
    [ $? -eq 0 ] || die 0 "ERROR" "Failed to create working directory."
    pushd $dumpdir > /dev/null
 


### PR DESCRIPTION
- syntax error in bash code
- Added /tmp to directory for mktemp
