### PR TITLE
Bug 909060 - Corrected forms to use proper semantic_errors

### DIFF
--- a/console/app/views/authorizations/edit.html.haml
+++ b/console/app/views/authorizations/edit.html.haml
@@ -4,7 +4,7 @@
 = flashes
 
 = semantic_form_for @authorization, :html => {:class => 'form'} do |f|
-  = f.semantic_errors
+  = f.semantic_errors :except => :note
   = f.inputs do
 
     %section

--- a/console/app/views/authorizations/new.html.haml
+++ b/console/app/views/authorizations/new.html.haml
@@ -4,7 +4,7 @@
 = flashes
 
 = semantic_form_for @authorization, :html => {:class => 'form'} do |f|
-  = f.semantic_errors :except => :scope
+  = f.semantic_errors :except => :note
   = f.inputs do
 
     .control-group{:class => @authorization.errors[:scope].present? ? 'error' : ''}

--- a/console/app/views/cartridge_types/show.html.haml
+++ b/console/app/views/cartridge_types/show.html.haml
@@ -8,7 +8,7 @@
 
 = semantic_form_for @cartridge, :url => application_cartridges_path(@application), :html => {:class => 'form'} do |f|
   = f.hidden_field :name, :value => @cartridge_type.name
-  = f.semantic_errors :name, :cartridge
+  = f.semantic_errors :except => [:name, :cartridge]
   %p
     Do you want to add the
     %strong

--- a/console/app/views/domains/_form.html.haml
+++ b/console/app/views/domains/_form.html.haml
@@ -1,12 +1,12 @@
 = semantic_form_for domain, :url => domain_path, :simple => true do |f|
-  = f.semantic_errors :name
+  = f.semantic_errors :alias => {:name => :id}, :except => :name
   .control-group.control-group-important{:class => domain.errors[:name].present? || domain.errors[:namespace].present? ? 'error' : '', :id => "domain_name_group", :data => domain.errors[:name].present? || domain.errors[:namespace].present? ? {:"server-error" => 'server-error'} : {}}
     .controls.first
       .input-prepend.input-append.wrap
         %span.add-on> http://applicationname&ndash;
         = f.text_field :name, :autofocus => true, :placeholder => 'Namespace', :class => 'domain_name'
         %span.add-on>= ".#{RestApi.application_domain_suffix}"
-      .help-block Your namespace must be letters or numbers with no spaces or symbols.
+      = f.semantic_errors :name, :alias => {:name => :id}, :class => [:unstyled, :errors, 'help-block']
   = f.buttons do
     = link_to "Cancel", account_path, :class => 'btn'
     = f.commit_button :label => domain.persisted? ? 'Save' : 'Create'

--- a/console/app/views/keys/_form.html.haml
+++ b/console/app/views/keys/_form.html.haml
@@ -1,12 +1,12 @@
 - input_html = defined?(input_class) ? { :class => input_class } : {}
 
 = semantic_form_for key, :html => {:class => 'form-horizontal'} do |f|
-  = f.semantic_errors
+  = f.semantic_errors :except => [:name, :raw_content, :content, :type]
   = f.inputs do
     = f.input :name, :label => 'Key name', :input_html => {:placeholder => 'A name for your key'}
-    = f.input :raw_content, 
-              :as => :text, 
-              :label => 'Paste the contents of your public key file', 
+    = f.input :raw_content,
+              :as => :text,
+              :label => 'Paste the contents of your public key file',
               :input_html => input_html.merge({:placeholder => 'The contents of your public key file', :title => "Your SSH key will start with a short prefix that describes its type, followed by a long string of numbers and characters.  Some keys have a bit of text at the end to describe who generated the key. Example:\n\nssh-rsa AAAAB3NzaC1yc....HcLJ bob@smith"})
   = f.buttons do
     = link_to "Cancel", account_path, :class => 'btn'

