### PR TITLE
Bug 915527 - Session capabilities not cleared when domain/app changed

### DIFF
--- a/console/app/controllers/domain_session_sweeper.rb
+++ b/console/app/controllers/domain_session_sweeper.rb
@@ -6,7 +6,10 @@ class DomainSessionSweeper < ActiveModel::Observer
     true
   end
   def self.after(controller)
-    controller.session[:domain] = nil if self.domain_changes?
+    if self.domain_changes?
+      controller.session[:domain] = nil
+      Rails.logger.debug "Session domain is reset"
+    end
   end
 
   def self.domain_changes?

--- a/console/app/controllers/user_session_sweeper.rb
+++ b/console/app/controllers/user_session_sweeper.rb
@@ -6,7 +6,10 @@ class UserSessionSweeper < ActiveModel::Observer
     true
   end
   def self.after(controller)
-    controller.session[:user_capabilities] = nil if self.user_changes?
+    if self.user_changes?
+      controller.session[:caps] = nil
+      Rails.logger.debug "Session capabilities are reset"
+    end
   end
 
   def self.user_changes?

--- a/console/test/functional/applications_controller_test.rb
+++ b/console/test/functional/applications_controller_test.rb
@@ -264,6 +264,15 @@ class ApplicationsControllerTest < ActionController::TestCase
     assert_template :delete
   end
 
+  test 'application destroy should clear session and succeed' do
+    with_domain
+    app = Application.create(:name => 'delete1', :cartridge => 'php-5.3', :domain => @domain)
+    assert app.persisted?
+    delete :destroy, {:id => app.name}, user_to_session(@user, :caps => [3])
+    assert_redirected_to applications_path
+    assert_nil session[:caps]
+  end
+
   test 'should support the creation of scalable apps with medium gears for privileged users' do
     with_user_with_multiple_gear_sizes
     find_or_create_domain


### PR DESCRIPTION
The session sweeper that clears capabilities was broken when we improved the
capabilities support last sprint.  It was still trying to delete the old name,
so the session cache wasn't cleared.

[merge]
