### PR TITLE
Create DNS plugin using Amazon Web Services Route 53

### DIFF
--- a/plugins/dns/route53/.gitignore
+++ b/plugins/dns/route53/.gitignore
@@ -1,0 +1,2 @@
+AWSCONFIG
+doc

--- a/plugins/dns/route53/COPYRIGHT
+++ b/plugins/dns/route53/COPYRIGHT
@@ -1,0 +1,1 @@
+Copyright 2013 Red Hat, Inc. and/or its affiliates.

--- a/plugins/dns/route53/Gemfile
+++ b/plugins/dns/route53/Gemfile
@@ -1,0 +1,3 @@
+source "http://rubygems.org"
+
+gemspec

--- a/plugins/dns/route53/LICENSE
+++ b/plugins/dns/route53/LICENSE
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/plugins/dns/route53/README.md
+++ b/plugins/dns/route53/README.md
@@ -1,0 +1,46 @@
+# Openshift Origin Dynamic DNS plugin for Amazon Web Services Route 53
+
+This package is a Dynamic DNS plugin for OpenShift Origin.
+
+It allows OpenShift Origin to use AWS Route53 DNS services to publish
+applications
+
+## Installation and Configuration
+
+* Install package *rubygem-openshift-origin-dns-route53*
+* Install package *rubygem-aws-sdk* (version >= 1.8.0)
+* Add gem *aws-sdk* to broker <code>Gemfile</code>
+
+  */var/www/openshift/broker/Gemfile*
+
+     <code>gem 'aws-sdk' >= 1.8.0</code>
+     
+* Create config file:
+
+  */etc/openshift/plugins.d/openshift-origin-dns-route53.conf*
+ 
+<code><pre>
+    # Settings related to the Amazon Web Services Route53 DNS service
+    # The AWS zone identifier
+    AWS_HOSTED_ZONE_ID="/hostedzone/YOURZONEID"
+    #
+    # AWS Access credentials
+    AWS_ACCESS_KEY_ID="YOURKEYID"
+    AWS_SECRET_KEY="YOURSECRETKEY"
+</pre></code>
+
+* Install package *rubygem-aws-sdk* (version >= 1.8.0)
+* Check gems using <code>cd /var/log/bundle --local</code>
+* Verify service with <code>rails console</code>
+
+## References:
+
+* AWS SDK for Ruby
+  http://aws.amazon.com/sdkforruby/
+
+* AWS Route 53 Developer Guide
+  http://docs.aws.amazon.com/Route53/latest/DeveloperGuide
+
+* AWS Route 53 API Reference
+  http://docs.aws.amazon.com/Route53/latest/APIReference
+ 

--- a/plugins/dns/route53/Rakefile
+++ b/plugins/dns/route53/Rakefile
@@ -1,0 +1,21 @@
+require "bundler/gem_tasks"
+require 'rake'
+require 'rake/testtask'
+require 'rspec/core/rake_task'
+require 'rdoc/task'
+
+task :default => [:rdoc]
+
+desc "Run RSpec unit tests"
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = "./spec/*/*_spec.rb" # don't need this, it's default.
+  # make sure ruby can find the superclass and dependencies
+  t.ruby_opts = "-I spec/lib -I ../../../common/lib -I ../../../controller/lib -I lib"
+end
+
+desc "Generate RDoc output"
+Rake::RDocTask.new do |rd|
+  rd.main = "README.rdoc"
+  rd.rdoc_dir = "doc"
+  rd.rdoc_files.include("README.rdoc", "lib/**/*.rb")
+end

--- a/plugins/dns/route53/conf/openshift-origin-dns-route53.conf.example
+++ b/plugins/dns/route53/conf/openshift-origin-dns-route53.conf.example
@@ -1,0 +1,8 @@
+# Settings related to the Amazon Web Services Route53 DNS service
+
+# The AWS zone identifier
+AWS_HOSTED_ZONE_ID="/hostedzone/ZONEID"
+
+# AWS Access credentials
+AWS_ACCESS_KEY_ID="key id string"
+AWS_SECRET_KEY="key secret"

