### PR TITLE
Some updates to get the console working on CentOS

### DIFF
--- a/openshift-console/httpd/console-scl-ruby193.conf
+++ b/openshift-console/httpd/console-scl-ruby193.conf
@@ -12,6 +12,7 @@ RailsEnv production
 PassengerPreStart http://127.0.0.1:8118/console
 PassengerUseGlobalQueue off
 RackBaseURI /console
+PassengerRuby /var/www/openshift/broker/script/broker_ruby
 
 <Directory /var/www/html/console>
     Options -MultiViews

--- a/openshift-console/httpd/httpd.conf.apache-2.3
+++ b/openshift-console/httpd/httpd.conf.apache-2.3
@@ -85,13 +85,13 @@ DefaultType text/plain
 HostnameLookups Off
 #EnableMMAP off
 #EnableSendfile off
-ErrorLog logs/error_log
+ErrorLog /var/log/openshift/console/httpd/error_log
 LogLevel error
 LogFormat "%{X-Client-IP}i %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" combined
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
 LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
-CustomLog logs/access_log combined
+CustomLog /var/log/openshift/console/httpd/access_log combined
 ServerSignature On
 #BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 

--- a/openshift-console/httpd/httpd.conf.apache-2.4
+++ b/openshift-console/httpd/httpd.conf.apache-2.4
@@ -90,13 +90,13 @@ DefaultType text/plain
 HostnameLookups Off
 #EnableMMAP off
 #EnableSendfile off
-ErrorLog logs/error_log
+ErrorLog /var/log/openshift/console/httpd/error_log
 LogLevel error
 LogFormat "%{X-Forwarded-For}i %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" combined
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
 LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
-CustomLog logs/access_log combined
+CustomLog /var/log/openshift/console/httpd/access_log combined
 ServerSignature On
 # BZ840030 (addendum to BZ785050): Alias /icons/ "/var/www/icons/"
 

--- a/openshift-console/openshift-origin-console.spec
+++ b/openshift-console/openshift-origin-console.spec
@@ -93,7 +93,7 @@ rm %{buildroot}%{consoledir}/httpd/console-scl-ruby193.conf
 %endif
 %if 0%{?rhel}
 rm %{buildroot}%{consoledir}/httpd/console.conf
-mv %{buildroot}%{consoledir}/httpd/console-scl-ruby193.conf %{buildroot}%{consoledir}/httpd/conf/console.conf
+mv %{buildroot}%{consoledir}/httpd/console-scl-ruby193.conf %{buildroot}%{consoledir}/httpd/console.conf
 %endif
 
 %if 0%{?fedora} >= 18


### PR DESCRIPTION
- openshift-console httpd logs location (logs to /var/log/openshift/console/httpd)
- add the line ruby passenger in console.conf (to avoid a error about the libruby 1.9.3 which was not found)
- rpms on centos put the console.conf in the wrong place (httpd/conf instead of httpd/)
