### PR TITLE
Bug 906217: Fix broken path reference in Python build script

### DIFF
--- a/cartridges/openshift-origin-cartridge-python-2.6/info/bin/build.sh
+++ b/cartridges/openshift-origin-cartridge-python-2.6/info/bin/build.sh
@@ -6,9 +6,10 @@ do
     . $f
 done
 
-VIRTENV="~/python-2.6/virtenv"
-
 cart_instance_dir=$OPENSHIFT_HOMEDIR/python-2.6
+
+VIRTENV=$cart_instance_dir/virtenv
+
 if `echo $OPENSHIFT_GEAR_DNS | egrep -qe "\.rhcloud\.com"`
 then 
     OPENSHIFT_PYTHON_MIRROR="-i http://mirror1.ops.rhcloud.com/mirror/python/web/simple"


### PR DESCRIPTION
Correct the broken cartridge instance directory reference which
causes the Python build to fail in Jenkins.

Resolve https://bugzilla.redhat.com/show_bug.cgi?id=906217.