--- a/plugins/dns/route53/config/initializers/openshift-origin-dns-route53.rb
+++ b/plugins/dns/route53/config/initializers/openshift-origin-dns-route53.rb
@@ -1,0 +1,21 @@
+require 'openshift-origin-common'
+
+Broker::Application.configure do
+  conf_file = File.join(OpenShift::Config::PLUGINS_DIR, File.basename(__FILE__, '.rb') + '.conf')
+  if Rails.env.development?
+    dev_conf_file = File.join(OpenShift::Config::PLUGINS_DIR, File.basename(__FILE__, '.rb') + '-dev.conf')
+    if File.exist? dev_conf_file
+      conf_file = dev_conf_file
+    else
+      Rails.logger.info "Development configuration for #{File.basename(__FILE__, '.rb')} not found. Using production configuration."
+    end
+  end
+  conf = OpenShift::Config.new(conf_file)
+
+  config.dns = {
+    :aws_hosted_zone_id => conf.get("AWS_HOSTED_ZONE_ID", "unset"),
+    :aws_access_key_id => conf.get("AWS_ACCESS_KEY_ID", "unset"),
+    :aws_access_key => conf.get("AWS_SECRET_KEY", "unset"),
+    :ttl => conf.get("TTL", 30) # default record TTL: 30 sec
+  }
+end

--- a/plugins/dns/route53/lib/openshift-origin-dns-route53.rb
+++ b/plugins/dns/route53/lib/openshift-origin-dns-route53.rb
@@ -1,0 +1,10 @@
+require "openshift-origin-common"
+
+module OpenShift
+  module Route53DnsModule
+    require 'route53_dns_engine' if defined?(Rails) && Rails::VERSION::MAJOR == 3
+  end
+end
+
+require "openshift/route53_plugin.rb"
+OpenShift::DnsService.provider=OpenShift::Route53Plugin

