### PR TITLE
allow cgroups to be disabled in node.conf

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/util
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/util
@@ -1014,13 +1014,15 @@ function run_user_hook {
 }
 
 function enable_cgroups {
-    if [ $ENABLE_CGROUPS -eq 1 ]; then
+    # default to ENABLE_CGROUPS=true
+    if [ "$ENABLE_CGROUPS" -ne 0 ]; then
       cgset -r cpu.cfs_quota_us=$cfs_quota /openshift/$uuid
     fi
 }
 
 function disable_cgroups {
-    if [ $ENABLE_CGROUPS -eq 1 ]; then
+    # default to ENABLE_CGROUPS=true
+    if [ "$ENABLE_CGROUPS" -ne 0 ]; then
       export cfs_quota=$(cgget -n -v -r cpu.cfs_quota_us /openshift/${uuid})
       cfs_period=$(cgget -n -v -r cpu.cfs_period_us /openshift/${uuid})
       cgset -r cpu.cfs_quota_us=${cfs_period} /openshift/${uuid}

--- a/node-util/bin/oo-accept-node
+++ b/node-util/bin/oo-accept-node
@@ -272,6 +272,11 @@ end
 def check_cgroup_config
     verbose("checking cgroups configuration")
 
+    if ENV['ENABLE_CGROUPS'] = "0"
+      eputs "WARNING: check_cgroup_config - cgroups are disabled in node.conf"
+      return
+    end
+
     if %x[lscgroup cpu,cpuacct,memory,freezer,net_cls:/openshift 2>/dev/null | wc -l].strip.to_i < 1
         do_fail("lscgroup /openshift path does not exist")
         $CGROUP_PASS=false
@@ -333,7 +338,7 @@ def check_users
         #Test home dir
         do_fail("user #{username} does not have a home directory #{home_dir}") unless File.exists? home_dir
         do_fail("user #{username} does not have a PAM limits file") unless File.exists?(conf_dir_templ % username)
-        if $CGROUP_PASS
+        if $CGROUP_PASS and not ENV['ENABLE_CGROUPS'] == 0
           check_user_cgroups username
         end
         if $TC_CHECK && $TC_PASS
@@ -354,6 +359,13 @@ end
 
 # Verify that the user has a cgroup in all subsystems and no others
 def check_user_cgroups(username)
+
+  if ENV['ENABLE_CGROUPS'] == "0"
+    #eputs "WARNING: check_user_cgroups - cgroups disabled in node.conf"
+    eputs "WARNING: check_user_cgroups - cgroups disabled in node.conf"
+    return
+  end
+
   user_cgroup="/openshift/#{username}"
   test_subsystems = ['cpu', 'cpuacct', 'memory', 'freezer', 'net_cls'].sort
 

--- a/node/misc/bin/oo-trap-user
+++ b/node/misc/bin/oo-trap-user
@@ -37,9 +37,6 @@ commands_map = {
 
 comment_re = re.compile("#.*$")
 
-# These should come from somewhere, not be hard coded - MAL
-openshift_cgroup_subsystems="cpu,cpuacct,memory,net_cls,freezer"
-
 #
 # Read in uservars variables.
 #
@@ -94,31 +91,8 @@ def read_config():
       config[split_line[0]] = value
   return config
 
-#
-# Join the user's cgroup if available
-#
-def join_cgroup():
-    """
-    Determine a user's cgroup and join it if possible
-    """
-
-    username = pwd.getpwuid(os.getuid())[0]
-    cgpath = "/openshift/%s" % username
-    pid = os.getpid()
-
-    cmd_template = "cgclassify -g %s:%s %d"
-    cmd = cmd_template % (openshift_cgroup_subsystems, cgpath, pid)
-    syslog.syslog("user %s: putting process %d in cgroups %s" % (username, pid, openshift_cgroup_subsystems))
-
-    retval = subprocess.call(cmd.split())
-    if retval != 0:
-        syslog.syslog("user %s: cgroup classification failed: retval = %d" % (username, retval))
-
-    # should raise an exception? MAL
-
 if __name__ == '__main__':
     # first self-apply restrictions
-    # join_cgroup()
     read_env_vars()
     config = read_config()
 

--- a/node/misc/sbin/oo-admin-ctl-cgroups
+++ b/node/misc/sbin/oo-admin-ctl-cgroups
@@ -441,6 +441,14 @@ status() {
     return $GROUP_RETVAL
 }
 
+# Check to see if cgroups are disabled: default enabled
+if [ "$ENABLE_CGROUPS" -eq 0 ]
+then
+    logger -p user.warning -t openshift "cgroups disabled: $0 $1 $2"
+    echo "cgroups disabled"
+    exit 0
+fi 
+
 case "$1" in
   startall)
     startall


### PR DESCRIPTION
Allow and respond to ENABLE_CGROUPS=0 in /etc/openshift/node.conf

This allows openshift to run on systems where cgroups do not exist, or where cgroup constraints on gears are not needed.
