### PR TITLE
Bug 842991 - Do not replace /etc/cron.minutely/openshift-facts when inst...

### DIFF
--- a/plugins/msg-node/mcollective/openshift-origin-msg-node-mcollective.spec
+++ b/plugins/msg-node/mcollective/openshift-origin-msg-node-mcollective.spec
@@ -52,9 +52,7 @@ cp -p facts/update_yaml.rb %{buildroot}/usr/libexec/mcollective/
 %{mco_agent_root}openshift.rb
 %{vendor_ruby}facter/openshift_facts.rb
 %attr(0700,-,-) /usr/libexec/mcollective/update_yaml.rb
-%attr(0700,-,-) /etc/cron.minutely/openshift-facts
-/etc/cron.minutely/openshift-facts
-
+%attr(0700,-,-) %config(noreplace) /etc/cron.minutely/openshift-facts
 
 %changelog
 * Fri Feb 08 2013 Adam Miller <admiller@redhat.com> 1.5.2-1


### PR DESCRIPTION
...alling new rpm.
- Ops may update this file via their normal procedures
