### PR TITLE
move logs to a more standard location

### DIFF
--- a/broker/config/application.rb
+++ b/broker/config/application.rb
@@ -15,6 +15,10 @@ module Broker
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    # Set logs to somewhere more standard
+    config.paths['log'] =  ENV['RAILS_LOG_PATH'] ||
+                              "/var/log/openshift/broker/#{Rails.env}.log"
+                                     
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
 

--- a/broker/httpd/httpd.conf.apache-2.3
+++ b/broker/httpd/httpd.conf.apache-2.3
@@ -91,13 +91,13 @@ DefaultType text/plain
 HostnameLookups Off
 #EnableMMAP off
 #EnableSendfile off
-ErrorLog logs/error_log
+ErrorLog /var/log/openshift/broker/httpd/error_log
 LogLevel error
 LogFormat "%{X-Forwarded-For}i %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
 LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
-CustomLog logs/access_log combined
+CustomLog /var/log/openshift/broker/httpd/access_log combined
 ServerSignature On
 # BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 

--- a/broker/httpd/httpd.conf.apache-2.4
+++ b/broker/httpd/httpd.conf.apache-2.4
@@ -97,13 +97,13 @@ TypesConfig /etc/mime.types
 HostnameLookups Off
 #EnableMMAP off
 #EnableSendfile off
-ErrorLog logs/error_log
+ErrorLog /var/log/openshift/broker/httpd/error_log
 LogLevel error
 LogFormat "%{X-Forwarded-For}i %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
 LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
-CustomLog logs/access_log combined
+CustomLog /var/log/openshift/broker/httpd/access_log combined
 ServerSignature On
 # BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 

--- a/console/rubygem-openshift-origin-console.spec
+++ b/console/rubygem-openshift-origin-console.spec
@@ -80,12 +80,22 @@ mkdir -p .%{gem_dir}
 rm -f Gemfile.lock
 bundle install --local
 
+mkdir -p %{buildroot}%{_var}/log/openshift/console/
+mkdir -m 770 %{buildroot}%{_var}/log/openshift/console/httpd/
+touch %{buildroot}%{_var}/log/openshift/console/production.log
+chmod 0666 %{buildroot}%{_var}/log/openshift/console/production.log
+
 pushd test/rails_app/
-CONSOLE_CONFIG_FILE=../../conf/console.conf.example RAILS_ENV=production RAILS_RELATIVE_URL_ROOT=/console bundle exec rake assets:precompile assets:public_pages
+CONSOLE_CONFIG_FILE=../../conf/console.conf.example \
+  RAILS_ENV=production \
+  RAILS_LOG_PATH=%{buildroot}%{_var}/log/openshift/console/production.log
+  RAILS_RELATIVE_URL_ROOT=/console bundle exec rake assets:precompile assets:public_pages
 
 rm -rf tmp/cache/*
-echo > log/production.log
+echo > %{buildroot}%{_var}/log/openshift/console/production.log
 popd
+
+rm -rf %{buildroot}%{_var}/log/openshift/*
 
 rm -f Gemfile.lock
 %endif

--- a/console/rubygem-openshift-origin-console.spec
+++ b/console/rubygem-openshift-origin-console.spec
@@ -88,7 +88,7 @@ chmod 0666 %{buildroot}%{_var}/log/openshift/console/production.log
 pushd test/rails_app/
 CONSOLE_CONFIG_FILE=../../conf/console.conf.example \
   RAILS_ENV=production \
-  RAILS_LOG_PATH=%{buildroot}%{_var}/log/openshift/console/production.log
+  RAILS_LOG_PATH=%{buildroot}%{_var}/log/openshift/console/production.log \
   RAILS_RELATIVE_URL_ROOT=/console bundle exec rake assets:precompile assets:public_pages
 
 rm -rf tmp/cache/*

--- a/openshift-console/config/application.rb
+++ b/openshift-console/config/application.rb
@@ -10,6 +10,10 @@ module OpenshiftConsole
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    # Set logs to somewhere more standard
+    config.paths['log'] =  ENV['RAILS_LOG_PATH'] ||
+                            "/var/log/openshift/site/#{Rails.env}.log"
+    
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
 

--- a/openshift-console/openshift-origin-console.spec
+++ b/openshift-console/openshift-origin-console.spec
@@ -1,6 +1,6 @@
-%global htmldir %{_localstatedir}/www/html
-%global openshiftconfigdir %{_localstatedir}/www/.openshift
-%global consoledir %{_localstatedir}/www/openshift/console
+%global htmldir %{_var}/www/html
+%global openshiftconfigdir %{_var}/www/.openshift
+%global consoledir %{_var}/www/openshift/console
 %if 0%{?fedora}%{?rhel} <= 6
     %global scl ruby193
     %global scl_prefix ruby193-
@@ -63,10 +63,8 @@ mkdir -p %{buildroot}%{htmldir}
 mkdir -p %{buildroot}%{consoledir}
 mkdir -p %{buildroot}%{consoledir}/httpd/root
 mkdir -p %{buildroot}%{consoledir}/httpd/run
-mkdir -p %{buildroot}%{consoledir}/httpd/logs
 mkdir -p %{buildroot}%{consoledir}/httpd/conf
 mkdir -p %{buildroot}%{consoledir}/httpd/conf.d
-mkdir -p %{buildroot}%{consoledir}/log
 mkdir -p %{buildroot}%{consoledir}/tmp
 mkdir -p %{buildroot}%{consoledir}/tmp/cache
 mkdir -p %{buildroot}%{consoledir}/tmp/pids
@@ -124,8 +122,8 @@ fi
 %files
 %defattr(0640,apache,apache,0750)
 %{openshiftconfigdir}
-%attr(0644,-,-) %ghost %{consoledir}/log/production.log
-%attr(0644,-,-) %ghost %{consoledir}/log/development.log
+%attr(0644,-,-) %ghost %{_var}/log/openshift/console/production.log
+%attr(0644,-,-) %ghost %{_var}/log/openshift/console/development.log
 %attr(0750,-,-) %{consoledir}/script
 %attr(0750,-,-) %{consoledir}/tmp
 %attr(0750,-,-) %{consoledir}/tmp/cache
@@ -151,8 +149,8 @@ fi
 %endif
 
 %post
-/bin/touch %{consoledir}/httpd/logs/error_log
-/bin/touch %{consoledir}/httpd/logs/access_log
+/bin/touch %{_var}/log/openshift/console/httpd/error_log
+/bin/touch %{_var}/log/openshift/console/access_log
 
 %if %{with_systemd}
 /bin/systemctl --system daemon-reload


### PR DESCRIPTION
- Wanted to move all logs to somewhere more standard
- Switched %{_localstatedir} to %{_var} because %{_localstatedir} get's redefined in SCL macros so we'd need to set defined? logic all over the place for when we want things to actually land in /var/ and that seemed messy.
