### PR TITLE
Bug 887353: removing a cartridge leaves info/ dir

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent-0.1/openshift-origin-cartridge-10gen-mms-agent-0.1.spec
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent-0.1/openshift-origin-cartridge-10gen-mms-agent-0.1.spec
@@ -48,6 +48,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0750,-,-) %{cartridgedir}/info/hooks/
 %attr(0750,-,-) %{cartridgedir}/info/build/
 %attr(0755,-,-) %{cartridgedir}/info/bin/

--- a/cartridges/openshift-origin-cartridge-haproxy-1.4/openshift-origin-cartridge-haproxy-1.4.spec
+++ b/cartridges/openshift-origin-cartridge-haproxy-1.4/openshift-origin-cartridge-haproxy-1.4.spec
@@ -76,6 +76,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks
 %attr(0750,-,-) %{cartridgedir}/info/hooks/*
 %attr(0755,-,-) %{cartridgedir}/info/hooks/tidy

--- a/cartridges/openshift-origin-cartridge-jbossas-7/openshift-origin-cartridge-jbossas-7.spec
+++ b/cartridges/openshift-origin-cartridge-jbossas-7/openshift-origin-cartridge-jbossas-7.spec
@@ -136,6 +136,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks
 %attr(0750,-,-) %{cartridgedir}/info/hooks/*
 %attr(0755,-,-) %{cartridgedir}/info/hooks/tidy

--- a/cartridges/openshift-origin-cartridge-jbosseap-6.0/openshift-origin-cartridge-jbosseap-6.0.spec
+++ b/cartridges/openshift-origin-cartridge-jbosseap-6.0/openshift-origin-cartridge-jbosseap-6.0.spec
@@ -146,6 +146,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks
 %attr(0750,-,-) %{cartridgedir}/info/hooks/*
 %attr(0755,-,-) %{cartridgedir}/info/hooks/tidy

--- a/cartridges/openshift-origin-cartridge-jbossews-1.0/openshift-origin-cartridge-jbossews-1.0.spec
+++ b/cartridges/openshift-origin-cartridge-jbossews-1.0/openshift-origin-cartridge-jbossews-1.0.spec
@@ -116,6 +116,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks
 %attr(0750,-,-) %{cartridgedir}/info/hooks/*
 %attr(0755,-,-) %{cartridgedir}/info/hooks/tidy

--- a/cartridges/openshift-origin-cartridge-jbossews-2.0/openshift-origin-cartridge-jbossews-2.0.spec
+++ b/cartridges/openshift-origin-cartridge-jbossews-2.0/openshift-origin-cartridge-jbossews-2.0.spec
@@ -114,6 +114,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks
 %attr(0750,-,-) %{cartridgedir}/info/hooks/*
 %attr(0755,-,-) %{cartridgedir}/info/hooks/tidy

--- a/cartridges/openshift-origin-cartridge-jenkins-1.4/openshift-origin-cartridge-jenkins-1.4.spec
+++ b/cartridges/openshift-origin-cartridge-jenkins-1.4/openshift-origin-cartridge-jenkins-1.4.spec
@@ -70,6 +70,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks
 %attr(0750,-,-) %{cartridgedir}/info/hooks/*
 %attr(0755,-,-) %{cartridgedir}/info/hooks/tidy

--- a/cartridges/openshift-origin-cartridge-jenkins-client-1.4/openshift-origin-cartridge-jenkins-client-1.4.spec
+++ b/cartridges/openshift-origin-cartridge-jenkins-client-1.4/openshift-origin-cartridge-jenkins-client-1.4.spec
@@ -54,6 +54,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0750,-,-) %{cartridgedir}/info/hooks/
 %attr(0750,-,-) %{cartridgedir}/info/build/
 %config(noreplace) %{cartridgedir}/info/configuration/

--- a/cartridges/openshift-origin-cartridge-mongodb-2.2/openshift-origin-cartridge-mongodb-2.2.spec
+++ b/cartridges/openshift-origin-cartridge-mongodb-2.2/openshift-origin-cartridge-mongodb-2.2.spec
@@ -69,6 +69,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0750,-,-) %{cartridgedir}/info/hooks/
 %attr(0750,-,-) %{cartridgedir}/info/data/
 %attr(0750,-,-) %{cartridgedir}/info/build/

--- a/cartridges/openshift-origin-cartridge-mysql-5.1/openshift-origin-cartridge-mysql-5.1.spec
+++ b/cartridges/openshift-origin-cartridge-mysql-5.1/openshift-origin-cartridge-mysql-5.1.spec
@@ -63,6 +63,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0750,-,-) %{cartridgedir}/info/hooks/
 %attr(0750,-,-) %{cartridgedir}/info/data/
 %attr(0750,-,-) %{cartridgedir}/info/build/

--- a/cartridges/openshift-origin-cartridge-nodejs-0.6/openshift-origin-cartridge-nodejs-0.6.spec
+++ b/cartridges/openshift-origin-cartridge-nodejs-0.6/openshift-origin-cartridge-nodejs-0.6.spec
@@ -92,6 +92,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks
 %attr(0750,-,-) %{cartridgedir}/info/hooks/*
 %attr(0755,-,-) %{cartridgedir}/info/hooks/tidy

--- a/cartridges/openshift-origin-cartridge-perl-5.10/openshift-origin-cartridge-perl-5.10.spec
+++ b/cartridges/openshift-origin-cartridge-perl-5.10/openshift-origin-cartridge-perl-5.10.spec
@@ -94,6 +94,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks
 %attr(0750,-,-) %{cartridgedir}/info/hooks/*
 %attr(0755,-,-) %{cartridgedir}/info/hooks/tidy

--- a/cartridges/openshift-origin-cartridge-php-5.3/openshift-origin-cartridge-php-5.3.spec
+++ b/cartridges/openshift-origin-cartridge-php-5.3/openshift-origin-cartridge-php-5.3.spec
@@ -99,6 +99,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks
 %attr(0750,-,-) %{cartridgedir}/info/hooks/*
 %attr(0755,-,-) %{cartridgedir}/info/hooks/tidy

--- a/cartridges/openshift-origin-cartridge-phpmyadmin-3.4/openshift-origin-cartridge-phpmyadmin-3.4.spec
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin-3.4/openshift-origin-cartridge-phpmyadmin-3.4.spec
@@ -47,6 +47,8 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0750,-,-) %{cartridgedir}/info/hooks/
 %attr(0750,-,-) %{cartridgedir}/info/connection-hooks/
 %attr(0750,-,-) %{cartridgedir}/info/build/

--- a/cartridges/openshift-origin-cartridge-postgresql-8.4/openshift-origin-cartridge-postgresql-8.4.spec
+++ b/cartridges/openshift-origin-cartridge-postgresql-8.4/openshift-origin-cartridge-postgresql-8.4.spec
@@ -88,6 +88,8 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0750,-,-) %{cartridgedir}/info/hooks/
 %attr(0750,-,-) %{cartridgedir}/info/data/
 %attr(0750,-,-) %{cartridgedir}/info/build/

--- a/cartridges/openshift-origin-cartridge-ruby-1.8/openshift-origin-cartridge-ruby-1.8.spec
+++ b/cartridges/openshift-origin-cartridge-ruby-1.8/openshift-origin-cartridge-ruby-1.8.spec
@@ -112,6 +112,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks
 %attr(0750,-,-) %{cartridgedir}/info/hooks/*
 %attr(0755,-,-) %{cartridgedir}/info/hooks/tidy

--- a/cartridges/openshift-origin-cartridge-ruby-1.9-scl/openshift-origin-cartridge-ruby-1.9-scl.spec
+++ b/cartridges/openshift-origin-cartridge-ruby-1.9-scl/openshift-origin-cartridge-ruby-1.9-scl.spec
@@ -186,6 +186,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks
 %attr(0750,-,-) %{cartridgedir}/info/hooks/*
 %attr(0755,-,-) %{cartridgedir}/info/hooks/tidy

--- a/cartridges/openshift-origin-cartridge-switchyard-0.6/openshift-origin-cartridge-switchyard-0.6.spec
+++ b/cartridges/openshift-origin-cartridge-switchyard-0.6/openshift-origin-cartridge-switchyard-0.6.spec
@@ -57,6 +57,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %{cartridgedir}
+%dir %{cartridgedir}/info
 %attr(0750,-,-) %{cartridgedir}/info/hooks/
 %attr(0750,-,-) %{cartridgedir}/info/build/
 %attr(0755,-,-) %{cartridgedir}/info/bin/


### PR DESCRIPTION
This commit adds each cartridge's %{cartridgedir}/ directory as well as its
%{cartridgedir}/info/ directory to the %files stanza of the cartridge so
that RPM recognises these directories as belonging to the cartridge and
removes them when the RPMs are removed.

Following the example of the python-2.6 cartridge, which already has these
directories in its %files stanza, this commit uses %dir for the
%{cartridgedir}/ and %{cartridgedir}/info/.  We do need the default
permissions (0755) on these two directories so that the MCollective agent
can read the info/ directory.

This commit fixes Bug 887353.
