### PR TITLE
Bug 916026 - Removing hardcoded library version references from jenkins ...

### DIFF
--- a/cartridges/openshift-origin-cartridge-jenkins-1.4/info/hooks/configure
+++ b/cartridges/openshift-origin-cartridge-jenkins-1.4/info/hooks/configure
@@ -44,7 +44,10 @@ function create_repo {
 
 function obfuscate_password {
     password="$1"
-    java -classpath "${APP_HOME}/app-root/data/war/WEB-INF/lib/acegi-security-1.0.5.jar:${APP_HOME}/app-root/data/war/WEB-INF/lib/acegi-security-1.0.7.jar:${APP_HOME}/app-root/data/war/WEB-INF/lib/commons-codec-1.6.jar:${APP_HOME}/app-root/data/war/WEB-INF/lib/commons-codec-1.4.jar:${CARTRIDGE_BASE_PATH}/jenkins-1.4/info/lib/password-encoder.jar" com.redhat.openshift.PasswordEncoder $password
+    acegi_security_path=`find ${APP_HOME}/app-root/data/war/WEB-INF/lib/ -name acegi-security-*.jar`
+    commons_codec_path=`find ${APP_HOME}/app-root/data/war/WEB-INF/lib/ -name commons-codec-*.jar`
+
+    java -classpath "${acegi_security_path}:${commons_codec_path}:${CARTRIDGE_BASE_PATH}/jenkins-1.4/info/lib/password-encoder.jar" com.redhat.openshift.PasswordEncoder $password
 }
 
 function generate_ssh_keys {


### PR DESCRIPTION
...password encoder classpath

Conflicts:

```
cartridges/openshift-origin-cartridge-jenkins-1.4/info/hooks/configure
```
