### PR TITLE
US3409 changes

### DIFF
--- a/broker-util/oo-admin-ctl-usage
+++ b/broker-util/oo-admin-ctl-usage
@@ -1,0 +1,352 @@
+#!/usr/bin/env oo-ruby
+require 'rubygems'
+require 'getoptlong'
+require 'socket'
+
+$log_file = "/var/log/openshift/broker/usage-billing.log"
+
+def usage
+    puts <<USAGE
+== Synopsis
+
+oo-admin-ctl-usage: Control usage
+
+== Usage
+
+oo-admin-ctl-usage OPTIONS
+
+Options:
+--list
+    List usage available to be synced
+--sync
+    Sync usage with the billing vendor
+--remove-sync-lock
+    Remove existing sync lock
+--enable-logger
+    Print error/warning messages to log file '#{$log_file}' instead of terminal.
+-h|--help
+    Show Usage info
+USAGE
+  exit 255
+end
+
+opts = GetoptLong.new(
+    ["--list",             "-l", GetoptLong::NO_ARGUMENT],
+    ["--sync",             "-s", GetoptLong::NO_ARGUMENT],
+    ["--remove-sync-lock", "-r", GetoptLong::NO_ARGUMENT],
+    ["--enable-logger",    "-e", GetoptLong::NO_ARGUMENT],
+    ["--help",             "-h", GetoptLong::NO_ARGUMENT]
+)
+
+args = {}
+begin
+  opts.each{ |k,v| args[k]=v }
+rescue GetoptLong::Error => e
+  usage
+end
+
+$list = args["--list"]
+$sync = args["--sync"]
+$remove_sync_lock = args["--remove-sync-lock"]
+$enable_logger = args["--enable-logger"]
+
+if args["--help"]
+  usage
+end
+
+unless $list || $sync || $remove_sync_lock
+  puts "You must specify --list and/or --sync and/or --remove-sync-lock"
+  usage
+end
+
+
+require "/var/www/openshift/broker/config/environment"
+# Disable analytics for admin scripts
+Rails.configuration.analytics[:enabled] = false
+# Indicates how many records to gather for reporting usage in bulk.
+$bulk_recs_threshold = 25
+$billing_api = OpenShift::BillingService.instance
+# User -> billing account# cache
+$billing_acct_info = {}
+$session = nil
+$cur_time = nil
+if $enable_logger
+  $billing_api.set_logger($log_file)
+else
+  $billing_api.set_logger
+end
+
+def get_mongo_session
+  config = Mongoid::Config.sessions["default"]
+  session = Moped::Session.new(config["hosts"])
+  session.use config["database"]
+  session.login(config["username"], config["password"])
+  session
+end
+
+def release_mongo_session(session)
+  session.logout
+end
+
+# Get billing account# from cloud_users collection, if it fails get it from billing vendor.
+# Cache user->billing a/c# for subsequent requests.
+def get_billing_acct_no(user)
+  acct_no = nil
+  begin
+    if $billing_acct_info.has_key?(user)
+      acct_no = $billing_acct_info[user]
+    else
+      user_obj = $session[:cloud_users].find(login: user).select(usage_account_id: 1).first
+      if user_obj
+        acct_no = user_obj['usage_account_id']
+        $billing_acct_info[user] = acct_no
+      end
+    end 
+  rescue Exception => e
+    $billing_api.print_warning "Failed to retrieve billing a/c# for User: #{user} from cloud_users collection, Error: #{e.message}"
+    acct_no = $billing_api.get_billing_acct_no(user)
+    $billing_acct_info[user] = acct_no
+  end
+  acct_no
+end
+# Print usage to terminal
+$prev_login = nil
+def list_usage(user_srecs)
+  return if user_srecs.empty?
+  billing_provider_name = $billing_api.get_provider_name
+  if billing_provider_name
+    billing_provider_str = ", #{billing_provider_name}#: #{get_billing_acct_no(srec['login'])}"
+  else
+    billing_provider_str = ""
+  end
+  user_srecs.each do |srec|
+    if $prev_login != srec['login']
+      puts "User: #{srec['login']}" + billing_provider_str
+      $prev_login = srec['login']
+    end
+    puts "\tGear: #{srec['gear_id']}, UsageType: #{srec['usage_type']}, Usage: #{srec['usage']}"
+  end 
+end
+
+def sync_usage(user_srecs)
+  return if user_srecs.empty?
+  # Handle users with *NO* billing account
+  srecs = []
+  user_srecs.delete_if do |srec|
+    if get_billing_acct_no(srec['login'])
+      false
+    else
+      srecs << srec
+      true
+    end
+  end
+  $billing_api.delete_ended_urecs($session, srecs)
+
+  continue_user_ids = srecs.map {|rec| rec['_id'] unless rec['ended']}
+  update_query = {"$set" => {event: UsageRecord::EVENTS[:continue], time: $cur_time, sync_time: nil}}
+  $session[:usage_records].find({_id: {"$in" => continue_user_ids}}).update_all(update_query) unless continue_user_ids.empty?
+
+  # Handle users with billing account
+  $billing_api.sync_usage($session, user_srecs, $cur_time)
+end
+
+# Check basic validations and try to fix/delete incorrect records
+def sanitize_usage_records(urecs)
+  return if urecs.empty?
+  if urecs.length > 2
+    $billing_api.print_error "Found more than 2 usage records, We expect only begin/continue and end records."\
+                             "Ivestigate these records: #{urecs.inspect}"
+    end_rec = nil
+    continue_rec = nil
+    begin_rec = nil
+    # Pick first available begin and end record if present
+    # Pick last available continue record if present
+    urecs.each do |urec|
+      if !end_rec and (urec['event'] == UsageRecord::EVENTS[:end])
+        end_rec = urec
+      elsif !begin_rec and (urec['event'] == UsageRecord::EVENTS[:begin])
+        begin_rec = urec
+      elsif urec['event'] == UsageRecord::EVENTS[:continue]
+        continue_rec = urec
+      end
+    end
+    if continue_rec && end_rec
+      new_urecs = [continue_rec, end_rec]
+    elsif begin_rec && end_rec
+      new_urecs = [begin_rec, end_rec]
+    elsif continue_rec
+      new_urecs = [continue_rec]
+    elsif begin_rec
+      new_urecs = [begin_rec]
+    elsif end_rec
+      new_urecs = []
+    else
+      $billing_api.print_error "Unexpected behavior found. Ivestigate these records: #{urecs.inspect}"
+      urecs = []
+      return # Ignore processing these records
+    end
+    urec_ids = urecs.map {|rec| rec['_id']}
+    new_urec_ids = new_urecs.map{|rec| rec['_id']}
+    delete_user_ids = urec_ids - new_urec_ids
+    # Delete incorrect records that are not needed any more.
+    $session[:usage_records].find({_id: {"$in" => delete_user_ids}}).remove_all unless delete_user_ids.empty?
+    urecs = new_urecs
+    return sanitize_usage_records(urecs)
+  else
+    if (urecs.first['event'] == UsageRecord::EVENTS[:end]) or !urecs.first['time']
+      if !urecs.first['time']
+        $billing_api.print_error "Event time not set for begin/continue usage record."\
+                  "Unexpected behavior found. Ivestigate these records: #{urecs.inspect}"
+      else
+        $billing_api.print_error "Found usage records with no begin/continue marker. Ivestigate these records: #{urecs.inspect}"
+      end
+      # Delete this set of records
+      $session[:usage_records].find(_id: urecs.first['_id']).remove
+      $session[:usage_records].find(_id: urecs.last['_id']).remove if urecs.length == 2
+      urecs = []
+      return
+    end
+    return urecs.length == 1
+
+    if urecs.last['event'] != UsageRecord::EVENTS[:end]
+      $billing_api.print_error "Found 2 usage records with no end marker. Ivestigate these records: #{urecs.inspect}"
+      # Keep last continue or first begin and delete the other record.
+      if urecs.last['event'] == UsageRecord::EVENTS[:continue]
+        $session[:usage_records].find(_id: urecs.first['_id']).remove
+        urecs = [urecs.last]
+      elsif urecs.first['event'] == UsageRecord::EVENTS[:begin]
+        $session[:usage_records].find(_id: urecs.last['_id']).remove
+        urecs = [urecs.first]
+      else
+        # Ignore processing these records, needs investigation.
+        urecs = [] 
+      end
+      return sanitize_usage_records(urecs)
+    end
+    if !urecs.last['time']
+      $billing_api.print_error "Event time not set for end usage record."\
+                  "Unexpected behavior found. Ivestigate these records: #{urecs.inspect}"
+      urecs.last['time'] = urecs.first['time']
+    end
+    if urecs.last['time'] < urecs.first['time']
+      $billing_api.print_error "End time less than begin/continue time. Ivestigate these records: #{urecs.inspect}"
+      urecs.last['time'] = urecs.first['time']
+    end
+  end
+end
+
+# Generate usage summary for the given usage records
+def populate_user_summary_records(urecs)
+  return if urecs.empty?
+  begin
+    sanitize_usage_records(urecs)
+    return if urecs.empty?
+    urec = urecs.first
+    return if urec['ended']
+
+    begin_time = urec['time']
+    end_time = urecs.last['time'] if urecs.length == 2
+    end_time = $cur_time unless end_time
+
+    billing_acct_no = get_billing_acct_no(urec['login'])
+    urec['usage'] = $billing_api.get_usage_time(billing_acct_no, urec, begin_time, end_time)
+    urec['end_time'] = end_time
+    if urecs.length == 2
+      urec['ended'] = true
+      urec['end_id'] = urecs.last['_id']
+    end
+  rescue Exception => e
+    $billing_api.print_error(e.message, urecs.first)
+    $billing_api.log.error e.backtrace.inspect
+    # Ignore processing these records, needs investigation.
+    urecs = []
+  end
+end
+
+# Process given chunk of usage recrods
+def process_user_usage_records(user_urecs)
+  return if user_urecs.empty?
+  $cur_time = Time.now.utc
+
+  begin
+    user_srecs = [] # user usage summary records
+    utype_recs = [] # user usage type records
+    user_urecs.each do |urec|
+      if utype_recs.empty? or
+         ((utype_recs.first['login'] == urec['login']) &&
+          (utype_recs.first['gear_id'] == urec['gear_id']) &&
+          (utype_recs.first['usage_type'] == urec['usage_type']))
+        utype_recs << urec
+        next if urec['event'] != UsageRecord::EVENTS[:end]
+        populate_user_summary_records(utype_recs)
+        user_srecs << utype_recs.first unless utype_recs.empty?
+        utype_recs = []
+      else
+        populate_user_summary_records(utype_recs)
+        user_srecs << utype_recs.first unless utype_recs.empty?
+        utype_recs = [urec]
+      end
+    end
+    unless utype_recs.empty?
+      populate_user_summary_records(utype_recs)
+      user_srecs << utype_recs.first unless utype_recs.empty?
+    end
+    # List and/or Sync usage
+    list_usage(user_srecs) if $list
+    sync_usage(user_srecs) if $sync
+  rescue Exception => e
+    $billing_api.print_error e.message
+    $billing_api.log.error e.backtrace.inspect
+  ensure
+    # Clear billing info cache
+    $billing_acct_info = {}
+  end
+end
+
+# Get usage records from mongo and process them in small chunks
+def process_usage_records
+  user_urecs = []
+  cur_urec_count = 0
+
+  # usage_records collection is indexed by 'login' field
+  # we prefer to process records by 'login' so that we can leverage 'login'=>'billing account#' cache
+  $session[:usage_records].find.sort({:login => 1, :gear_id => 1, :usage_type => 1, :time => 1}).no_timeout.each do |urec|
+    user_urecs << urec
+    cur_urec_count += 1
+    # Always end the chunk with a record that has 'end' event
+    if (cur_urec_count >= $bulk_recs_threshold) and (urec['event'] == UsageRecord::EVENTS[:end])
+      process_user_usage_records(user_urecs)
+      user_urecs = []
+      cur_urec_count = 0
+    end
+  end
+  process_user_usage_records(user_urecs) unless user_urecs.empty?
+end
+
+# Main logic starts here
+# Acquires distributed lock to list and/or sync usage
+if $remove_sync_lock
+  OpenShift::DistributedLock.release_lock("sync_usage")
+end
+
+if $list or $sync
+  hostname = Socket.gethostname
+  if OpenShift::DistributedLock.obtain_lock("sync_usage", hostname)
+    $billing_api.log.info "\n---------- STARTED ----------\n"
+    begin
+      $session = get_mongo_session
+      process_usage_records
+    rescue Exception => e
+      $billing_api.print_error e.message
+      $billing_api.log.error e.backtrace.inspect
+    ensure
+      $billing_api.log.info "\n---------- ENDED, #Errors: #{$billing_api.error_count}, #Warnings: #{$billing_api.warning_count} ----------\n"
+      release_mongo_session($session) rescue nil
+      OpenShift::DistributedLock.release_lock("sync_usage", hostname)
+    end
+  else
+    $billing_api.log.error "Failed to obtain lock to interact with usage data"
+    exit 1
+  end
+end
+exit 0

