### PR TITLE
make Source line uniform among all spec files

### DIFF
--- a/broker-util/openshift-origin-broker-util.spec
+++ b/broker-util/openshift-origin-broker-util.spec
@@ -5,7 +5,7 @@ Release:        1%{?dist}
 Group:          Network/Daemons
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        http://mirror.openshift.com/pub/origin-server/source/%{name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 Requires:       ruby(abi) >= 1.8
 Requires:       openshift-origin-broker
 # For oo-register-dns

--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -8,7 +8,7 @@ Release:   1%{?dist}
 Group:     Network/Daemons
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0:   openshift-origin-broker-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 %if 0%{?fedora} >= 16 || 0%{?rhel} >= 7
 %define with_systemd 1

--- a/cartridges/openshift-origin-cartridge-abstract/openshift-origin-cartridge-abstract.spec
+++ b/cartridges/openshift-origin-cartridge-abstract/openshift-origin-cartridge-abstract.spec
@@ -7,7 +7,7 @@ Release:   1%{?dist}
 Group:     Network/Daemons
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0:   http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 BuildArch: noarch
 
 Requires:  facter

--- a/cartridges/openshift-origin-cartridge-community-pod-0.1/openshift-origin-cartridge-community-pod-0.1.spec
+++ b/cartridges/openshift-origin-cartridge-community-pod-0.1/openshift-origin-cartridge-community-pod-0.1.spec
@@ -7,7 +7,7 @@ Release:       1%{?dist}
 Group:         Development/Languages
 License:       ASL 2.0
 URL:           http://openshift.redhat.com
-Source0:       http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 BuildArch:     noarch
 BuildRequires: git
 Requires:      openshift-origin-cartridge-abstract

--- a/cartridges/openshift-origin-cartridge-community-python-2.7/openshift-origin-cartridge-community-python-2.7.spec
+++ b/cartridges/openshift-origin-cartridge-community-python-2.7/openshift-origin-cartridge-community-python-2.7.spec
@@ -7,7 +7,7 @@ Release:       1%{?dist}
 Group:         Development/Languages
 License:       ASL 2.0
 URL:           http://openshift.redhat.com
-Source0:       http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 BuildArch:     noarch
 BuildRequires: git
 Requires:      openshift-origin-cartridge-abstract

--- a/cartridges/openshift-origin-cartridge-community-python-3.3/openshift-origin-cartridge-community-python-3.3.spec
+++ b/cartridges/openshift-origin-cartridge-community-python-3.3/openshift-origin-cartridge-community-python-3.3.spec
@@ -7,7 +7,7 @@ Release:       1%{?dist}
 Group:         Development/Languages
 License:       ASL 2.0
 URL:           http://openshift.redhat.com
-Source0:       http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 BuildArch:     noarch
 BuildRequires: git
 Requires:      openshift-origin-cartridge-abstract

--- a/cartridges/openshift-origin-cartridge-cron-1.4/openshift-origin-cartridge-cron-1.4.spec
+++ b/cartridges/openshift-origin-cartridge-cron-1.4/openshift-origin-cartridge-cron-1.4.spec
@@ -8,7 +8,7 @@ Release:   1%{?dist}
 Group:     Network/Daemons
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0:   http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 BuildArch: noarch
 
 Requires:  openshift-origin-cartridge-abstract

--- a/cartridges/openshift-origin-cartridge-diy-0.1/openshift-origin-cartridge-diy-0.1.spec
+++ b/cartridges/openshift-origin-cartridge-diy-0.1/openshift-origin-cartridge-diy-0.1.spec
@@ -7,7 +7,7 @@ Release:       1%{?dist}
 Group:         Development/Languages
 License:       ASL 2.0
 URL:           http://openshift.redhat.com
-Source0:       http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 BuildArch:     noarch
 BuildRequires: git
 Requires:      openshift-origin-cartridge-abstract

