### PR TITLE
Bug 908047 -  Perl dependency testing flag was backwards

### DIFF
--- a/cartridges/openshift-origin-cartridge-perl-5.10/info/bin/build.sh
+++ b/cartridges/openshift-origin-cartridge-perl-5.10/info/bin/build.sh
@@ -41,13 +41,13 @@ then
            echo "***  Please add $f to deplist.txt to install it from CPAN."
            continue;
         fi
-        ENABLE_TEST=""
+        DISABLE_TEST="-n"
         if [ -f "${OPENSHIFT_REPO_DIR}/.openshift/markers/enable_cpan_tests" ]
         then
             echo ".openshift/markers/enable_cpan_tests!  enabling default cpan tests" 1>&2
-            ENABLE_TEST="-n"
+            DISABLE_TEST=""
         fi
-        cpanm $ENABLE_TEST $OPENSHIFT_CPAN_MIRROR -L ~/${cartridge_type}/perl5lib "$f"
+        cpanm $DISABLE_TEST $OPENSHIFT_CPAN_MIRROR -L ~/${cartridge_type}/perl5lib "$f"
     done
 fi
 

--- a/node-util/bin/rhc-list-ports
+++ b/node-util/bin/rhc-list-ports
@@ -10,7 +10,7 @@
 for f in $(ls -1 ~/.env/.uservars/*_DB_HOST 2>/dev/null); do
     DB=$(echo $f |sed -e 's/.*OPENSHIFT_\(.*\)_DB_HOST/\1/' |tr '[A-Z]' '[a-z]')
     PORT_FILE=$(echo $f |sed 's/_DB_HOST/_DB_PORT/')
-    echo $DB '->' $(cat $f)\:$(cat $PORT_FILE)
+    echo $DB '->' $(cat $f)\:$(cat $PORT_FILE) 1>&2
 done
 
 gear_registry="./haproxy-1.4/conf/gear-registry.db"


### PR DESCRIPTION
- marker file enable_cpan_tests actually turned tests off
