### PR TITLE
Bug 911956 - Fixed miss-spelled method name

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -426,7 +426,7 @@ module OpenShift
       cart_model.do_control("status", cart_name)
     end
 
-    def thread_dump(cart_name)
+    def threaddump(cart_name)
       cart_model.do_control("threaddump", cart_name)
     end
   end


### PR DESCRIPTION
- ApplicationContainer#thread_dump should have been threaddump
