### PR TITLE
Bug 916917 - uninitialized constant ApplicationState

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -136,7 +136,7 @@ module OpenShift
     #
     # TODO: exception handling
     def force_stop
-      @state.value = ApplicationState::State::STOPPED
+      @state.value = OpenShift::State::STOPPED
       UnixUser.kill_procs(@user.uid)
     end
 

--- a/node/test/unit/application_container_test.rb
+++ b/node/test/unit/application_container_test.rb
@@ -24,6 +24,7 @@ end
 require 'test_helper'
 require 'openshift-origin-node/model/application_container'
 require 'openshift-origin-node/model/v2_cart_model'
+require 'openshift-origin-node/model/unix_user'
 require 'openshift-origin-node/utils/environ'
 require 'openshift-origin-common'
 require 'test/unit'
@@ -176,5 +177,11 @@ class ApplicationContainerTest < Test::Unit::TestCase
     @container.expects(:start_gear)
 
     @container.tidy
+  end
+
+  def test_force_stop
+    FileUtils.mkpath("/tmp/#@user_uid/app-root/runtime")
+    OpenShift::UnixUser.stubs(:kill_procs).with(@user_uid).returns(nil)
+    @container.force_stop
   end
 end


### PR DESCRIPTION
- Wrong module used to address constant.
- Missing test coverage added
