### PR TITLE
oo-cgroup-read: open4 is a rubygem

### DIFF
--- a/node/misc/bin/oo-cgroup-read
+++ b/node/misc/bin/oo-cgroup-read
@@ -4,6 +4,7 @@
 
 require 'optparse'
 require 'etc'
+require 'rubygems'
 require 'open4'
 
 # each value begins with the subsystem name and a dot (.)


### PR DESCRIPTION
Require rubygems before open4 in oo-cgroup-read