--- a/broker-util/openshift-origin-broker-util.spec
+++ b/broker-util/openshift-origin-broker-util.spec
@@ -52,6 +52,7 @@ cp kickstart/openshift-origin-remix.ks %{buildroot}/usr/share/openshift/kickstar
 %attr(0750,-,-) %{_sbindir}/oo-admin-ctl-authorization
 %attr(0750,-,-) %{_sbindir}/oo-admin-ctl-district
 %attr(0750,-,-) %{_sbindir}/oo-admin-ctl-domain
+%attr(0750,-,-) %{_sbindir}/oo-admin-ctl-usage
 %attr(0750,-,-) %{_sbindir}/oo-admin-ctl-user
 %attr(0750,-,-) %{_sbindir}/oo-admin-move
 %attr(0750,-,-) %{_sbindir}/oo-admin-usage

--- a/broker/conf/broker.conf
+++ b/broker/conf/broker.conf
@@ -20,15 +20,16 @@ MONGO_DB="openshift_broker_dev"
 MONGO_SSL="false"
 #Enables gear/filesystem resource usage tracking
 ENABLE_USAGE_TRACKING_DATASTORE="false"
-#Log resource usage information to syslog
-ENABLE_USAGE_TRACKING_SYSLOG="false"
+#Log resource usage information
+ENABLE_USAGE_TRACKING_AUDIT_LOG="false"
+USAGE_TRACKING_AUDIT_LOG_FILE="/var/log/openshift/broker/usage.log"
 
 #Enable all broker analytics
 ENABLE_ANALYTICS="false"
 
 #Enables logging of REST API operations and success/failure
 ENABLE_USER_ACTION_LOG="true"
