### PR TITLE
Add option to select gear profile when creating a cartridge

### DIFF
--- a/controller/app/controllers/emb_cart_controller.rb
+++ b/controller/app/controllers/emb_cart_controller.rb
@@ -70,6 +70,7 @@ class EmbCartController < BaseController
     scales_from = Integer(params[:scales_from]) rescue nil
     scales_to = Integer(params[:scales_to]) rescue nil
     additional_storage = Integer(params[:additional_storage]) rescue nil
+    gear_profile = params[:gear_profile] rescue nil
 
     begin
       domain = Domain.find_by(owner: @cloud_user, canonical_namespace: domain_id.downcase)
@@ -126,11 +127,12 @@ class EmbCartController < BaseController
       unless colocate_component_instance.nil?
         group_overrides << {"components" => [colocate_component_instance.to_hash, comp_spec]}
       end
-      if !scales_to.nil? or !scales_from.nil? or !additional_storage.nil?
+      if !scales_to.nil? or !scales_from.nil? or !additional_storage.nil? or !gear_profile.nil?
         group_override = {"components" => [comp_spec]}
         group_override["min_gears"] = scales_from unless scales_from.nil?
         group_override["max_gears"] = scales_to unless scales_to.nil?
         group_override["additional_filesystem_gb"] = additional_storage unless additional_storage.nil?
+        group_override["gear_size"] = gear_profile unless gear_profile.nil?
         group_overrides << group_override
       end
 

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1075,7 +1075,9 @@ class Application
     connections, new_group_instances, cleaned_group_overrides = elaborate(features, group_overrides)
     current_group_instance = self.group_instances.map { |gi| gi.to_hash }
     changes, moves = compute_diffs(current_group_instance, new_group_instances)
-    
+    if moves.size > 0
+      raise OpenShift::UserException.new("Requested operation is not supported")
+    end
     calculate_ops(changes, moves, connections, cleaned_group_overrides,init_git_url)
   end
 
@@ -1692,6 +1694,7 @@ class Application
       
       cleaned_override["min_gears"] = group_override["min_gears"] if group_override.has_key?("min_gears")
       cleaned_override["max_gears"] = group_override["max_gears"] if group_override.has_key?("max_gears")
+      cleaned_override["gear_size"] = group_override["gear_size"] if group_override.has_key?("gear_size")      
       cleaned_override["additional_filesystem_gb"] = group_override["additional_filesystem_gb"] if group_override.has_key?("additional_filesystem_gb")
       cleaned_overrides << cleaned_override if group_override["components"] and group_override["components"].count > 0
     end


### PR DESCRIPTION
Fix bug where gear profile was not being added to group overrides

Adds a new API option:

```
  curl -u <user>:<pass> -X POST https://<broker host>/broker/rest/domains/localns/applications/testphp/cartridges.xml -dcartridge=mysql -dgear_profile=medium
```
