### PR TITLE
Fedora 18 moved the httxt2dbm command.

### DIFF
--- a/node/lib/openshift-origin-node/model/frontend_httpd.rb
+++ b/node/lib/openshift-origin-node/model/frontend_httpd.rb
@@ -930,7 +930,13 @@ module OpenShift
       Dir.mktmpdir([File.basename(@filename) + ".db-", ""], File.dirname(@filename)) do |wd|
         tmpdb = File.join(wd, 'new.db')
 
-        cmd = %{/usr/sbin/httxt2dbm -f DB -i #{@filename}#{self.SUFFIX} -o #{tmpdb}}
+        httxt2dbm = ["/usr/bin","/usr/sbin","/bin","/sbin"].map {|d| File.join(d, "httxt2dbm")}.select {|p| File.exists?(p)}.pop
+        if httxt2dbm.nil?
+          Syslog.alert("WARNING: no httxt2dbm command found, relying on PATH")
+          httxt2dbm="httxt2dbm"
+        end
+
+        cmd = %{#{httxt2dbm} -f DB -i #{@filename}#{self.SUFFIX} -o #{tmpdb}}
         out,err,rc = shellCmd(cmd)
         if rc == 0
           Syslog.debug("httxt2dbm: #{@filename}: #{rc}: stdout: #{out} stderr:#{err}")

--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -8,6 +8,11 @@
 %global rubyabi 1.9.1
 %global appdir %{_var}/lib/openshift
 %global apprundir %{_var}/run/openshift
+%if 0%{?fedora} <= 18
+    %global httxt2dbm /usr/sbin/httxt2dbm
+%else
+    %global httxt2dbm /usr/bin/httxt2dbm
+%endif
 
 Summary:       Cloud Development Node
 Name:          rubygem-%{gem_name}
@@ -33,6 +38,9 @@ Requires:      httpd
 Requires:      libcgroup
 %else
 Requires:      libcgroup-tools
+%endif
+%if 0%{?fedora} >= 18
+Requires:       httpd-tools
 %endif
 Requires:      libcgroup-pam
 Requires:      pam_openshift
@@ -187,7 +195,7 @@ for map in nodes aliases idler sts
 do
     mapf="/etc/httpd/conf.d/openshift/${map}"
     touch "${mapf}.txt"
-    /usr/sbin/httxt2dbm -f DB -i "${mapf}.txt" -o "${mapf}.db"
+    %{httxt2dbm} -f DB -i "${mapf}.txt" -o "${mapf}.db"
 done
 
 for map in containers routes


### PR DESCRIPTION
https://github.com/openshift/li/pull/905
