### PR TITLE
Fix bugz 907372 - snapshot restore failure w/ python 2.7/3.3

### DIFF
--- a/cartridges/openshift-origin-cartridge-community-python-2.7/info/bin/restore.sh
+++ b/cartridges/openshift-origin-cartridge-community-python-2.7/info/bin/restore.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+cartridge_type='python-2.7'
+source /etc/openshift/node.conf
+source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
+source ${CARTRIDGE_BASE_PATH}/${cartridge_type}/info/lib/util
+
+include_git="$1"
+
+# Import Environment Variables
+for f in ~/.env/*
+do
+    . $f
+done
+
+# Import Environment Variables
+source ${CARTRIDGE_BASE_PATH}/${cartridge_type}/info/bin/source_env_vars
+
+if [ "$include_git" = "INCLUDE_GIT" ]
+then
+  # prevent feeding the tarball to pre-receive on stdin
+  ~/git/${OPENSHIFT_GEAR_NAME}.git/hooks/pre-receive < /dev/null 1>&2
+  echo "Removing old git repo: ~/git/${OPENSHIFT_GEAR_NAME}.git/" 1>&2
+  /bin/rm -rf ~/git/${OPENSHIFT_GEAR_NAME}.git/[^h]*/*
+else
+  stop_app.sh 1>&2
+fi
+
+echo "Removing old data dir: ~/app-root/data/*" 1>&2
+/bin/rm -rf ~/app-root/data/* ~/app-root/data/.[^.]*
+
+restore_tar.sh $include_git
+
+for db in $(get_attached_databases)
+do
+    restore_cmd=${CARTRIDGE_BASE_PATH}/${db}/info/bin/restore.sh
+    echo "Running extra restore for $db" 1>&2
+    $restore_cmd
+done
+
+if [ "$include_git" = "INCLUDE_GIT" ]
+then
+  GIT_DIR=~/git/${OPENSHIFT_GEAR_NAME}.git/ ~/git/${OPENSHIFT_GEAR_NAME}.git/hooks/post-receive 1>&2  
+else
+  start_app.sh 1>&2
+fi

--- a/cartridges/openshift-origin-cartridge-community-python-2.7/info/bin/snapshot.sh
+++ b/cartridges/openshift-origin-cartridge-community-python-2.7/info/bin/snapshot.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+cartridge_type='python-2.7'
+source /etc/openshift/node.conf
+source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
+source ${CARTRIDGE_BASE_PATH}/${cartridge_type}/info/lib/util
+
+# Import Environment Variables
+for f in ~/.env/*
+do
+    . $f
+done
+
+# Import Environment Variables
+source ${CARTRIDGE_BASE_PATH}/${cartridge_type}/info/bin/source_env_vars
+
+# Run pre-dump dumps
+for db in $(get_attached_databases)
+do
+    dump_cmd=${CARTRIDGE_BASE_PATH}/${db}/info/bin/dump.sh
+    echo "Running extra dump for $db" 1>&2
+    $dump_cmd
+done
+
+# stop
+stop_app.sh 1>&2
+
+# Run tar, saving to stdout
+cd ~
+cd ..
+echo "Creating and sending tar.gz" 1>&2
+
+/bin/tar --ignore-failed-read -czf - \
+        --exclude=./$OPENSHIFT_GEAR_UUID/.tmp \
+        --exclude=./$OPENSHIFT_GEAR_UUID/.ssh \
+        --exclude=./$OPENSHIFT_GEAR_UUID/.sandbox \
+        --exclude=./$OPENSHIFT_GEAR_UUID/*/conf.d/openshift.conf \
+        --exclude=./$OPENSHIFT_GEAR_UUID/*/run/httpd.pid \
+        --exclude=./$OPENSHIFT_GEAR_UUID/haproxy-\*/run/stats \
+        --exclude=./$OPENSHIFT_GEAR_UUID/app-root/runtime/.state \
+        --exclude=./$OPENSHIFT_GEAR_UUID/app-root/data/.bash_history \
+        --exclude=./$OPENSHIFT_GEAR_UUID/$cartridge_type/openshift-community-cartridge-\* \
+        ./$OPENSHIFT_GEAR_UUID
+
+# Cleanup
+for db in $(get_attached_databases)
+do
+    cleanup_cmd=${CARTRIDGE_BASE_PATH}/${db}/info/bin/cleanup.sh
+    echo "Running extra cleanup for $db" 1>&2
+    $cleanup_cmd
+done
+
+
+# start_app
+start_app.sh 1>&2