--- a/plugins/dns/route53/lib/openshift/route53_plugin.rb
+++ b/plugins/dns/route53/lib/openshift/route53_plugin.rb
@@ -1,0 +1,230 @@
+#
+# Make OpenShift updates to Amazon Web Services Route53 DNS service
+#
+# http://docs.aws.amazon.com/AWSRubySDK/latest/frames.html
+# http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/Route53/Client.html
+#
+require 'rubygems'
+require 'aws-sdk'
+
+module OpenShift
+
+  # Implement the OpenShift::DnsService interface using AWS Route53
+  # 
+  class Route53Plugin < OpenShift::DnsService
+    @oo_dns_provider = OpenShift::Route53Plugin
+
+    # DEPENDENCIES
+    # Rails.application.config.openshift[:domain_suffix]
+    # Rails.application.config.dns[...]
+
+    attr_reader :aws_hosted_zone_id
+    attr_reader :aws_access_key_id, :aws_access_key, :ttl
+
+    def initialize(access_info = nil)
+      if access_info != nil
+        @domain_suffix = access_info[:domain_suffix]
+      elsif defined? Rails
+        # extract from Rails.application.config[dns,ss]
+        access_info = Rails.application.config.dns
+        @domain_suffix = Rails.application.config.openshift[:domain_suffix]
+      else
+        raise Exception.new("AWS Route 53 DNS service is not initialized")
+      end      
+      @aws_hosted_zone_id = access_info[:aws_hosted_zone_id]
+      @aws_access_key_id = access_info[:aws_access_key_id]
+      @aws_access_key = access_info[:aws_access_key]
+      @ttl = access_info[:ttl].to_i || 30 # default 30 sec
+    end
+
+    #
+    # Publish the location of an application
+    #
+    # INPUTS:
+    #   app_name:        String: the name of the application
+    #   namespace:       String: avoid customer app name collisions
+    #   public_hostname: String: Fully qualified domain name of the host
+    #                            on which the app resides
+    # RETURNS:
+    #   The result of the change request, including the request ID for
+    #   polling the request status
+    #
+    def register_application(app_name, namespace, public_hostname)
+
+      # create an A record for the application in the domain
+      fqdn = "#{app_name}-#{namespace}.#{@domain_suffix}"
+
+      # create an update record
+
+      update = {
+        :comment => "Add an application record for #{fqdn}",
+        :changes => [change_record("CREATE", fqdn, @ttl, public_hostname)]
+      }
+      
+      res = r53.change_resource_record_sets({
+                                              :hosted_zone_id => @aws_hosted_zone_id,
+                                              :change_batch => update
+                                            })
+    end
+
+    #
+    # Un-publish the location of an application
+    #
+    # INPUTS:
+    #   app_name:        String: the name of the application
+    #   namespace:       String: avoid customer app name collisions
+    #
+    # RETURNS:
+    #   The result of the change request, including the request ID for
+    #   polling the request status
+    #
+    def deregister_application(app_name, namespace)
+      # delete the CNAME record for the application in the domain
+      fqdn = "#{app_name}-#{namespace}.#{@domain_suffix}"
+
+      # Get the record you mean to delete.
+      # We need the TTL and value to delete it.
+      record = get_record(fqdn)
+
+      # If record is nil, then we're done.  Raise an exception for trying?
+      return if record == nil
+      ttl = record[:ttl]
+      public_hostname = record[:resource_records][0][:value]
+
+      delete = {
+        :comment => "Delete an application record for #{fqdn}",
+        :changes => [change_record("DELETE", fqdn, @ttl, public_hostname)]
+      }
+      
+      res = r53.change_resource_record_sets({
+                                              :hosted_zone_id => @aws_hosted_zone_id,
+                                              :change_batch => delete
+                                            })
+    end
+  
+    #
+    # Change the published location of an application
+    #
+    # INPUTS:
+    #   app_name:        String: the name of the application
+    #   namespace:       String: avoid customer app name collisions
+    #
+    # RETURNS:
+    #   The result of the change request, including the request ID for
+    #   polling the request status
+    #
+    def modify_application(app_name, namespace, new_public_hostname)
+      # delete the CNAME record for the application in the domain
+      fqdn = "#{app_name}-#{namespace}.#{@domain_suffix}"
+
+      # Get the record you mean to delete.
+      # We need the TTL and value to delete it.
+      record = get_record(fqdn)
+
+      # If record is nil, then we're done.  Raise an exception for trying?
+      return if record == nil
+      ttl = record[:ttl]
+      old_public_hostname = record[:resource_records][0][:value]
+
+      update = {
+        :comment => "Update an application record for #{fqdn}",
+        :changes => [change_record("DELETE", fqdn, @ttl, old_public_hostname),
+                     change_record("CREATE", fqdn, @ttl, new_public_hostname)]
+      }
+      
+
+      res = r53.change_resource_record_sets({
+                                              :hosted_zone_id => @aws_hosted_zone_id,
+                                              :change_batch => update
+                                            })
+    end
+
+    #
+    # execute queued changes (noop)
+    #
+    # INPUTS: None
+    #
+    # RETURNS: Nil
+    #
+    def publish
+    end
+
+
+    #
+    # end communication with the service (noop)
+    #
+    # INPUTS: None
+    #
+    # RETURNS: Nil
+    #    
+    def close
+    end
+    
+
+    private
+
+    # create a Route53 communications client.
+    def r53()
+      AWS::Route53.new(:access_key_id => @aws_access_key_id,
+                       :secret_access_key => @aws_access_key).client
+    end
+
+    #
+    # Create an Route53 change record data structure
+    #
+    # INPUTS:
+    #   action: String  - "CREATE" or "DELETE"
+    #   fqdn:   String  - the fully qualified domain name to be changed
+    #   ttl:    Integer - Time To Live (seconds)
+    #   value:  String  - The value to be assigned to the record
+    #
+    # RETURNS:
+    #   Hash: a structure suitable for use as a change record in
+    #         an AWS update request.
+    #
+    def change_record(action, fqdn, ttl, value)
+      # the CNAME values must be quoted
+      {
+        :action => action,
+        :resource_record_set => {
+          :name => fqdn,
+          :type => "CNAME",
+          :ttl => ttl,
+          :resource_records => [{:value => value}],
+        }
+      }
+    end
+        
+    # 
+    # Retrieve a record from the AWS Route53 service
+    # 
+    # INPUTS:
+    #   fqdn: String - The fully qualified domain name of the record to get
+    #
+    # RETURNS:
+    #   Hash: a single AWS Route 53 resource record hash
+    #
+    def get_record(fqdn)
+      # Request a single record "starting with" the desired record.
+      reply = r53.list_resource_record_sets(
+                :hosted_zone_id => @aws_hosted_zone_id,
+                :start_record_name => fqdn,
+                :max_items => 1
+            )
+
+      # If the returned record name matches exactly, return it.
+      # record fqdn are returned with the trailing anchor (.)
+      return nil if not reply
+
+      # Check if we found it exactly
+      res = reply[:resource_record_sets][0]
+      return nil if not res
+
+      return res if res[:name] == fqdn + "."
+
+      # If not, then you got nothing or a record which didn't match.
+      nil
+    end
+
+  end
+end

