### PR TITLE
US2626 changes based on feedback

### DIFF
--- a/broker/test/unit/usage_model_test.rb
+++ b/broker/test/unit/usage_model_test.rb
@@ -7,7 +7,8 @@ class UsageModelTest < ActiveSupport::TestCase
 
   test "create and find usage event" do
     orig = usage
-    ue = Usage.new(login: orig.login, gear_id: orig.gear_id, begin_time: orig.begin_time, end_time: orig.end_time, usage_type: UsageRecord::USAGE_TYPES[:gear_usage], gear_size: orig.gear_size)
+    ue = Usage.new(login: orig.login, app_name: orig.app_name, gear_id: orig.gear_id, begin_time: orig.begin_time,
+                   end_time: orig.end_time, usage_type: UsageRecord::USAGE_TYPES[:gear_usage], gear_size: orig.gear_size)
     ue._id = orig._id
     ue.save!
     ue = Usage.find(orig._id)
@@ -132,10 +133,9 @@ class UsageModelTest < ActiveSupport::TestCase
   end
 
   def usage
-    obj = Usage.new(login: "user#{gen_uuid}", gear_id: "gear#{gen_uuid}", begin_time: Time.now.utc, end_time: nil, usage_type: UsageRecord::USAGE_TYPES[:gear_usage])
+    obj = Usage.new(login: "user#{gen_uuid}", app_name: "app#{gen_uuid}", gear_id: "gear#{gen_uuid}", begin_time: Time.now.utc, end_time: nil, usage_type: UsageRecord::USAGE_TYPES[:gear_usage])
     obj.gear_size = 'small'
     obj.addtl_fs_gb = 5
-    obj.updated_at = nil
     obj
   end
 end

--- a/common/lib/openshift-origin-common/models/cartridge.rb
+++ b/common/lib/openshift-origin-common/models/cartridge.rb
@@ -89,14 +89,14 @@ module OpenShift
       return categories.include?('premium')
     end
 
-    def price
-      price = 0
+    def usage_rate(currency)
+      rate = 0
       if self.is_premium?
         data = {:cart => self.name}
-        self.class.notify_observers(:get_cart_pricing, data)
-        price = data[:price]
+        self.class.notify_observers(:get_cart_usage_rate, data)
+        rate = data[:rate][currency] if data[:rate]
       end
-      price
+      rate
     end
  
     def from_descriptor(spec_hash={})

--- a/controller/app/models/pending_app_op_group.rb
+++ b/controller/app/models/pending_app_op_group.rb
@@ -171,7 +171,7 @@ class PendingAppOpGroup
             raise OpenShift::NodeException.new("Unable to create gear", result_io.exitcode, result_io) if result_io.exitcode != 0
             self.inc(:num_gears_created, 1)
           when :track_usage
-            UsageRecord.track_usage(op.args["login"], op.args["gear_ref"], op.args["event"], op.args["usage_type"],
+            UsageRecord.track_usage(op.args["login"], op.args["app_name"], op.args["gear_ref"], op.args["event"], op.args["usage_type"],
                                     op.args["gear_size"], op.args["additional_filesystem_gb"], op.args["cart_name"])
           when :register_dns          
             gear.register_dns

--- a/controller/app/models/usage.rb
+++ b/controller/app/models/usage.rb
@@ -1,6 +1,8 @@
 # Usage Summary 
 # @!attribute [r] login
 #   @return [String] Login name for the user.
+# @!attribute [r] app_name
+#   @return [String] Application name that belongs to the user.
 # @!attribute [r] gear_id
 #   @return [String] Gear identifier
 # @!attribute [r] usage_type
@@ -21,6 +23,7 @@ class Usage
   store_in collection: "usage"
 
   field :login, type: String
+  field :app_name, type: String
   field :gear_id, type: Moped::BSON::ObjectId
   field :begin_time, type: Time
   field :end_time, type: Time
@@ -29,6 +32,8 @@ class Usage
   field :addtl_fs_gb, type: Integer
   field :cart_name, type: String
 
+  validates :login, :presence => true
+  validates :app_name, :presence => true
   validates_inclusion_of :usage_type, in: UsageRecord::USAGE_TYPES.values
   validates :gear_size, :presence => true, :if => :validate_gear_size?
   validates :addtl_fs_gb, :presence => true, :if => :validate_addtl_fs_gb?

--- a/controller/app/rest_models/rest_cartridge.rb
+++ b/controller/app/rest_models/rest_cartridge.rb
@@ -1,7 +1,7 @@
 class RestCartridge < OpenShift::Model
   attr_accessor :type, :name, :version, :license, :license_url, :tags, :website, 
     :help_topics, :properties, :display_name, :description, :scales_from, :scales_to,
-    :supported_scales_to, :supported_scales_from, :current_scale, :scales_with, :price
+    :supported_scales_to, :supported_scales_from, :current_scale, :scales_with, :usage_rate_usd
 
   def initialize(cart)
     self.name = cart.name
@@ -23,7 +23,7 @@ class RestCartridge < OpenShift::Model
     scaling_cart = CartridgeCache.find_cartridge_by_category("scales")[0]
     self.scales_with = scaling_cart.name
     self.help_topics = cart.help_topics
-    self.price = cart.price
+    self.usage_rate_usd = cart.usage_rate(:usd)
   end
 
   def to_xml(options={})


### PR DESCRIPTION
- Add application name in Usage and UsageRecord models
- Change 'price' to 'usage_rate_usd' in rest cartridge model
- Change 'charges' to 'usage_rates' in rails configuration
- Rails configuration stores usage_rates for different currencies (currently only have usd)

Pass app name to track_usage
