### PR TITLE
Fix broken user guide link

### DIFF
--- a/console/app/helpers/console/help_helper.rb
+++ b/console/app/helpers/console/help_helper.rb
@@ -23,7 +23,7 @@ module Console::HelpHelper
   end
 
   def add_domains_user_guide_topic_url
-    user_guide_topic_url 'sect-OpenShift-User_Guide-Working_With_Domains.html'
+    user_guide_topic_url 'sect-OpenShift-User_Guide-Working_With_Namespaces.html'
   end
 
   def cartridge_list_url

--- a/console/app/views/account/_domains.html.haml
+++ b/console/app/views/account/_domains.html.haml
@@ -1,7 +1,7 @@
 %h2 Namespace
 %p
-  See #{link_to 'the User Guide', add_domains_user_guide_topic_url} for 
-  information about adding your own domain names to an application.
+  See the #{link_to 'User Guide', add_domains_user_guide_topic_url, :class => 'external'}
+  for information about adding your own domain names to an application.
 
 .well
   http://applicationname&ndash;<strong class="namespace">#{@domain.name}</strong>.#{RestApi.application_domain_suffix}


### PR DESCRIPTION
Bug 912194 - The "the User Guide" link on my account page is broken
