### PR TITLE
US3350 - Improve capability extension

### DIFF
--- a/console/app/controllers/capability_aware.rb
+++ b/console/app/controllers/capability_aware.rb
@@ -8,7 +8,7 @@ module CapabilityAware
   def current_api_user
     @current_api_user ||= begin
         @user_capabilities = nil
-        session[:user_capabilities] = nil
+        session[:caps] = nil
         User.find :one, :as => current_user
       end
   end
@@ -17,9 +17,10 @@ module CapabilityAware
   # refresh of the values stored in session
   def user_capabilities(args = {})
     @user_capabilities = nil if args[:refresh]
+    model = Console.config.capabilities_model_class
     @user_capabilities ||=
-      (Capabilities::Cacheable.from(session[:user_capabilities]) rescue nil) ||
-      current_api_user.to_capabilities.tap{ |c| session[:user_capabilities] = c.to_a }
+      (model.from(session[:caps]) rescue nil) ||
+      model.from(current_api_user).tap{ |c| session[:caps] = c.to_session }
   end
 end
 RestApi::Base.observers << UserSessionSweeper

--- a/console/app/models/application.rb
+++ b/console/app/models/application.rb
@@ -1,10 +1,6 @@
 #
 # The REST API model object representing an application instance.
 #
-
-# Explicitly require the gear group to prevent race conditions with autoload - http://bit.ly/SVrPH3
-require 'gear_group'
-
 class Application < RestApi::Base
   include AsyncAware
 

--- a/console/app/models/domain.rb
+++ b/console/app/models/domain.rb
@@ -17,8 +17,8 @@ class Domain < RestApi::Base
   def applications
     @applications ||= Application.find :all, { :params => { :domain_id => self.id }, :as => as }
   end
-  def find_application(name)
-    Application.find name, { :params => { :domain_id => self.id }, :as => as}
+  def find_application(name, opts={})
+    Application.find name, { :params => { :domain_id => self.id }, :as => as}.deep_merge!(opts)
   end
 
   #FIXME should have an observer pattern that clears cached associations on reload

--- a/console/app/models/rest_api/base.rb
+++ b/console/app/models/rest_api/base.rb
@@ -67,33 +67,14 @@ class ActiveResource::Base
       find_or_create_resource_for(ActiveSupport::Inflector.singularize(name.to_s))
     end
 
+    alias_method :original_find_or_create_resource_for, :find_or_create_resource_for
+    # Tries to find a resource for a given name; if it fails, then the resource is created
     def find_or_create_resource_for(name)
       # also sanitize names with dashes
       name = name.to_s.gsub(/[^\w\:]/, '_')
       # association support
       return reflections[name.to_sym].klass if reflections.key?(name.to_sym)
-
-      resource_name = name.to_s.camelize
-      ancestors = self.class.name.split("::")
-      if ancestors.size > 1
-        find_resource_in_modules(resource_name, ancestors)
-      else
-        self.class.const_get(resource_name)
-      end
-    rescue NameError => e
-      begin
-        if self.class.const_defined?(resource_name)
-          resource = self.class.const_get(resource_name)
-        else
-          resource = self.class.const_set(resource_name, Class.new(ActiveResource::Base))
-        end
-      rescue NameError # invalid constant name (starting by number for example)
-        resource_name = 'Constant' + resource_name
-        resource = self.class.const_set(resource_name, Class.new(ActiveResource::Base))
-      end
-      resource.prefix = self.class.prefix_source
-      resource.site   = self.class.site
-      resource
+      original_find_or_create_resource_for(name)
     end
 end
 

--- a/console/app/models/rest_api/cacheable.rb
+++ b/console/app/models/rest_api/cacheable.rb
@@ -80,8 +80,8 @@ module RestApi
           key
         end
 
-        def cache_find_method(symbol, key=[name, "find_#{symbol}"])
-          cache_method "find_#{symbol}", key, :before => remove_authorization_from_model
+        def cache_find_method(symbol, key=[name, "find_#{symbol}"], opts={})
+          cache_method "find_#{symbol}", key, opts.reverse_merge!(:before => remove_authorization_from_model)
         end
         def remove_authorization_from_model
           lambda { |e| Array(e).each { |c| c.as = nil } }

--- a/console/app/models/user.rb
+++ b/console/app/models/user.rb
@@ -5,29 +5,16 @@ class User < RestApi::Base
   singleton
 
   schema do
-    string :login, :plan_id
+    string :id, :login, :plan_id
     integer :max_gears, :consumed_gears
   end
 
   has_many :keys
   has_many :domains
 
-  def plan_id
-    super or 'freeshift'
-  end
-
-  def plan
-    @plan ||= Aria::MasterPlan.cached.find plan_id
-  end
-  def plan=(plan)
-    @plan_id = plan.is_a?(String) ? plan : plan.id
+  def consumed_gears
+    attributes[:consumed_gears] || 0
   end
 
   include Capabilities
-  def to_capabilities
-    Capabilities::Cacheable.from(self.capabilities.merge :max_gears => max_gears, :consumed_gears => consumed_gears || 0)
-  end
-  def gear_sizes
-    Array(capabilities[:gear_sizes]).map(&:to_sym)
-  end
 end

--- a/console/lib/console/configuration.rb
+++ b/console/lib/console/configuration.rb
@@ -36,11 +36,15 @@ module Console
     config_accessor :include_helpers
 
     #
-    # Additional user capabilities to cache in
-    # the session. Changing the order of this 
-    # value will break existing sessions.
+    # A class that represents the capabilities object
     #