--- a/cartridges/openshift-origin-cartridge-community-python-3.3/info/bin/restore.sh
+++ b/cartridges/openshift-origin-cartridge-community-python-3.3/info/bin/restore.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+cartridge_type='python-3.3'
+source /etc/openshift/node.conf
+source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
+source ${CARTRIDGE_BASE_PATH}/${cartridge_type}/info/lib/util
+
+include_git="$1"
+
+# Import Environment Variables
+for f in ~/.env/*
+do
+    . $f
+done
+
+# Import Environment Variables
+source ${CARTRIDGE_BASE_PATH}/${cartridge_type}/info/bin/source_env_vars
+
+if [ "$include_git" = "INCLUDE_GIT" ]
+then
+  # prevent feeding the tarball to pre-receive on stdin
+  ~/git/${OPENSHIFT_GEAR_NAME}.git/hooks/pre-receive < /dev/null 1>&2
+  echo "Removing old git repo: ~/git/${OPENSHIFT_GEAR_NAME}.git/" 1>&2
+  /bin/rm -rf ~/git/${OPENSHIFT_GEAR_NAME}.git/[^h]*/*
+else
+  stop_app.sh 1>&2
+fi
+
+echo "Removing old data dir: ~/app-root/data/*" 1>&2
+/bin/rm -rf ~/app-root/data/* ~/app-root/data/.[^.]*
+
+restore_tar.sh $include_git
+
+for db in $(get_attached_databases)
+do
+    restore_cmd=${CARTRIDGE_BASE_PATH}/${db}/info/bin/restore.sh
+    echo "Running extra restore for $db" 1>&2
+    $restore_cmd
+done
+
+if [ "$include_git" = "INCLUDE_GIT" ]
+then
+  GIT_DIR=~/git/${OPENSHIFT_GEAR_NAME}.git/ ~/git/${OPENSHIFT_GEAR_NAME}.git/hooks/post-receive 1>&2  
+else
+  start_app.sh 1>&2
+fi

--- a/cartridges/openshift-origin-cartridge-community-python-3.3/info/bin/snapshot.sh
+++ b/cartridges/openshift-origin-cartridge-community-python-3.3/info/bin/snapshot.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+cartridge_type='python-3.3'
+source /etc/openshift/node.conf
+source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
+source ${CARTRIDGE_BASE_PATH}/${cartridge_type}/info/lib/util
+
+# Import Environment Variables
+for f in ~/.env/*
+do
+    . $f
+done
+
+# Import Environment Variables
+source ${CARTRIDGE_BASE_PATH}/${cartridge_type}/info/bin/source_env_vars
+
+# Run pre-dump dumps
+for db in $(get_attached_databases)
+do
+    dump_cmd=${CARTRIDGE_BASE_PATH}/${db}/info/bin/dump.sh
+    echo "Running extra dump for $db" 1>&2
+    $dump_cmd
+done
+
+# stop
+stop_app.sh 1>&2
+
+# Run tar, saving to stdout
+cd ~
+cd ..
+echo "Creating and sending tar.gz" 1>&2
+
+/bin/tar --ignore-failed-read -czf - \
+        --exclude=./$OPENSHIFT_GEAR_UUID/.tmp \
+        --exclude=./$OPENSHIFT_GEAR_UUID/.ssh \
+        --exclude=./$OPENSHIFT_GEAR_UUID/.sandbox \
+        --exclude=./$OPENSHIFT_GEAR_UUID/*/conf.d/openshift.conf \
+        --exclude=./$OPENSHIFT_GEAR_UUID/*/run/httpd.pid \
+        --exclude=./$OPENSHIFT_GEAR_UUID/haproxy-\*/run/stats \
+        --exclude=./$OPENSHIFT_GEAR_UUID/app-root/runtime/.state \
+        --exclude=./$OPENSHIFT_GEAR_UUID/app-root/data/.bash_history \
+        --exclude=./$OPENSHIFT_GEAR_UUID/$cartridge_type/openshift-community-cartridge-\* \
+        ./$OPENSHIFT_GEAR_UUID
+
+# Cleanup
+for db in $(get_attached_databases)
+do
+    cleanup_cmd=${CARTRIDGE_BASE_PATH}/${db}/info/bin/cleanup.sh
+    echo "Running extra cleanup for $db" 1>&2
+    $cleanup_cmd
+done
+
+
+# start_app
+start_app.sh 1>&2


### PR DESCRIPTION
Bug 907372 - [US3327]Meet error "could not create 'YourAppName.egg-info': Permission denied" when snapshot restored for python-2.7/python-3.3 apps
