### PR TITLE
Guard against bad quickstart descriptions

### DIFF
--- a/console/app/helpers/console/layout_helper.rb
+++ b/console/app/helpers/console/layout_helper.rb
@@ -143,6 +143,10 @@ module Console::LayoutHelper
     wizard_steps(CartridgeWizardStepsCreate, active, options)
   end
 
+  def show_description(description, opts={})
+    simple_format(truncate(description, {:length => opts[:length] || 550, :separator => "\n\n", :omission => ""}.reverse_merge!(opts)), opts)
+  end
+
   def wizard_steps(items, active, options={})
     content_tag(
       :ol,

--- a/console/app/views/application_types/_application_type.html.haml
+++ b/console/app/views/application_types/_application_type.html.haml
@@ -2,18 +2,15 @@
 = div_for type, :class => 'tile tile-click label-tags' do
   %h3= link_to type.display_name, application_type_path(type)
 
-  - if application_type.description.html_safe?
-    = application_type.description
-  - else
-    %p= application_type.description
+  = show_description type.description
 
   - if type.website
     %p=  link_to type.website, type.website
 
-  - if application_type.learn_more_url
-    %p= link_to "Learn more", application_type.learn_more_url
+  - if type.learn_more_url
+    %p= link_to "Learn more", type.learn_more_url
 
-  - if application_type.tags.include? :in_development
+  - if type.tags.include? :in_development
     %p This type is development only and will not be accessible in production
 
   = application_type_tags(type.tags - excluded_tags)

--- a/console/app/views/application_types/_persisted.html.haml
+++ b/console/app/views/application_types/_persisted.html.haml
@@ -1,8 +1,5 @@
 %h3= application_type.display_name
-- if application_type.description.html_safe?
-  = application_type.description
-- else
-  %p= application_type.description
+= show_description application_type.description
 
 - if application_type.website
   %p Website: #{link_to application_type.website, application_type.website}

--- a/console/app/views/application_types/index.html.haml
+++ b/console/app/views/application_types/index.html.haml
@@ -34,12 +34,6 @@
       - @featured_types.each do |type|
         %div{:class => @featured_types.length > 2 ? 'span4 tile-dark' : 'span6 tile-dark'}
           = render :partial => 'application_type', :object => type, :locals => {:excluded_tags => []}
-          -#= div_for type, :class => 'tile tile-click' do
-            %h3= link_to type.display_name, application_type_path(type)
-            %p= type.description
-            - if type.website
-              %p=  link_to type.website, type.website
-            = application_type_tags(type.tags)
 
 %section
   - if @type_groups.empty?

--- a/console/app/views/application_types/show.html.haml
+++ b/console/app/views/application_types/show.html.haml
@@ -50,10 +50,7 @@
 
       .controls
         - if @application_type.persisted?
-          - if @application_type.description.html_safe?
-            = @application_type.description
-          - else
-            %p.help-block= @application_type.description
+          = show_description(@application_type.description, :class => 'help-block')
 
           - if @application_type.website
             %p.help-block= link_to @application_type.website, @application_type.website

--- a/console/app/views/cartridge_types/_cartridge_type.html.haml
+++ b/console/app/views/cartridge_types/_cartridge_type.html.haml
@@ -35,7 +35,7 @@
           %span= cartridge_type.version
 
   - if not (inactive and reason == :installed) and cartridge_type.description.present?
-    %p= cartridge_type.description
+    = show_description cartridge_type.description
 
   - if cartridge_type.learn_more_url
     = link_to "Learn more", cartridge_type.learn_more_url

--- a/console/config/initializers/rdiscount.rb
+++ b/console/config/initializers/rdiscount.rb
@@ -1,8 +1,0 @@
-class RDiscount
-  def html_safe
-    to_html.html_safe
-  end
-  def to_s
-    text
-  end
-end


### PR DESCRIPTION
Ensure descriptions for cartridges and application types are safe and limited
in the UI.

[merge]
