### PR TITLE
remove rhel5 spec stuff

### DIFF
--- a/broker-util/openshift-origin-broker-util.spec
+++ b/broker-util/openshift-origin-broker-util.spec
@@ -31,8 +31,6 @@ They must be run on a openshift broker instance.
 %build
 
 %install
-rm -rf %{buildroot}
-
 mkdir -p %{buildroot}%{_sbindir}
 cp oo-* %{buildroot}%{_sbindir}/
 
@@ -40,9 +38,6 @@ mkdir -p %{buildroot}%{_mandir}/man8/
 cp man/*.8 %{buildroot}%{_mandir}/man8/
 mkdir -p %{buildroot}/usr/share/openshift/kickstarts
 cp kickstart/openshift-origin-remix.ks %{buildroot}/usr/share/openshift/kickstarts
-
-%clean
-rm -rf $RPM_BUILD_ROOT
 
 %files
 %attr(0750,-,-) %{_sbindir}/oo-admin-chk

--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -16,7 +16,6 @@ Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{nam
 %define with_systemd 0
 %endif
 
-BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 Requires:  httpd
 Requires:  bind
 Requires:  mod_ssl
@@ -51,7 +50,6 @@ This includes the public APIs for the client tools.
 %build
 
 %install
-rm -rf %{buildroot}
 %if %{with_systemd}
 mkdir -p %{buildroot}%{_unitdir}
 %else
@@ -111,9 +109,6 @@ mv %{buildroot}%{brokerdir}/httpd/broker-scl-ruby193.conf %{buildroot}%{brokerdi
 %if 0%{?fedora} >= 17
 rm %{buildroot}%{brokerdir}/httpd/broker-scl-ruby193.conf
 %endif
-
-%clean
-rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(0640,apache,apache,0750)

--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent-0.1/openshift-origin-cartridge-10gen-mms-agent-0.1.spec
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent-0.1/openshift-origin-cartridge-10gen-mms-agent-0.1.spec
@@ -10,8 +10,6 @@ Group: Applications/Internet
 License: ASL 2.0
 URL: http://openshift.redhat.com
 Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 Requires: openshift-origin-cartridge-abstract
@@ -33,7 +31,6 @@ Provides 10gen MMS agent cartridge support
 
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
 cp -r info %{buildroot}%{cartridgedir}/
@@ -42,12 +39,7 @@ cp COPYRIGHT %{buildroot}%{cartridgedir}/
 ln -s %{cartridgedir} %{buildroot}/%{frameworkdir}
 
 
-%clean
-rm -rf %{buildroot}
-
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0750,-,-) %{cartridgedir}/info/hooks/

--- a/cartridges/openshift-origin-cartridge-abstract/openshift-origin-cartridge-abstract.spec
+++ b/cartridges/openshift-origin-cartridge-abstract/openshift-origin-cartridge-abstract.spec
@@ -50,7 +50,6 @@ openshift jboss cartridges.
 %build
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartdir}
 cp -rv abstract %{buildroot}%{cartdir}/
 cp -rv abstract-httpd %{buildroot}%{cartdir}/

--- a/cartridges/openshift-origin-cartridge-haproxy-1.4/openshift-origin-cartridge-haproxy-1.4.spec
+++ b/cartridges/openshift-origin-cartridge-haproxy-1.4/openshift-origin-cartridge-haproxy-1.4.spec
@@ -13,9 +13,6 @@ Group:     Network/Daemons
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 BuildRequires: git
@@ -50,7 +47,6 @@ touch git_template.git/refs/heads/.gitignore
 
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}%{cartridgedir}/info/data/
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
@@ -70,12 +66,7 @@ ln -s %{cartridgedir}/../../abstract/info/hooks/threaddump %{buildroot}%{cartrid
 ln -s %{cartridgedir}/../../abstract/info/hooks/system-messages %{buildroot}%{cartridgedir}/info/hooks/system-messages
 
 
-%clean
-rm -rf %{buildroot}
-
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks

--- a/cartridges/openshift-origin-cartridge-jbossas-7/openshift-origin-cartridge-jbossas-7.spec
+++ b/cartridges/openshift-origin-cartridge-jbossas-7/openshift-origin-cartridge-jbossas-7.spec
@@ -10,8 +10,6 @@ Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 BuildRequires: git
@@ -51,7 +49,6 @@ popd
 
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}%{cartridgedir}/info/connection-hooks/
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
@@ -132,12 +129,7 @@ ln -fs /usr/share/java/postgresql-jdbc3.jar /etc/alternatives/jbossas-7/modules/
 cp -p %{cartridgedir}/info/configuration/postgresql_module.xml /etc/alternatives/jbossas-7/modules/org/postgresql/jdbc/main/module.xml
 
 
-%clean
-rm -rf %{buildroot}
-
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks

--- a/cartridges/openshift-origin-cartridge-jbosseap-6.0/openshift-origin-cartridge-jbosseap-6.0.spec
+++ b/cartridges/openshift-origin-cartridge-jbosseap-6.0/openshift-origin-cartridge-jbosseap-6.0.spec
@@ -10,8 +10,6 @@ Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 BuildRequires: git
@@ -61,7 +59,6 @@ popd
 
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}%{cartridgedir}/info/connection-hooks/
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
@@ -137,12 +134,7 @@ ln -fs /usr/share/java/postgresql-jdbc3.jar /etc/alternatives/jbosseap-6.0/modul
 cp -p %{cartridgedir}/info/configuration/postgresql_module.xml /etc/alternatives/jbosseap-6.0/modules/org/postgresql/jdbc/main/module.xml
 
 
-%clean
-rm -rf %{buildroot}
-
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks

--- a/cartridges/openshift-origin-cartridge-jbossews-1.0/openshift-origin-cartridge-jbossews-1.0.spec
+++ b/cartridges/openshift-origin-cartridge-jbossews-1.0/openshift-origin-cartridge-jbossews-1.0.spec
@@ -10,8 +10,6 @@ Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 BuildRequires: git
@@ -49,7 +47,6 @@ popd
 
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}%{cartridgedir}/info/connection-hooks/
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
@@ -110,12 +107,7 @@ alternatives --set jbossews-1.0 /usr/share/tomcat6
 #cp -p %{cartridgedir}/info/configuration/postgresql_module.xml /etc/alternatives/jbossews-1.0/modules/org/postgresql/jdbc/main/module.xml
 
 
-%clean
-rm -rf %{buildroot}
-
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks

--- a/cartridges/openshift-origin-cartridge-jbossews-2.0/openshift-origin-cartridge-jbossews-2.0.spec
+++ b/cartridges/openshift-origin-cartridge-jbossews-2.0/openshift-origin-cartridge-jbossews-2.0.spec
@@ -10,8 +10,6 @@ Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 BuildRequires: git
@@ -49,7 +47,6 @@ popd
 
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}%{cartridgedir}/info/connection-hooks/
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
@@ -108,12 +105,7 @@ alternatives --set jbossews-2.0 /usr/share/tomcat7
 #cp -p %{cartridgedir}/info/configuration/postgresql_module.xml /etc/alternatives/jbossews-2.0/modules/org/postgresql/jdbc/main/module.xml
 
 
-%clean
-rm -rf %{buildroot}
-
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks

--- a/cartridges/openshift-origin-cartridge-jenkins-1.4/openshift-origin-cartridge-jenkins-1.4.spec
+++ b/cartridges/openshift-origin-cartridge-jenkins-1.4/openshift-origin-cartridge-jenkins-1.4.spec
@@ -8,8 +8,6 @@ Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildArch: noarch
 
 BuildRequires: git
@@ -38,7 +36,6 @@ chkconfig jenkins off
 
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}%{cartridgedir}/info/data/
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
@@ -64,12 +61,7 @@ ln -s %{cartridgedir}/../abstract/info/hooks/threaddump %{buildroot}%{cartridged
 ln -s %{cartridgedir}/../abstract/info/hooks/system-messages %{buildroot}%{cartridgedir}/info/hooks/system-messages
 
 
-%clean
-rm -rf %{buildroot}
-
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks

--- a/cartridges/openshift-origin-cartridge-jenkins-client-1.4/openshift-origin-cartridge-jenkins-client-1.4.spec
+++ b/cartridges/openshift-origin-cartridge-jenkins-client-1.4/openshift-origin-cartridge-jenkins-client-1.4.spec
@@ -9,8 +9,6 @@ Group: Network/Daemons
 License: ASL 2.0
 URL: https://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 Requires: openshift-origin-cartridge-abstract
@@ -38,7 +36,6 @@ Provides embedded jenkins client support
 
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
 cp LICENSE %{buildroot}%{cartridgedir}/
@@ -48,12 +45,7 @@ ln -s %{cartridgedir}/info/configuration/ %{buildroot}/%{_sysconfdir}/openshift/
 ln -s %{cartridgedir} %{buildroot}/%{frameworkdir}
 
 
-%clean
-rm -rf %{buildroot}
-
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0750,-,-) %{cartridgedir}/info/hooks/

--- a/cartridges/openshift-origin-cartridge-mongodb-2.2/openshift-origin-cartridge-mongodb-2.2.spec
+++ b/cartridges/openshift-origin-cartridge-mongodb-2.2/openshift-origin-cartridge-mongodb-2.2.spec
@@ -10,8 +10,6 @@ Group: Network/Daemons
 License: ASL 2.0
 URL: http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 BuildRequires: git
@@ -50,7 +48,6 @@ touch git_template.git/refs/heads/.gitignore
 
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}%{cartridgedir}/info/data/
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
@@ -63,12 +60,7 @@ ln -s %{cartridgedir} %{buildroot}/%{frameworkdir}
 ln -s %{cartridgedir}/../../abstract/info/hooks/update-namespace %{buildroot}%{cartridgedir}/info/hooks/update-namespace
 
 
-%clean
-rm -rf %{buildroot}
-
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0750,-,-) %{cartridgedir}/info/hooks/

--- a/cartridges/openshift-origin-cartridge-mysql-5.1/openshift-origin-cartridge-mysql-5.1.spec
+++ b/cartridges/openshift-origin-cartridge-mysql-5.1/openshift-origin-cartridge-mysql-5.1.spec
@@ -10,8 +10,6 @@ Group: Network/Daemons
 License: ASL 2.0
 URL: http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 BuildRequires: git
@@ -44,7 +42,6 @@ touch git_template.git/refs/heads/.gitignore
 
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}%{cartridgedir}/info/data/
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
@@ -57,12 +54,7 @@ ln -s %{cartridgedir} %{buildroot}/%{frameworkdir}
 ln -s %{cartridgedir}/../../abstract/info/hooks/update-namespace %{buildroot}%{cartridgedir}/info/hooks/update-namespace
 
 
-%clean
-rm -rf %{buildroot}
-
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0750,-,-) %{cartridgedir}/info/hooks/

--- a/cartridges/openshift-origin-cartridge-nodejs-0.6/openshift-origin-cartridge-nodejs-0.6.spec
+++ b/cartridges/openshift-origin-cartridge-nodejs-0.6/openshift-origin-cartridge-nodejs-0.6.spec
@@ -8,8 +8,6 @@ Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 BuildRequires: git
@@ -51,7 +49,6 @@ touch git_template.git/refs/heads/.gitignore
 
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}%{cartridgedir}/info/data/
 mkdir -p %{buildroot}%{cartridgedir}/info/connection-hooks/
@@ -83,12 +80,7 @@ ln -s %{cartridgedir}/../abstract/info/connection-hooks/set-nosql-db-connection-
 ln -s %{cartridgedir}/../abstract/info/bin/sync_gears.sh %{buildroot}%{cartridgedir}/info/bin/sync_gears.sh
 
 
-%clean
-rm -rf %{buildroot}
-
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks

--- a/cartridges/openshift-origin-cartridge-perl-5.10/openshift-origin-cartridge-perl-5.10.spec
+++ b/cartridges/openshift-origin-cartridge-perl-5.10/openshift-origin-cartridge-perl-5.10.spec
@@ -8,8 +8,6 @@ Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 BuildRequires: git
@@ -53,7 +51,6 @@ touch git_template.git/refs/heads/.gitignore
 
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
 ln -s %{cartridgedir}/info/configuration/ %{buildroot}/%{_sysconfdir}/openshift/cartridges/%{name}
@@ -84,13 +81,7 @@ ln -s %{cartridgedir}/../abstract/info/connection-hooks/set-db-connection-info %
 ln -s %{cartridgedir}/../abstract/info/connection-hooks/set-nosql-db-connection-info %{buildroot}%{cartridgedir}/info/connection-hooks/set-nosql-db-connection-info
 ln -s %{cartridgedir}/../abstract/info/bin/sync_gears.sh %{buildroot}%{cartridgedir}/info/bin/sync_gears.sh
 
-
-%clean
-rm -rf %{buildroot}
-
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks

--- a/cartridges/openshift-origin-cartridge-php-5.3/openshift-origin-cartridge-php-5.3.spec
+++ b/cartridges/openshift-origin-cartridge-php-5.3/openshift-origin-cartridge-php-5.3.spec
@@ -8,9 +8,6 @@ Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 BuildRequires: git
@@ -60,7 +57,6 @@ rm -rf git_template
 touch git_template.git/refs/heads/.gitignore
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
 ln -s %{cartridgedir}/info/configuration/ %{buildroot}/%{_sysconfdir}/openshift/cartridges/%{name}
@@ -91,11 +87,7 @@ ln -s %{cartridgedir}/../abstract/info/connection-hooks/set-db-connection-info %
 ln -s %{cartridgedir}/../abstract/info/connection-hooks/set-nosql-db-connection-info %{buildroot}%{cartridgedir}/info/connection-hooks/set-nosql-db-connection-info
 ln -s %{cartridgedir}/../abstract/info/bin/sync_gears.sh %{buildroot}%{cartridgedir}/info/bin/sync_gears.sh
 
-%clean
-rm -rf %{buildroot}
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks

--- a/cartridges/openshift-origin-cartridge-phpmyadmin-3.4/openshift-origin-cartridge-phpmyadmin-3.4.spec
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin-3.4/openshift-origin-cartridge-phpmyadmin-3.4.spec
@@ -10,7 +10,6 @@ Group: Applications/Internet
 License: ASL 2.0
 URL: https://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-BuildRoot:    %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildArch: noarch
 
 Requires: openshift-origin-cartridge-abstract
@@ -27,8 +26,6 @@ Provides rhc phpMyAdmin cartridge support
 %build
 
 %install
-rm -rf $RPM_BUILD_ROOT
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}%{cartridgedir}/info/connection-hooks/
 ln -s %{cartridgedir}/../../abstract/info/connection-hooks/set-db-connection-info %{buildroot}%{cartridgedir}/info/connection-hooks/set-db-connection-info
@@ -42,11 +39,7 @@ ln -s %{cartridgedir} %{buildroot}/%{frameworkdir}
 %post
 cp %{cartridgedir}/info/configuration/etc/phpMyAdmin/config.inc.php %{_sysconfdir}/phpMyAdmin/config.inc.php
 
-%clean
-rm -rf $RPM_BUILD_ROOT
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0750,-,-) %{cartridgedir}/info/hooks/

--- a/cartridges/openshift-origin-cartridge-postgresql-8.4/openshift-origin-cartridge-postgresql-8.4.spec
+++ b/cartridges/openshift-origin-cartridge-postgresql-8.4/openshift-origin-cartridge-postgresql-8.4.spec
@@ -10,8 +10,6 @@ Group: Network/Daemons
 License: ASL 2.0
 URL: http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot:    %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildArch: noarch
 
 BuildRequires: git
@@ -68,8 +66,6 @@ touch git_template.git/refs/heads/.gitignore
 
 
 %install
-rm -rf $RPM_BUILD_ROOT
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}%{cartridgedir}/info/data/
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
@@ -81,13 +77,7 @@ ln -s %{cartridgedir}/info/configuration/ %{buildroot}/%{_sysconfdir}/openshift/
 ln -s %{cartridgedir} %{buildroot}/%{frameworkdir}
 ln -s %{cartridgedir}/../../abstract/info/hooks/update-namespace %{buildroot}%{cartridgedir}/info/hooks/update-namespace
 
-
-%clean
-rm -rf $RPM_BUILD_ROOT
-
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0750,-,-) %{cartridgedir}/info/hooks/

--- a/cartridges/openshift-origin-cartridge-python-2.6/openshift-origin-cartridge-python-2.6.spec
+++ b/cartridges/openshift-origin-cartridge-python-2.6/openshift-origin-cartridge-python-2.6.spec
@@ -8,8 +8,6 @@ Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires: git
 Requires:  openshift-origin-cartridge-abstract
 Requires:  rubygem(openshift-origin-node)
@@ -55,7 +53,6 @@ rm -rf git_template
 touch git_template.git/refs/heads/.gitignore
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
 ln -s %{cartridgedir}/info/configuration/ %{buildroot}/%{_sysconfdir}/openshift/cartridges/%{name}
@@ -86,11 +83,7 @@ ln -s %{cartridgedir}/../abstract/info/connection-hooks/set-db-connection-info %
 ln -s %{cartridgedir}/../abstract/info/connection-hooks/set-nosql-db-connection-info %{buildroot}%{cartridgedir}/info/connection-hooks/set-nosql-db-connection-info
 ln -s %{cartridgedir}/../abstract/info/bin/sync_gears.sh %{buildroot}%{cartridgedir}/info/bin/sync_gears.sh
 
-%clean
-rm -rf %{buildroot}
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info/
 %attr(0755,-,-) %{cartridgedir}/info/hooks

--- a/cartridges/openshift-origin-cartridge-ruby-1.8/openshift-origin-cartridge-ruby-1.8.spec
+++ b/cartridges/openshift-origin-cartridge-ruby-1.8/openshift-origin-cartridge-ruby-1.8.spec
@@ -8,8 +8,6 @@ Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires: git
 Requires:  openshift-origin-cartridge-abstract
 Requires:  rubygem(openshift-origin-node)
@@ -75,7 +73,6 @@ rm -rf git_template
 touch git_template.git/refs/heads/.gitignore
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
 ln -s %{cartridgedir}/info/configuration/ %{buildroot}/%{_sysconfdir}/openshift/cartridges/%{name}
@@ -104,11 +101,7 @@ ln -s %{cartridgedir}/../abstract/info/connection-hooks/set-db-connection-info %
 ln -s %{cartridgedir}/../abstract/info/connection-hooks/set-nosql-db-connection-info %{buildroot}%{cartridgedir}/info/connection-hooks/set-nosql-db-connection-info
 ln -s %{cartridgedir}/../abstract/info/bin/sync_gears.sh %{buildroot}%{cartridgedir}/info/bin/sync_gears.sh
 
-%clean
-rm -rf %{buildroot}
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks

--- a/cartridges/openshift-origin-cartridge-ruby-1.9-scl/openshift-origin-cartridge-ruby-1.9-scl.spec
+++ b/cartridges/openshift-origin-cartridge-ruby-1.9-scl/openshift-origin-cartridge-ruby-1.9-scl.spec
@@ -8,8 +8,6 @@ Group:     Development/Languages
 License:   ASL 2.0
 URL:       http://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires: git
 Requires:  openshift-origin-cartridge-abstract
 Requires:  rubygem(openshift-origin-node)
@@ -149,7 +147,6 @@ rm -rf git_template
 touch git_template.git/refs/heads/.gitignore
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
 ln -s %{cartridgedir}/info/configuration/ %{buildroot}/%{_sysconfdir}/openshift/cartridges/%{name}
@@ -178,11 +175,7 @@ ln -s %{cartridgedir}/../abstract/info/connection-hooks/set-db-connection-info %
 ln -s %{cartridgedir}/../abstract/info/connection-hooks/set-nosql-db-connection-info %{buildroot}%{cartridgedir}/info/connection-hooks/set-nosql-db-connection-info
 ln -s %{cartridgedir}/../abstract/info/bin/sync_gears.sh %{buildroot}%{cartridgedir}/info/bin/sync_gears.sh
 
-%clean
-rm -rf %{buildroot}
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0755,-,-) %{cartridgedir}/info/hooks

--- a/cartridges/openshift-origin-cartridge-switchyard-0.6/openshift-origin-cartridge-switchyard-0.6.spec
+++ b/cartridges/openshift-origin-cartridge-switchyard-0.6/openshift-origin-cartridge-switchyard-0.6.spec
@@ -9,8 +9,6 @@ Group: Network/Daemons
 License: ASL 2.0
 URL: https://openshift.redhat.com
 Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 Requires: openshift-origin-cartridge-abstract
@@ -34,7 +32,6 @@ Provides embedded switchyard support for JBoss cartridges
 
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
 mkdir -p %{buildroot}%{cartridgedir}/info/data/
 mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges
@@ -50,13 +47,7 @@ alternatives --remove switchyard-0.6 /usr/share/switchyard
 alternatives --install /etc/alternatives/switchyard-0.6 switchyard-0.6 /usr/share/switchyard 102
 alternatives --set switchyard-0.6 /usr/share/switchyard
 
-
-%clean
-rm -rf %{buildroot}
-
-
 %files
-%defattr(-,root,root,-)
 %dir %{cartridgedir}
 %dir %{cartridgedir}/info
 %attr(0750,-,-) %{cartridgedir}/info/hooks/

--- a/common/rubygem-openshift-origin-common.spec
+++ b/common/rubygem-openshift-origin-common.spec
@@ -15,7 +15,6 @@ Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
 Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby
 Requires:       %{?scl:%scl_prefix}rubygems
 Requires:       %{?scl:%scl_prefix}rubygem(activemodel)
@@ -70,9 +69,6 @@ gem install -V \
 %install
 mkdir -p %{buildroot}%{gem_dir}
 cp -a ./%{gem_dir}/* %{buildroot}%{gem_dir}/
-
-%clean
-rm -rf %{buildroot}                                
 
 %files
 %dir %{gem_instdir}

--- a/console/rubygem-openshift-origin-console.spec
+++ b/console/rubygem-openshift-origin-console.spec
@@ -15,7 +15,6 @@ Group:          Development/Languages
 License:        ASL 2.0
 URL:            https://openshift.redhat.com
 Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby
 Requires:       %{?scl:%scl_prefix}rubygems
@@ -107,9 +106,6 @@ gem install -V \
 %install
 mkdir -p %{buildroot}%{gem_dir}
 cp -a ./%{gem_dir}/* %{buildroot}%{gem_dir}/
-
-%clean
-rm -rf %{buildroot}
 
 %files
 %doc %{gem_instdir}/Gemfile

--- a/controller/rubygem-openshift-origin-controller.spec
+++ b/controller/rubygem-openshift-origin-controller.spec
@@ -15,7 +15,6 @@ Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
 Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby
 Requires:       %{?scl:%scl_prefix}rubygems

--- a/mcollective-qpid-plugin/mcollective-qpid-plugin.spec
+++ b/mcollective-qpid-plugin/mcollective-qpid-plugin.spec
@@ -6,7 +6,6 @@ Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
 Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       mcollective
 Requires:       ruby-qpid-qmf
 BuildArch:      noarch
@@ -20,15 +19,10 @@ Plugin to enable m-collective communication over amqp 1.0 enabled broker
 %build
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}/usr/libexec/mcollective/mcollective/connector/
 cp src/qpid.rb %{buildroot}/usr/libexec/mcollective/mcollective/connector/
 
-%clean
-rm -rf %{buildroot}
-
 %files
-%defattr(-,root,root,-)
 %doc COPYRIGHT LICENSE README.md
 /usr/libexec/mcollective/mcollective/connector/qpid.rb
 

--- a/node-proxy/openshift-origin-node-proxy.spec
+++ b/node-proxy/openshift-origin-node-proxy.spec
@@ -38,8 +38,6 @@ traffic) for an OpenShift Origin node.
 %build
 
 %install
-rm -rf %{buildroot}
-
 #  Runtime directories.
 mkdir -p %{buildroot}%{_var}/lock/subsys
 mkdir -p %{buildroot}%{_var}/run
@@ -111,9 +109,6 @@ if [ "$1" -eq "0" ]; then
 %endif
 fi
 
-
-%clean
-rm -rf $RPM_BUILD_ROOT
 
 %files
 %if %{with_systemd}

--- a/node-util/openshift-origin-node-util.spec
+++ b/node-util/openshift-origin-node-util.spec
@@ -25,7 +25,6 @@ run on a node instance.
 %build
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{_sbindir}
 cp bin/oo-* %{buildroot}%{_sbindir}/
 cp bin/rhc-* %{buildroot}%{_sbindir}/
@@ -49,9 +48,6 @@ cp init.d/openshift-gears %{buildroot}%{_initddir}/
 mkdir -p %{buildroot}/etc/systemd/system
 mv services/openshift-gears.service %{buildroot}/etc/systemd/system/openshift-gears.service
 %endif
-
-%clean
-rm -rf $RPM_BUILD_ROOT
 
 %files
 %attr(0750,-,-) %{_sbindir}/oo-accept-node

--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -18,7 +18,6 @@ Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
 Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby
 Requires:       %{?scl:%scl_prefix}rubygems
@@ -131,11 +130,7 @@ cp %{buildroot}%{gem_instdir}/misc/init/openshift-cgroups %{buildroot}/etc/rc.d/
 # Don't install or package what's left in the misc directory
 rm -rf %{buildroot}%{gem_instdir}/misc
 
-%clean
-rm -rf %{buildroot}
-
 %files
-%defattr(-,root,root,-)
 %doc LICENSE COPYRIGHT
 %doc %{gem_docdir}
 %{gem_instdir}

--- a/openshift-console/openshift-origin-console.spec
+++ b/openshift-console/openshift-origin-console.spec
@@ -24,7 +24,6 @@ Source0:   http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{nam
 %global gemdir /opt/rh/ruby193/root/usr/share/gems/gems
 %endif
 
-BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 Requires:  rubygem-openshift-origin-console
 Requires:  %{?scl:%scl_prefix}rubygem-passenger
 Requires:  %{?scl:%scl_prefix}rubygem-passenger-native
@@ -54,7 +53,6 @@ This includes the configuration necessary to run the console with mod_passenger.
 %build
 
 %install
-rm -rf %{buildroot}
 %if %{with_systemd}
 mkdir -p %{buildroot}%{_unitdir}
 %else
@@ -102,9 +100,6 @@ rm %{buildroot}%{consoledir}/httpd/console-scl-ruby193.conf
 rm %{buildroot}%{consoledir}/httpd/console.conf
 mv %{buildroot}%{consoledir}/httpd/console-scl-ruby193.conf %{buildroot}%{consoledir}/httpd/conf/console.conf
 %endif
-
-%clean
-rm -rf $RPM_BUILD_ROOT
 
 %preun
 if [ "$1" -eq "0" ]; then

--- a/plugins/auth/kerberos/rubygem-openshift-origin-auth-kerberos.spec
+++ b/plugins/auth/kerberos/rubygem-openshift-origin-auth-kerberos.spec
@@ -15,7 +15,6 @@ Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
 Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby
 Requires:       %{?scl:%scl_prefix}rubygems
@@ -76,11 +75,7 @@ cp -a .%{gem_dir}/* %{buildroot}%{gem_dir}/
 mkdir -p %{buildroot}/etc/openshift/plugins.d
 cp conf/openshift-origin-auth-kerberos.conf.example %{buildroot}/etc/openshift/plugins.d/
 
-%clean
-rm -rf %{buildroot}
-
 %files
-%defattr(-,root,root,-)
 %doc LICENSE COPYRIGHT Gemfile
 %exclude %{gem_cache}
 %{gem_instdir}

--- a/plugins/auth/mongo/rubygem-openshift-origin-auth-mongo.spec
+++ b/plugins/auth/mongo/rubygem-openshift-origin-auth-mongo.spec
@@ -15,7 +15,6 @@ Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
 Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby
 Requires:       %{?scl:%scl_prefix}rubygems
@@ -82,11 +81,7 @@ mkdir -p %{buildroot}/etc/openshift/plugins.d
 cp %{buildroot}/%{gem_instdir}/conf/openshift-origin-auth-mongo.conf.example %{buildroot}/etc/openshift/plugins.d/
 
 
-%clean
-rm -rf %{buildroot}
-
 %files
-%defattr(-,root,root,-)
 %doc LICENSE COPYRIGHT Gemfile
 %exclude %{gem_cache}
 %{gem_instdir}

--- a/plugins/auth/remote-user/rubygem-openshift-origin-auth-remote-user.spec
+++ b/plugins/auth/remote-user/rubygem-openshift-origin-auth-remote-user.spec
@@ -75,11 +75,7 @@ install -m 755 conf/%{gem_name}-kerberos.conf.sample %{buildroot}%{brokerdir}/ht
 mkdir -p %{buildroot}/etc/openshift/plugins.d
 cp conf/openshift-origin-auth-remote-user.conf.example %{buildroot}/etc/openshift/plugins.d/openshift-origin-auth-remote-user.conf.example
 
-%clean
-rm -rf %{buildroot}
-
 %files
-%defattr(-,root,root,-)
 %doc %{gem_docdir}
 %doc %{_docdir}/%{name}-%{version}
 %{gem_instdir}

--- a/plugins/dns/bind/rubygem-openshift-origin-dns-bind.spec
+++ b/plugins/dns/bind/rubygem-openshift-origin-dns-bind.spec
@@ -15,7 +15,6 @@ Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
 Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby
 Requires:       %{?scl:%scl_prefix}rubygems
@@ -79,11 +78,7 @@ cp %{buildroot}/%{gem_dir}/gems/%{gem_name}-%{version}/conf/openshift-origin-dns
 mkdir -p %{buildroot}/usr/share/selinux/packages/rubygem-openshift-origin-dns-bind
 cp %{buildroot}%{gem_dir}/gems/openshift-origin-dns-bind-*/doc/examples/dhcpnamedforward.* %{buildroot}/usr/share/selinux/packages/rubygem-openshift-origin-dns-bind
 