--- a/console/app/views/keys/_simple_form.html.haml
+++ b/console/app/views/keys/_simple_form.html.haml
@@ -1,7 +1,7 @@
 - input_html = { :class => input_class } if defined? input_class
 
 = semantic_form_for key, :simple => true do |f|
-  = f.semantic_errors
+  = f.semantic_errors :except => [:name, :raw_content, :content, :type]
   = f.inputs do
     = f.hidden_field :name, :value => 'default'
     = f.hidden_field :first, :name => 'first', :value => true

--- a/console/app/views/scaling/show.html.haml
+++ b/console/app/views/scaling/show.html.haml
@@ -17,7 +17,7 @@
                             :method => :put,
                             :url => application_scaling_cartridge_path(@application.id, cartridge.name) do |f|
 
-          = f.semantic_errors :scales_from, :scales_to
+          = f.semantic_errors :except => [:scales_to, :scales_from]
 
           - if cartridge.tags.include?(:web_framework)
             %p
@@ -43,6 +43,10 @@
             = f.commit_button :label => 'Save', :button_html => {:class => 'btn btn-small'}
             = f.loading
 
+            -# Scaling errors are currently reported to base, but if they get reported here, this will work
+            - if [cartridge.errors[:scales_from], cartridge.errors[:scales_to]].flatten.compact.present?
+              .control-group.control-group-important.error.help-block
+                = f.semantic_errors :scales_from, :scales_to, :class => [:unstyled, :errors, 'help-block']
 
         - if cartridge.tags.include?(:web_framework)
 

--- a/console/app/views/storage/show.html.haml
+++ b/console/app/views/storage/show.html.haml
@@ -56,8 +56,9 @@
                             :method => :put,
                             :url => application_storage_cartridge_path(@application.id, cartridge.name) do |f|
 
-          = f.semantic_errors :additional_gear_storage
-          = f.inputs :inline => true, :without_errors => true do
+          -# Currently storage errors are reported in :base, but this will properly handle :additional_gear_storage errors
+          = f.semantic_errors :except => :additional_gear_storage
+          = f.inputs :inline => true do
             .input-prepend
               %span.add-on Additional Storage Per Gear
               :ruby

--- a/console/test/functional/scaling_controller_test.rb
+++ b/console/test/functional/scaling_controller_test.rb
@@ -101,14 +101,14 @@ class ScalingControllerTest < ActionController::TestCase
   test 'rejects unlimited scales_from' do
     put :update, {:cartridge => {:scales_from => -1, :scales_to => 2}}.merge(scalable_app_params)
     assert_response :success
-    assert_select 'ul.alert-error > li', "Invalid scales_from factor -1 provided"
+    assert_select 'ul.errors.help-block > li', "Invalid scales_from factor -1 provided"
   end
 
   test 'rejects out of range scales_from' do
     if scalable_cartridge.supported_scales_from > 0
       put :update, {:cartridge => {:scales_from => 0, :scales_to => 2}}.merge(scalable_app_params)
       assert_response :success
-      assert_select 'ul.alert-error > li', "Invalid scales_from factor 0 provided"
+      assert_select 'ul.errors.help-block > li', "Invalid scales_from factor 0 provided"
     else
       fail 'Test case needs to be updated, a cart can be scaled to 0 now'
     end
@@ -118,7 +118,7 @@ class ScalingControllerTest < ActionController::TestCase
     put :update, {:cartridge => {:scales_from => 2, :scales_to => -2}}.merge(scalable_app_params)
     assert_response :success
     # scaling_controller flips the values so scales_from < scales_to so the error shows up with scales from
-    assert_select 'ul.alert-error > li', "Invalid scales_from factor -2 provided"
+    assert_select 'ul.errors.help-block > li', "Invalid scales_from factor -2 provided"
   end
 
   [true, false].each do |mock|


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=909060

`semantic_errors` was pulling all errors into the `full_errors` array.
When using `semantic_errors`, provide `:except => [<inputs>]` to indicate which inputs are being handled in the form/inline.
All other errors will show up at the top as a "flash".
