### PR TITLE
[TO_STAGE] Bug 912803 - mongoid being confused with unix uid

### DIFF
--- a/node/lib/openshift-origin-node/model/unix_user.rb
+++ b/node/lib/openshift-origin-node/model/unix_user.rb
@@ -722,8 +722,9 @@ Dir(after)    #{@uuid}/#{@uid} => #{list_home_dir(@homedir)}
     # Created because an error in FileUtils.chown where an all digit user or group name is assumed
     # to be a uid or a gid.  Mongoids can be all numeric.
     def oo_chown(user, group, list, options = {})
-      user = Etc.getpwnam(user).uid if user
-      group = Etc.getgrnam(group).gid if group
+      user = get_uid(user)
+      group = get_gid(group)
+
       FileUtils.chown(user, group, list, options)
     end
 
@@ -733,9 +734,37 @@ Dir(after)    #{@uuid}/#{@uid} => #{list_home_dir(@homedir)}
     # Created because an error in FileUtils.chown where an all digit user or group name is assumed
     # to be a uid or a gid.  Mongoids can be all numeric.
     def oo_chown_R(user, group, list, options = {})
-      user = Etc.getpwnam(user).uid if user
-      group = Etc.getgrnam(group).gid if group
+      user = get_uid(user)
+      group = get_gid(group)
+
       FileUtils.chown_R(user, group, list, options)
+    end
+
+    private
+
+    def get_uid(user)
+      return nil unless user
+      case user
+        when Integer
+          user <  4294967296 ? user : Etc.getpwnam(user.to_s)
+        when /\A\d{1,10}\z/
+          user.to_i
+        else
+          Etc.getpwnam(user).uid
+      end
+    end
+
+    def get_gid(group)
+      return nil unless group
+
+      case group
+        when Integer
+          group <  4294967296 ? group : Etc.getgrnam(group.to_s)
+        when /\A\d{1,10}\z/
+          group.to_i
+        else
+          Etc.getgrnam(group).gid
+      end
     end
   end
 end

--- a/node/lib/openshift-origin-node/model/unix_user.rb
+++ b/node/lib/openshift-origin-node/model/unix_user.rb
@@ -746,7 +746,7 @@ Dir(after)    #{@uuid}/#{@uid} => #{list_home_dir(@homedir)}
       return nil unless user
       case user
         when Integer
-          user <  4294967296 ? user : Etc.getpwnam(user.to_s)
+          user <  4294967296 ? user : Etc.getpwnam(user.to_s).uid
         when /\A\d{1,10}\z/
           user.to_i
         else
@@ -759,7 +759,7 @@ Dir(after)    #{@uuid}/#{@uid} => #{list_home_dir(@homedir)}
 
       case group
         when Integer
-          group <  4294967296 ? group : Etc.getgrnam(group.to_s)
+          group <  4294967296 ? group : Etc.getgrnam(group.to_s).gid
         when /\A\d{1,10}\z/
           group.to_i
         else

--- a/node/test/unit/unix_user_test.rb
+++ b/node/test/unit/unix_user_test.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env oo-ruby
 #--
 # Copyright 2012 Red Hat, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,7 @@ require 'openshift-origin-node/model/unix_user'
 require 'test/unit'
 
 # Run unit test manually
-# ruby -Iopenshift/node/lib/:openshift/common/lib/ openshift/node/test/unit/unix_user_test.rb 
+# ruby -Iopenshift/node/lib/:openshift/common/lib/ openshift/node/test/unit/unix_user_test.rb
 class TestUnixUserModel < Test::Unit::TestCase
 
   def assert_directory?(file)
@@ -33,8 +33,8 @@ class TestUnixUserModel < Test::Unit::TestCase
   end
 
   def setup
-    @gear_uuid = Process.euid.to_s
-    @user_uid = Process.euid.to_s
+    @gear_uuid = "1000"
+    @user_uid = "1000"
     @app_name = 'UnixUserTestCase'
     @gear_name = @app_name
     @namespace = 'jwh201204301647'


### PR DESCRIPTION
- first patch missed case when group 0 given. Etc.getgrnam did not support lookup.
