### PR TITLE
Fixed rhc_ctl_destroy helper to look for correct exit code

### DIFF
--- a/controller/test/cucumber/support/command_helper.rb
+++ b/controller/test/cucumber/support/command_helper.rb
@@ -356,24 +356,22 @@ module CommandHelper
     rhc_do('rhc_ctl_destroy') do
       time = Benchmark.realtime do
         exit_code = -1
-        retries = 5
-        while retries > 0 and (exit_code != 0 or exit_code != 101)
-          sleep 30 unless retries == 5
+        5.times do
           exit_code = run("#{$rhc_script} app delete #{app.name} --confirm #{default_args(app)}")
-          retries -= 1
+          break if [0,101].include?(exit_code)
+          sleep 30
         end
         (exit_code == 0 or exit_code == 101).should == true
       end
       log_event "#{time} DESTROY_APP #{app.name} #{app.login}"
-      time = Benchmark.realtime do 
+      time = Benchmark.realtime do
         exit_code = -1
-        retries = 5
-        while retries > 0 and exit_code != 0
-          sleep 30 unless retries == 5
-          exit_code = run("#{$rhc_script} app show #{app.name} --state #{default_args(app)} | grep 'does not exist'")
-          retries -= 1
+        5.times do
+          exit_code = run("#{$rhc_script} app show #{app.name} --state #{default_args(app)}")
+          break if exit_code == 101
+          sleep 30
         end
-        exit_code.should == 0
+        exit_code.should == 101
       end
       log_event "#{time} STATUS_APP #{app.name} #{app.login}"
       run("sed -i '/#{app.name}-#{app.namespace}.#{$domain}/d' /etc/hosts") if use_hosts


### PR DESCRIPTION
Since changing the output to match the server message, these tests were broken. Changed to rely on the exit code since it's now correct and specific.

Also changed the retry loop. This saves about 2 minutes per lifecycle feature.
