### PR TITLE
Fix endpoint manifest entries in database cartridges

### DIFF
--- a/cartridges/openshift-origin-cartridge-mongodb-2.2/info/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mongodb-2.2/info/manifest.yml
@@ -46,4 +46,4 @@ Scaling:
   Min: 1
   Max: 1
 Endpoints:
-  - "IP:PORT(27017):DB_PROXY_PORT"
+  - "DB_HOST:DB_PORT(27017):DB_PROXY_PORT"

--- a/cartridges/openshift-origin-cartridge-mysql-5.1/info/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mysql-5.1/info/manifest.yml
@@ -1,4 +1,5 @@
 Name: mysql-5.1
+Namespace: MYSQL
 Version: 5.1
 Architecture: noarch
 Display-Name: MySQL Database 5.1
@@ -40,4 +41,4 @@ Scaling:
   Min: 1
   Max: 1
 Endpoints:
-  - "HOST:PORT(3306):DB_PROXY_PORT"
+  - "DB_HOST:DB_PORT(3306):DB_PROXY_PORT"

--- a/cartridges/openshift-origin-cartridge-postgresql-8.4/info/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-postgresql-8.4/info/manifest.yml
@@ -38,4 +38,4 @@ Scaling:
   Min: 1
   Max: 1
 Endpoints:
-  - "IP:PORT(5432):DB_PROXY_PORT"
+  - "DB_HOST:DB_PORT(5432):DB_PROXY_PORT"


### PR DESCRIPTION
Make the private IP/Port names consistent with the public endpoint
naming expectations and with the expectations of the configure scripts.