--- a/plugins/dns/route53/lib/route53_dns_engine.rb
+++ b/plugins/dns/route53/lib/route53_dns_engine.rb
@@ -1,0 +1,7 @@
+require 'openshift-origin-controller'
+require 'rails'
+
+module OpenShift
+  class Route53DnsEngine < Rails::Engine
+  end
+end

--- a/plugins/dns/route53/openshift-origin-dns-route53.gemspec
+++ b/plugins/dns/route53/openshift-origin-dns-route53.gemspec
@@ -1,0 +1,35 @@
+# -*- encoding: utf-8 -*-
+config_dir  = File.join(File.join("config", "**"), "*")
+$:.push File.expand_path("../lib", __FILE__)
+lib_dir  = File.join(File.join("lib", "**"), "*")
+test_dir  = File.join(File.join("test", "**"), "*")
+bin_dir  = File.join("bin", "*")
+doc_dir  = File.join(File.join("doc", "**"), "*")
+conf_dir  = File.join(File.join("conf", "**"), "*")
+spec_file = "rubygem-openshift-origin-dns-route53.spec"
+
+Gem::Specification.new do |s|
+  s.name        = "openshift-origin-dns-route53"
+  s.version     = `rpm -q --define 'rhel 7' --qf "%{version}\n" --specfile #{spec_file}`.split[0]
+  s.license     = `rpm -q --define 'rhel 7' --qf "%{license}\n" --specfile #{spec_file}`.split[0]
+  s.authors     = ["Mark Lamourine"]
+  s.email       = ["markllama@gmail.com"]
+  s.homepage    = `rpm -q --define 'rhel 7' --qf "%{url}\n" --specfile #{spec_file}`.split[0]
+  s.summary     = `rpm -q --define 'rhel 7' --qf "%{description}\n" --specfile #{spec_file}`.split[0]
+  s.description = `rpm -q --define 'rhel 7' --qf "%{description}\n" --specfile #{spec_file}`.split[0]
+
+  s.rubyforge_project = "openshift-origin-dns-route53"
+
+  s.files       = Dir[lib_dir] + Dir[doc_dir] + Dir[conf_dir] + Dir[config_dir]
+  s.test_files  = Dir[test_dir]
+  s.executables   = Dir[bin_dir]
+  s.files       += %w(README.md Rakefile Gemfile rubygem-openshift-origin-dns-route53.spec openshift-origin-dns-route53.gemspec LICENSE COPYRIGHT)
+  s.require_paths = ["lib"]
+
+  s.add_dependency('aws-sdk')
+  s.add_dependency('openshift-origin-controller')
+  s.add_development_dependency('rake', '>= 0.8.7', '<= 0.9.2.2')  
+  s.add_development_dependency('rspec')
+  s.add_development_dependency('bundler')
+  s.add_development_dependency('mocha')
+end