--- a/cartridges/openshift-origin-cartridge-haproxy-1.4/openshift-origin-cartridge-haproxy-1.4.spec
+++ b/cartridges/openshift-origin-cartridge-haproxy-1.4/openshift-origin-cartridge-haproxy-1.4.spec
@@ -12,7 +12,7 @@ Release:   1%{?dist}
 Group:     Network/Daemons
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root

--- a/cartridges/openshift-origin-cartridge-jbossas-7/openshift-origin-cartridge-jbossas-7.spec
+++ b/cartridges/openshift-origin-cartridge-jbossas-7/openshift-origin-cartridge-jbossas-7.spec
@@ -9,7 +9,7 @@ Release:   1%{?dist}
 Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch

--- a/cartridges/openshift-origin-cartridge-jbosseap-6.0/openshift-origin-cartridge-jbosseap-6.0.spec
+++ b/cartridges/openshift-origin-cartridge-jbosseap-6.0/openshift-origin-cartridge-jbosseap-6.0.spec
@@ -9,7 +9,7 @@ Release:   1%{?dist}
 Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch

--- a/cartridges/openshift-origin-cartridge-jbossews-1.0/openshift-origin-cartridge-jbossews-1.0.spec
+++ b/cartridges/openshift-origin-cartridge-jbossews-1.0/openshift-origin-cartridge-jbossews-1.0.spec
@@ -9,7 +9,7 @@ Release:   1%{?dist}
 Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0:   http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch

--- a/cartridges/openshift-origin-cartridge-jbossews-2.0/openshift-origin-cartridge-jbossews-2.0.spec
+++ b/cartridges/openshift-origin-cartridge-jbossews-2.0/openshift-origin-cartridge-jbossews-2.0.spec
@@ -9,7 +9,7 @@ Release:   1%{?dist}
 Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0:   http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch

--- a/cartridges/openshift-origin-cartridge-jenkins-1.4/openshift-origin-cartridge-jenkins-1.4.spec
+++ b/cartridges/openshift-origin-cartridge-jenkins-1.4/openshift-origin-cartridge-jenkins-1.4.spec
@@ -7,7 +7,7 @@ Release:   1%{?dist}
 Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildArch: noarch

--- a/cartridges/openshift-origin-cartridge-jenkins-client-1.4/openshift-origin-cartridge-jenkins-client-1.4.spec
+++ b/cartridges/openshift-origin-cartridge-jenkins-client-1.4/openshift-origin-cartridge-jenkins-client-1.4.spec
@@ -8,7 +8,7 @@ Summary: Embedded jenkins client support for express
 Group: Network/Daemons
 License: ASL 2.0
 URL: https://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch

--- a/cartridges/openshift-origin-cartridge-mongodb-2.2/openshift-origin-cartridge-mongodb-2.2.spec
+++ b/cartridges/openshift-origin-cartridge-mongodb-2.2/openshift-origin-cartridge-mongodb-2.2.spec
@@ -9,7 +9,7 @@ Summary: Embedded mongodb support for OpenShift
 Group: Network/Daemons
 License: ASL 2.0
 URL: http://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch

--- a/cartridges/openshift-origin-cartridge-mysql-5.1/openshift-origin-cartridge-mysql-5.1.spec
+++ b/cartridges/openshift-origin-cartridge-mysql-5.1/openshift-origin-cartridge-mysql-5.1.spec
@@ -9,7 +9,7 @@ Summary: Provides embedded mysql support
 Group: Network/Daemons
 License: ASL 2.0
 URL: http://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch

--- a/cartridges/openshift-origin-cartridge-nodejs-0.6/openshift-origin-cartridge-nodejs-0.6.spec
+++ b/cartridges/openshift-origin-cartridge-nodejs-0.6/openshift-origin-cartridge-nodejs-0.6.spec
@@ -7,7 +7,7 @@ Release:   1%{?dist}
 Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0:   http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch

--- a/cartridges/openshift-origin-cartridge-perl-5.10/openshift-origin-cartridge-perl-5.10.spec
+++ b/cartridges/openshift-origin-cartridge-perl-5.10/openshift-origin-cartridge-perl-5.10.spec
@@ -7,7 +7,7 @@ Release:   1%{?dist}
 Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch

--- a/cartridges/openshift-origin-cartridge-php-5.3/openshift-origin-cartridge-php-5.3.spec
+++ b/cartridges/openshift-origin-cartridge-php-5.3/openshift-origin-cartridge-php-5.3.spec
@@ -7,7 +7,7 @@ Release:   1%{?dist}
 Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root

--- a/cartridges/openshift-origin-cartridge-phpmyadmin-3.4/openshift-origin-cartridge-phpmyadmin-3.4.spec
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin-3.4/openshift-origin-cartridge-phpmyadmin-3.4.spec
@@ -9,7 +9,7 @@ Summary: Embedded phpMyAdmin support for express
 Group: Applications/Internet
 License: ASL 2.0
 URL: https://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 BuildRoot:    %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildArch: noarch
 

--- a/cartridges/openshift-origin-cartridge-postgresql-8.4/openshift-origin-cartridge-postgresql-8.4.spec
+++ b/cartridges/openshift-origin-cartridge-postgresql-8.4/openshift-origin-cartridge-postgresql-8.4.spec
@@ -9,7 +9,7 @@ Summary: Provides embedded PostgreSQL support
 Group: Network/Daemons
 License: ASL 2.0
 URL: http://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot:    %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildArch: noarch

--- a/cartridges/openshift-origin-cartridge-python-2.6/openshift-origin-cartridge-python-2.6.spec
+++ b/cartridges/openshift-origin-cartridge-python-2.6/openshift-origin-cartridge-python-2.6.spec
@@ -7,7 +7,7 @@ Release:   1%{?dist}
 Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires: git

--- a/cartridges/openshift-origin-cartridge-ruby-1.8/openshift-origin-cartridge-ruby-1.8.spec
+++ b/cartridges/openshift-origin-cartridge-ruby-1.8/openshift-origin-cartridge-ruby-1.8.spec
@@ -7,7 +7,7 @@ Release:   1%{?dist}
 Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires: git

--- a/cartridges/openshift-origin-cartridge-ruby-1.9-scl/openshift-origin-cartridge-ruby-1.9-scl.spec
+++ b/cartridges/openshift-origin-cartridge-ruby-1.9-scl/openshift-origin-cartridge-ruby-1.9-scl.spec
@@ -7,7 +7,7 @@ Release:   1%{?dist}
 Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires: git

--- a/cartridges/openshift-origin-cartridge-switchyard-0.6/openshift-origin-cartridge-switchyard-0.6.spec
+++ b/cartridges/openshift-origin-cartridge-switchyard-0.6/openshift-origin-cartridge-switchyard-0.6.spec
@@ -8,7 +8,7 @@ Summary: Embedded SwitchYard modules for JBoss
 Group: Network/Daemons
 License: ASL 2.0
 URL: https://openshift.redhat.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch

--- a/common/rubygem-openshift-origin-common.spec
+++ b/common/rubygem-openshift-origin-common.spec
@@ -14,7 +14,7 @@ Release:        1%{?dist}
 Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        rubygem-%{gem_name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby
 Requires:       %{?scl:%scl_prefix}rubygems

--- a/console/rubygem-openshift-origin-console.spec
+++ b/console/rubygem-openshift-origin-console.spec
@@ -14,7 +14,7 @@ Release:        1%{?dist}
 Group:          Development/Languages
 License:        ASL 2.0
 URL:            https://openshift.redhat.com
-Source0:        rubygem-%{gem_name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby

--- a/controller/rubygem-openshift-origin-controller.spec
+++ b/controller/rubygem-openshift-origin-controller.spec
@@ -14,7 +14,7 @@ Release:        1%{?dist}
 Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        rubygem-%{gem_name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby

--- a/mcollective-qpid-plugin/mcollective-qpid-plugin.spec
+++ b/mcollective-qpid-plugin/mcollective-qpid-plugin.spec
@@ -5,7 +5,7 @@ Release:        1%{?dist}
 Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        %{name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       mcollective
 Requires:       ruby-qpid-qmf

--- a/msg-common/openshift-origin-msg-common.spec
+++ b/msg-common/openshift-origin-msg-common.spec
@@ -16,7 +16,7 @@ Version: 1.2.1
 Release:        1%{?dist}
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 Requires:       %{?scl:%scl_prefix}mcollective-common
 BuildArch:      noarch
 

--- a/node-proxy/openshift-origin-node-proxy.spec
+++ b/node-proxy/openshift-origin-node-proxy.spec
@@ -8,7 +8,7 @@ Release:        1%{?dist}
 Group:          Network/Daemons
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 Requires:       nodejs
 Requires:       nodejs-async

--- a/node-util/openshift-origin-node-util.spec
+++ b/node-util/openshift-origin-node-util.spec
@@ -6,7 +6,7 @@ Release:        1%{?dist}
 Group:          Network/Daemons
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 Requires:       oddjob
 Requires:       rng-tools

--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -17,7 +17,7 @@ Release:        1%{?dist}
 Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        rubygem-%{gem_name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby

--- a/pam_openshift/pam_openshift.spec
+++ b/pam_openshift/pam_openshift.spec
@@ -5,7 +5,7 @@ Summary:        Openshift PAM module
 Group:          System Environment/Base
 License:        GPLv2
 URL:            http://www.openshift.com/
-Source0:        http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 Requires:       policycoreutils
 

--- a/plugins/auth/kerberos/rubygem-openshift-origin-auth-kerberos.spec
+++ b/plugins/auth/kerberos/rubygem-openshift-origin-auth-kerberos.spec
@@ -14,7 +14,7 @@ Release:        1%{?dist}
 Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        rubygem-%{gem_name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby

--- a/plugins/auth/mongo/rubygem-openshift-origin-auth-mongo.spec
+++ b/plugins/auth/mongo/rubygem-openshift-origin-auth-mongo.spec
@@ -14,7 +14,7 @@ Release:        1%{?dist}
 Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        rubygem-%{gem_name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby

--- a/plugins/auth/remote-user/rubygem-openshift-origin-auth-remote-user.spec
+++ b/plugins/auth/remote-user/rubygem-openshift-origin-auth-remote-user.spec
@@ -16,7 +16,7 @@ Release:        1%{?dist}
 Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        rubygem-%{gem_name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby
 Requires:       %{?scl:%scl_prefix}rubygems

--- a/plugins/dns/bind/rubygem-openshift-origin-dns-bind.spec
+++ b/plugins/dns/bind/rubygem-openshift-origin-dns-bind.spec
@@ -14,7 +14,7 @@ Release:        1%{?dist}
 Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        rubygem-%{gem_name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby

--- a/plugins/dns/nsupdate/rubygem-openshift-origin-dns-nsupdate.spec
+++ b/plugins/dns/nsupdate/rubygem-openshift-origin-dns-nsupdate.spec
@@ -14,7 +14,7 @@ Release:        1%{?dist}
 Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        rubygem-%{gem_name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby

--- a/plugins/msg-broker/mcollective/rubygem-openshift-origin-msg-broker-mcollective.spec
+++ b/plugins/msg-broker/mcollective/rubygem-openshift-origin-msg-broker-mcollective.spec
@@ -14,7 +14,7 @@ Release:        1%{?dist}
 Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        rubygem-%{gem_name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby

--- a/util-scl/openshift-origin-util-scl.spec
+++ b/util-scl/openshift-origin-util-scl.spec
@@ -5,7 +5,7 @@ Release:        1%{?dist}
 Group:          Network/Daemons
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
-Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{name}-%{version}.tar.gz
+Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 
 BuildArch:      noarch
 


### PR DESCRIPTION
The Source0 line was different among the various spec files.  I made them all uniform in a format that will work for Fedora.
