### PR TITLE
Bug 916958, Bug 917513 - V1 Model not honoring Broker contract

### DIFF
--- a/node/lib/openshift-origin-node/model/v1_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v1_cart_model.rb
@@ -144,7 +144,7 @@ module OpenShift
 
       if exitcode != 0
         raise OpenShift::Utils::ShellExecutionException.new(
-          "Control action '#{action}' returned an error. rc=#{exitcode}", exitcode, output)
+          "Control action '#{action}' returned an error. rc=#{exitcode}\n#{output}", exitcode, output)
       end
 
       output


### PR DESCRIPTION
- All cartridge stdout messages where not propagated to the Broker when cartridge returned non-zero exit status