--- a/plugins/dns/route53/rubygem-openshift-origin-dns-route53.spec
+++ b/plugins/dns/route53/rubygem-openshift-origin-dns-route53.spec
@@ -1,0 +1,100 @@
+%if 0%{?fedora}%{?rhel} <= 6
+    %global scl ruby193
+    %global scl_prefix ruby193-
+%endif
+%{!?scl:%global pkg_name %{name}}
+%{?scl:%scl_package rubygem-%{gem_name}}
+%global gem_name openshift-origin-dns-route53
+%global rubyabi 1.9.1
+
+Summary:       OpenShift plugin for AWS Route53 service
+Name:          rubygem-%{gem_name}
+Version:       0.1.4
+Release:       1%{?dist}
+Group:         Development/Languages
+License:       ASL 2.0
+URL:           http://openshift.redhat.com
+Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
+Requires:      %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
+Requires:      %{?scl:%scl_prefix}ruby
+Requires:      %{?scl:%scl_prefix}rubygems
+Requires:      rubygem(openshift-origin-common)
+Requires:      openshift-origin-broker
+Requires:      %{?scl:%scl_prefix}rubygem-aws-sdk >= 1.8.0
+%if 0%{?fedora}%{?rhel} <= 6
+BuildRequires: ruby193-build
+BuildRequires: scl-utils-build
+%endif
+BuildRequires: %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
+BuildRequires: %{?scl:%scl_prefix}ruby 
+BuildRequires: %{?scl:%scl_prefix}rubygems
+BuildRequires: %{?scl:%scl_prefix}rubygems-devel
+BuildArch:     noarch
+Provides:      rubygem(%{gem_name}) = %version
+
+%description
+Provides an AWS Route53  DNS update service based plugin
+
+%prep
+%setup -q
+
+%build
+%{?scl:scl enable %scl - << \EOF}
+mkdir -p ./%{gem_dir}
+# Create the gem as gem install only works on a gem file
+gem build %{gem_name}.gemspec
+rdoc
+export CONFIGURE_ARGS="--with-cflags='%{optflags}'"
+# gem install compiles any C extensions and installs into a directory
+# We set that to be a local directory so that we can move it into the
+# buildroot in %%install
+gem install -V \
+        --local \
+        --install-dir ./%{gem_dir} \
+        --force \
+        --rdoc \
+        %{gem_name}-%{version}.gem
+%{?scl:EOF}
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -a ./%{gem_dir}/* %{buildroot}%{gem_dir}/
+
+# Add documents/examples
+mkdir -p %{buildroot}%{_docdir}/%{name}-%{version}/
+cp -r doc/* %{buildroot}%{_docdir}/%{name}-%{version}/
+
+#Config file
+mkdir -p %{buildroot}/etc/openshift/plugins.d
+cp %{buildroot}/%{gem_dir}/gems/%{gem_name}-%{version}/conf/openshift-origin-dns-route53.conf.example %{buildroot}/etc/openshift/plugins.d/openshift-origin-dns-route53.conf.example
+
+
+%files
+%doc %{gem_docdir}
+%doc %{_docdir}/%{name}-%{version}
+%{gem_instdir}
+%{gem_spec}
+%{gem_cache}
+/etc/openshift/plugins.d/openshift-origin-dns-route53.conf.example
+
+
+%changelog
+* Wed Feb 20 2013 Mark Lamourine <<mlamouri@redhat.com>> 0.1.4-1
+- update copyright (mlamouri@redhat.com)
+- remove references to selinux (mlamouri@redhat.com)
+- Create DNS plugin using Amazon Web Services Route 53 (mlamouri@redhat.com)
+
+* Thu Feb 14 2013 Mark Lamourine <mlamouri@redhat.com> 0.1.3-1
+- new package built with tito
+
+* Thu Feb 14 2013 Mark Lamourine <mlamouri@redhat.com> 0.1.2-1
+- get packaging to work
+- added example file and ignore doc directory (mlamouri@redhat.com)
+- create rdoc documentation (mlamouri@redhat.com)
+- cleaning packaging (mlamouri@redhat.com)
+
+* Thu Feb 14 2013 Mark Lamourine <mlamouri@redhat.com> 0.1.1-1
+- new package built with tito
+
+* Mon Feb 11 2013 Mark Lamourine <mlamouri@redhat.com> 0.1.0
+- Initial checkin of a skeleton for a new plugin

--- a/plugins/dns/route53/spec/unit/route53_mocked_spec.rb
+++ b/plugins/dns/route53/spec/unit/route53_mocked_spec.rb
@@ -126,8 +126,6 @@ module OpenShift
                                                $test_namespace,
                                                $test_nodename)
 
-      puts "add reply\n#{reply}"
-
       message = reply[:change_info]
       message[:status].should be == "PENDING"
       message[:id].should match(/\/change\/[A-Z]+/)
@@ -162,14 +160,18 @@ module OpenShift
       # should call list_test_record_set
       # with structure = 
 
+      dns_service = Route53Plugin.new()
+      reply = dns_service.modify_application(
+        $test_appname, 
+        $test_namespace,
+        $test_nodename
+        )
+
       # should recieve response:
+      message = reply[:change_info]
+      message[:status].should be == "PENDING"
+      message[:id].should match(/\/change\/[A-Z]+/)
 
-      # should call change_test_record_set
-      # with structure = 
-
-      # should recieve response: 
-
-      pending "not defined"
     end
 
     it "can retrieve application records from Route53" do

--- a/plugins/dns/route53/spec/unit/route53_mocked_spec.rb
+++ b/plugins/dns/route53/spec/unit/route53_mocked_spec.rb
@@ -1,0 +1,186 @@
+#Test each of the basic functions of the NsupdateDnsPlugin
+
+require 'rubygems'
+
+# the plugin extends classes in the OpenShift::Controller module
+# load the superclass for all DnsService classes: Openshift::DnsService
+require 'openshift/dns_service'
+
+require 'openshift/route53_plugin'
+
+$hosted_zone = "apps.example.com"
+$hosted_zone_id = "MYHOSTEDZONEID"
+$aws_access_key_id = "MYAWSACCESSKEYIDLALA"
+$aws_access_key = "notaR33lAws4ccessk3ylalalalasisboombahla"
+$test_nodename = "node1.example.com"
+$test_appname = "app1"
+$test_namespace = "ns1"
+
+# Mock up the rails application configuration object
+module Rails
+  def self.application()
+    Application.new
+  end
+
+  class Application
+
+    class Configuration
+      attr_accessor :openshift, :dns
+      
+      def initialize()
+        @openshift = { :domain_suffix => $hosted_zone }
+        @dns = {
+          :zone => $hosted_zone,
+          :aws_hosted_zone_id => $hosted_zone_id,
+          :aws_access_key_id => $aws_access_key_id,
+          :aws_access_key => $aws_access_key,
+          :ttl => 10
+        }
+      end
+
+    end
+
+    def config()
+     Configuration.new
+    end
+  end
+end
+
+
+
+
+module OpenShift
+
+  describe Route53Plugin do
+
+    before(:each) do
+
+      @sample_list = {
+        :resource_record_sets=>[
+          {:resource_records=>[{:value=>"node1.example.com."}], 
+            :name=>"app1-ns1.apps.example.com.", :type=>"CNAME", :ttl=>30}
+        ],
+        :is_truncated=>false,
+        :max_items=>1
+      }
+
+      @sample_request = {
+          :comment => "",
+          :changes => {
+            :action => "",
+            :resource_record_set => {
+              :name => "app1-ns1.apps.example.com",
+              :type => "CNAME",
+              :ttl => 30,
+              :resource_records => [{:value => "node1.example.com"}],
+            }
+          }
+        }
+
+       
+      @change_result = {
+        :change_info => {
+          :changes => [],
+          :status => "PENDING",
+          :id => "/change/ABCDEFGABCDEFG"
+        }
+      }
+
+      AWS::Route53::Client.any_instance.stub(:list_resource_record_sets).and_return(@sample_list)
+      AWS::Route53::Client.any_instance.stub(:change_resource_record_sets).and_return(@change_result)
+    end
+
+    it "can be initialized with arguments" do
+      
+      dns_service = 
+        Route53Plugin.new({
+                                  :domain_suffix => $hosted_zone,
+                                  :aws_hosted_zone_id => $hosted_zone_id,
+                                  :aws_access_key_id => $aws_access_key_id,
+                                  :aws_access_key => $aws_access_key,
+                                  :ttl => 20
+                                })
+      dns_service.aws_hosted_zone_id.should be == $hosted_zone_id
+      dns_service.aws_access_key_id.should be == $aws_access_key_id
+      dns_service.aws_access_key.should be == $aws_access_key
+      dns_service.ttl.should be == 20
+    end
+
+    it "can be initialized from the Rails Application configuration" do
+      dns_service = Route53Plugin.new()
+      dns_service.aws_hosted_zone_id.should be == $hosted_zone_id
+      dns_service.aws_access_key_id.should be == $aws_access_key_id
+      dns_service.aws_access_key.should be == $aws_access_key
+      dns_service.ttl.should be == 10
+    end
+
+    it "can add application records to Route53" do
+      #set_test_record("DELETE")
+      # should call change_test_record_set
+      # with structure = 
+
+      # should recieve response: 
+
+      dns_service = Route53Plugin.new()
+      reply = dns_service.register_application($test_appname, 
+                                               $test_namespace,
+                                               $test_nodename)
+
+      puts "add reply\n#{reply}"
+
+      message = reply[:change_info]
+      message[:status].should be == "PENDING"
+      message[:id].should match(/\/change\/[A-Z]+/)
+                                       
+    end
+
+
+    it "can delete application records from Route53" do
+      #set_test_record("CREATE")
+      # should call list_test_record_set
+      # with structure = 
+
+      # should recieve response:
+
+      # should call change_test_record_set
+      # with structure = 
+
+      # should recieve response: 
+
+      dns_service = Route53Plugin.new()
+      reply = dns_service.deregister_application($test_appname, 
+                                                 $test_namespace)
+
+      message = reply[:change_info]
+      message[:status].should be == "PENDING"
+      message[:id].should match(/\/change\/[A-Z]+/)
+
+    end
+
+    it "can modify existing application records on Route53" do
+      #set_test_record("CREATE")
+      # should call list_test_record_set
+      # with structure = 
+
+      # should recieve response:
+
+      # should call change_test_record_set
+      # with structure = 
+
+      # should recieve response: 
+
+      pending "not defined"
+    end
+
+    it "can retrieve application records from Route53" do
+      # should call list_test_record_set
+      # with structure = 
+
+      # should recieve response:
+
+      pending "not defined"
+    end
+
+  end
+
+end

--- a/plugins/dns/route53/spec/unit/route53_spec.rb
+++ b/plugins/dns/route53/spec/unit/route53_spec.rb
@@ -35,6 +35,8 @@ $test_appname = ENV['AWS_ROUTE53_TEST_APPNAME'] || "pluginapp1"
 $test_nodename = ENV['AWS_ROUTE53_TEST_NODENAME'] || "pluginnode1.#{$hosted_zone}"
 
 if ! $hosted_zone or ! $hosted_zone_id then
+  puts "Missing envvars: AWS_ROUTE53_HOSTED_ZONE and/or AWS_ROUTE53_HOSTED_ZONE_ID"
+  exit
   raise Exception.new("Missing required AWS Route 53 Configuration: hosted_zone or hosted_zone_id")
 end
 

--- a/plugins/dns/route53/spec/unit/route53_spec.rb
+++ b/plugins/dns/route53/spec/unit/route53_spec.rb
@@ -1,0 +1,218 @@
+#Test each of the basic functions of the NsupdateDnsPlugin
+
+require 'rubygems'
+require 'dnsruby'
+require 'parseconfig'
+
+
+# the plugin extends classes in the OpenShift::Controller module
+# load the superclass for all DnsService classes: Openshift::DnsService
+require 'openshift/dns_service'
+
+require 'openshift/route53_plugin'
+
+#
+# Check for AWS credentials
+#
+cfgfile = ENV['HOME'] + "/.awscred"
+
+if ENV['AWSAccessKeyId'] and ENV['AWSSecretKey'] then
+  $aws_access_key_id = ENV['AWSAccessKeyId']
+  $aws_secret_key = ENV['AWSSecretKey']
+elsif File.exists? cfgfile then
+  cfg = ParseConfig.new(cfgfile)
+  $aws_access_key_id = cfg['AWSAccessKeyId']
+  $aws_access_key = cfg['AWSSecretKey']
+else
+  raise Exception.new("Missing required AWS Credentials")
+end
+
+$hosted_zone = ENV['AWS_ROUTE53_HOSTED_ZONE']
+$hosted_zone_id = ENV['AWS_ROUTE53_HOSTED_ZONE_ID']
+
+$test_namespace = ENV['AWS_ROUTE53_TEST_NAMESPACE'] || "pluginns1"
+$test_appname = ENV['AWS_ROUTE53_TEST_APPNAME'] || "pluginapp1"
+$test_nodename = ENV['AWS_ROUTE53_TEST_NODENAME'] || "pluginnode1.#{$hosted_zone}"
+
+if ! $hosted_zone or ! $hosted_zone_id then
+  raise Exception.new("Missing required AWS Route 53 Configuration: hosted_zone or hosted_zone_id")
+end
+
+# Mock up the rails application configuration object
+module Rails
+  def self.application()
+    Application.new
+  end
+
+  class Application
+
+    class Configuration
+      attr_accessor :openshift, :dns
+      
+      def initialize()
+        @openshift = { :domain_suffix => $hosted_zone }
+        @dns = {
+          :zone => $hosted_zone,
+          :aws_hosted_zone_id => $hosted_zone_id,
+          :aws_access_key_id => $aws_access_key_id,
+          :aws_access_key => $aws_access_key,
+          :ttl => 10
+        }
+      end
+
+    end
+
+    def config()
+     Configuration.new
+    end
+  end
+end
+
+def get_record(fqdn)
+  r53 = AWS::Route53.new(:access_key_id => $aws_access_key_id,
+                         :secret_access_key => $aws_access_key).client
+
+  # Request a single record "starting with" the desired record.
+  reply = r53.list_resource_record_sets(
+                                        :hosted_zone_id => $hosted_zone_id,
+                                        :start_record_name => fqdn,
+                                        :max_items => 1
+                                        )
+
+  # If the returned record name matches exactly, return it.
+  # record fqdn are returned with the trailing anchor (.)
+
+  return nil if not reply
+  
+  res = reply[:resource_record_sets][0]
+  return nil if not res
+
+  return res if (res[:name] == fqdn + ".")
+
+  nil
+end
+
+# Add a record with the correct signature for testing
+def set_test_record(action)
+
+  # Here's the record name we want
+  fqdn = "#{$test_appname}-#{$test_namespace}.#{$hosted_zone}"
+
+  reply = get_record(fqdn)
+  
+  # If it's not there and that's what we want, we're done
+  return if (action == "DELETE" and reply == nil)
+
+  record = reply[:resource_records][0]
+  public_hostname = record[:value]
+
+  # If we already have the right record, we're done
+  return if (action == "CREATE" and public_hostname == $test_nodename)
+
+  
+  return if ((not get_record(fqdn) == nil) ^ (action == "DELETE"))
+
+  change_record = {
+    :action => action,
+    :resource_record_set => {
+      :name => fqdn,
+      :type => "CNAME",
+      :ttl => 10,
+      :resource_records => [{:value => "\"#{$test_nodename}\""}],
+    }
+  }
+
+  add_record = {
+    :comment => "set a test record",
+    :changes => [change_record]
+  }
+  
+  r53 = AWS::Route53.new(:access_key_id => $aws_access_key_id,
+                         :secret_access_key => $aws_access_key).client
+
+  res = r53.change_resource_record_sets({:hosted_zone_id => $hosted_zone_id,
+                                          :change_batch => add_record})
+
+  change_id = res[:change_info][:id]
+
+  accepted = false
+
+  while accepted == false do
+    sleep 5
+    poll = r53.get_change({:id => res[:change_info][:id]})
+
+    if poll[:change_info][:status] === "INSYNC" then
+      accepted = true
+    end
+
+  end  
+end
+
+module OpenShift
+
+  describe Route53Plugin do
+
+    it "can be initialized with arguments" do
+      
+      set_test_record("DELETE")
+
+      dns_service = 
+        Route53Plugin.new({
+                                  :domain_suffix => $hosted_zone,
+                                  :aws_hosted_zone_id => $hosted_zone_id,
+                                  :aws_access_key_id => $aws_access_key_id,
+                                  :aws_access_key => $aws_access_key,
+                                  :ttl => 20
+                                })
+      dns_service.aws_hosted_zone_id.should be == $hosted_zone_id
+      dns_service.aws_access_key_id.should be == $aws_access_key_id
+      dns_service.aws_access_key.should be == $aws_access_key
+      dns_service.ttl.should be == 20
+    end
+
+    it "can be initialized from the Rails Application configuration" do
+      dns_service = Route53Plugin.new()
+      dns_service.aws_hosted_zone_id.should be == $hosted_zone_id
+      dns_service.aws_access_key_id.should be == $aws_access_key_id
+      dns_service.aws_access_key.should be == $aws_access_key
+      dns_service.ttl.should be == 10
+    end
+
+    it "can add application records to Route53" do
+      set_test_record("DELETE")
+
+      dns_service = Route53Plugin.new()
+      reply = dns_service.register_application($test_appname, 
+                                               $test_namespace,
+                                               $test_nodename)
+
+      message = reply[:change_info]
+      message[:status].should be == "PENDING"
+      message[:id].should match(/\/change\/[A-Z]+/)
+                                       
+    end
+
+
+    it "can delete application records from Route53" do
+      set_test_record("CREATE")
+
+      dns_service = Route53Plugin.new()
+      reply = dns_service.deregister_application($test_appname, 
+                                                 $test_namespace)
+
+      message = reply[:change_info]
+      message[:status].should be == "PENDING"
+      message[:id].should match(/\/change\/[A-Z]+/)
+
+    end
+
+    it "can modify existing application records on Route53" do
+
+    end
+
+    it "can retrieve application records from Route53" do
+
+    end
+  end
+
+end

--- a/rel-eng/packages/rubygem-openshift-origin-dns-aws-route53
+++ b/rel-eng/packages/rubygem-openshift-origin-dns-aws-route53
@@ -1,0 +1,1 @@
+0.1.2-1 plugins/dns/aws-route53/

--- a/rel-eng/packages/rubygem-openshift-origin-dns-route53
+++ b/rel-eng/packages/rubygem-openshift-origin-dns-route53
@@ -1,0 +1,1 @@
+0.1.4-1 plugins/dns/route53/


### PR DESCRIPTION
A DNS plugin to use Amazon Web Services Route53 as the back end.

Requires rubygem-aws-sdk >= 1.8.0

Requires adding gem aws-sdk to broker Gemfile

RSpec tests require AWS credentials and a hosted_zone.
