### PR TITLE
Bug 903564: Fix inconsistent sed when updating haproxy cfg

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy-1.4/info/bin/update_namespace.sh
+++ b/cartridges/openshift-origin-cartridge-haproxy-1.4/info/bin/update_namespace.sh
@@ -29,7 +29,7 @@ setup_user_vars
 # haproxy_dir=$(get_cartridge_instance_dir "$cartridge_type")
 haproxy_dir=$APP_HOME/$cartridge_type
 sed -i "s#cookie\s*\(.*\)-$old_namespace#cookie \1-$new_namespace#g;   \
-        s#gear-\(.*\)-$old_namespace\s*#gear-\1-$new_namespace #g"     \
+        s#gear-\(.*\)-$old_namespace #gear-\1-$new_namespace #g"     \
     $haproxy_dir/conf/haproxy.cfg
 sed -i "s#\(.*\)-$old_namespace\.#\1-$new_namespace\.#g"   \
     $haproxy_dir/conf/gear-registry.db


### PR DESCRIPTION
Make the sed which updates the haproxy cfg on namespace update
work consistently. For some input, the previous regex would
produce an invalid config, causing haproxy to fail to load
during namespace update, aborting the entire operation.

Resolve https://bugzilla.redhat.com/show_bug.cgi?id=903564.
