### PR TITLE
Bug 908164

### DIFF
--- a/console/lib/console/formtastic/bootstrap_form_builder.rb
+++ b/console/lib/console/formtastic/bootstrap_form_builder.rb
@@ -57,7 +57,9 @@ module Console
         html_options = args.extract_options!
         html_options[:class] ||= 'alert alert-error unstyled errors'
         except = Array(html_options.delete(:except))
-        args = (@object.errors.keys - except) unless except.blank?
+        # Skip the base here because we will add it later if desired
+        except << :base
+        args = (@object.errors.keys - except)
 
         full_errors = args.inject([]) do |array, method|
           attribute = localized_string(method, method.to_sym, :label) || humanized_attribute_name(method)


### PR DESCRIPTION
Any errors for the `:base` key were effectively being added twice to the error messages. Since we explicitly add the `:base` errors a few lines later, we do not want to iterate through them in the first loop.
