### PR TITLE
Update code for default server.js so no warning are displayed

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs-0.6/template/server.js
+++ b/cartridges/openshift-origin-cartridge-nodejs-0.6/template/server.js
@@ -118,7 +118,7 @@ var SampleApp = function() {
      */
     self.initializeServer = function() {
         self.createRoutes();
-        self.app = express.createServer();
+        self.app = express();
 
         //  Add handlers for the app (from the routes).
         for (var r in self.routes) {


### PR DESCRIPTION
When running with a newest express module, this
message is shown :

  Warning: express.createServer() is deprecated, express
  applications no longer inherit from http.Server,
  please use:

```
var express = require("express");
var app = express();
```
