### PR TITLE
removed the submit_form action keep the authenticity_token out of the ur...

### DIFF
--- a/console/app/views/application_types/show.html.haml
+++ b/console/app/views/application_types/show.html.haml
@@ -92,7 +92,7 @@
                 (branch '#{@application_type.initial_git_branch}')
             - else
               Default 
-            %small= link_to "Change", advanced_path, :data => {:submit_form => true}
+            %small= link_to "Change", advanced_path
 
       .controls
         %p.help-block 


### PR DESCRIPTION
I found that having the submit form action there causes an issue with the authenticity_token being appended in the url. What I think causes it is an issue with JS and Rails, from what I can tell the POST action of the page refresh is causing the authenticity_token to no longer be hidden. Which is weird cause the action specified in the JS is GET. To the best of my knowledge rails shouldn't check the authenticity token on a GET request anyway. After a bit of research I found:

Since the authenticity token is stored in the session, the client can not know its value. So naturally having it in the url is a bad thing. Rails by default only checks the POST, PUT, and DELETE requests. Plus the HTTP specification states that GET requests should NOT create, alter, or destroy resources at the server, and the request should be idempotent.

I could be wrong but I don't see a reason for a form to be submitted here. Your just adding an input field and not really submitting anything. After I took it out everything looked fine and allowed the user to continue with application creation without any adverse affects. Validations even worked when you left the field blank or didn't put a proper git url in there. However I still would like for someone to double-check my work and make sure I'm not missing something big here. 

[test] [review] 
