### PR TITLE
 Bug 913423 - Incorrect syntax for ReverseCookiePath

### DIFF
--- a/node/httpd/openshift_route.include
+++ b/node/httpd/openshift_route.include
@@ -172,4 +172,3 @@ RequestHeader set X-Client-IP %{REMOTE_HOST}e
 # Configure reverse proxy based on set variable
 #
 ProxyPassReverse ${V_MATCH_PATH} http://${V_ROUTE} interpolate
-ProxyPassReverseCookiePath ${V_MATCH_PATH} http://${V_ROUTE} interpolate

--- a/node/lib/openshift-origin-node/model/frontend_httpd.rb
+++ b/node/lib/openshift-origin-node/model/frontend_httpd.rb
@@ -942,8 +942,8 @@ module OpenShift
           Syslog.debug("httxt2dbm: #{@filename}: #{rc}: stdout: #{out} stderr:#{err}")
           begin
             oldstat = File.stat(@filename + '.db')
-            FileUtils.chown(oldstat.uid, oldstat.gid, tmpdb)
-            FileUtils.chmod(oldstat.mode & 0777, tmpdb)
+            File.chown(oldstat.uid, oldstat.gid, tmpdb)
+            File.chmod(oldstat.mode & 0777, tmpdb)
           rescue Errno::ENOENT
           end
           FileUtils.mv(tmpdb, @filename + '.db', :force=>true)


### PR DESCRIPTION
The way the node table lookup works we do not have the information broken out in a way that supports the correct syntax.
