### PR TITLE
Updating tests to ignore warnings from facter

### DIFF
--- a/controller/test/cucumber/step_definitions/idler_steps.rb
+++ b/controller/test/cucumber/step_definitions/idler_steps.rb
@@ -14,7 +14,7 @@ When /^I oo-(idle|restore) the application$/ do |action|
 end
 
 Then /^I record the active capacity( after idling)?$/ do |negate|
-  @active_capacity = `facter active_capacity`.to_f
+  @active_capacity = `facter active_capacity`.split("\n").last.to_f
 
   if (negate)
     # active capacity may be 0.0 after idling.
@@ -25,7 +25,7 @@ Then /^I record the active capacity( after idling)?$/ do |negate|
 end
 
 Then /^the active capacity has been (reduced|increased)$/ do |change|
-  current_capacity = `facter active_capacity`.to_f
+  @active_capacity = `facter active_capacity`.split("\n").last.to_f
   current_capacity.should be >= 0.0
 
   case change


### PR DESCRIPTION
https://originci-openshift.rhcloud.com/job/runtime_extended/9/console

Eg: 
[root@ec2-174-129-84-21 ec2-user]# facter active_capacity 2> /dev/null 
ParseConfig Deprecation Warning: get_value() is deprecated. Use config['param'] or config['group']['param'] instead.
46.0