-%clean
-rm -rf %{buildroot}                                
-
 %files
-%defattr(-,root,root,-)
 %doc %{gem_docdir}
 %doc %{_docdir}/%{name}-%{version}
 %{gem_instdir}

--- a/plugins/dns/nsupdate/rubygem-openshift-origin-dns-nsupdate.spec
+++ b/plugins/dns/nsupdate/rubygem-openshift-origin-dns-nsupdate.spec
@@ -15,7 +15,6 @@ Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
 Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby
 Requires:       %{?scl:%scl_prefix}rubygems
@@ -73,11 +72,7 @@ mkdir -p %{buildroot}%{_docdir}/%{name}-%{version}/
 mkdir -p %{buildroot}/etc/openshift/plugins.d
 cp %{buildroot}/%{gem_dir}/gems/%{gem_name}-%{version}/conf/openshift-origin-dns-nsupdate.conf.example %{buildroot}/etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf.example
 
-%clean
-rm -rf %{buildroot}                                
-
 %files
-%defattr(-,root,root,-)
 %doc %{gem_docdir}
 %doc %{_docdir}/%{name}-%{version}
 %{gem_instdir}

--- a/plugins/msg-broker/mcollective/rubygem-openshift-origin-msg-broker-mcollective.spec
+++ b/plugins/msg-broker/mcollective/rubygem-openshift-origin-msg-broker-mcollective.spec
@@ -15,7 +15,6 @@ Group:          Development/Languages
 License:        ASL 2.0
 URL:            http://openshift.redhat.com
 Source0:        http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl:%scl_prefix}ruby
 Requires:       %{?scl:%scl_prefix}rubygems
