### PR TITLE
Fix pam_openshift default config

### DIFF
--- a/node-util/bin/oo-setup-node
+++ b/node-util/bin/oo-setup-node
@@ -362,6 +362,12 @@ find_and_replace("/etc/pam.d/sshd", "pam_selinux", "pam_openshift")
   rescue Errno::ENOENT
   end
 end
+['/tmp','/var/tmp'].each do |dir|
+  File.open('/etc/security/namespace.d/openshift_' + dir.gsub('/','') + '.conf', 'w') do |f|
+    f.write("# file create by oo-setup-node for openshift directory polyinstanciation, see http://selinuxproject.org/page/NB_Poly\n")
+    f.write(dir + "$HOME/.tmp/   user:iscript=/usr/sbin/oo-namespace-init root,adm,apache\n")
+  end
+end
 
 $log.info "Increasing kernel port, connection and semaphore limits"
 insert_if_not_exist("/etc/sysctl.conf", "net.ipv4.ip_local_port_range = 15000 35530", "net.ipv4.ip_local_port_range = 15000 35530\n")

--- a/pam_openshift/namespace.d/sandbox.conf
+++ b/pam_openshift/namespace.d/sandbox.conf
@@ -1,1 +1,0 @@
-# /sandbox        $HOME/.sandbox/      user:iscript=/usr/sbin/oo-namespace-init       root,adm,apache,gdm,liveuser

--- a/pam_openshift/namespace.d/tmp.conf
+++ b/pam_openshift/namespace.d/tmp.conf
@@ -1,1 +1,0 @@
-/tmp        $HOME/.tmp/      user:iscript=/usr/sbin/oo-namespace-init root,adm,apache,gdm,liveuser

--- a/pam_openshift/namespace.d/vartmp.conf
+++ b/pam_openshift/namespace.d/vartmp.conf
@@ -1,1 +1,0 @@
-/var/tmp    $HOME/.tmp/   user:iscript=/usr/sbin/oo-namespace-init root,adm,apache,gdm,liveuser

--- a/pam_openshift/pam_openshift.spec
+++ b/pam_openshift/pam_openshift.spec
@@ -35,8 +35,6 @@ install -D -m 644 pam_openshift.8 %{buildroot}/%{_mandir}/man8/pam_openshift.8
 
 install -D -m 755 oo-namespace-init %{buildroot}/%{_sbindir}/oo-namespace-init
 
-mkdir -p %{buildroot}/%{_sysconfdir}/security/namespace.d
-install -D -m 644 namespace.d/* %{buildroot}/%{_sysconfdir}/security/namespace.d
 
 %files
 %doc AUTHORS ChangeLog COPYING README README.xml
@@ -44,7 +42,6 @@ install -D -m 644 namespace.d/* %{buildroot}/%{_sysconfdir}/security/namespace.d
 %attr(0755,root,root) /%{_lib}/security/pam_libra.so
 %attr(0644,root,root) %{_mandir}/man8/pam_openshift.8.gz
 %attr(0755,root,root) %{_sbindir}/oo-namespace-init
-%attr(0644,root,root) %config(noreplace) %{_sysconfdir}/security/namespace.d/*
 
 %changelog
 * Sat Nov 17 2012 Adam Miller <admiller@redhat.com> 1.2.1-1


### PR DESCRIPTION
Default configuration make a default fedora unable to log a user, since the boolean in selinux for polyinstanciation is set on off. So this pull request remove the configuration, and create it in oo-setup-node, once we are sure the boolean is set. This also remove gdm and liveuser from the configuration, since they do not belong here ( ie, that's just for the livecd )
