### PR TITLE
Bug 905568: Skip endpoint deletion if no Endpoints in manifest

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -346,12 +346,19 @@ module OpenShift
       # Load the manifest for the cartridge
       begin
         manifest = get_cart_manifest(cart)
-        endpoints = manifest["Endpoints"]
       rescue => e
-        @logger.error(%Q{Failed to retrieve endpoints from manifest for cart #{cart} in gear #{@uuid}: #{e.message}
+        @logger.error(%Q{Failed to parse manifest for cart #{cart} in gear #{@uuid}: #{e.message}
           #{e.backtrace}
           })
         raise "Couldn't delete endpoints for cart #{cart} in gear #{@uuid}"
+      end
+
+      endpoints = manifest["Endpoints"]
+
+      # Nothing to do if no endpoints are defined in the manifest
+      if endpoints == nil
+        @logger.info("No Endpoints present in manifest for cart #{cart} in gear #{@uuid}; endpoint deletion skipped")
+        return
       end
 
       proxy = OpenShift::FrontendProxyServer.new(@logger)


### PR DESCRIPTION
Don't try and delete endpoints for a cart if no Endpoints are defined
in the cart manifest.
