### PR TITLE
disable viminfo creation on node

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/util
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/util
@@ -447,11 +447,20 @@ function print_sed_exp_replace_env_var {
         printf "%s\n" "$sed_exp"
 }
 
+function create_vim_config {
+    cat <<EOF > "$APP_HOME/.vimrc"
+# disable viminfo, avoid error when closing vim
+set viminfo=
+EOF
+}
+
+
 function create_standard_app_dirs {
     mkdir -p run tmp ci
     [ -e repo ] || ln -s ../app-root/repo repo
     [ -e data ] || ln -s ../app-root/data data
     [ -e runtime ] || ln -s ../app-root/runtime runtime
+    create_vim_config
 }
 
 function create_cartridge_instance_dir {

--- a/node/README.writing_cartridges.md
+++ b/node/README.writing_cartridges.md
@@ -204,6 +204,7 @@ directory:
     .sandbox
     .tmp
     .env
+    .vimrc
     any not hidden directory or file
 
 You may create any hidden file or directory (one that starts with a


### PR DESCRIPTION
each time I connect by ssh to a gear and run vim, vim try to
create a .viminfo file in my home, where I do not have the right to create
anything. So either we create a file with proper permissions or
a different location, or we disable .viminfo. I choose the last one.