-    config_accessor :cached_capabilities
+    # Must implement:
+    #
+    #   - new(User)
+    #   - from(<session_object>)
+    #   - #to_session => <session_object>
+    #
+    config_accessor :capabilities_model
 
     Builtin = {
       :openshift => {
@@ -99,6 +103,14 @@ module Console
     end
     def user_agent=(agent)
       @user_agent = agent
+    end
+
+    def capabilities_model_class
+      @capabilities_model_class ||= @capabilities_model.constantize
+    end
+    def capabilities_model=(name)
+      @capabilities_model_class = nil
+      @capabilities_model = name
     end
 
     protected
@@ -166,6 +178,6 @@ module Console
     config.parent_controller = 'ApplicationController'
     config.security_controller = 'Console::Auth::Basic'
     config.include_helpers = true
-    config.cached_capabilities = []
+    config.capabilities_model = 'Capabilities::Cacheable'
   end
 end

--- a/console/lib/console/engine.rb
+++ b/console/lib/console/engine.rb
@@ -20,6 +20,11 @@ module Console
         app.middleware.insert_before(::ActionDispatch::Static, ::ActionDispatch::Static, "#{root}/public")
       end
     end
+
+    def self.require_relative(file)
+      file = File.expand_path(file)
+      require_dependency "#{root}/#{Pathname.new(file).relative_path_from(Rails.application.root)}"
+    end
   end
 end
 

--- a/console/test/functional/application_types_controller_test.rb
+++ b/console/test/functional/application_types_controller_test.rb
@@ -178,13 +178,13 @@ class ApplicationTypesControllerTest < ActionController::TestCase
     type = types[0]
 
     # confirm the session is clear of relevant keys
-    assert session.has_key?(:user_capabilities) == false
+    assert !session.has_key?(:caps)
 
     # make the request
     get :show, :id => type.id
 
     # compare the session cache with expected values
-    assert_equal [user.max_gears, user.consumed_gears, user.gear_sizes, true], session[:user_capabilities]
+    assert_equal [user.max_gears, user.consumed_gears, user.gear_sizes, nil, true], session[:caps]
     assert_equal user.gear_sizes, assigns(:capabilities).gear_sizes
     assert_equal user.max_gears, assigns(:capabilities).max_gears
     assert_equal user.consumed_gears, assigns(:capabilities).consumed_gears
@@ -198,13 +198,13 @@ class ApplicationTypesControllerTest < ActionController::TestCase
     type = types[0]
 
     # seed the cache with values that will never be returned by the broker.
-    session[:user_capabilities] = ['test_value','test_value',['test_value','test_value'], 'test_value']
+    session[:caps] = ['test_value','test_value',['test_value','test_value'], 'test_value']
 
     # make the request
     get :show, :id => type.id
 
     # confirm that the assigned values match our cached values
-    assert_equal [user.max_gears, user.consumed_gears, user.gear_sizes, true], session[:user_capabilities]
+    assert_equal [user.max_gears, user.consumed_gears, user.gear_sizes, nil, true], session[:caps]
     assert_equal user.max_gears, assigns(:capabilities).max_gears
     assert_equal user.consumed_gears, assigns(:capabilities).consumed_gears
     assert_equal user.gear_sizes, assigns(:capabilities).gear_sizes

--- a/console/test/unit/capability_aware_test.rb
+++ b/console/test/unit/capability_aware_test.rb
@@ -15,13 +15,13 @@ class CapabilityAwareTest < ActiveSupport::TestCase
   end
 
   def session_defaults(*args)
-    arr
+    args
   end
 
   test 'user capabilities handles defaults' do
     User.expects(:find).returns(User.new(:capabilities => {}))
     assert cap = obj.user_capabilities
-    assert_equal session_defaults(nil,0,[]), obj.session[:user_capabilities]
+    assert_equal session_defaults(nil,0,[], nil), obj.session[:caps]
     assert_equal Capabilities::UnlimitedGears, cap.max_gears
     assert_equal 0, cap.consumed_gears
     assert cap.gears_free?
@@ -30,18 +30,19 @@ class CapabilityAwareTest < ActiveSupport::TestCase
   end
 
   test 'user capabilities handles API 1.1 settings' do
-    User.expects(:find).returns(User.new(:max_gears => 3, :consumed_gears => 1, :capabilities => {:gear_sizes => ['small','medium']}))
+    User.expects(:find).returns(User.new(:max_gears => 3, :consumed_gears => 1, :plan_id => 'foo', :capabilities => {:gear_sizes => ['small','medium']}))
     assert cap = obj.user_capabilities
-    assert_equal session_defaults(3,1,[:small,:medium]), obj.session[:user_capabilities]
+    assert_equal session_defaults(3,1,[:small,:medium], 'foo'), obj.session[:caps]
     assert_equal 3, cap.max_gears
     assert_equal 1, cap.consumed_gears
+    assert_equal 'foo', cap.plan_id
     assert cap.gears_free?
     assert_equal 2, cap.gears_free
     assert_equal [:small, :medium], cap.gear_sizes
   end
 
   test 'user capabilities deserializes session' do
-    obj.session[:user_capabilities] = [nil, 0, ['small']]
+    obj.session[:caps] = [nil, 0, ['small']]
     assert cap = obj.user_capabilities
     assert_equal Capabilities::UnlimitedGears, cap.max_gears
     assert_equal 0, cap.consumed_gears


### PR DESCRIPTION
More fixes that clean up the codebase

Fix caching issues in plan controller, handle new attributes, revert to
correct version of Rails model lookup code (caused Cartridge.prefix to be
reset)

Include: https://github.com/openshift/li/pull/851

[merge]
