### PR TITLE
Gemfile.lock ownership fixes

### DIFF
--- a/broker/init.d/openshift-broker
+++ b/broker/init.d/openshift-broker
@@ -43,6 +43,7 @@ start() {
         pushd $osdir > /dev/null
           rm -rf Gemfile.lock
           scl enable ruby193 "bundle install --local > /dev/null"
+          chown apache:apache Gemfile.lock
           RETVAL=$?
         popd > /dev/null
         if [ $RETVAL != 0 ]; then

--- a/openshift-console/init.d/openshift-console
+++ b/openshift-console/init.d/openshift-console
@@ -42,6 +42,7 @@ start() {
         pushd /var/www/openshift/console
           rm -rf Gemfile.lock
           scl enable ruby193 "bundle install --local" > /dev/null
+          chown apache:apache Gemfile.lock
         popd > /dev/null
         echo -n $"Starting $prog: "
         LANG=$HTTPD_LANG daemon --pidfile=${pidfile} $httpd $OPTIONS


### PR DESCRIPTION
A user on #openshift-dev somehow got into a state where Gemfile.lock had a mode
of 640.  Previously it was owned by root.  It's probably more correct to change
the ownership since the intent is that Apache should _always_ be able to read
that file.
