### PR TITLE
In production, don't attempt to connect to the REST API on startup

### DIFF
--- a/console/config/initializers/rest_api.rb
+++ b/console/config/initializers/rest_api.rb
@@ -4,12 +4,14 @@ require 'rest_api/railties/controller_runtime'
 
 RestApi::LogSubscriber.attach_to :active_resource
 
-begin
-  info = RestApi.info
-  Rails.logger.info "Connected to #{info.url} with version #{info.version}"
-rescue Exception => e
-  puts e if Rails.env.development?
-  Rails.logger.warn e.message
+unless Rails.env.production?
+  begin
+    info = RestApi.info
+    Rails.logger.info "Connected to #{info.url} with version #{info.version}"
+  rescue Exception => e
+    puts e if Rails.env.development?
+    Rails.logger.warn e.message
+  end
 end
 
 ActiveSupport.on_load(:action_controller) do


### PR DESCRIPTION
Passenger can only boot one rack app at a time, and attempting to contact the
broker during startup causes a timeout and then wait (broker can't be started
until site completes, and we can't change the order).

[merge]