@@ -60,7 +59,6 @@ gem install -V \
 %{?scl:EOF}
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{gem_dir}
 
 cp -a ./%{gem_dir}/* %{buildroot}%{gem_dir}/
@@ -68,11 +66,7 @@ cp -a ./%{gem_dir}/* %{buildroot}%{gem_dir}/
 mkdir -p %{buildroot}/etc/openshift/plugins.d
 cp %{buildroot}/%{gem_dir}/gems/%{gem_name}-%{version}/conf/openshift-origin-msg-broker-mcollective.conf.example %{buildroot}/etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf.example
 
-%clean
-rm -rf %{buildroot}
-
 %files
-%defattr(-,root,root,-)
 %dir %{gem_instdir}
 %dir %{gem_dir}
 %doc Gemfile LICENSE

--- a/port-proxy/openshift-origin-port-proxy.spec
+++ b/port-proxy/openshift-origin-port-proxy.spec
@@ -77,7 +77,6 @@ if [ "$1" -eq "0" ]; then
 fi
 
 %files
-%defattr(-,root,root,-)
 %doc LICENSE
 %if %{with_systemd}
 %{_unitdir}/openshift-port-proxy.service

--- a/util-scl/openshift-origin-util-scl.spec
+++ b/util-scl/openshift-origin-util-scl.spec
@@ -18,13 +18,8 @@ This package contains a set of utility scripts for the broker and node.
 %build
 
 %install
-rm -rf %{buildroot}
-
 mkdir -p %{buildroot}%{_bindir}
 cp oo-* %{buildroot}%{_bindir}/
-
-%clean
-rm -rf $RPM_BUILD_ROOT
 
 %files
 %attr(0755,-,-) %{_bindir}/oo-ruby


### PR DESCRIPTION
There are several sections in the rpm spec file that are only needed for RHEL5.
We are not supported on RHEL5 due to various dependencies not available in RHEL5.
I am pulling out all of these various things, because I have to do it for each package when we put them in Fedora.

remove BuildRoot:
remove %clean section
remove rm -rf %{buildroot} from install section
remove %defattr(-,root,root,-) from file section, when not needed
