### PR TITLE
[test] BZ902630: fix `service openshift-broker reload`

### DIFF
--- a/broker/init.d/openshift-broker
+++ b/broker/init.d/openshift-broker
@@ -75,7 +75,8 @@ stop() {
 }
 reload() {
     echo -n $"Reloading $prog: "
-    if ! LANG=$HTTPD_LANG $httpd $OPTIONS -t >&/dev/null; then
+    eval "set -- $OPTIONS"
+    if ! LANG=$HTTPD_LANG $httpd "$@" -t >&/dev/null; then
         RETVAL=6
         echo $"not reloading due to configuration syntax error"
         failure $"not reloading $httpd due to configuration syntax error"
@@ -85,6 +86,8 @@ reload() {
         RETVAL=$?
         if [ $RETVAL -eq 7 ]; then
             failure $"httpd shutdown"
+        else
+            success
         fi
     fi
     echo


### PR DESCRIPTION
In the initscript, the options to give to httpd are stored in the
$OPTIONS variable.  In the current version of the script, the status
action has an error that causes $OPTIONS to be expanded incorrectly.
This commit resolves the issue by using eval, set, and "$@" to coax BASH
into performing the expansion we want.

This commit also fixes an unrelated issue: The reload action did not
print anything on success, and now it will.

This commit should fix BZ902630.
