### PR TITLE
Bug 906671: Fix log location in Ruby tidy hook

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby-1.8/info/hooks/tidy
+++ b/cartridges/openshift-origin-cartridge-ruby-1.8/info/hooks/tidy
@@ -9,10 +9,10 @@ done
 source "/etc/openshift/node.conf"
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
-if [ -d ${OPENSHIFT_REPO_DIR}log/ ]
+if [ -d $OPENSHIFT_RUBY_LOG_DIR ]
 then
-    client_message "Emptying log dir: ${OPENSHIFT_REPO_DIR}log/"
-    rm -rf ${OPENSHIFT_REPO_DIR}log/* ${OPENSHIFT_REPO_DIR}log/.[^.]*
+    client_message "Emptying log dir: ${OPENSHIFT_RUBY_LOG_DIR}"
+    rm -rf ${OPENSHIFT_RUBY_LOG_DIR}/* ${OPENSHIFT_RUBY_LOG_DIR}/.[^.]*
 fi
 
 if [ -d ${OPENSHIFT_REPO_DIR}tmp/ ]

--- a/cartridges/openshift-origin-cartridge-ruby-1.9-scl/info/hooks/tidy
+++ b/cartridges/openshift-origin-cartridge-ruby-1.9-scl/info/hooks/tidy
@@ -9,10 +9,10 @@ done
 source "/etc/openshift/node.conf"
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
-if [ -d ${OPENSHIFT_REPO_DIR}log/ ]
+if [ -d $OPENSHIFT_RUBY_LOG_DIR ]
 then
-    client_message "Emptying log dir: ${OPENSHIFT_REPO_DIR}log/"
-    rm -rf ${OPENSHIFT_REPO_DIR}log/* ${OPENSHIFT_REPO_DIR}log/.[^.]*
+    client_message "Emptying log dir: ${OPENSHIFT_RUBY_LOG_DIR}"
+    rm -rf ${OPENSHIFT_RUBY_LOG_DIR}/* ${OPENSHIFT_RUBY_LOG_DIR}/.[^.]*
 fi
 
 if [ -d ${OPENSHIFT_REPO_DIR}tmp/ ]


### PR DESCRIPTION
Fix the Ruby tidy hooks to clean logs from the correct location.

Resolve https://bugzilla.redhat.com/show_bug.cgi?id=906671.
