### PR TITLE
Bug 904100: Tolerate missing Endpoint cart manifest entries

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -290,14 +290,21 @@ module OpenShift
       # Load the manifest for the cartridge
       begin
         manifest = get_cart_manifest(cart)
-        endpoints = manifest["Endpoints"]
       rescue => e
-        @logger.error(%Q{Failed to retrieve endpoints from manifest for cart #{cart} in gear #{@uuid}: #{e.message}
+        @logger.error(%Q{Failed to parse manifest for cart #{cart} in gear #{@uuid}: #{e.message}
           #{e.backtrace}
           })
         raise "Couldn't create endpoints for cart #{cart} in gear #{@uuid}"
       end
-      
+
+      endpoints = manifest["Endpoints"]
+
+      # Nothing to do if no endpoints are defined in the manifest
+      if endpoints == nil
+        @logger.info("No Endpoints present in manifest for cart #{cart} in gear #{@uuid}; endpoint creation skipped")
+        return
+      end
+     
       proxy = OpenShift::FrontendProxyServer.new(@logger)
       cart_ip = get_cart_ip(env, cart)
       

--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -1213,15 +1213,27 @@ module OpenShift
       # * method on Gear or Cart?
       #            
       def get_expose_port_job(app, gear, cart)
-        RemoteJob.new(cart, 'expose-port', "'#{gear.name}' '#{app.domain.namespace}' '#{gear.uuid}'")
+        args = Hash.new
+        args['--with-app-uuid'] = app.uuid
+        args['--with-container-uuid'] = gear.uuid
+        args['--cart-name'] = cart
+        RemoteJob.new('openshift-origin-node', 'expose-port', args)
       end
       
       def get_conceal_port_job(app, gear, cart)
-        RemoteJob.new(cart, 'conceal-port', "'#{gear.name}' '#{app.domain.namespace}' '#{gear.uuid}'")
+        args = Hash.new
+        args['--with-app-uuid'] = app.uuid
+        args['--with-container-uuid'] = gear.uuid
+        args['--cart-name'] = cart
+        RemoteJob.new('openshift-origin-node', 'conceal-port', args)
       end
       
       def get_show_port_job(app, gear, cart)
-        RemoteJob.new(cart, 'show-port', "'#{gear.name}' '#{app.domain.namespace}' '#{gear.uuid}'")
+        args = Hash.new
+        args['--with-app-uuid'] = app.uuid
+        args['--with-container-uuid'] = gear.uuid
+        args['--cart-name'] = cart
+        RemoteJob.new('openshift-origin-node', 'show-port', args)
       end
       
       def expose_port(app, gear, cart)


### PR DESCRIPTION
Skip endpoint creation if no Endpoints item is present in a given
cart manifest. Carts with no Endpoints is a valid state.
