### PR TITLE
Bug 916388: Fix JBoss tidy scripts

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas-7/info/hooks/tidy
+++ b/cartridges/openshift-origin-cartridge-jbossas-7/info/hooks/tidy
@@ -9,7 +9,7 @@ done
 source "/etc/openshift/node.conf"
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
-JBOSS_DIR="$OPENSHIFT_HOMEDIR/jbossews-2.0/jbossews-2.0"
+JBOSS_DIR="$OPENSHIFT_HOMEDIR/jbossas-7/jbossas-7"
 
 # Clean up logs
 for logdir in `awk 'BEGIN {

--- a/cartridges/openshift-origin-cartridge-jbossas-7/openshift-origin-cartridge-jbossas-7.spec
+++ b/cartridges/openshift-origin-cartridge-jbossas-7/openshift-origin-cartridge-jbossas-7.spec
@@ -65,7 +65,6 @@ ln -s %{cartridgedir}/../abstract/info/hooks/update-namespace %{buildroot}%{cart
 ln -s %{cartridgedir}/../abstract/info/hooks/deploy-httpd-proxy %{buildroot}%{cartridgedir}/info/hooks/deploy-httpd-proxy
 ln -s %{cartridgedir}/../abstract/info/hooks/remove-httpd-proxy %{buildroot}%{cartridgedir}/info/hooks/remove-httpd-proxy
 ln -s %{cartridgedir}/../abstract/info/hooks/status %{buildroot}%{cartridgedir}/info/hooks/status
-ln -s %{cartridgedir}/../abstract/info/hooks/tidy %{buildroot}%{cartridgedir}/info/hooks/tidy
 ln -s %{cartridgedir}/../abstract/info/hooks/move %{buildroot}%{cartridgedir}/info/hooks/move
 ln -s %{cartridgedir}/../abstract/info/hooks/system-messages %{buildroot}%{cartridgedir}/info/hooks/system-messages
 ln -s %{cartridgedir}/../abstract/info/connection-hooks/publish-gear-endpoint %{buildroot}%{cartridgedir}/info/connection-hooks/publish-gear-endpoint

--- a/cartridges/openshift-origin-cartridge-jbosseap-6.0/info/hooks/tidy
+++ b/cartridges/openshift-origin-cartridge-jbosseap-6.0/info/hooks/tidy
@@ -9,7 +9,7 @@ done
 source "/etc/openshift/node.conf"
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
-JBOSS_DIR="$OPENSHIFT_HOMEDIR/jbossews-2.0/jbossews-2.0"
+JBOSS_DIR="$OPENSHIFT_HOMEDIR/jbosseap-6.0/jbosseap-6.0"
 
 # Clean up logs
 for logdir in `awk 'BEGIN {

--- a/cartridges/openshift-origin-cartridge-jbosseap-6.0/openshift-origin-cartridge-jbosseap-6.0.spec
+++ b/cartridges/openshift-origin-cartridge-jbosseap-6.0/openshift-origin-cartridge-jbosseap-6.0.spec
@@ -75,7 +75,6 @@ ln -s %{cartridgedir}/../abstract/info/hooks/update-namespace %{buildroot}%{cart
 ln -s %{cartridgedir}/../abstract/info/hooks/deploy-httpd-proxy %{buildroot}%{cartridgedir}/info/hooks/deploy-httpd-proxy
 ln -s %{cartridgedir}/../abstract/info/hooks/remove-httpd-proxy %{buildroot}%{cartridgedir}/info/hooks/remove-httpd-proxy
 ln -s %{cartridgedir}/../abstract/info/hooks/status %{buildroot}%{cartridgedir}/info/hooks/status
-ln -s %{cartridgedir}/../abstract/info/hooks/tidy %{buildroot}%{cartridgedir}/info/hooks/tidy
 ln -s %{cartridgedir}/../abstract/info/hooks/move %{buildroot}%{cartridgedir}/info/hooks/move
 ln -s %{cartridgedir}/../abstract/info/hooks/system-messages %{buildroot}%{cartridgedir}/info/hooks/system-messages
 ln -s %{cartridgedir}/../abstract/info/connection-hooks/publish-gear-endpoint %{buildroot}%{cartridgedir}/info/connection-hooks/publish-gear-endpoint

--- a/cartridges/openshift-origin-cartridge-jbossews-1.0/info/hooks/tidy
+++ b/cartridges/openshift-origin-cartridge-jbossews-1.0/info/hooks/tidy
@@ -9,7 +9,7 @@ done
 source "/etc/openshift/node.conf"
 source ${CARTRIDGE_BASE_PATH}/abstract/info/lib/util
 
-JBOSS_DIR="$OPENSHIFT_HOMEDIR/jbossews-2.0/jbossews-2.0"
+JBOSS_DIR="$OPENSHIFT_HOMEDIR/jbossews-1.0/jbossews-1.0"
 
 # Clean up logs
 for logdir in `awk 'BEGIN {

--- a/cartridges/openshift-origin-cartridge-jbossews-1.0/openshift-origin-cartridge-jbossews-1.0.spec
+++ b/cartridges/openshift-origin-cartridge-jbossews-1.0/openshift-origin-cartridge-jbossews-1.0.spec
@@ -63,7 +63,6 @@ ln -s %{cartridgedir}/../abstract/info/hooks/update-namespace %{buildroot}%{cart
 ln -s %{cartridgedir}/../abstract/info/hooks/deploy-httpd-proxy %{buildroot}%{cartridgedir}/info/hooks/deploy-httpd-proxy
 ln -s %{cartridgedir}/../abstract/info/hooks/remove-httpd-proxy %{buildroot}%{cartridgedir}/info/hooks/remove-httpd-proxy
 ln -s %{cartridgedir}/../abstract/info/hooks/status %{buildroot}%{cartridgedir}/info/hooks/status
-ln -s %{cartridgedir}/../abstract/info/hooks/tidy %{buildroot}%{cartridgedir}/info/hooks/tidy
 ln -s %{cartridgedir}/../abstract/info/hooks/move %{buildroot}%{cartridgedir}/info/hooks/move
 ln -s %{cartridgedir}/../abstract/info/hooks/system-messages %{buildroot}%{cartridgedir}/info/hooks/system-messages
 ln -s %{cartridgedir}/../abstract/info/connection-hooks/publish-gear-endpoint %{buildroot}%{cartridgedir}/info/connection-hooks/publish-gear-endpoint


### PR DESCRIPTION
Correct the JBoss tidy scripts to properly clean the JBoss temp directory.