-USER_ACTION_LOG_FILE="/var/log/openshift/user_action.log"
+USER_ACTION_LOG_FILE="/var/log/openshift/broker/user_action.log"
 
 AUTH_SALT="ClWqe5zKtEW4CJEMyjzQ"
 AUTH_PRIVKEYFILE="/etc/openshift/server_priv.pem"

--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -48,8 +48,9 @@ Broker::Application.configure do
   }
 
   config.usage_tracking = {
-    :datastore_enabled => conf.get_bool("ENABLE_USAGE_TRACKING_DATASTORE", "false"),
-    :syslog_enabled => conf.get_bool("ENABLE_USAGE_TRACKING_SYSLOG", "false")
+    :datastore_enabled => conf.get_bool("ENABLE_USAGE_TRACKING_DATASTORE", "true"),
+    :audit_log_enabled => conf.get_bool("ENABLE_USAGE_TRACKING_AUDIT_LOG", "true"),
+    :audit_log_filepath => conf.get_bool("USAGE_TRACKING_AUDIT_LOG_FILE", "/var/log/openshift/broker/usage.log")
   }
 
   config.analytics = {
@@ -58,7 +59,7 @@ Broker::Application.configure do
 
   config.user_action_logging = {
     :logging_enabled => conf.get_bool("ENABLE_USER_ACTION_LOG", "true"),
-    :log_filepath => conf.get("USER_ACTION_LOG_FILE", "/var/log/openshift/user_action.log")
+    :log_filepath => conf.get("USER_ACTION_LOG_FILE", "/var/log/openshift/broker/user_action.log")
   }
 
   config.openshift = {

--- a/broker/config/environments/production.rb
+++ b/broker/config/environments/production.rb
@@ -49,7 +49,8 @@ Broker::Application.configure do
 
   config.usage_tracking = {
     :datastore_enabled => conf.get_bool("ENABLE_USAGE_TRACKING_DATASTORE", "false"),
-    :syslog_enabled => conf.get_bool("ENABLE_USAGE_TRACKING_SYSLOG", "false")
+    :audit_log_enabled => conf.get_bool("ENABLE_USAGE_TRACKING_AUDIT_LOG", "false"),
+    :audit_log_filepath => conf.get_bool("USAGE_TRACKING_AUDIT_LOG_FILE", "/var/log/openshift/broker/usage.log")
   }
 
   config.analytics = {
@@ -58,7 +59,7 @@ Broker::Application.configure do
 
   config.user_action_logging = {
     :logging_enabled => conf.get_bool("ENABLE_USER_ACTION_LOG", "true"),
-    :log_filepath => conf.get("USER_ACTION_LOG_FILE", "/var/log/openshift/user_action.log")
+    :log_filepath => conf.get("USER_ACTION_LOG_FILE", "/var/log/openshift/broker/user_action.log")
   }
 
   config.openshift = {

--- a/broker/config/environments/test.rb
+++ b/broker/config/environments/test.rb
@@ -46,8 +46,9 @@ Broker::Application.configure do
   }
 
   config.usage_tracking = {
-    :datastore_enabled => conf.get_bool("ENABLE_USAGE_TRACKING_DATASTORE", "false"),
-    :syslog_enabled => conf.get_bool("ENABLE_USAGE_TRACKING_SYSLOG", "false")
+    :datastore_enabled => conf.get_bool("ENABLE_USAGE_TRACKING_DATASTORE", "true"),
+    :audit_log_enabled => conf.get_bool("ENABLE_USAGE_TRACKING_AUDIT_LOG", "true"),
+    :audit_log_filepath => conf.get_bool("USAGE_TRACKING_AUDIT_LOG_FILE", "/var/log/openshift/broker/usage.log")
   }
 
   config.analytics = {
@@ -56,7 +57,7 @@ Broker::Application.configure do
 
   config.user_action_logging = {
     :logging_enabled => conf.get_bool("ENABLE_USER_ACTION_LOG", "true"),
-    :log_filepath => conf.get("USER_ACTION_LOG_FILE", "/var/log/openshift/user_action.log")
+    :log_filepath => conf.get("USER_ACTION_LOG_FILE", "/var/log/openshift/broker/user_action.log")
   }
 
   config.openshift = {

--- a/broker/test/unit/distributed_lock_test.rb
+++ b/broker/test/unit/distributed_lock_test.rb
@@ -1,0 +1,22 @@
+ENV["TEST_NAME"] = "unit_distributed_lock_test"
+require 'test_helper'
+
+class DistributedLockTest < ActiveSupport::TestCase
+  def setup
+    super
+  end
+
+  test "distributed lock" do
+    dl = OpenShift::DistributedLock
+    type = gen_uuid
+    assert(dl.obtain_lock(type, "1"))
+    assert(!dl.obtain_lock(type, "1"))
+    assert(!dl.obtain_lock(type, "2"))
+    dl.release_lock(type, "1")
+    assert(dl.obtain_lock(type, "2"))
+    assert(dl.obtain_lock(type, "2", true))
+    dl.release_lock(type)
+    assert(dl.obtain_lock(type, "2"))
+    dl.release_lock(type)
+  end
+end

--- a/controller/app/models/usage.rb
+++ b/controller/app/models/usage.rb
@@ -39,6 +39,9 @@ class Usage
   validates :addtl_fs_gb, :presence => true, :if => :validate_addtl_fs_gb?
   validates :cart_name, :presence => true, :if => :validate_cart_name?
 
+  index({'login' => 1})
+  create_indexes
+
   def validate_gear_size?
     (self.usage_type == UsageRecord::USAGE_TYPES[:gear_usage]) ? true : false
   end

--- a/controller/config/initializers/usage_audit_log.rb
+++ b/controller/config/initializers/usage_audit_log.rb
@@ -1,0 +1,9 @@
+if Rails.configuration.usage_tracking[:audit_log_enabled]
+  if file = Rails.configuration.usage_tracking[:audit_log_filepath]
+    logger = Logger.new(file)
+    logger.formatter = proc do |severity, datetime, progname, msg|
+      "#{datetime}:: #{msg}\n"
+    end
+    OpenShift::UsageAuditLog.logger = logger
+  end
+end

--- a/controller/lib/openshift-origin-controller.rb
+++ b/controller/lib/openshift-origin-controller.rb
@@ -21,10 +21,12 @@ module OpenShift
 
   autoload :AuthService,               'openshift/auth_service'
   autoload :DnsService,                'openshift/dns_service'
+  autoload :BillingService,            'openshift/billing_service'
   autoload :DataStore,                 'openshift/data_store'
-  autoload :MongoDataStore,            'openshift/mongo_data_store'
+  autoload :DistributedLock,           'openshift/distributed_lock'
 
   autoload :UserActionLog,             'openshift/user_action_log'
+  autoload :UsageAuditLog,             'openshift/usage_audit_log'
 end
 
 require "openshift/exceptions"

--- a/controller/lib/openshift/billing_service.rb
+++ b/controller/lib/openshift/billing_service.rb
@@ -1,0 +1,114 @@
+module OpenShift
+  # Generic Billing provider service interface
+  # Currently, this interface is consumed by oo-admin-ctl-usage
+  class BillingService
+    attr_accessor :log, :error_count, :warning_count
+    @oo_billing_provider = OpenShift::BillingService
+
+    def self.provider=(provider_class)
+      @oo_billing_provider = provider_class
+    end
+
+    def self.instance
+      @oo_billing_provider.new
+    end
+
+    def initialize
+      @log = nil
+      @error_count = 0
+      @warning_count = 0
+    end
+
+    def set_logger(log_file=nil)
+      if log_file
+        @log = Logger.new(log_file)
+        output = log_file
+      else
+        @log = Logger.new(STDOUT)
+        output = "terminal"
+      end
+      @log.level = Logger::DEBUG
+      @log.formatter = proc do |severity, datetime, progname, msg|
+          "#{datetime} #{severity}:: #{msg}\n"
+      end
+      puts "Errors/Warnings will be logged to #{output}"
+    end
+
+    # Unique usage id that can be used to narrow down to specific set of records.
+    # This will be helpful in debuging.
+    def get_uid(urec)
+      "User: #{urec['login']}, Gear: #{urec['gear_id']}, UsageType: #{urec['usage_type']}"
+    end
+
+    def print_error(msg, urec=nil)
+      @error_count += 1
+      msg += "(#{get_uid(urec)})" if urec
+      @log.error msg
+    end
+
+    def print_warning(msg, urec=nil)
+      @warning_count += 1
+      msg += "(#{get_uid(urec)})" if urec
+      @log.warn msg
+    end
+
+    def get_provider_name
+    end
+
+    def get_plans
+    end
+
+    def get_billing_acct_no(user)
+    end
+
+    def get_usage_time(billing_acct_no, urec, begin_time, end_time)
+      total_time = 0
+      if end_time > begin_time
+        total_time = (end_time - begin_time) / 3600 #hours
+      end
+      total_time
+    end
+
+    def sync_usage(session, user_usage_records, sync_time)
+    end
+
+    # Check UsageRecord and Usage collection consistency
+    def check_usage_consistency(session, srec)
+      usage = session[:usage].find(login: srec['login'], gear_id: srec['gear_id'],
+                                   usage_type: srec['usage_type'], begin_time: srec['time']).first
+      unless usage
+        print_warning "Record NOT found in Usage collection.", srec
+        usage = Usage.new
+        usage.login = srec['login']
+        usage.gear_id = srec['gear_id']
+        usage.usage_type = srec['usage_type']
+        usage.app_name = srec['app_name']
+        usage.begin_time = srec['time']
+        usage.gear_size = srec['gear_size']
+        usage.addtl_fs_gb = srec['addtl_fs_gb']
+        usage.cart_name = srec['cart_name']
+        usage.end_time = srec['end_time'] if srec['ended']
+        usage.save!
+      else srec['ended'] && usage['end_time'].nil?
+        print_warning "End time NOT set in Usage collection.", srec
+        session[:usage].find(_id: usage['_id']).update({"$set" => {end_time: srec['end_time']}})
+      end
+    end
+ 
+    # For ended usage records: delete from mongo
+    def delete_ended_urecs(session, srecs)
+      return if srecs.empty?
+      user_ids = []
+      srecs.each do |srec|
+        if srec['ended']
+          check_usage_consistency(session, srec)
+          user_ids << srec['_id']
+          user_ids << srec['end_id'] if srec['end_id']
+        end
+      end
+      # Deleting ended usage records
+      user_ids.uniq!
+      session[:usage_records].find({_id: {"$in" => user_ids}}).remove_all unless user_ids.empty?
+    end
+  end
+end

--- a/controller/lib/openshift/distributed_lock.rb
+++ b/controller/lib/openshift/distributed_lock.rb
@@ -1,0 +1,51 @@
+module OpenShift
+  # Represents a generic distributed lock object
+  # @!attribute [r] type
+  #   @return [String] Lock type/name, eg: sync_usage, billing_plan
+  # @!attribute [r] owner_id
+  #   @return [String] Lock owner, eg: node ip address 
+  # @!attribute [r] allow_multiple_access
+  #   @return [Boolean] allows owner to acquire same lock type multiple times
+  class DistributedLock
+    include Mongoid::Document
+    include Mongoid::Timestamps
+
+    field :type, type: String
+    field :owner_id, type: String
+    field :allow_multiple_access, type: Boolean, default: false
+
+    validates :type, presence: true
+    validates :owner_id, presence: true
+
+    index({:type => 1}, {:unique => true})
+    create_indexes
+
+    def self.obtain_lock(type, owner_id, allow_multiple_access=false)
+      Rails.logger.debug "obtain_distributed_lock, type: #{type}, owner_id: #{owner_id}"
+      filter = {:type => type}
+      if allow_multiple_access
+        filter["$or"] = [{:owner_id => owner_id}, {:owner_id => nil}, {:owner_id.exists => false}]
+      else
+        filter["$or"] = [{:owner_id => nil}, {:owner_id.exists => false}]
+      end
+      dlock_obj = nil
+      begin
+        dlock_obj = with(consistency: :strong).where(filter).find_and_modify({"$set" => {owner_id: owner_id, type: type}}, 
+                                                  {:upsert => true, :new => true})
+      rescue Moped::Errors::OperationFailure
+      end
+      if dlock_obj && dlock_obj.owner_id == owner_id
+        return true
+      else
+        return false
+      end
+    end
+
+    def self.release_lock(type, owner_id=nil)
+      Rails.logger.debug "release_distributed_lock, type: #{type}, owner_id: #{owner_id}"
+      filter = { "type" => type }
+      filter["owner_id"] = owner_id if owner_id
+      with(consistency: :strong).where(filter).destroy
+    end
+  end
+end

--- a/controller/lib/openshift/usage_audit_log.rb
+++ b/controller/lib/openshift/usage_audit_log.rb
@@ -1,0 +1,17 @@
+module OpenShift::UsageAuditLog
+
+  def self.is_enabled?
+    (logger ? true : false)
+  end
+
+  def self.log(message)
+    return unless logger
+    logger.info message
+  end
+
+  class << self
+    attr_writer :logger
+    private
+      attr_reader :logger
+  end
+end


### PR DESCRIPTION
Added index on 'login' for usage_record and usage mongoid models
Added separate usage audit log, /var/log/openshift/broker/usage.log instead of syslog.
Moved user action log from /var/log/openshift/user_action.log to /var/log/openshift/broker/user_action.log
Added Distributed lock used in oo-admin-ctl-usage script
Added Billing Service interface
Added oo-admin-ctl-usage script to list and sync usage records to billing vendor
Added oo-admin-ctl-usage to broker-util spec file
Fixed distributed lock test
Added billing service to origin-controller
Some more bug fixes
