### PR TITLE
Feature/node/cgroup unify

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/util
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/util
@@ -1016,14 +1016,15 @@ function run_user_hook {
 
 function enable_cgroups {
     if [ $ENABLE_CGROUPS -eq 1 ]; then
-      echo $cfs_quota > "/cgroup/all/openshift/$uuid/cpu.cfs_quota_us"
+      cgset -r cpu.cfs_quota_us=$cfs_quota /openshift/$uuid
     fi
 }
 
 function disable_cgroups {
     if [ $ENABLE_CGROUPS -eq 1 ]; then
-      export cfs_quota=$(cat "/cgroup/all/openshift/$uuid/cpu.cfs_quota_us")
-      cat /cgroup/all/openshift/$uuid/cpu.cfs_period_us  > "/cgroup/all/openshift/$uuid/cpu.cfs_quota_us"
+      export cfs_quota=$(cgget -n -v -r cpu.cfs_quota_us /openshift/${uuid})
+      cfs_period=$(cgget -n -v -r cpu.cfs_period_us /openshift/${uuid})
+      cgset -r cpu.cfs_quota_us=${cfs_period} /openshift/${uuid}
     fi
 }
 

--- a/node-util/bin/oo-accept-node
+++ b/node-util/bin/oo-accept-node
@@ -276,14 +276,6 @@ def check_cgroup_config
         do_fail("lscgroup /openshift path does not exist")
         $CGROUP_PASS=false
     end
-
-    ["/cgroup", "/cgroup/all", "/cgroup/all/openshift"].each { |path|
-        verbose("checking presence of #{path}")
-        next if File.exists? path
-        do_fail("cgroup root /cgroup directory does not exist")
-        $CGROUP_PASS=false
-        break
-    }
 end
 
 #
@@ -335,7 +327,6 @@ end
 def check_users
     verbose("checking #{users.length} user accounts")
     conf_dir_templ = "#{$LIMITS_CONF_DIR}/84-%s.conf"
-    user_cgroup="/cgroup/all/openshift/%s"
     users.each do |user|
         username,password,uid,gid,gecos,home_dir,shell = user.split(":")
         $ALL_USERS << username #store it so we can use it later
@@ -343,7 +334,7 @@ def check_users
         do_fail("user #{username} does not have a home directory #{home_dir}") unless File.exists? home_dir
         do_fail("user #{username} does not have a PAM limits file") unless File.exists?(conf_dir_templ % username)
         if $CGROUP_PASS
-            do_fail("user #{username} does not have a cgroup directory") unless File.exists?(user_cgroup % username)
+          check_user_cgroups username
         end
         if $TC_CHECK && $TC_PASS
             hex_uid = uid.to_i.to_s(16)
@@ -358,6 +349,26 @@ def check_users
             do_fail("user #{username} does not have quotas imposed")
         end
     end
+
+end
+
+# Verify that the user has a cgroup in all subsystems and no others
+def check_user_cgroups(username)
+  user_cgroup="/openshift/#{username}"
+  test_subsystems = ['cpu', 'cpuacct', 'memory', 'freezer', 'net_cls'].sort
+
+  # Create the list of cgroups to query
+  cmd =  "lscgroup " + test_subsystems.map {|s| "#{s}:#{user_cgroup}"}.join(' ')
+  reply = %x[#{cmd}]
+
+  # This is a horrible bit of cleverness
+  # each group is on one line.  split the lines to an array
+  # extract the subsystem list (before the colon) for each group
+  # split the subsystems on commas (in case there are joined subsystems)
+  # then flatten the list sort and remove duplicates
+  actual = reply.split.map {|s| s[/([^:]+)/,1] }.map {|g| g.split(',')}.flatten.uniq.sort
+
+  do_fail("user #{username} must have all cgroup subsystems") if not (actual == test_subsystems)
 
 end
 

--- a/node-util/bin/oo-setup-node
+++ b/node-util/bin/oo-setup-node
@@ -334,7 +334,6 @@ else
 end
 
 $log.info "Enabling CGroups"
-find_and_replace("/etc/systemd/system.conf", /^(#?)JoinControllers=.*$/, "JoinControllers=cpu,cpuacct,memory,freezer,net_cls") if use_systemd
 FileUtils.mkdir_p "/cgroup"
 run "/bin/cp -r /usr/share/doc/rubygem-openshift-origin-node-*/cgconfig.conf /etc/cgconfig.conf"
 
@@ -354,6 +353,9 @@ $log.info "Restore SELinux default security contexts."
 run "/sbin/restorecon /var/lib/openshift || :"
 run "/sbin/restorecon /var/lib/openshift/.httpd.d/ || :"
 
+$log.info "Enable pam_cgroup on sshd"
+insert_if_not_exist("/etc/pam.d/sshd", "pam_cgroup.so", "session\t\optional\tpam_cgroup.so\n")
+                                   
 $log.info "Set pam-openshift and polyinstantiation"
 find_and_replace("/etc/pam.d/sshd", "pam_selinux", "pam_openshift")
 ["runuser", "runuser-l", "sshd", "su", "system-auth-ac"].each do |pamf|

--- a/node/misc/bin/oo-admin-ctl-cgroups
+++ b/node/misc/bin/oo-admin-ctl-cgroups
@@ -49,7 +49,7 @@ function classid() {
 
 function set_net_cls() {
     # USERNAME=$1
-    CGPATH=openshift/$1
+    CGPATH=${OPENSHIFT_CGROUP_ROOT}/$1
     USERID=`uid $1`
     USERCLASSID=`classid $USERID`
     cgset -r net_cls.classid=$USERCLASSID $CGPATH
@@ -61,7 +61,7 @@ function set_net_cls() {
 CPUVARS="cfs_period_us cfs_quota_us rt_period_us rt_runtime_us shares"
 function set_cpu() {
     # USERNAME=$1
-    CGPATH=openshift/$1
+    CGPATH=${OPENSHIFT_CGROUP_ROOT}/$1
 
     for VARNAME in $CPUVARS
     do
@@ -82,7 +82,7 @@ function set_cpu() {
 MEMVARS="limit_in_bytes memsw.limit_in_bytes soft_limit_in_bytes swappiness"
 function set_memory() {
     # USERNAME=$1
-    CGPATH=openshift/$1
+    CGPATH=${OPENSHIFT_CGROUP_ROOT}/$1
 
     # for each var get and set the value
     for VARNAME in $MEMVARS
@@ -104,7 +104,7 @@ function set_memory() {
 BLKIOVARS="weight weight_device"
 function set_blkio() {
     # USERNAME=$1
-    CGPATH=/$1
+    CGPATH=${OPENSHIFT_CGROUP_ROOT}/$1
 
     # for each var get and set the value
     for VARNAME in $BLKIOVARS
@@ -192,10 +192,11 @@ delete_cgroup_rule() {
 #
 collect_tasks() {
     # USERNAME=$1
+    CGPATH=${OPENSHIFT_CGROUP_ROOT}/$1
 
     # add existing processes to the group
     for PID in $(ps -opid= -u $1) ; do
-	echo $PID > /cgroup/all/${OPENSHIFT_CGROUP_ROOT}/$1/tasks
+	cgclassify -g ${OPENSHIFT_CGROUP_SUBSYSTEMS}:${CGPATH} $PID
     done
 }
 

--- a/node/misc/bin/oo-cgroup-read
+++ b/node/misc/bin/oo-cgroup-read
@@ -3,6 +3,10 @@
 # BZ 901449: SELinux failure prevent using "/usr/bin/env ruby".
 
 require 'etc'
+require 'open4'
+
+# each value begins with the subsystem name and a dot (.)
+# extract the subsystem name and check it against the list
 
 # When combined with selinux, this script will allow users to read their own
 # cgroups entries but not other users cgroups entries
@@ -15,12 +19,17 @@ unless attribute =~ /\A[a-zA-Z0-9\.\-_]*\z/
     exit 1
 end
 
-if File.exists? "/cgroup/all/openshift/#{login}/#{attribute}"
-    fp = File.new("/cgroup/all/openshift/#{login}/#{attribute}")
-    value = fp.gets
-    fp.close
-else
-    puts "Could not find attribute #{attribute}"
+cmd = "cgget -n -v -r #{attribute} /openshift/#{login}"
+# This would be simple, but we can't catch errors
+#value = %x[%{cmd}]
+pid, stdin, stdout, stderr = open4(cmd)
+
+value = stdout.read.strip
+error = stderr.read.strip
+
+if not error == "" then
+    $stderr.puts "Could not find attribute #{attribute}"
+    $stderr.puts error
     exit 2
 end
 

--- a/node/misc/bin/oo-cgroup-read
+++ b/node/misc/bin/oo-cgroup-read
@@ -2,6 +2,7 @@
 
 # BZ 901449: SELinux failure prevent using "/usr/bin/env ruby".
 
+require 'optparse'
 require 'etc'
 require 'open4'
 
@@ -10,27 +11,90 @@ require 'open4'
 
 # When combined with selinux, this script will allow users to read their own
 # cgroups entries but not other users cgroups entries
-euid = Process::Sys.geteuid
-login = Etc.getpwuid(euid).name
 
-attribute=ARGV[0]
-unless attribute =~ /\A[a-zA-Z0-9\.\-_]*\z/
-    puts "#{attribute} is an invalid attribute"
-    exit 1
+
+def usage
+  puts <<EOF
+usage: oo-cgroup-read [-h|--help] <attrname>
+
+attrname: the name of the cgroup attribute requested
+EOF
+
 end
 
-cmd = "cgget -n -v -r #{attribute} /openshift/#{login}"
-# This would be simple, but we can't catch errors
-#value = %x[%{cmd}]
-pid, stdin, stdout, stderr = open4(cmd)
 
-value = stdout.read.strip
-error = stderr.read.strip
+# Check that the user didn't send any nasty strings at us.
+def scrub_input(instring)
+  unless instring =~ /\A[a-zA-Z0-9\.\-_]*\z/
+    puts "#{instring} is an invalid attribute"
+    exit 1
+  end
+end
 
-if not error == "" then
+#
+# Call cgget to retrieve the value for the user.
+# cgget does not set a return flag on failure to find a value or error
+# You have to check the stdout
+#
+def get_cgroup_attribute(attribute, username)
+  cmd = "cgget -n -v -r #{attribute} /openshift/#{username}"
+  # This would be simple, but we can't catch errors
+  #value = %x[%{cmd}]
+  pid, stdin, stdout, stderr = open4(cmd)
+
+  # get the error string (if any).  Remove trailing newlines.
+  error = stderr.read.strip
+
+  if not error == "" then
     $stderr.puts "Could not find attribute #{attribute}"
     $stderr.puts error
     exit 2
+  end
+
+  # Get the output string. Remove trailing newlines (just one)
+  value = stdout.read.strip
 end
+
+#
+# Check for a help request from the user
+#
+# Only check for help.
+#
+def parse_options
+  options = {}
+
+  optparse = OptionParser.new do |opts|
+    opts.banner = "Usage: #{File.basename($0)} [-h|--help] <attrname>"
+
+    # Help
+    opts.on('-h', '--help', 'Display usage information') do
+      usage
+      exit
+    end
+  end
+
+  optparse.parse!
+end
+  
+
+# Check for help request
+parse_options
+
+# What user is making the request?
+euid = Process::Sys.geteuid
+username = Etc.getpwuid(euid).name
+
+# What attribute are they asking for?
+attrname = ARGV[0]
+
+if attrname == nil then
+  $stderr.puts "ERROR: no attribute name requested"
+  usage
+  exit 2
+end
+
+scrub_input attrname
+
+value = get_cgroup_attribute attrname, username
 
 puts value

--- a/node/misc/bin/oo-trap-user
+++ b/node/misc/bin/oo-trap-user
@@ -9,6 +9,7 @@ import base64
 import commands
 import re
 import selinux
+import subprocess
 
 EXT_LIB = "/usr/libexec/openshift/lib/util"
 
@@ -35,6 +36,9 @@ commands_map = {
 }
 
 comment_re = re.compile("#.*$")
+
+# These should come from somewhere, not be hard coded - MAL
+openshift_cgroup_subsystems="cpu,cpuacct,memory,net_cls,freezer"
 
 #
 # Read in uservars variables.
@@ -99,38 +103,22 @@ def join_cgroup():
     """
 
     username = pwd.getpwuid(os.getuid())[0]
+    cgpath = "/openshift/%s" % username
     pid = os.getpid()
 
-    # this should come from /etc/openshift/node.conf:OPENSHIFT_CGROUP_ROOT
-    cgroup_root = "/cgroup/all/openshift"
-    cgroup_user = os.path.join(cgroup_root, username)
-    cgroup_tasks = os.path.join(cgroup_user, "tasks")
+    cmd_template = "cgclassify -g %s:%s %d"
+    cmd = cmd_template % (openshift_cgroup_subsystems, cgpath, pid)
+    syslog.syslog("user %s: putting process %d in cgroups %s" % (username, pid, openshift_cgroup_subsystems))
 
-    syslog.syslog("user %s: putting process %d in cgroup %s" % (username, pid, cgroup_root))
+    retval = subprocess.call(cmd.split())
+    if retval != 0:
+        syslog.syslog("user %s: cgroup classification failed: retval = %d" % (username, retval))
 
-    if not os.path.isdir(cgroup_root):
-        # raise an exception
-        return
-
-    if not os.path.isdir(cgroup_user):
-        # raise an exception
-        return
-
-    if not os.path.isfile(cgroup_tasks):
-        # raise an exception
-        return 
-
-    # try:
-    taskfile = open(cgroup_tasks, 'w')
-    taskfile.write(str(pid) + "\n")
-    taskfile.flush()
-    taskfile.close()
-    # except IOError, e:
-    #    write "can't join cgroup" message
+    # should raise an exception? MAL
 
 if __name__ == '__main__':
     # first self-apply restrictions
-    join_cgroup()
+    # join_cgroup()
     read_env_vars()
     config = read_config()
 
@@ -236,7 +224,7 @@ if __name__ == '__main__':
     target_context = 'unconfined_u:system_r:openshift_t:%s' % mcs_level
     actual_context = selinux.getcon()[1]
     if target_context != actual_context:
-        print "Invalid context"
+        print "Invalid context: %s, expected %s\n" % (actual_context, target_context)
         sys.exit(40)
         # This else is left in because at the time of writing this statement
         # We have a patched ssh running.  Remove the exit above and it should

--- a/node/misc/doc/cgconfig.conf
+++ b/node/misc/doc/cgconfig.conf
@@ -16,11 +16,11 @@
 
 mount {
 	cpuset	= /cgroup/cpuset;
-	cpu	= /cgroup/all;
-	cpuacct	= /cgroup/all;
-	memory	= /cgroup/all;
+	cpu	= /cgroup/cpu;
+	cpuacct	= /cgroup/cpuacct;
+	memory	= /cgroup/memory;
 	devices	= /cgroup/devices;
-	freezer	= /cgroup/all;
-	net_cls	= /cgroup/all;
+	freezer	= /cgroup/freezer;
+	net_cls	= /cgroup/net_cls;
 	blkio	= /cgroup/blkio;
 }

--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -34,8 +34,10 @@ Requires:      libcgroup
 %else
 Requires:      libcgroup-tools
 %endif
+Requires:      libcgroup-pam
 Requires:      pam_openshift
 Requires:      quota
+
 %if 0%{?fedora}%{?rhel} <= 6
 BuildRequires: ruby193-build
 BuildRequires: scl-utils-build
@@ -161,11 +163,26 @@ rm -rf %{buildroot}%{gem_instdir}/misc
 %post
 echo "/usr/bin/oo-trap-user" >> /etc/shells
 
+# Enable cgroups on ssh logins
+if [ -f /etc/pam.d/sshd ] ; then
+   if ! grep pam_cgroup.so /etc/pam.d/sshd > /dev/null ; then
+     echo "session    optional     pam_cgroup.so" >> /etc/pam.d/sshd
+   else
+     logger -t rpm-post "pam_cgroup.so is already enabled for sshd"
+   fi
+else
+   logger -t rpm-post "cannot add pam_cgroup.so to /etc/pamd./sshd: file not found"
+fi
+
 # copying this file in the post hook so that this file can be replaced by rhc-node
 # copy this file only if it doesn't already exist
 if ! [ -f /etc/openshift/resource_limits.conf ]; then
   cp -f /etc/openshift/resource_limits.template /etc/openshift/resource_limits.conf
 fi
+
+%preun
+# disable cgroups on sshd logins
+sed -i -e '/pam_cgroup/d' /etc/pam.d/sshd
 
 %changelog
 * Fri Feb 08 2013 Adam Miller <admiller@redhat.com> 1.5.2-1


### PR DESCRIPTION
replace filesystem interface on cgroups with the libcgroup-tools cli commands.

This removes the need to customize the filesystem configuration for cgroups and unifies the behavior on init and systemd based distributions.

This should be pulled in coordination with li pull request 837 for testing.
