### PR TITLE
pam_openshift build requires gcc

### DIFF
--- a/pam_openshift/pam_openshift.spec
+++ b/pam_openshift/pam_openshift.spec
@@ -7,6 +7,7 @@ License:       GPLv2
 URL:           http://www.openshift.com/
 Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 Requires:      policycoreutils
+BuildRequires: gcc
 BuildRequires: pam-devel
 BuildRequires: libselinux-devel
 BuildRequires: libattr-devel


### PR DESCRIPTION
Searching the Git repo using BuildRequires for package build requirements does not find 'gcc'.

Gcc is required to build the pam_openshift package.
