### PR TITLE
Bug 916559 - Existing broker keys broken after stage upgrade

### DIFF
--- a/broker/test/unit/broker_auth_test.rb
+++ b/broker/test/unit/broker_auth_test.rb
@@ -24,7 +24,7 @@ class BrokerAuthTest < Test::Unit::TestCase
     t = Time.new
 
     user.expects(:domains).returns(domains)
-    user.expects(:id).returns('1')
+    user.expects(:login).returns('1')
 
     domain.expects(:owner).returns(user)
 
@@ -34,7 +34,7 @@ class BrokerAuthTest < Test::Unit::TestCase
     app.expects(:domain).returns(domain)
     app.expects(:created_at).at_least_once.returns(t)
 
-    CloudUser.expects(:find).at_least_once.returns(user)
+    CloudUser.expects(:find_by_identity).at_least_once.returns(user)
     domain.expects(:applications).at_least_once.returns([app])
 
     iv,token = svc.generate_broker_key(app)

--- a/controller/lib/openshift/auth/broker_key.rb
+++ b/controller/lib/openshift/auth/broker_key.rb
@@ -31,7 +31,7 @@ module OpenShift
         cipher.key = cipher_key
         cipher.iv = iv = cipher.random_iv
         token = {:app_name => app.name,
-                 token_login_key => app.domain.owner.id,
+                 token_login_key => app.domain.owner.login,
                  :creation_time => app.created_at}
         encrypted_token = cipher.update(token.to_json)
         encrypted_token << cipher.final
@@ -61,14 +61,14 @@ module OpenShift
         end
 
         token = JSON.parse(json_token)
-        user_id = token[token_login_key.to_s]
+        user_login = token[token_login_key.to_s]
         app_name = token['app_name']           #FIXME should be app id
         creation_time = token['creation_time']
 
         user = begin
-                 CloudUser.find(user_id)
+                 CloudUser.find_by_identity(nil, user_login)
                rescue Mongoid::Errors::DocumentNotFound
-                 raise OpenShift::AccessDeniedException, "No such user exists #{user_id}"
+                 raise OpenShift::AccessDeniedException, "No such user exists with login #{user_login}"
                end
         app = Application.find(user, app_name) #FIXME should be app id
 


### PR DESCRIPTION
Broker keys used to store login.  Code in sprint24 changed it to use user
UUID.  This broke existing broker keys.  Reverting back to original behavior
and will update in the future (for identity support where login is !=
unique/present)
