### PR TITLE
Modify cucumber test cases so that the retry login in origin-dev-tools does not run Fedora tests on RHEL.

### DIFF
--- a/controller/test/cucumber/cartridge-10gen-mms-agent.feature
+++ b/controller/test/cucumber/cartridge-10gen-mms-agent.feature
@@ -4,37 +4,10 @@
 @not-enterprise
 Feature: 10gen-mms-agent Embedded Cartridge
 
-  Scenario Outline: Add Remove 10gen-mms-agent to one application
-    Given a new <perl_version> type application
-    And I embed a mongodb-2.2 cartridge into the application
-    And an agent settings.py file is created
-    And I embed a 10gen-mms-agent-0.1 cartridge into the application
-
-    Then 1 process named python will be running
-    And the embedded 10gen-mms-agent-0.1 cartridge subdirectory named mms-agent will exist
-    And the embedded 10gen-mms-agent-0.1 cartridge log files will exist
-    And the embedded 10gen-mms-agent-0.1 cartridge control script will not exist
-
-    When I stop the 10gen-mms-agent-0.1 cartridge
-    Then 0 processes named python will be running
-
-    When I start the 10gen-mms-agent-0.1 cartridge
-    Then 1 processes named python will be running
-
-    When I restart the 10gen-mms-agent-0.1 cartridge
-    Then 1 processes named python will be running
-
-    When I destroy the application
-    Then 0 processes named python will be running
-    And the embedded 10gen-mms-agent-0.1 cartridge subdirectory named mms-agent will not exist
-    And the embedded 10gen-mms-agent-0.1 cartridge log files will not exist
-
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | perl_version |
-      | perl-5.10    |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | perl_version |
-      | perl-5.16    |
+  @rhel-only
+  Scenario: 10gen-mms-agent Embedded Cartridge (RHEL/CentOS)
+    Given a perl-5.10 application, verify addition and removal of 10gen-mms-agent
+    
+  @fedora-only
+  Scenario: 10gen-mms-agent Embedded Cartridge (Fedora)
+    Given a perl-5.16 application, verify addition and removal of 10gen-mms-agent

--- a/controller/test/cucumber/cartridge-cron.feature
+++ b/controller/test/cucumber/cartridge-cron.feature
@@ -3,41 +3,10 @@
 @runtime1
 Feature: cron Embedded Cartridge
 
-  Scenario Outline: Add Remove cron to one application
-    # Change back the perl-5.10 when refactor is done
-    Given a new <php_version> type application
-    And I embed a cron-1.4 cartridge into the application
-    And cron is running
-
-    Then the embedded cron-1.4 cartridge directory will exist
-    And the embedded cron-1.4 cartridge subdirectory named log will exist
-    And the embedded cron-1.4 cartridge subdirectory named run will exist
-    And cron jobs will be enabled
-
-    When I stop the cron-1.4 cartridge
-    Then cron jobs will not be enabled
-    And cron is stopped
-
-    When I start the cron-1.4 cartridge
-    Then cron jobs will be enabled
-    And cron is running
-
-    When I restart the cron-1.4 cartridge
-    Then cron jobs will be enabled
-
-    When I destroy the application
-    Then cron is stopped
-    And the embedded cron-1.4 cartridge directory will not exist
-    And the embedded cron-1.4 cartridge subdirectory named log will not exist
-    And the embedded cron-1.4 cartridge control script will not exist
-    And the embedded cron-1.4 cartridge subdirectory named run will not exist
-
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
+  @rhel-only
+  Scenario: Add Remove cron to one application (RHEL/CentOS)
+    Given a php-5.3 application, verify addition and removal of cron
+  
+  @fedora-only
+  Scenario: Add Remove cron to one application (Fedora)
+    Given a php-5.4 application, verify addition and removal of cron

--- a/controller/test/cucumber/cartridge-haproxy.feature
+++ b/controller/test/cucumber/cartridge-haproxy.feature
@@ -2,44 +2,40 @@
 @runtime
 @runtime3
 Feature: HAProxy Application Sub-Cartridge
-  
-  Scenario Outline: Create Delete one application with haproxy
-    Given a new <type> type application
-    Then a <proc_name> process will be running
+  @rhel-only
+  Scenario Outline: Create Delete Application With haproxy Scenarios (RHEL/CentOS)
+    Given a new <cart_name> application, verify haproxy-1.4 using httpd process
     
-    When I embed a haproxy-1.4 cartridge into the application
-    Then 0 process named haproxy will be running
-    And the embedded haproxy-1.4 cartridge directory will exist
-    And the haproxy configuration file will exist
-    And the haproxy PATH override will exist
+    Scenario: RHEL compatible cartridges
+      | cart_name  |
+      | ruby-1.8   |
+      | php-5.3    |
+      | perl-5.10  |
+      | python-2.6 |
+      | ruby-1.8   |
+    
+  @jboss
+  Scenario Outline: Create Delete Application With haproxy Scenarios (JBoss)
+    Given a new <cart_name> application, verify haproxy-1.4 using java process
+    
+    Scenario: JBoss based cartridges
+      | cart_name    |
+      | jbossas-7    |
+      | jbosseap-6.0 |
+    
+  @fedora-only
+  Scenario Outline: Create Delete Application With haproxy Scenarios (Fedora)
+    Given a new <cart_name> application, verify haproxy-1.4 using httpd process
+    
+    Scenario: Fedora compatible cartridges
+      | cart_name  |
+      | php-5.4    |
+      | perl-5.16  |
 
-    When I destroy the application
-    Then 0 processes named haproxy will be running
-    And a <proc_name> process will not be running
-    And the embedded haproxy-1.4 cartridge directory will not exist
-    And the haproxy configuration file will not exist
-
-    @rhel-only
-    Scenarios: Create Delete Application With haproxy Scenarios - RHEL
-      | type         | proc_name |
-      | ruby-1.8     | httpd     |
-      | php-5.3      | httpd     |
-      | perl-5.10    | httpd     |
-      | python-2.6   | httpd     |
-
-    @jboss
-    Scenarios: Create Delete Application With haproxy Scenarios - Fedora 18
-      | type         | proc_name |
-      | jbossas-7    | java      |
-      | jbosseap-6.0 | java      |
-
-    @fedora-only
-    Scenarios: Create Delete Application With haproxy Scenarios - Fedora 18
-      | type         | proc_name |
-      | php-5.4      | httpd     |
-      | perl-5.16    | httpd     |
-
-    Scenarios: Create Delete Application With haproxy Scenarios - Common
-      | type         | proc_name |
-      | ruby-1.9     | httpd     |
-      | nodejs-0.6   | node      |
+  Scenario Outline: Create Delete Application With haproxy Scenarios (Common)
+    Given a new <cart_name> application, verify haproxy-1.4 using httpd process
+    
+    Scenario: Common cartridges
+      | cart_name  |
+      | nodejs-0.6 |
+      | ruby-1.9   |

--- a/controller/test/cucumber/cartridge-jenkins-client.feature
+++ b/controller/test/cucumber/cartridge-jenkins-client.feature
@@ -3,19 +3,10 @@
 @runtime1
 @jenkins
 Feature: Jenkins Client Embedded Cartridge
-
-  # See cartridge-jenkins-build for the success Scenario
-  Scenario Outline: Add Jenkins Client to one application without Jenkins server available
-    Given a new <perl_version> type application
-    When I fail to embed a jenkins-client-1.4 cartridge into the application
-    Then the embedded jenkins-client-1.4 cartridge directory will not exist
-
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | perl_version |
-      | perl-5.10    |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | perl_version |
-      | perl-5.16    |
+  @rhel-only
+  Scenario: Add Jenkins Client to one application without Jenkins server available (RHEL/CentOS)
+    Given a perl-5.10 application, verify that you cannot add jenkins client without server being available
+    
+  @fedora-only
+  Scenario: Add Jenkins Client to one application without Jenkins server available (Fedora)
+    Given a perl-5.16 application, verify that you cannot add jenkins client without server being available

--- a/controller/test/cucumber/cartridge-lifecycle-perl.feature
+++ b/controller/test/cucumber/cartridge-lifecycle-perl.feature
@@ -2,64 +2,36 @@
 @runtime_extended3
 @runtime_extended_other3
 Feature: Cartridge Lifecycle Perl Verification Tests
-  Scenario Outline: Application Creation
-    Given the libra client tools
-    And an accepted node
-    When 1 <perl_version> applications are created
-    Then the applications should be accessible
-
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | perl_version |
-      | perl-5.10    |
+  @rhel-only
+  Scenario: Application Creation (RHEL/CentOS)
+    Given a new perl-5.10 application, verify its availability
+  
+  @rhel-only
+  Scenario: Application Modification (RHEL/CentOS)
+    Given an existing perl-5.10 application, verify code updates
+  
+  @rhel-only
+  Scenario: Application Restarting  (RHEL/CentOS)
+    Given an existing perl-5.10 application, verify it can be restarted
     
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | perl_version |
-      | perl-5.16    |
-
-  Scenario Outline: Application Modification
-    Given an existing <perl_version> application
-    When the application is changed
-    Then it should be updated successfully
-    And the application should be accessible
-
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | perl_version |
-      | perl-5.10    |
+  @rhel-only
+  Scenario: Application Destroying  (RHEL/CentOS)
+    Given an existing perl-5.10 application, verify it can be destroyed  
     
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | perl_version |
-      | perl-5.16    |
-
-  Scenario Outline: Application Restarting
-    Given an existing <perl_version> application
-    When the application is restarted
-    Then the application should be accessible
-
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | perl_version |
-      | perl-5.10    |
+#######
     
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | perl_version |
-      | perl-5.16    |
+  @fedora-only
+  Scenario: Application Creation (RHEL/CentOS)
+    Given a new perl-5.16 application, verify its availability
 
-  Scenario Outline: Application Destroying
-    Given an existing <perl_version> application
-    When the application is destroyed
-    Then the application should not be accessible
-
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | perl_version |
-      | perl-5.10    |
+  @fedora-only
+  Scenario: Application Modification (RHEL/CentOS)
+    Given an existing perl-5.16 application, verify code updates
     
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | perl_version |
-      | perl-5.16    |
+  @fedora-only
+  Scenario: Application Restarting  (RHEL/CentOS)
+    Given an existing perl-5.16 application, verify it can be restarted
+  
+  @fedora-only
+  Scenario: Application Destroying  (RHEL/CentOS)
+    Given an existing perl-5.16 application, verify it can be destroyed

--- a/controller/test/cucumber/cartridge-lifecycle-php.feature
+++ b/controller/test/cucumber/cartridge-lifecycle-php.feature
@@ -3,174 +3,92 @@
 @runtime_other4
 @not-enterprise
 Feature: Cartridge Lifecycle PHP Verification Tests
-  Scenario Outline: Application Creation
-    Given the libra client tools
-    And an accepted node
-    When 1 <php_version> applications are created
-    Then the applications should be accessible
-    Then the applications should be accessible via node-web-proxy
+  @rhel-only
+  Scenario: Application Creation (RHEL/CentOS)
+    Given a new php-5.3 application, verify its availability
+  
+  @rhel-only
+  Scenario: Server Alias (RHEL/CentOS)
+    Given an existing php-5.3 application, verify application aliases
+
+  @rhel-only
+  Scenario: Application Submodule Addition (RHEL/CentOS)
+    Given an existing php-5.3 application, verify submodules
     
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
-
-  Scenario Outline: Server Alias
-    Given an existing <php_version> application
-    When the application is aliased
-    Then the application should respond to the alias
+  @rhel-only
+  Scenario: Application Modification (RHEL/CentOS)
+    Given an existing php-5.3 application, verify code updates
+  
+  @rhel-only
+  Scenario: Application Stopping  (RHEL/CentOS)
+    Given an existing php-5.3 application, verify it can be stopped
+  
+  @rhel-only
+  Scenario: Application Starting  (RHEL/CentOS)
+    Given an existing php-5.3 application, verify it can be started  
+  
+  @rhel-only
+  Scenario: Application Restarting  (RHEL/CentOS)
+    Given an existing php-5.3 application, verify it can be restarted
+  
+  @rhel-only
+  Scenario: Application Tidy  (RHEL/CentOS)
+    Given an existing php-5.3 application, verify it can be tidied
+  
+  @rhel-only
+  Scenario: Application Snapshot  (RHEL/CentOS)
+    Given an existing php-5.3 application, verify it can be snapshotted and restored
+  
+  @rhel-only
+  Scenario: Application Change Namespace  (RHEL/CentOS)
+    Given an existing php-5.3 application, verify its namespace can be changed
     
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
-
-  Scenario Outline: Application Submodule Addition
-    Given an existing <php_version> application
-    When the submodule is added
-    Then the submodule should be deployed successfully
-    And the application should be accessible
+  @rhel-only
+  Scenario: Application Destroying  (RHEL/CentOS)
+    Given an existing php-5.3 application, verify it can be destroyed  
     
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
-
-  Scenario Outline: Application Modification
-    Given an existing <php_version> application
-    When the application is changed
-    Then it should be updated successfully
-    And the application should be accessible
+#######
     
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
+  @fedora-only
+  Scenario: Application Creation (RHEL/CentOS)
+    Given a new php-5.4 application, verify its availability
+  
+  @fedora-only
+  Scenario: Server Alias (RHEL/CentOS)
+    Given an existing php-5.4 application, verify application aliases
 
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
-
-  Scenario Outline: Application Stopping
-    Given an existing <php_version> application
-    When the application is stopped
-    Then the application should not be accessible
-    
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
-
-  Scenario Outline: Application Starting
-    Given an existing <php_version> application
-    When the application is started
-    Then the application should be accessible
-    
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
-
-  Scenario Outline: Application Restarting
-    Given an existing <php_version> application
-    When the application is restarted
-    Then the application should be accessible
-    
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
-
-  Scenario Outline: Application Tidy
-    Given an existing <php_version> application
-    When I tidy the application
-    Then the application should be accessible
-    
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
-
-  Scenario Outline: Application Snapshot
-    Given an existing <php_version> application
-    When I snapshot the application
-    Then the application should be accessible
-    When I restore the application
-    Then the application should be accessible
-    
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
-
-  Scenario Outline: Application Change Namespace
-    Given an existing <php_version> application
-    When the application namespace is updated
-    Then the application should be accessible
-    
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
-
-  Scenario Outline: Application Destroying
-    Given an existing <php_version> application
-    When the application is destroyed
-    Then the application should not be accessible
-    Then the application should not be accessible via node-web-proxy
-    
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
+  @fedora-only
+  Scenario: Application Submodule Addition (RHEL/CentOS)
+    Given an existing php-5.4 application, verify submodules
+  
+  @fedora-only
+  Scenario: Application Modification (RHEL/CentOS)
+    Given an existing php-5.4 application, verify code updates
+  
+  @fedora-only
+  Scenario: Application Stopping  (RHEL/CentOS)
+    Given an existing php-5.4 application, verify it can be stopped
+  
+  @fedora-only
+  Scenario: Application Starting  (RHEL/CentOS)
+    Given an existing php-5.4 application, verify it can be started  
+  
+  @fedora-only
+  Scenario: Application Restarting  (RHEL/CentOS)
+    Given an existing php-5.4 application, verify it can be restarted
+  
+  @fedora-only
+  Scenario: Application Tidy  (RHEL/CentOS)
+    Given an existing php-5.4 application, verify it can be tidied
+  
+  @fedora-only
+  Scenario: Application Snapshot  (RHEL/CentOS)
+    Given an existing php-5.4 application, verify it can be snapshotted and restored
+  
+  @fedora-only
+  Scenario: Application Change Namespace  (RHEL/CentOS)
+    Given an existing php-5.4 application, verify its namespace can be changed
+  
+  @fedora-only
+  Scenario: Application Destroying  (RHEL/CentOS)
+    Given an existing php-5.4 application, verify it can be destroyed

--- a/controller/test/cucumber/cartridge-mongodb.feature
+++ b/controller/test/cucumber/cartridge-mongodb.feature
@@ -3,41 +3,10 @@
 @runtime1
 @not-enterprise
 Feature: MongoDB Application Sub-Cartridge
+  @rhel-only
+  Scenario: Create Delete one application with a MongoDB database (RHEL/CentOS)
+    Given a perl-5.10 application, verify addition and removal of MongoDB database
   
-  Scenario Outline: Create Delete one application with a MongoDB database
-    Given a new <perl_version> type application
-    
-    When I embed a mongodb-2.2 cartridge into the application
-    Then 1 process named mongod will be running
-    And the embedded mongodb-2.2 cartridge directory will exist
-    And the mongodb configuration file will exist
-    And the mongodb database will exist
-    And the embedded mongodb-2.2 cartridge control script will not exist
-    And the mongodb admin user will have access
-
-    When I stop the mongodb-2.2 cartridge
-    Then 0 processes named mongod will be running
-
-    When I start the mongodb-2.2 cartridge
-    Then 1 process named mongod will be running
-
-    When the application cartridge PIDs are tracked
-    And I restart the mongodb-2.2 cartridge
-    Then 1 process named mongod will be running
-    And the tracked application cartridge PIDs should be changed
-
-    When I destroy the application
-    Then 0 processes named mongod will be running
-    And the mongodb database will not exist
-    And the mongodb configuration file will not exist
-    And the embedded mongodb-2.2 cartridge directory will not exist
-
-    @fedora-only
-    Scenario: Fedora 18 scenarios
-      | perl_version |
-      | perl-5.16    |
-      
-    @rhel-only
-    Scenario: RHEL scenarios
-      | perl_version |
-      | perl-5.10    |
+  @fedora-only
+  Scenario: Create Delete one application with a MongoDB database (RHEL/CentOS)
+    Given a perl-5.16 application, verify addition and removal of MongoDB database

--- a/controller/test/cucumber/cartridge-mysql.feature
+++ b/controller/test/cucumber/cartridge-mysql.feature
@@ -2,40 +2,10 @@
 @runtime
 @runtime4
 Feature: MySQL Application Sub-Cartridge
-  
-  Scenario Outline: Create Delete one application with a MySQL database
-    Given a new <php_version> type application
+  @rhel-only
+  Scenario: Create Delete one application with a MySQL database (RHEL/CentOS)
+    Given a php-5.3 application, verify addition and removal of mysql
     
-    When I embed a mysql-5.1 cartridge into the application
-    Then a mysqld process will be running
-    And the embedded mysql-5.1 cartridge directory will exist
-    And the mysql configuration file will exist
-    And the mysql database will exist
-    And the mysql admin user will have access
-    
-    When I stop the mysql-5.1 cartridge
-    Then a mysqld process will not be running
-    
-    When I start the mysql-5.1 cartridge
-    Then a mysqld process will be running
-    
-    When the application cartridge PIDs are tracked
-    And I restart the mysql-5.1 cartridge
-    Then a mysqld process will be running
-    And the tracked application cartridge PIDs should be changed
-    
-    When I destroy the application
-    Then a mysqld process will not be running
-    And the mysql database will not exist
-    And the mysql configuration file will not exist
-    And the embedded mysql-5.1 cartridge directory will not exist
-    
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
+  @fedora-only
+  Scenario: Create Delete one application with a MySQL database (RHEL/CentOS)
+    Given a php-5.4 application, verify addition and removal of mysql

--- a/controller/test/cucumber/cartridge-php.feature
+++ b/controller/test/cucumber/cartridge-php.feature
@@ -2,23 +2,10 @@
 @runtime
 @runtime2
 Feature: PHP Application
-
-  Scenario Outline: Test Alias Hooks
-    Given a new <php_version> type application
-    And I add an alias to the application
-    Then the php application will be aliased
-    And the php file permissions are correct
-    When I remove an alias from the application
-    Then the php application will not be aliased 
-    When I destroy the application
-    Then the http proxy will not exist
-
-    @fedora-only
-    Scenario: Fedora 18
-     | php_version |
-     | php-5.4     |
-
-    @rhel-only
-    Scenario: RHEL
-     | php_version |
-     | php-5.3     |
+  @rhel-only
+  Scenario: Test Alias Hooks (RHEL/CentOS)
+    Given a new php-5.3 application, verify application alias setup on the node
+    
+  @fedora-only
+  Scenario: Test Alias Hooks (Fedora)
+    Given a new php-5.3 application, verify application alias setup on the node

--- a/controller/test/cucumber/cartridge-phpmyadmin.feature
+++ b/controller/test/cucumber/cartridge-phpmyadmin.feature
@@ -4,40 +4,10 @@
 @not-enterprise
 Feature: phpMyAdmin Embedded Cartridge
 
-  Scenario Outline: Add Remove phpMyAdmin to one application
-    Given a new <php_version> type application
-    
-    When I embed a mysql-5.1 cartridge into the application
-    And I embed a <phpmyadmin_version> cartridge into the application
-    Then the http proxy /phpmyadmin will exist
-    And 4 processes named httpd will be running
-    And the embedded <phpmyadmin_version> cartridge directory will exist
-    And the embedded <phpmyadmin_version> cartridge log files will exist
-
-    When I stop the <phpmyadmin_version> cartridge
-    Then 2 processes named httpd will be running
-    And the web console for the <phpmyadmin_version> cartridge is not accessible
-
-    When I start the <phpmyadmin_version> cartridge
-    Then 4 processes named httpd will be running
-    And the web console for the <phpmyadmin_version> cartridge is accessible
-    
-    When I restart the <phpmyadmin_version> cartridge
-    Then 4 processes named httpd will be running
-    And the web console for the <phpmyadmin_version> cartridge is accessible
-
-    When I destroy the application
-    Then 0 processes named httpd will be running
-    And the http proxy /phpmyadmin will not exist
-    And the embedded <phpmyadmin_version> cartridge directory will not exist
-    And the embedded <phpmyadmin_version> cartridge log files will not exist
-    
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version | phpmyadmin_version |
-      | php-5.3     | phpmyadmin-3.4     |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version | phpmyadmin_version |
-      | php-5.4     | phpmyadmin-3.5     |
+  @rhel-only
+  Scenario: Add Remove phpMyAdmin to one application
+    Given a php-5.3 application, verify addition and removal of phpmyadmin-3.4
+  
+  @fedora-only
+  Scenario: Add Remove phpMyAdmin to one application
+    Given a php-5.4 application, verify addition and removal of phpmyadmin-3.5

--- a/controller/test/cucumber/cartridge-postgresql.feature
+++ b/controller/test/cucumber/cartridge-postgresql.feature
@@ -2,40 +2,11 @@
 @runtime
 @runtime3
 Feature: PostgreSQL Application Sub-Cartridge
-  Scenario Outline: Create Delete one application with a PostgreSQL database
-    Given a new perl-5.10 type application
 
-    When I embed a <postgres> cartridge into the application
-    Then a postgres process will be running
-    And the embedded <postgres> cartridge directory will exist
-    And the postgresql configuration file will exist
-    And the postgresql database will exist
-    And the embedded <postgres> cartridge control script will not exist
-    And the postgresql admin user will have access
+  @rhel-only
+  Scenario: Create Delete one application with a PostgreSQL database
+    Given a perl-5.10 application, verify addition and removal of postgresql 8.4
 
-    When I stop the <postgres> cartridge
-    Then a postgres process will not be running
-
-    When I start the <postgres> cartridge
-    Then a postgres process will be running
-
-    When the application cartridge PIDs are tracked
-    And I restart the <postgres> cartridge
-    Then a postgres process will be running
-    And the tracked application cartridge PIDs should be changed
-
-    When I destroy the application
-    Then a postgres process will not be running
-    And the postgresql database will not exist
-    And the postgresql configuration file will not exist
-    And the embedded <postgres> cartridge directory will not exist
-
-    @rhel-only
-    Scenario: Postgres 8.4
-    | postgres       |
-    | postgresql-8.4 |
-
-    @fedora-only
-    Scenario: Postgres 9.1
-    | postgres       |
-    | postgresql-9.1 |
+  @fedora-only
+  Scenario: Create Delete one application with a PostgreSQL database
+    Given a perl-5.16 application, verify addition and removal of postgresql 9.2

--- a/controller/test/cucumber/cartridge-runtime-extended-db.feature
+++ b/controller/test/cucumber/cartridge-runtime-extended-db.feature
@@ -3,91 +3,41 @@ Feature: Cartridge Runtime Extended Checks (Database)
 
   #@runtime_extended_other2
   @runtime_extended2
-  Scenario Outline: Embed and then remove database cartridges
-    Given a new <app_type> type application
-    
-    When I embed a <db_cart_type> cartridge into the application
-    Then a <db_proc> process will be running
-    And the embedded <db_cart_type> cartridge directory will exist
-    And the <db_name> configuration file will exist
-    And the <db_name> database will exist
-    And the <db_name> admin user will have access
-    And the embedded <db_cart_type> cartridge control script will not exist
-    
-    When I remove the <db_cart_type> cartridge from the application
-    Then a <db_proc> process will not be running
-    And the <db_name> database will not exist
-    And the <db_name> configuration file will not exist
-    And the embedded <db_cart_type> cartridge directory will not exist
-
+  Scenario Outline: Embed and then remove database cartridges (Common)
+    Given a <app_type> application, add and remove <db_cart_type> database and use <db_proc> proc and <db_name> name to verify
     Scenarios: Embed/Unembed database cartridge scenarios - origin
       | app_type  | db_cart_type    | db_proc   | db_name     |
       | ruby-1.9  | mongodb-2.2     | mongod    | mongodb     |
 
-    @fedora-only
+  @runtime_extended2
+  @fedora-only
+  Scenario Outline: Embed and then remove database cartridges (Fedora)
+    Given a <app_type> application, add and remove <db_cart_type> database and use <db_proc> proc and <db_name> name to verify
     Scenarios: Embed/Unembed database cartridge scenarios
       | app_type  | db_cart_type    | db_proc   | db_name     |
       | php-5.4   | mysql-5.1       | mysqld    | mysql       |
       | php-5.4   | mongodb-2.2     | mongod    | mongodb     |
+      | php-5.4   | postgresql-9.2  | postgres  | postgresql  |      
 
-    @rhel-only
+  @runtime_extended2
+  @rhel-only
+  Scenario Outline: Embed and then remove database cartridges (Fedora)
+    Given a <app_type> application, add and remove <db_cart_type> database and use <db_proc> proc and <db_name> name to verify
     Scenarios: Embed/Unembed database cartridge scenarios
       | app_type  | db_cart_type    | db_proc   | db_name     |
       | php-5.3   | mysql-5.1       | mysqld    | mysql       |
       | php-5.3   | mongodb-2.2     | mongod    | mongodb     |
       | ruby-1.8  | mongodb-2.2     | mongod    | mongodb     |
-
-
-  #@runtime_extended_other2
-  @runtime_extended2
-  Scenario Outline: Embed and then remove database cartridges
-    Given a new <app_type> type application
-    
-    When I embed a <db_cart_type> cartridge into the application
-    Then a <db_proc> process will be running
-    And the embedded <db_cart_type> cartridge directory will exist
-    And the <db_name> configuration file will exist
-    And the <db_name> database will exist
-    And the embedded <db_cart_type> cartridge control script will not exist
-    
-    When I remove the <db_cart_type> cartridge from the application
-    Then a <db_proc> process will not be running
-    And the <db_name> database will not exist
-    And the embedded <db_cart_type> cartridge control script will not exist
-    And the <db_name> configuration file will not exist
-    And the embedded <db_cart_type> cartridge directory will not exist
-
-    @fedora-only
-    Scenarios: Embed/Unembed database cartridge scenarios - origin
-      | app_type  | db_cart_type    | db_proc   | db_name     |
-      | php-5.4   | postgresql-9.2  | postgres  | postgresql  |
-
-    @rhel-only
-    Scenarios: Embed/Unembed database cartridge scenarios
-      | app_type  | db_cart_type    | db_proc   | db_name     |
-      | php-5.3   | postgresql-8.4  | postgres  | postgresql  |
+      | php-5.3   | postgresql-8.4  | postgres  | postgresql  |      
 
   #@runtime_extended_other2
   @runtime_extended2
-  Scenario Outline: Embed all databases into one cartridges
-    Given a new <php_version> type application
-    When I embed a mysql-5.1 cartridge into the application
-    And I embed a <postgres_cart> cartridge into the application
-    And I embed a mongodb-2.2 cartridge into the application
-    Then a mysqld process will be running
-    And the embedded mysql-5.1 cartridge directory will exist
-    And a postgres process will be running
-    And the embedded <postgres_cart> cartridge directory will exist
-    And a mongod process will be running
-    And the embedded mongodb-2.2 cartridge directory will exist
+  @rhel-only
+  Scenario Outline: Embed all databases into one cartridges (RHEL/CentOS)
+    Given a php-5.3 application, embed mysql-5.1, postgresql-8.4, mongodb-2.2
 
-    @fedora-only
-    Scenarios: database cartridge scenarios - origin
-      | postgres_cart  | php_version |
-      | postgresql-9.2 | php-5.4     |
-
-    @rhel-only
-    Scenarios: database cartridge scenarios
-      | postgres_cart  | php_version |
-      | postgresql-8.4 | php-5.3     |
-
+  #@runtime_extended_other2
+  @runtime_extended2
+  @Fedora-only
+  Scenario Outline: Embed all databases into one cartridges (Fedora)
+    Given a php-5.4 application, embed mysql-5.1, postgresql-9.2, mongodb-2.2

--- a/controller/test/cucumber/cartridge-runtime-extended-mysql.feature
+++ b/controller/test/cucumber/cartridge-runtime-extended-mysql.feature
@@ -1,21 +1,10 @@
 #@runtime_extended_other3
 @runtime_extended3
 Feature: Mysql extended tests
-  
+  @rhel-only
   Scenario Outline: Use socket file to connect to database 
-    Given a new <php_version> type application
-    And I embed a mysql-5.1 cartridge into the application
-    And the application is made publicly accessible
-
-    When I select from the mysql database using the socket file
-    Then the select result from the mysql database should be valid
-
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
-
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
+    Given a new php-5.3 application, verify using socket file to connect to database
+    
+  @fedora-only
+  Scenario Outline: Use socket file to connect to database 
+    Given a new php-5.4 application, verify using socket file to connect to database

--- a/controller/test/cucumber/cartridge-runtime-extended-perl.feature
+++ b/controller/test/cucumber/cartridge-runtime-extended-perl.feature
@@ -1,25 +1,13 @@
-@runtime
+#@runtime_extended_other2
+@runtime_extended2
 Feature: Cartridge Runtime Extended Checks (Perl)
 
-  #@runtime_extended_other2
-  @runtime_extended2
-  Scenario Outline: Hot deployment tests
-    Given a new <type> type application
-    And the application is made publicly accessible
-    And hot deployment <hot_deploy_status> for the application
-    And the application cartridge PIDs are tracked
-    When an update is pushed to the application repo
-    Then a <proc_name> process will be running
-    And the tracked application cartridge PIDs <pid_changed> changed
-    When I destroy the application
-    Then a <proc_name> process will not be running
-
   @rhel-only
-  Scenarios: Code push scenarios
-    | type         | proc_name | hot_deploy_status | pid_changed   |
-    | perl-5.10    | httpd     | is not enabled    | should be     |
+  @runtime_extended2
+  Scenario Outline: Hot deployment tests (RHEL/CentOS)
+    Given a new perl-5.10 application, verify when hot deploy is not enabled, it does change pid of httpd proc
 
   @fedora-only
-  Scenarios: Code push scenarios
-    | type         | proc_name | hot_deploy_status | pid_changed   |
-    | perl-5.16    | httpd     | is not enabled    | should be     |
+  @runtime_extended2
+  Scenario Outline: Hot deployment tests (Fedora)
+    Given a new perl-5.16 application, verify when hot deploy is not enabled, it does change pid of httpd proc

--- a/controller/test/cucumber/cartridge-runtime-extended-php.feature
+++ b/controller/test/cucumber/cartridge-runtime-extended-php.feature
@@ -3,25 +3,19 @@ Feature: Cartridge Runtime Extended Checks (PHP)
 
   #@runtime_extended_other2
   @runtime_extended2
-  Scenario Outline: Hot deployment tests
-    Given a new <type> type application
-    And the application is made publicly accessible
-    And hot deployment <hot_deploy_status> for the application
-    And the application cartridge PIDs are tracked
-    When an update is pushed to the application repo
-    Then a <proc_name> process will be running
-    And the tracked application cartridge PIDs <pid_changed> changed
-    When I destroy the application
-    Then a <proc_name> process will not be running
-
-    @rhel-only
+  @rhel-only
+  Scenario Outline: Hot deployment tests (RHEL/CentOS)
+    Given a new php-5.3 application, verify when hot deploy <hot_deploy_status>, it <pid_changed> pid of httpd proc    
     Scenarios: Code push scenarios
-      | type         | proc_name | hot_deploy_status | pid_changed   |
-      | php-5.3      | httpd     | is enabled        | should not be |
-      | php-5.3      | httpd     | is not enabled    | should be     |
+      | hot_deploy_status | pid_changed     |
+      | is enabled        | does not change |
+      | is not enabled    | does change     |
       
-    @fedora-only
+  @runtime_extended2
+  @fedora-only
+  Scenario Outline: Hot deployment tests (RHEL/CentOS)
+    Given a new php-5.4 application, verify when hot deploy <hot_deploy_status>, it <pid_changed> pid of httpd proc    
     Scenarios: Code push scenarios
-      | type         | proc_name | hot_deploy_status | pid_changed   |
-      | php-5.4      | httpd     | is enabled        | should not be |
-      | php-5.4      | httpd     | is not enabled    | should be     |      
+      | hot_deploy_status | pid_changed     |
+      | is enabled        | does not change |
+      | is not enabled    | does change     |

--- a/controller/test/cucumber/cartridge-runtime-extended-postgresql.feature
+++ b/controller/test/cucumber/cartridge-runtime-extended-postgresql.feature
@@ -10,11 +10,6 @@ Feature: Postgresql extended tests
     When I select from the postgresql database using the socket file
     Then the select result from the postgresql database should be valid
     
-    @fedora-only
-    Scenarios: database cartridge scenarios - origin
-      | postgres_cart  | php_version |
-      | postgresql-9.2 | php-5.4     |
-
     @rhel-only
     Scenarios: database cartridge scenarios
       | postgres_cart  | php_version |

--- a/controller/test/cucumber/cartridge-runtime-extended-ruby.feature
+++ b/controller/test/cucumber/cartridge-runtime-extended-ruby.feature
@@ -3,24 +3,18 @@ Feature: Cartridge Runtime Extended Checks (Ruby)
 
   #@runtime_extended_other2
   @runtime_extended2
-  Scenario Outline: Hot deployment tests
-    Given a new <type> type application
-    And the application is made publicly accessible
-    And hot deployment <hot_deploy_status> for the application
-    And the application cartridge PIDs are tracked
-    When an update is pushed to the application repo
-    Then a <proc_name> process will be running
-    And the tracked application cartridge PIDs <pid_changed> changed
-    When I destroy the application
-    Then a <proc_name> process will not be running
-
-    @rhel-only
+  @rhel-only
+  Scenario Outline: Hot deployment tests (RHEL/CentOS)
+    Given a new ruby-1.8 application, verify when hot deploy <hot_deploy_status>, it <pid_changed> pid of PassengerWatchd proc    
     Scenarios: Code push scenarios
-      | type         | proc_name        | hot_deploy_status | pid_changed   |
-      | ruby-1.8     | PassengerWatchd  | is not enabled    | should be     |
-      | ruby-1.8     | PassengerWatchd  | is enabled        | should not be |
-
-    Scenarios: Code push scenarios - origin
-      | type         | proc_name        | hot_deploy_status | pid_changed   |
-      | ruby-1.9     | PassengerWatchd  | is not enabled    | should be     |
-      | ruby-1.9     | PassengerWatchd  | is enabled        | should not be |
+      | hot_deploy_status | pid_changed     |
+      | is enabled        | does not change |
+      | is not enabled    | does change     |
+        
+  @runtime_extended2
+  Scenario Outline: Hot deployment tests (RHEL/CentOS)
+    Given a new ruby-1.9 application, verify when hot deploy <hot_deploy_status>, it <pid_changed> pid of PassengerWatchd proc    
+    Scenarios: Code push scenarios
+      | hot_deploy_status | pid_changed     |
+      | is enabled        | does not change |
+      | is not enabled    | does change     |

--- a/controller/test/cucumber/cartridge-runtime-standard-perl.feature
+++ b/controller/test/cucumber/cartridge-runtime-standard-perl.feature
@@ -3,15 +3,11 @@ Feature: Cartridge Runtime Standard Checks (Perl)
 
   #@runtime_other2
   @runtime2
-  Scenario Outline: Perl cartridge checks
-    Given a new <perl_version> application, verify it using httpd
-  
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | perl_version |
-      | perl-5.10    |
-      
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | perl_version |
-      | perl-5.16    |
+  @rhel-only
+  Scenario: Perl cartridge checks (RHEL/CentOS)
+    Given a new perl-5.10 application, verify it using httpd
+
+  @runtime2
+  @fedora-only
+  Scenario: Perl cartridge checks (Fedora)
+    Given a new perl-5.16 application, verify it using httpd

--- a/controller/test/cucumber/cartridge-runtime-standard-php.feature
+++ b/controller/test/cucumber/cartridge-runtime-standard-php.feature
@@ -3,15 +3,11 @@ Feature: Cartridge Runtime Standard Checks (PHP)
 
   #@runtime_other2
   @runtime2
+  @rhel-only
   Scenario Outline: PHP cartridge checks
-    Given a new <php_version> application, verify it using httpd
+    Given a new php-5.3 application, verify it using httpd
     
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | php_version |
-      | php-5.3     |
-      
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | php_version |
-      | php-5.4     |
+  @runtime2
+  @fedora-only
+  Scenario Outline: PHP cartridge checks
+    Given a new php-5.4 application, verify it using httpd

--- a/controller/test/cucumber/cartridge-runtime-standard-ruby.feature
+++ b/controller/test/cucumber/cartridge-runtime-standard-ruby.feature
@@ -3,14 +3,10 @@ Feature: Cartridge Runtime Standard Checks (Ruby)
 
   #@runtime_other1
   @runtime1
-  Scenario Outline: Ruby cartridge checks
-    Given a new <ruby_version> application, verify it using httpd
+  @rhel-only
+  Scenario: Ruby cartridge checks (RHEL/CentOS)
+    Given a new ruby-1.8 application, verify it using httpd
 
-    @rhel-only
-    Scenarios:
-      | ruby_version |
-      | ruby-1.8     |
-
-    Scenarios:
-      | ruby_version |
-      | ruby-1.9     |      
+  @runtime1
+  Scenario: Ruby cartridge checks (RHEL/CentOS)
+    Given a new ruby-1.9 application, verify it using httpd

--- a/controller/test/cucumber/embedded.feature
+++ b/controller/test/cucumber/embedded.feature
@@ -2,40 +2,18 @@
 @runtime_extended
 @runtime_extended3
 Feature: Embedded Cartridge Verification Tests
+  @rhel-only
+  Scenario Outline: Embedded Usage (RHEL/CentOS)
+  Given the libra client tools, create a new php-<php_version> application, verify addition and removal of mysql-5.1 , phpmyadmin-<phpmyadmin_version> , cron-1.4 , mongodb-2.2
 
-  Scenario Outline: Embedded Usage
-    Given the libra client tools
-    And an accepted node
-    When 1 <php_version> applications are created
-    Then the applications should be accessible
-
-    Given an existing <php_version> application without an embedded cartridge
-    When the embedded mysql-5.1 cartridge is added
-    And the embedded <phpmyadmin_version> cartridge is added
-    Then the application should be accessible
-    When the application uses mysql
-    Then the application should be accessible
-    And the mysql response is successful
-    When the embedded <phpmyadmin_version> cartridge is removed
-    And the embedded mysql-5.1 cartridge is removed
-    Then the application should be accessible
-
-    When the embedded mongodb-2.2 cartridge is added
-    And the embedded cron-1.4 cartridge is added
-    Then the application should be accessible
-    And the embedded mongodb-2.2 cartridge is removed
-    And the embedded cron-1.4 cartridge is removed
-    Then the application should be accessible
-
-    When the application is destroyed
-    Then the application should not be accessible
-
-    @rhel-only
     Scenarios: RHEL scenarios
       | php_version | phpmyadmin_version |
       | php-5.3     | phpmyadmin-3.4     |
 
-    @fedora-only
+  @fedora-only
+  Scenario Outline: Embedded Usage (Fedora)
+  Given the libra client tools, create a new php-<php_version> application, verify addition and removal of mysql-5.1 , phpmyadmin-<phpmyadmin_version> , cron-1.4 , mongodb-2.2  
+  
     Scenarios: Fedora 18 scenarios
       | php_version | phpmyadmin_version |
       | php-5.4     | phpmyadmin-3.5     |

--- a/controller/test/cucumber/idler.feature
+++ b/controller/test/cucumber/idler.feature
@@ -1,21 +1,18 @@
 @singleton
 Feature: Explicit idle/restore checks
 
-  Scenario Outline: Idle one application
-    Given a new <type> type application
-    Then a <proc_name> process will be running
-    And I record the active capacity
-
-    When I oo-idle the application
-    Then a <proc_name> process will not be running
-    And the active capacity has been reduced
+  Scenario Outline: Idle one application (Common)
+    Given a new <type> application with <proc_name> process, verify that it can be idled
 
     Scenarios:
       | type         | proc_name |
       | nodejs-0.6   | node      |
       | ruby-1.9     | httpd     |
 
-    @rhel-only
+  @rhel-only
+  Scenario Outline: Idle one application (RHEL/CentOS)
+    Given a new <type> application with <proc_name> process, verify that it can be idled
+
     Scenarios:
       | type         | proc_name |
       | perl-5.10    | httpd     |
@@ -26,32 +23,25 @@ Feature: Explicit idle/restore checks
       | php-5.3      | httpd     |
       | python-2.6   | httpd     |
       
-    @fedora-only
+  @fedora-only
+  Scenario Outline: Idle one application (Fedora)
+    Given a new <type> application with <proc_name> process, verify that it can be idled    
+      
     Scenarios:
       | type         | proc_name |
       | perl-5.16    | httpd     |
       | php-5.4      | httpd     |
 
-  Scenario Outline: Restore one application
-    Given a new <type> type application
-    Then a <proc_name> process will be running
-    And I record the active capacity
-
-    When I oo-idle the application
-    Then a <proc_name> process will not be running
-    And the active capacity has been reduced
-    And I record the active capacity after idling
-
-    When I oo-restore the application
-    Then a <proc_name> process will be running
-    And the active capacity has been increased
-
+  Scenario Outline: Restore one application (Common)
+    Given a new <type> application with <proc_name> process, verify that it can be restored after idling
     Scenarios:
       | type         | proc_name |
       | nodejs-0.6   | node      |
       | ruby-1.9     | httpd     |
 
-    @rhel-only
+  @rhel-only
+  Scenario Outline: Restore one application (RHEL/CentOS)
+    Given a new <type> application with <proc_name> process, verify that it can be restored after idling
     Scenarios:
       | type         | proc_name |
       | perl-5.10    | httpd     |
@@ -61,33 +51,25 @@ Feature: Explicit idle/restore checks
       | ruby-1.8     | httpd     |
       | php-5.3      | httpd     |
       | python-2.6   | httpd     |
-      
-    @fedora-only
+
+  @fedora-only    
+  Scenario Outline: Restore one application (Fedora)
+    Given a new <type> application with <proc_name> process, verify that it can be restored after idling    
     Scenarios:
       | type         | proc_name |
       | perl-5.16    | httpd     |
       | php-5.4      | httpd     |
-
-  Scenario Outline: Auto-restore one application
-    Given a new <type> type application
-    Then a <proc_name> process will be running
-    And I record the active capacity
-
-    When I oo-idle the application
-    Then a <proc_name> process will not be running
-    And the active capacity has been reduced
-    And I record the active capacity after idling
-
-    When I run the health-check for the <type> cartridge
-    Then a <proc_name> process will be running
-    And the active capacity has been increased
-
+      
+  Scenario Outline: Auto-restore one application (Common)
+    Given a new <type> application with <proc_name> process, verify that it can be auto-restored after idling
     Scenarios:
       | type         | proc_name |
       | nodejs-0.6   | node      |
       | ruby-1.9     | httpd     |
 
-    @rhel-only
+  @rhel-only
+  Scenario Outline: Auto-restore one application (RHEL/CentOS)
+    Given a new <type> application with <proc_name> process, verify that it can be auto-restored after idling
     Scenarios:
       | type         | proc_name |
       | perl-5.10    | httpd     |
@@ -97,8 +79,10 @@ Feature: Explicit idle/restore checks
       | ruby-1.8     | httpd     |
       | php-5.3      | httpd     |
       | python-2.6   | httpd     |
-      
-    @fedora-only
+
+  @fedora-only    
+  Scenario Outline: Auto-restore one application (Fedora)
+    Given a new <type> application with <proc_name> process, verify that it can be auto-restored after idling    
     Scenarios:
       | type         | proc_name |
       | perl-5.16    | httpd     |

--- a/controller/test/cucumber/rest-applications.feature
+++ b/controller/test/cucumber/rest-applications.feature
@@ -4,361 +4,204 @@ Feature: applications
   As an API client
   In order to do things with domains
   I want to List, Create, Retrieve, Start, Stop, Restart, Force-stop and Delete applications
-  
-  Scenario Outline: List applications
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
-    Then the response should be "201"
-    When I send a GET request to "/domains/api<random>/applications"
-    Then the response should be "200"
-    When I send a DELETE request to "/domains/api<random>/applications/app"
-    Then the response should be "204"
+
+  @rhel-only  
+  Scenario Outline: List applications (RHEL/CentOS)
+    Given a new user, create a php-<php_version> application using <format> format and verify application list API
     
-    @rhel-only
     Scenarios: RHEL scenarios
       | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
+      | JSON   |     5.3     |
+      | XML    |     5.3     |
       
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
-
-  Scenario Outline: Create application
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
-    Then the response should be "201"
-    And the response should be a "application" with attributes "name=app&framework=<php_version>"
-    When I send a DELETE request to "/domains/api<random>/applications/app"
-    Then the response should be "204"
+  @fedora-only  
+  Scenario Outline: List applications (Fedora)
+    Given a new user, create a php-<php_version> application using <format> format and verify application list API
     
-    @rhel-only
+    Scenarios: Fedora scenarios
+      | format | php_version |
+      | JSON   |     5.4     |
+      | XML    |     5.4     |
+
+  @rhel-only  
+  Scenario Outline: Create application (RHEL/CentOS)
+    Given a new user, create a php-<php_version> application using <format> format and verify application creation API
+    
     Scenarios: RHEL scenarios
       | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
+      | JSON   |     5.3     |
+      | XML    |     5.3     |
       
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
-
-  Scenario Outline: Create application with multiple cartridges
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridges=<php_version>&cartridges=mysql-5.1&cartridges=<phpmyadmin_version>&initial_git_url=https://github.com/openshift/wordpress-example"
-    Then the response should be "201"
-    And the response should be a "application" with attributes "name=app&framework=<php_version>"
-    When I send a DELETE request to "/domains/api<random>/applications/app"
-    Then the response should be "204"
+  @fedora-only  
+  Scenario Outline: Create application (Fedora)
+    Given a new user, create a php-<php_version> application using <format> format and verify application creation API
     
-    @rhel-only
+    Scenarios: Fedora scenarios
+      | format | php_version |
+      | JSON   |     5.4     |
+      | XML    |     5.4     |
+
+  @rhel-only  
+  Scenario Outline: Create application with multiple cartridges (RHEL/CentOS)
+    Given a new user, create a php-<php_version> application with <phpmyadmin_version> using <format> format and verify application creation API
+    
     Scenarios: RHEL scenarios
       | format | php_version | phpmyadmin_version |
-      | JSON   | php-5.3     | phpmyadmin-3.4     |
-      | XML    | php-5.3     | phpmyadmin-3.4     |
+      | JSON   |     5.3     |        3.4         |
+      | XML    |     5.3     |        3.4         |
       
-    @fedora-only
+  @fedora-only  
+  Scenario Outline: Create application with multiple cartridges (Fedora)
+    Given a new user, create a php-<php_version> application with <phpmyadmin_version> using <format> format and verify application creation API
+    
     Scenarios: Fedora 18 scenarios
-      | format | php_version | phpmyadmin_version |
-      | JSON   | php-5.4     | phpmyadmin-3.5     |
-      | XML    | php-5.4     | phpmyadmin-3.5     |
+    | format | php_version | phpmyadmin_version |
+    | JSON   |     5.4     |         3.5        |
+    | XML    |     5.4     |         3.5        |
      
-  Scenario Outline: Create application with invalid cartridge combinations
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridges=mysql-5.1&cartridges=<phpmyadmin_version>"
-    Then the response should be "422"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridges=<php_version>&cartridges=ruby-1.9"
-    Then the response should be "422"
-    
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | format | phpmyadmin_version |
-      | JSON   | phpmyadmin-3.4     |
-      | XML    | phpmyadmin-3.4     |
-      
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | format | phpmyadmin_version |
-      | JSON   | phpmyadmin-3.5     |
-      | XML    | phpmyadmin-3.5     |
+  @rhel-only
+  Scenario Outline: Create application with invalid cartridge combinations (RHEL/CentOS)
+    Given a new user, create an invalid application with php-<php_version>, ruby-1.9, mysql-5.1, phpmyadmin-<phpmyadmin_version> using <format> format and verify application creation API
 
-  Scenario Outline: Create application with blank, missing, too long and invalid name
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=&cartridge=<php_version>"
-    Then the response should be "422"
-    And the error message should have "field=name&severity=error&exit_code=105"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"cartridge=<php_version>"
-    Then the response should be "422"
-    And the error message should have "field=name&severity=error&exit_code=105"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app?one&cartridge=<php_version>"
-    Then the response should be "422"
-    And the error message should have "field=name&severity=error&exit_code=105"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=appone1234567890123456789012345678901234567890&cartridge=<php_version>"
-    Then the response should be "422"
-    And the error message should have "field=name&severity=error&exit_code=105"
+    Scenarios: RHEL scenarios
+      | format | php_version | phpmyadmin_version |
+      | JSON   |     5.3     |        3.4         |
+      | XML    |     5.3     |        3.4         |
+
+  @fedora-only
+  Scenario Outline: Create application with invalid cartridge combinations (Fedora)
+    Given a new user, create an invalid application with php-<php_version>, ruby-1.9, mysql-5.1, phpmyadmin-<phpmyadmin_version> using <format> format and verify application creation API
+
+    Scenarios: RHEL scenarios
+      | format | php_version | phpmyadmin_version |
+      | JSON   |     5.4     |         3.5        |
+      | XML    |     5.4     |         3.5        |
+
+  @rhel-only
+  Scenario Outline: Create application with blank, missing, too long and invalid name (RHEL/CentOS)
+    Given a new user, create a php-<php_version> application using <format> format with blank, missing, too long and invalid name and verify application creation API
     
-    @rhel-only
     Scenarios: RHEL scenarios
       | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
-      
-    @fedora-only
+      | JSON   |     5.3     |
+      | XML    |     5.3     |
+
+  @fedora-only
+  Scenario Outline: Create application with blank, missing, too long and invalid name (Fedora)
+    Given a new user, create a php-<php_version> application using <format> format with blank, missing, too long and invalid name and verify application creation API
+
     Scenarios: Fedora 18 scenarios
       | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
+      | JSON   |     5.4     |
+      | XML    |     5.4     |
 
-  Scenario Outline: Retrieve application
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
-    Then the response should be "201"
-    When I send a GET request to "/domains/api<random>/applications/app"
-    Then the response should be "200"
-    And the response should be a "application" with attributes "name=app&framework=<php_version>"
-    When I send a DELETE request to "/domains/api<random>/applications/app"
-    Then the response should be "204"
+  @rhel-only
+  Scenario Outline: Retrieve application (RHEL/CentOS)
+    Given a new user, create a php-<php_version> application using <format> format verify retrieving application details
     
-    @rhel-only
     Scenarios: RHEL scenarios
       | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
+      | JSON   |     5.3     |
+      | XML    |     5.3     |
       
-    @fedora-only
+  @fedora-only
+  Scenario Outline: Retrieve application (Fedora)
+    Given a new user, create a php-<php_version> application using <format> format verify retrieving application details
+      
     Scenarios: Fedora 18 scenarios
       | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
+      | JSON   |     5.4     |
+      | XML    |     5.4     |
 
-
-  Scenario Outline: Start application
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=start"
-    Then the response should be "200"
-    When I send a DELETE request to "/domains/api<random>/applications/app"
-    Then the response should be "204"
+  @rhel-only
+  Scenario Outline: Start/Stop/Restart application (RHEL/CentOS)
+    Given a new user, create a php-<php_version> application using <format> format verify application <event> API
     
-    @rhel-only
     Scenarios: RHEL scenarios
-      | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
-      
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
+      | format | php_version |    event    |
+      | JSON   |     5.3     |    start    |
+      | XML    |     5.3     |    start    |
+      | JSON   |     5.3     |    stop     |
+      | XML    |     5.3     |    stop     |
+      | JSON   |     5.3     |   restart   |
+      | XML    |     5.3     |   restart   |
+      | JSON   |     5.3     | force-stop  |
+      | XML    |     5.3     | force-stop  |
+      | JSON   |     5.3     | thread-dump |
+      | XML    |     5.3     | thread-dump |
 
-
-  Scenario Outline: Stop application
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=stop"
-    Then the response should be "200"
-    When I send a DELETE request to "/domains/api<random>/applications/app"
-    Then the response should be "204"
-    
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
-      
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
-
-
-  Scenario Outline: Restart application
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=restart"
-    Then the response should be "200"
-    When I send a DELETE request to "/domains/api<random>/applications/app"
-    Then the response should be "204"
-    
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
-      
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
-
-
-  Scenario Outline: Force-stop application
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=force-stop"
-    Then the response should be "200"
-    When I send a DELETE request to "/domains/api<random>/applications/app"
-    Then the response should be "204"
+  @fedora-only
+  Scenario Outline: Start/Stop/Restart application (Fedora)
+    Given a new user, create a php-<php_version> application using <format> format verify application <event> API
   
-    @rhel-only
+    Scenarios: RHEL scenarios
+      | format | php_version |    event    |
+      | JSON   |     5.4     |    start    |
+      | XML    |     5.4     |    start    |
+      | JSON   |     5.4     |    stop     |
+      | XML    |     5.4     |    stop     |
+      | JSON   |     5.4     |   restart   |
+      | XML    |     5.4     |   restart   |
+      | JSON   |     5.4     | force-stop  |
+      | XML    |     5.4     | force-stop  |
+      | JSON   |     5.4     | thread-dump |
+      | XML    |     5.4     | thread-dump |
+
+  @rhel-only
+  Scenario Outline: Add and remove application alias (RHEL/CentOS)
+    Given a new user, create a php-<php_version> application using <format> format verify adding and removing application aliases
+    
     Scenarios: RHEL scenarios
       | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
-      
-    @fedora-only
+      | JSON   |     5.3     |
+      | XML    |     5.3     |
+
+  @fedora-only
+  Scenario Outline: Add and remove application alias (Fedora)
+    Given a new user, create a php-<php_version> application using <format> format verify adding and removing application aliases
+
     Scenarios: Fedora 18 scenarios
       | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
+      | JSON   |     5.4     |
+      | XML    |     5.4     |
 
   
   @rhel-only
-  Scenario Outline: Threaddump application
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<ruby_version>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=thread-dump"
-    Then the response should be "200"
-    When I send a DELETE request to "/domains/api<random>/applications/app"
-    Then the response should be "204"
-    
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | format | ruby_version |
-      | JSON   | ruby-1.8     |
-      | XML    | ruby-1.8     |
-      
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | format | ruby_version |
-      | JSON   | ruby-1.9     |
-      | XML    | ruby-1.9     |
-
-  Scenario Outline: Add and remove application alias
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=add-alias"
-    Then the response should be "422"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=add-alias&alias=app-api.foobar.com"
-    Then the response should be "200"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=remove-alias&alias=app-api.foobar.com"
-    Then the response should be "200"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=add-alias&alias=app-@#$api.foobar.com"
-    Then the response should be "422"
-    When I send a DELETE request to "/domains/api<random>/applications/app"
-    Then the response should be "204"
-    
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
-      
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
-
+  Scenario Outline: Delete application (RHEL/CentOS)
+    Given a new user, create a php-<php_version> application using <format> format verify application deletion
   
-  Scenario Outline: Delete application
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
-    Then the response should be "201"
-    When I send a DELETE request to "/domains/api<random>/applications/app"
-    Then the response should be "204"
-    When I send a GET request to "/domains/api<random>/applications/app"
-    Then the response should be "404"
-  
-    @rhel-only
     Scenarios: RHEL scenarios
       | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
-      
-    @fedora-only
+      | JSON   |     5.3     |
+      | XML    |     5.3     |
+
+  @fedora-only
+  Scenario Outline: Delete application (Fedora)
+    Given a new user, create a php-<php_version> application using <format> format verify application deletion
+
     Scenarios: Fedora 18 scenarios
       | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
+      | JSON   |     5.4     |
+      | XML    |     5.4     |
 
 
-  Scenario Outline: Create duplicate application
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
-    Then the response should be "422"
-    And the error message should have "field=name&severity=error&exit_code=100"
-    When I send a DELETE request to "/domains/api<random>/applications/app"
-    Then the response should be "204"
+  @rhel-only
+  Scenario Outline: Create duplicate application (RHEL/CentOS)
+    Given a new user, create a php-<php_version> application using <format> format verify that duplicate application creation fails
     
-    @rhel-only
     Scenarios: RHEL scenarios
       | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
+      | JSON   |     5.3     |
+      | XML    |     5.3     |
       
-    @fedora-only
+  @fedora-only
+  Scenario Outline: Create duplicate application (Fedora)
+    Given a new user, create a php-<php_version> application using <format> format verify that duplicate application creation fails
+      
     Scenarios: Fedora 18 scenarios
       | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
-
+      | JSON   |     5.4     |
+      | XML    |     5.4     |
 
   Scenario Outline: Create application with invalid, blank or missing cartridge
     Given a new user
@@ -398,43 +241,35 @@ Feature: applications
      | JSON   | 
      | XML    | 
 
-  Scenario Outline: Retrieve application descriptor
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications/app/cartridges" with the following:"cartridge=mysql-5.1"
-    Then the response should be "201"
-    When I send a GET request to "/domains/api<random>/applications/app/descriptor"
-    Then the response descriptor should have "<php_version>,mysql-5.1" as dependencies
-    When I send a DELETE request to "/domains/api<random>/applications/app"
-    Then the response should be "204"
-    
-    @rhel-only
+  @rhel-only
+  Scenario Outline: Retrieve application descriptor (RHEL/CentOS)
+    Given a new user, create a php-<php_version> application using <format> format verify the application descriptor API
+
     Scenarios: RHEL scenarios
       | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
+      | JSON   |     5.3     |
+      | XML    |     5.3     |
       
-    @fedora-only
+  @fedora-only
+  Scenario Outline: Retrieve application descriptor (Fedora)
+    Given a new user, create a php-<php_version> application using <format> format verify the application descriptor API    
+    
     Scenarios: Fedora 18 scenarios
       | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
+      | JSON   |     5.4     |
+      | XML    |     5.4     |
 
   Scenario Outline: Stop and Start embedded cartridge
     Given a new user
     And I accept "<format>"
     When I send a POST request to "/domains" with the following:"id=api<random>"
     Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=diy-0.1"
     Then the response should be "201"
     When I send a POST request to "/domains/api<random>/applications/app/cartridges" with the following:"cartridge=mysql-5.1"
     Then the response should be "201"
     When I send a GET request to "/domains/api<random>/applications/app/descriptor"
-    Then the response descriptor should have "<php_version>,mysql-5.1" as dependencies
+    Then the response descriptor should have "diy-0.1,mysql-5.1" as dependencies
     When I send a POST request to "/domains/api<random>/applications/app/cartridges/mysql-5.1/events" with the following:"event=stop"
     Then the response should be "200"
     When I send a POST request to "/domains/api<random>/applications/app/cartridges/mysql-5.1/events" with the following:"event=start"
@@ -442,81 +277,56 @@ Feature: applications
     When I send a DELETE request to "/domains/api<random>/applications/app"
     Then the response should be "204"
     
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
-      
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
-
+    Scenarios: scenarios
+      | format |
+      | JSON   |
+      | XML    |
 
   Scenario Outline: Restart embedded cartridge
     Given a new user
     And I accept "<format>"
     When I send a POST request to "/domains" with the following:"id=api<random>"
     Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=diy-0.1"
     Then the response should be "201"  
     When I send a POST request to "/domains/api<random>/applications/app/cartridges" with the following:"cartridge=mysql-5.1"
     Then the response should be "201"
     When I send a GET request to "/domains/api<random>/applications/app/cartridges/mysql-5.1"
     Then the response should be "200"
     When I send a GET request to "/domains/api<random>/applications/app/descriptor"
-    Then the response descriptor should have "<php_version>,mysql-5.1" as dependencies
+    Then the response descriptor should have "diy-0.1,mysql-5.1" as dependencies
     When I send a POST request to "/domains/api<random>/applications/app/cartridges/mysql-5.1/events" with the following:"event=restart"
     Then the response should be "200"
     When I send a DELETE request to "/domains/api<random>/applications/app"
     Then the response should be "204"
     
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
-      
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
-
+    Scenarios: scenarios
+      | format |
+      | JSON   |
+      | XML    |
 
   Scenario Outline: Remove embedded cartridge
     Given a new user
     And I accept "<format>"
     When I send a POST request to "/domains" with the following:"id=api<random>"
     Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=diy-0.1"
     Then the response should be "201"
     When I send a POST request to "/domains/api<random>/applications/app/cartridges" with the following:"cartridge=mysql-5.1"
     Then the response should be "201"
     When I send a GET request to "/domains/api<random>/applications/app/descriptor"
-    Then the response descriptor should have "<php_version>,mysql-5.1" as dependencies
+    Then the response descriptor should have "diy-0.1,mysql-5.1" as dependencies
     When I send a DELETE request to "/domains/api<random>/applications/app/cartridges/mysql-5.1"
     Then the response should be "200"
     When I send a GET request to "/domains/api<random>/applications/app/descriptor"
-    Then the response descriptor should have "<php_version>" as dependencies
+    Then the response descriptor should have "diy-0.1" as dependencies
     When I send a DELETE request to "/domains/api<random>/applications/app"
     Then the response should be "204"
   
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
-      
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
-
-     
+    Scenarios: scenarios
+      | format |
+      | JSON   |
+      | XML    |
      
   Scenario Outline: Scale-up and scale-down as application that is not scalable
     Given a new user
@@ -540,43 +350,29 @@ Feature: applications
   Scenario Outline: add application or application event to a non-existent domain
     Given a new user
     And I accept "<format>"
-    When I send a POST request to "/domains/bogus/applications" with the following:"name=app&cartridge=<php_version>"
+    When I send a POST request to "/domains/bogus/applications" with the following:"name=app&cartridge=diy-0.1"
     Then the response should be "404"
     And the error message should have "severity=error&exit_code=127"
     When I send a POST request to "/domains/bogus/applications/app/events" with the following:"event=scale-up"
     Then the response should be "404"
     And the error message should have "severity=error&exit_code=127"
 
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
-      
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
+    Scenarios: scenarios
+      | format |
+      | JSON   |
+      | XML    |
 
   Scenario Outline: Resolve application dns
     Given a new user
     And I accept "<format>"
     When I send a POST request to "/domains" with the following:"id=api<random>"
     Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=diy-0.1"
     Then the response should be "201"
     When I send a GET request to "/domains/api<random>/applications/app/dns_resolvable"
     Then the response should be one of "200,404"
     
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | format | php_version |
-      | JSON   | php-5.3     |
-      | XML    | php-5.3     |
-      
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | format | php_version |
-      | JSON   | php-5.4     |
-      | XML    | php-5.4     |
+    Scenarios: scenarios
+      | format |
+      | JSON   |
+      | XML    |

--- a/controller/test/cucumber/rest-gears.feature
+++ b/controller/test/cucumber/rest-gears.feature
@@ -4,41 +4,10 @@ Feature: gear-groups
   As an API client
   I want to check the application state on each of the gears within each gear group
 
-  Scenario Outline: Check application state on gear with xml
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
-    Then the response should be "201"
-
-    When I send a GET request to "/domains/api<random>/applications/app/gear_groups"
-    Then the response should be a "gear-group/gears/gear" with attributes "state=started"
-
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=stop"
-    Then the response should be "200"
-    When I send a GET request to "/domains/api<random>/applications/app/gear_groups"
-    Then the response should be a "gear-group/gears/gear" with attributes "state=stopped"
-
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=start"
-    Then the response should be "200"
-    When I send a GET request to "/domains/api<random>/applications/app/gear_groups"
-    Then the response should be a "gear-group/gears/gear" with attributes "state=started"
-
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=restart"
-    Then the response should be "200"
-    When I send a GET request to "/domains/api<random>/applications/app/gear_groups"
-    Then the response should be a "gear-group/gears/gear" with attributes "state=started"
-
-    When I send a DELETE request to "/domains/api<random>/applications/app"
-    Then the response should be "204"
-
-    @rhel-only
-    Scenarios: RHEL scenarios
-      | format | php_version |
-      | XML    | php-5.3     |
-      
-    @fedora-only
-    Scenarios: Fedora 18 scenarios
-      | format | php_version |
-      | XML    | php-5.4     |
+  @rhel-only
+  Scenario: Check application state on gear with xml (RHEL/CentOS)
+    Given a new user, create a php-5.3 application using XML format and verify application state on gear
+    
+  @fedora-only
+  Scenario: Check application state on gear with xml (RHEL/CentOS)
+    Given a new user, create a php-5.4 application using XML format and verify application state on gear

--- a/controller/test/cucumber/rest-workflow.feature
+++ b/controller/test/cucumber/rest-workflow.feature
@@ -1,71 +1,22 @@
 @broker
 Feature: Rest Quick tests
   As an developer I want to make sure I didn't break anything that is going to prevent others from working
-    
+  
+  @fedora-only
   Scenario Outline: Typical Workflow
-    Given a new user
-    And I accept "<format>"
-    When I send a POST request to "/user/keys" with the following:"name=api&type=ssh-rsa&content=XYZ123567"
-    Then the response should be "201"
-    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=XYZ123567"
-    When I send a GET request to "/user/keys/api"
-    Then the response should be "200"
-    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=XYZ123567"
-    When I send a POST request to "/domains" with the following:"id=api<random>"
-    Then the response should be "201"
-    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=<php_version>"
-    Then the response should be "201"
-    And the response should be a "application" with attributes "name=app&framework=<php_version>"
-    When I send a GET request to "/domains/api<random>/applications/app"
-    Then the response should be "200"
-    And the response should be a "application" with attributes "name=app&framework=<php_version>"
-    When I send a GET request to "/domains/api<random>/applications"
-    Then the response should be "200"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=stop"
-    Then the response should be "200"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=start"
-    Then the response should be "200"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=start"
-    Then the response should be "200"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=force-stop"
-    Then the response should be "200"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=add-alias&alias=app-api<random>.foobar.com"
-    Then the response should be "200"
-    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=remove-alias&alias=app-api<random>.foobar.com"
-    Then the response should be "200"
-    When I send a POST request to "/domains/api<random>/applications/app/cartridges" with the following:"cartridge=mysql-5.1"
-    Then the response should be "201"
-    When I send a GET request to "/domains/api<random>/applications/app/descriptor"
-    Then the response descriptor should have "<php_version>,mysql-5.1" as dependencies
-    When I send a POST request to "/domains/api<random>/applications/app/cartridges/mysql-5.1/events" with the following:"event=stop"
-    Then the response should be "200"
-    When I send a POST request to "/domains/api<random>/applications/app/cartridges/mysql-5.1/events" with the following:"event=start"
-    Then the response should be "200"
-    When I send a POST request to "/domains/api<random>/applications/app/cartridges/mysql-5.1/events" with the following:"event=restart"
-    Then the response should be "200"
-    When I send a DELETE request to "/domains/api<random>/applications/app/cartridges/mysql-5.1"
-    Then the response should be "200"
-    When I send a PUT request to "/domains/api<random>" with the following:"id=apiX<random>"
-    Then the response should be "200"
-    And the response should be a "domain" with attributes "id=apiX<random>"
-    When I send a DELETE request to "/domains/apiX<random>/applications/app"
-    Then the response should be "204"
-    When I send a GET request to "/domains/apiX<random>/applications/app"
-    Then the response should be "404"
-    When I send a DELETE request to "/domains/apiX<random>"
-    Then the response should be "204"
-    When I send a DELETE request to "/user/keys/api"
-    Then the response should be "204"
+    Given a new user, verify typical REST interactios with a <php_version> application over <format> format
     
-    @fedora-only
     Scenarios: Fedora 18
-     | format | php_version |
-     | JSON   |  php-5.4    |
-     | XML    |  php-5.4    |
-
-    @rhel-only
+      | format | php_version |
+      | JSON   |  php-5.4    |
+      | XML    |  php-5.4    |
+  
+  @rhel-only
+  Scenario Outline: Typical Workflow
+    Given a new user, verify typical REST interactios with a <php_version> application over <format> format
+    
     Scenarios: RHEL
-     | format | php_version |
-     | JSON   |  php-5.3    |
-     | XML    |  php-5.3    |
+      | format | php_version |
+      | JSON   |  php-5.3    |
+      | XML    |  php-5.3    |
 

--- a/controller/test/cucumber/step_definitions/api_steps.rb
+++ b/controller/test/cucumber/step_definitions/api_steps.rb
@@ -31,6 +31,273 @@ After do |scenario|
   end
 end
 
+Given /^a new user, verify typical REST interactios with a ([^ ]+) application over ([^ ]+) format$/ do |cart_name, format|
+  steps %{
+    Given a new user
+    And I accept "#{format}"
+    When I send a POST request to "/user/keys" with the following:"name=api&type=ssh-rsa&content=XYZ123567"
+    Then the response should be "201"
+    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=XYZ123567"
+    When I send a GET request to "/user/keys/api"
+    Then the response should be "200"
+    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=XYZ123567"
+    When I send a POST request to "/domains" with the following:"id=api<random>"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=#{cart_name}"
+    Then the response should be "201"
+    And the response should be a "application" with attributes "name=app&framework=#{cart_name}"
+    When I send a GET request to "/domains/api<random>/applications/app"
+    Then the response should be "200"
+    And the response should be a "application" with attributes "name=app&framework=#{cart_name}"
+    When I send a GET request to "/domains/api<random>/applications"
+    Then the response should be "200"
+    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=stop"
+    Then the response should be "200"
+    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=start"
+    Then the response should be "200"
+    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=start"
+    Then the response should be "200"
+    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=force-stop"
+    Then the response should be "200"
+    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=add-alias&alias=app-api<random>.foobar.com"
+    Then the response should be "200"
+    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=remove-alias&alias=app-api<random>.foobar.com"
+    Then the response should be "200"
+    When I send a POST request to "/domains/api<random>/applications/app/cartridges" with the following:"cartridge=mysql-5.1"
+    Then the response should be "201"
+    When I send a GET request to "/domains/api<random>/applications/app/descriptor"
+    Then the response descriptor should have "#{cart_name},mysql-5.1" as dependencies
+    When I send a POST request to "/domains/api<random>/applications/app/cartridges/mysql-5.1/events" with the following:"event=stop"
+    Then the response should be "200"
+    When I send a POST request to "/domains/api<random>/applications/app/cartridges/mysql-5.1/events" with the following:"event=start"
+    Then the response should be "200"
+    When I send a POST request to "/domains/api<random>/applications/app/cartridges/mysql-5.1/events" with the following:"event=restart"
+    Then the response should be "200"
+    When I send a DELETE request to "/domains/api<random>/applications/app/cartridges/mysql-5.1"
+    Then the response should be "200"
+    When I send a PUT request to "/domains/api<random>" with the following:"id=apiX<random>"
+    Then the response should be "200"
+    And the response should be a "domain" with attributes "id=apiX<random>"
+    When I send a DELETE request to "/domains/apiX<random>/applications/app"
+    Then the response should be "204"
+    When I send a GET request to "/domains/apiX<random>/applications/app"
+    Then the response should be "404"
+    When I send a DELETE request to "/domains/apiX<random>"
+    Then the response should be "204"
+    When I send a DELETE request to "/user/keys/api"
+    Then the response should be "204"
+  }
+end
+
+Given /^a new user, create a ([^ ]+) application using ([^ ]+) format and verify application state on gear$/ do |cart_name, format|
+  steps %{
+    Given a new user
+    And I accept "#{format}"
+    When I send a POST request to "/domains" with the following:"id=api<random>"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=#{cart_name}"
+    Then the response should be "201"
+    
+    When I send a GET request to "/domains/api<random>/applications/app/gear_groups"
+    Then the response should be a "gear-group/gears/gear" with attributes "state=started"
+    
+    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=stop"
+    Then the response should be "200"
+    When I send a GET request to "/domains/api<random>/applications/app/gear_groups"
+    Then the response should be a "gear-group/gears/gear" with attributes "state=stopped"
+    
+    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=start"
+    Then the response should be "200"
+    When I send a GET request to "/domains/api<random>/applications/app/gear_groups"
+    Then the response should be a "gear-group/gears/gear" with attributes "state=started"
+    
+    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=restart"
+    Then the response should be "200"
+    When I send a GET request to "/domains/api<random>/applications/app/gear_groups"
+    Then the response should be a "gear-group/gears/gear" with attributes "state=started"
+    
+    When I send a DELETE request to "/domains/api<random>/applications/app"
+    Then the response should be "204"
+  }
+end
+
+Given /^a new user, create a ([^ ]+) application using ([^ ]+) format and verify application list API$/ do |cart_name, format|
+  steps %{
+    Given a new user
+    And I accept "#{format}"
+    When I send a POST request to "/domains" with the following:"id=api<random>"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=#{cart_name}"
+    Then the response should be "201"
+    When I send a GET request to "/domains/api<random>/applications"
+    Then the response should be "200"
+    When I send a DELETE request to "/domains/api<random>/applications/app"
+    Then the response should be "204"
+  }
+end
+
+Given /^a new user, create a ([^ ]+) application using ([^ ]+) format and verify application creation API$/ do |cart_name, format|
+  steps %{
+    Given a new user
+    And I accept "#{format}"
+    When I send a POST request to "/domains" with the following:"id=api<random>"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=#{cart_name}"
+    Then the response should be "201"
+    And the response should be a "application" with attributes "name=app&framework=#{cart_name}"
+    When I send a DELETE request to "/domains/api<random>/applications/app"
+    Then the response should be "204"
+  }
+end
+
+Given /^a new user, create a ([^ ]+) application with ([^ ]+) using ([^ ]+) format and verify application creation API$/ do |cart_name, add_cart_name, format|
+  steps %{
+    Given a new user
+    And I accept "#{format}"
+    When I send a POST request to "/domains" with the following:"id=api<random>"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridges=#{cart_name}&cartridges=mysql-5.1&cartridges=#{add_cart_name}&initial_git_url=https://github.com/openshift/wordpress-example"
+    Then the response should be "201"
+    And the response should be a "application" with attributes "name=app&framework=#{cart_name}"
+    When I send a DELETE request to "/domains/api<random>/applications/app"
+    Then the response should be "204"
+  }
+end
+
+Given /^a new user, create an invalid application with php-([^ ]+), ruby-1.9, mysql-5.1, phpmyadmin-([^ ]+) using ([^ ]+) format and verify application creation API$/ do |php_version, phpmyadmin_version, format|
+  steps %{
+    Given a new user
+    And I accept "#{format}"
+    When I send a POST request to "/domains" with the following:"id=api<random>"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridges=mysql-5.1&cartridges=phpmyadmin-#{phpmyadmin_version}"
+    Then the response should be "422"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridges=php-#{php_version}&cartridges=ruby-1.9"
+    Then the response should be "422"
+  }
+end
+
+Given /^a new user, create a php-([^ ]+) application using ([^ ]+) format with blank, missing, too long and invalid name and verify application creation API$/ do |php_version, format|
+  steps %{
+    Given a new user
+    And I accept "#{format}"
+    When I send a POST request to "/domains" with the following:"id=api<random>"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=&cartridge=php-#{php_version}"
+    Then the response should be "422"
+    And the error message should have "field=name&severity=error&exit_code=105"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"cartridge=php-#{php_version}"
+    Then the response should be "422"
+    And the error message should have "field=name&severity=error&exit_code=105"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app?one&cartridge=php-#{php_version}"
+    Then the response should be "422"
+    And the error message should have "field=name&severity=error&exit_code=105"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=appone1234567890123456789012345678901234567890&cartridge=php-#{php_version}"
+    Then the response should be "422"
+    And the error message should have "field=name&severity=error&exit_code=105"
+  }
+end
+
+Given /^a new user, create a php-([^ ]+) application using ([^ ]+) format verify retrieving application details$/ do |php_version, format|
+  steps %{
+    Given a new user
+    And I accept "#{format}"
+    When I send a POST request to "/domains" with the following:"id=api<random>"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=php-#{php_version}"
+    Then the response should be "201"
+    When I send a GET request to "/domains/api<random>/applications/app"
+    Then the response should be "200"
+    And the response should be a "application" with attributes "name=app&framework=php-#{php_version}"
+    When I send a DELETE request to "/domains/api<random>/applications/app"
+    Then the response should be "204"
+  }
+end
+
+Given /^a new user, create a php-([^ ]+) application using ([^ ]+) format verify application ([^ ]+) API$/ do |php_version, format, event|
+  steps %{
+    Given a new user
+    And I accept "#{format}"
+    When I send a POST request to "/domains" with the following:"id=api<random>"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=php-#{php_version}"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=#{event}"
+    Then the response should be "200"
+    When I send a DELETE request to "/domains/api<random>/applications/app"
+    Then the response should be "204"
+  }
+end
+
+Given /^a new user, create a php-([^ ]+) application using ([^ ]+) format verify adding and removing application aliases$/ do |php_version, format|
+  steps %{
+    Given a new user
+    And I accept "#{format}"
+    When I send a POST request to "/domains" with the following:"id=api<random>"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=php-#{php_version}"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=add-alias"
+    Then the response should be "422"
+    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=add-alias&alias=app-api.foobar.com"
+    Then the response should be "200"
+    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=remove-alias&alias=app-api.foobar.com"
+    Then the response should be "200"
+    When I send a POST request to "/domains/api<random>/applications/app/events" with the following:"event=add-alias&alias=app-@#$api.foobar.com"
+    Then the response should be "422"
+    When I send a DELETE request to "/domains/api<random>/applications/app"
+    Then the response should be "204"
+  }
+end
+
+Given /^a new user, create a php-([^ ]+) application using ([^ ]+) format verify application deletion$/ do |php_version, format|
+  steps %{
+    Given a new user
+    And I accept "#{format}"
+    When I send a POST request to "/domains" with the following:"id=api<random>"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=php-#{php_version}"
+    Then the response should be "201"
+    When I send a DELETE request to "/domains/api<random>/applications/app"
+    Then the response should be "204"
+    When I send a GET request to "/domains/api<random>/applications/app"
+    Then the response should be "404"
+  }
+end
+
+Given /^a new user, create a php-([^ ]+) application using ([^ ]+) format verify that duplicate application creation fails$/ do |php_version, format|
+  steps %{
+    Given a new user
+    And I accept "#{format}"
+    When I send a POST request to "/domains" with the following:"id=api<random>"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=php-#{php_version}"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=php-#{php_version}"
+    Then the response should be "422"
+    And the error message should have "field=name&severity=error&exit_code=100"
+    When I send a DELETE request to "/domains/api<random>/applications/app"
+    Then the response should be "204"
+  }
+end
+
+Given /^a new user, create a php-([^ ]+) application using ([^ ]+) format verify the application descriptor API$/ do |php_version, format|
+  steps %{
+    Given a new user
+    And I accept "#{format}"
+    When I send a POST request to "/domains" with the following:"id=api<random>"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications" with the following:"name=app&cartridge=php-#{php_version}"
+    Then the response should be "201"
+    When I send a POST request to "/domains/api<random>/applications/app/cartridges" with the following:"cartridge=mysql-5.1"
+    Then the response should be "201"
+    When I send a GET request to "/domains/api<random>/applications/app/descriptor"
+    Then the response descriptor should have "php-#{php_version},mysql-5.1" as dependencies
+    When I send a DELETE request to "/domains/api<random>/applications/app"
+    Then the response should be "204"
+  }
+end
+
 Given /^a new user$/ do
   @random = rand(99999999)
   @username = "rest-test-#{@random}"

--- a/controller/test/cucumber/step_definitions/cartridge-10gen-mms-agent_steps.rb
+++ b/controller/test/cucumber/step_definitions/cartridge-10gen-mms-agent_steps.rb
@@ -1,5 +1,33 @@
 require 'fileutils'
 
+Given /^a ([^ ]+) application, verify addition and removal of 10gen-mms-agent$/ do |cart_name|
+  steps %Q{
+    Given a new #{cart_name} type application
+    And I embed a mongodb-2.2 cartridge into the application
+    And an agent settings.py file is created
+    And I embed a 10gen-mms-agent-0.1 cartridge into the application
+
+    Then 1 process named python will be running
+    And the embedded 10gen-mms-agent-0.1 cartridge subdirectory named mms-agent will exist
+    And the embedded 10gen-mms-agent-0.1 cartridge log files will exist
+    And the embedded 10gen-mms-agent-0.1 cartridge control script will not exist
+
+    When I stop the 10gen-mms-agent-0.1 cartridge
+    Then 0 processes named python will be running
+
+    When I start the 10gen-mms-agent-0.1 cartridge
+    Then 1 processes named python will be running
+
+    When I restart the 10gen-mms-agent-0.1 cartridge
+    Then 1 processes named python will be running
+
+    When I destroy the application
+    Then 0 processes named python will be running
+    And the embedded 10gen-mms-agent-0.1 cartridge subdirectory named mms-agent will not exist
+    And the embedded 10gen-mms-agent-0.1 cartridge log files will not exist
+  }
+end
+
 Given /^an agent settings.py file is created$/ do
   filepath = "/var/lib/openshift/#{@gear.uuid}/app-root/repo/.openshift/mms/settings.py"
 

--- a/controller/test/cucumber/step_definitions/cartridge-cron_steps.rb
+++ b/controller/test/cucumber/step_definitions/cartridge-cron_steps.rb
@@ -1,5 +1,36 @@
 require 'fileutils'
 
+Given /^a ([^ ]+) application, verify addition and removal of cron$/ do |cart_name|
+  steps %Q{
+    Given a new #{cart_name} type application
+    And I embed a cron-1.4 cartridge into the application
+    And cron is running
+
+    Then the embedded cron-1.4 cartridge directory will exist
+    And the embedded cron-1.4 cartridge subdirectory named log will exist
+    And the embedded cron-1.4 cartridge subdirectory named run will exist
+    And cron jobs will be enabled
+
+    When I stop the cron-1.4 cartridge
+    Then cron jobs will not be enabled
+    And cron is stopped
+
+    When I start the cron-1.4 cartridge
+    Then cron jobs will be enabled
+    And cron is running
+
+    When I restart the cron-1.4 cartridge
+    Then cron jobs will be enabled
+
+    When I destroy the application
+    Then cron is stopped
+    And the embedded cron-1.4 cartridge directory will not exist
+    And the embedded cron-1.4 cartridge subdirectory named log will not exist
+    And the embedded cron-1.4 cartridge control script will not exist
+    And the embedded cron-1.4 cartridge subdirectory named run will not exist
+  }
+end
+
 Given /^cron is (running|stopped)$/ do | status |
   cron_cart = @gear.carts['cron-1.4']
 

--- a/controller/test/cucumber/step_definitions/cartridge-haproxy_steps.rb
+++ b/controller/test/cucumber/step_definitions/cartridge-haproxy_steps.rb
@@ -5,6 +5,24 @@ require 'fileutils'
 # Hack to ensure haproxy_ctld_daemon continues to work
 ENV['BUNDLE_GEMFILE'] = nil
 
+Given /^a new ([^ ]+) application, verify haproxy-1.4 using ([^ ]+) process$/ do |cart_name, proc_name|
+  steps %Q{
+    Given a new #{cart_name} type application
+    Then a #{proc_name} process will be running
+    
+    When I embed a haproxy-1.4 cartridge into the application
+    Then 0 process named haproxy will be running
+    And the embedded haproxy-1.4 cartridge directory will exist
+    And the haproxy configuration file will exist
+    And the haproxy PATH override will exist
+
+    When I destroy the application
+    Then 0 processes named haproxy will be running
+    And a #{proc_name} process will not be running
+    And the embedded haproxy-1.4 cartridge directory will not exist
+    And the haproxy configuration file will not exist
+  }
+end
 
 Then /^the haproxy PATH override will( not)? exist$/ do |negate|
   path_location = "#{$home_root}/#{@gear.uuid}/.env/PATH"

--- a/controller/test/cucumber/step_definitions/cartridge-jenkins_steps.rb
+++ b/controller/test/cucumber/step_definitions/cartridge-jenkins_steps.rb
@@ -8,6 +8,14 @@ require 'rest-client'
 
 include AppHelper
 
+Given /^a ([^ ]+) application, verify that you cannot add jenkins client without server being available$/ do |cart_name|
+  steps %Q{
+    Given a new #{cart_name} type application
+    When I fail to embed a jenkins-client-1.4 cartridge into the application
+    Then the embedded jenkins-client-1.4 cartridge directory will not exist
+  }
+end
+
 When /^I configure a hello_world diy application with jenkins enabled$/ do
     @app = TestApp.create_unique('diy-0.1', 'diy')
     run "echo -e \"Host #{@app.hostname}\n\tStrictHostKeyChecking no\n\" >> ~/.ssh/config"

--- a/controller/test/cucumber/step_definitions/cartridge-mongodb_steps.rb
+++ b/controller/test/cucumber/step_definitions/cartridge-mongodb_steps.rb
@@ -3,6 +3,37 @@
 require 'mongo'
 require 'fileutils'
 
+Given /^a ([^ ]+) application, verify addition and removal of MongoDB database$/ do |cart_name|
+  steps %Q{
+    Given a new #{cart_name} type application
+    
+    When I embed a mongodb-2.2 cartridge into the application
+    Then 1 process named mongod will be running
+    And the embedded mongodb-2.2 cartridge directory will exist
+    And the mongodb configuration file will exist
+    And the mongodb database will exist
+    And the embedded mongodb-2.2 cartridge control script will not exist
+    And the mongodb admin user will have access
+
+    When I stop the mongodb-2.2 cartridge
+    Then 0 processes named mongod will be running
+
+    When I start the mongodb-2.2 cartridge
+    Then 1 process named mongod will be running
+
+    When the application cartridge PIDs are tracked
+    And I restart the mongodb-2.2 cartridge
+    Then 1 process named mongod will be running
+    And the tracked application cartridge PIDs should be changed
+
+    When I destroy the application
+    Then 0 processes named mongod will be running
+    And the mongodb database will not exist
+    And the mongodb configuration file will not exist
+    And the embedded mongodb-2.2 cartridge directory will not exist
+  }
+end
+
 Then /^the mongodb configuration file will( not)? exist$/ do |negate|
   cart = @gear.carts['mongodb-2.2']
   user_root = "#{$home_root}/#{@gear.uuid}/#{cart.name}"

--- a/controller/test/cucumber/step_definitions/cartridge-mysql_steps.rb
+++ b/controller/test/cucumber/step_definitions/cartridge-mysql_steps.rb
@@ -4,6 +4,36 @@ require 'rubygems'
 require 'mysql'
 require 'fileutils'
 
+Given /^a ([^ ]+) application, verify addition and removal of mysql$/ do |cart_name|
+  steps %Q{
+    Given a new #{cart_name} type application
+    
+    When I embed a mysql-5.1 cartridge into the application
+    Then a mysqld process will be running
+    And the embedded mysql-5.1 cartridge directory will exist
+    And the mysql configuration file will exist
+    And the mysql database will exist
+    And the mysql admin user will have access
+    
+    When I stop the mysql-5.1 cartridge
+    Then a mysqld process will not be running
+    
+    When I start the mysql-5.1 cartridge
+    Then a mysqld process will be running
+    
+    When the application cartridge PIDs are tracked
+    And I restart the mysql-5.1 cartridge
+    Then a mysqld process will be running
+    And the tracked application cartridge PIDs should be changed
+    
+    When I destroy the application
+    Then a mysqld process will not be running
+    And the mysql database will not exist
+    And the mysql configuration file will not exist
+    And the embedded mysql-5.1 cartridge directory will not exist
+  }
+end
+
 Then /^the mysql configuration file will( not)? exist$/ do |negate|
   mysql_cart = @gear.carts['mysql-5.1']
 

--- a/controller/test/cucumber/step_definitions/cartridge-phpmyadmin_steps.rb
+++ b/controller/test/cucumber/step_definitions/cartridge-phpmyadmin_steps.rb
@@ -1,0 +1,30 @@
+Given /^a php-([\d\.]+) application, verify addition and removal of phpmyadmin-([\d\.]+)$/ do |php_version, phpmyadmin_version|
+  steps %Q{    
+    Given a new php-#{php_version} type application
+        
+    When I embed a mysql-5.1 cartridge into the application
+    And I embed a phpmyadmin-#{phpmyadmin_version} cartridge into the application
+    Then the http proxy /phpmyadmin will exist
+    And 4 processes named httpd will be running
+    And the embedded phpmyadmin-#{phpmyadmin_version} cartridge directory will exist
+    And the embedded phpmyadmin-#{phpmyadmin_version} cartridge log files will exist
+    
+    When I stop the phpmyadmin-#{phpmyadmin_version} cartridge
+    Then 2 processes named httpd will be running
+    And the web console for the phpmyadmin-#{phpmyadmin_version} cartridge is not accessible
+    
+    When I start the phpmyadmin-#{phpmyadmin_version} cartridge
+    Then 4 processes named httpd will be running
+    And the web console for the phpmyadmin-#{phpmyadmin_version} cartridge is accessible
+        
+    When I restart the phpmyadmin-#{phpmyadmin_version} cartridge
+    Then 4 processes named httpd will be running
+    And the web console for the phpmyadmin-#{phpmyadmin_version} cartridge is accessible
+    
+    When I destroy the application
+    Then 0 processes named httpd will be running
+    And the http proxy /phpmyadmin will not exist
+    And the embedded phpmyadmin-#{phpmyadmin_version} cartridge directory will not exist
+    And the embedded phpmyadmin-#{phpmyadmin_version} cartridge log files will not exist
+  }
+end

--- a/controller/test/cucumber/step_definitions/cartridge-postgresql_steps.rb
+++ b/controller/test/cucumber/step_definitions/cartridge-postgresql_steps.rb
@@ -3,6 +3,36 @@
 require 'pg'
 require 'fileutils'
 
+Given /^a ([^ ]+) application, verify addition and removal of postgresql ([^ ]+)$/ do |cart_name, version|
+  steps %Q{
+    Given a new #{cart_name} type application
+    
+    When I embed a postgresql-#{version} cartridge into the application
+    Then a postgres process will be running
+    And the embedded postgresql-#{version} cartridge directory will exist
+    And the postgresql configuration file will exist
+    And the postgresql database will exist
+    And the embedded postgresql-#{version} cartridge control script will not exist
+    And the postgresql admin user will have access
+    
+    When I stop the postgresql-#{version} cartridge
+    Then a postgres process will not be running
+    
+    When I start the postgresql-#{version} cartridge
+    Then a postgres process will be running
+    
+    When the application cartridge PIDs are tracked
+    And I restart the postgresql-#{version} cartridge
+    Then a postgres process will be running
+    And the tracked application cartridge PIDs should be changed
+    
+    When I destroy the application
+    Then a postgres process will not be running
+    And the postgresql database will not exist
+    And the postgresql configuration file will not exist
+    And the embedded postgresql-#{version} cartridge directory will not exist
+  }
+end
 
 Then /^the postgresql configuration file will( not)? exist$/ do |negate|
   pgsql_cart = nil

--- a/controller/test/cucumber/step_definitions/client_steps.rb
+++ b/controller/test/cucumber/step_definitions/client_steps.rb
@@ -2,6 +2,36 @@ Given /^an accepted node$/ do
   # TODO: Add any required checks here
 end
 
+Given /^the libra client tools, create a new php-([^ ]+) application, verify addition and removal of mysql-5.1 , phpmyadmin-([^ ]+) , cron-1.4 , mongodb-2.2$/ do |php_version, phpmyadmin_version|
+  steps %{
+    Given the libra client tools
+    And an accepted node
+    When 1 php-#{php_version} applications are created
+    Then the applications should be accessible
+
+    Given an existing #{php_version} application without an embedded cartridge
+    When the embedded mysql-5.1 cartridge is added
+    And the embedded phpmyadmin-#{phpmyadmin_version} cartridge is added
+    Then the application should be accessible
+    When the application uses mysql
+    Then the application should be accessible
+    And the mysql response is successful
+    When the embedded phpmyadmin-#{phpmyadmin_version} cartridge is removed
+    And the embedded mysql-5.1 cartridge is removed
+    Then the application should be accessible
+
+    When the embedded mongodb-2.2 cartridge is added
+    And the embedded cron-1.4 cartridge is added
+    Then the application should be accessible
+    And the embedded mongodb-2.2 cartridge is removed
+    And the embedded cron-1.4 cartridge is removed
+    Then the application should be accessible
+
+    When the application is destroyed
+    Then the application should not be accessible
+  }
+end
+
 Given /^the libra client tools$/ do
   File.exists?($client_config).should be_true
   File.exists?($rhc_script).should be_true

--- a/controller/test/cucumber/step_definitions/idler_steps.rb
+++ b/controller/test/cucumber/step_definitions/idler_steps.rb
@@ -1,3 +1,49 @@
+Given /^a new ([^ ]+) application with ([^ ]+) process, verify that it can be idled$/ do |cart_name, proc_name|
+  steps %{
+    Given a new #{cart_name} type application
+    Then a #{proc_name} process will be running
+    And I record the active capacity
+  
+    When I oo-idle the application
+    Then a #{proc_name} process will not be running
+    And the active capacity has been reduced
+  }
+end
+
+Given /^a new ([^ ]+) application with ([^ ]+) process, verify that it can be restored after idling$/ do |cart_name, proc_name|
+  steps %{
+    Given a new #{cart_name} type application
+    Then a #{process} process will be running
+    And I record the active capacity
+
+    When I oo-idle the application
+    Then a #{process} process will not be running
+    And the active capacity has been reduced
+    And I record the active capacity after idling
+
+    When I oo-restore the application
+    Then a #{process} process will be running
+    And the active capacity has been increased
+  }
+end
+
+Given /^a new ([^ ]+) application with ([^ ]+) process, verify that it can be auto-restored after idling$/ do |cart_name, proc_name|
+  steps %{
+    Given a new #{cart_name} type application
+    Then a #{proc_name} process will be running
+    And I record the active capacity
+
+    When I oo-idle the application
+    Then a #{proc_name} process will not be running
+    And the active capacity has been reduced
+    And I record the active capacity after idling
+
+    When I run the health-check for the <type> cartridge
+    Then a #{proc_name} process will be running
+    And the active capacity has been increased
+  }
+end
+
 # match against oo-idle and oo-restore to avoid conflict
 When /^I oo-(idle|restore) the application$/ do |action|
   cmd = nil

--- a/controller/test/cucumber/step_definitions/runtime-extended-cartridge_steps.rb
+++ b/controller/test/cucumber/step_definitions/runtime-extended-cartridge_steps.rb
@@ -1,0 +1,37 @@
+Given /^a ([^ ]+) application, add and remove ([^ ]+) database and use ([^ ]+) proc and ([^ ]+) name to verify$/ do |cart_name, db_cart_type, db_proc, db_name|
+  steps %Q{
+    Given a new #{cart_name} type application
+    
+    When I embed a #{db_cart_type} cartridge into the application
+    Then a #{db_proc} process will be running
+    And the embedded #{db_cart_type} cartridge directory will exist
+    And the #{db_name} configuration file will exist
+    And the #{db_name} database will exist
+    And the #{db_name} admin user will have access
+    And the embedded #{db_cart_type} cartridge control script will not exist
+    
+    When I remove the #{db_cart_type} cartridge from the application
+    Then a #{db_proc} process will not be running
+    And the embedded #{db_cart_type} cartridge control script will not exist    
+    And the #{db_name} database will not exist
+    And the #{db_name} configuration file will not exist
+    And the embedded #{db_cart_type} cartridge directory will not exist
+  }
+end
+
+Given /^a ([^ ]+) application, embed mysql-([^ ]+), postgresql-([^ ]+), mongodb-([^ ]+) $/ do |cart_name, mysql_version, postgresql_version, mongodb_version|
+  steps %Q{
+    Given a new #{cart_name} type application
+    When I embed a mysql-#{mysql_version} cartridge into the application
+    And I embed a postgresql-#{postgresql_version} cartridge into the application
+    And I embed a mongodb-#{mongodb_version} cartridge into the application
+    Then a mysqld process will be running
+    And the embedded mysql-#{mysql_version} cartridge directory will exist
+    And a postgres process will be running
+    And the embedded postgresql-#{postgresql_version} cartridge directory will exist
+    And a mongod process will be running
+    And the embedded mongodb-#{mongodb_version} cartridge directory will exist
+  }
+end
+
+

--- a/controller/test/cucumber/step_definitions/runtime_steps.rb
+++ b/controller/test/cucumber/step_definitions/runtime_steps.rb
@@ -67,6 +67,206 @@ Given /^a new ([^ ]+) application, verify start, stop, restart using ([^ ]+)$/ d
   }
 end
 
+Given /^a new ([^ ]+) application, verify its availability$/ do |cart_name|
+  steps %{
+    Given the libra client tools
+    And an accepted node
+    When 1 #{cart_name} applications are created
+    Then the applications should be accessible
+    Then the applications should be accessible via node-web-proxy
+  }
+end
+
+Given /^an existing ([^ ]+) application, verify application aliases$/ do |cart_name|
+  steps %{
+    Given an existing #{cart_name} application
+    When the application is aliased
+    Then the application should respond to the alias
+  }
+end
+
+Given /^a new ([^ ]+) application, verify application alias setup on the node$/ do |cart_name|
+  steps %{
+    Given a new #{cart_name} type application
+    And I add an alias to the application
+    Then the php application will be aliased
+    And the php file permissions are correct
+    When I remove an alias from the application
+    Then the php application will not be aliased 
+    When I destroy the application
+    Then the http proxy will not exist
+  }
+end
+
+Given /^an existing ([^ ]+) application, verify submodules$/ do |cart_name|
+  steps %{
+    Given an existing #{cart_name} application
+    When the submodule is added
+    Then the submodule should be deployed successfully
+    And the application should be accessible
+  }
+end
+
+Given /^an existing ([^ ]+) application, verify code updates$/ do |cart_name|
+  steps %{
+    Given an existing #{cart_name} application
+    When the application is changed
+    Then it should be updated successfully
+    And the application should be accessible
+  }
+end
+
+Given /^an existing ([^ ]+) application, verify it can be stopped$/ do |cart_name|
+  steps %{
+    Given an existing #{cart_name} application
+    When the application is stopped
+    Then the application should not be accessible
+  }
+end
+
+Given /^an existing ([^ ]+) application, verify it can be started$/ do |cart_name|
+  steps %{
+    Given an existing #{cart_name} application
+    When the application is started
+    Then the application should be accessible
+  }
+end
+
+Given /^an existing ([^ ]+) application, verify it can be restarted$/ do |cart_name|
+  steps %{
+    Given an existing #{cart_name} application
+    When the application is restarted
+    Then the application should be accessible
+  }
+end
+
+Given /^an existing ([^ ]+) application, verify it can be tidied$/ do |cart_name|
+  steps %{
+    Given an existing #{cart_name} application
+    When I tidy the application
+    Then the application should be accessible
+  }
+end
+
+Given /^an existing ([^ ]+) application, verify it can be snapshotted and restored$/ do |cart_name|
+  steps %{
+    Given an existing #{cart_name} application    
+    When I snapshot the application
+    Then the application should be accessible
+    When I restore the application
+    Then the application should be accessible
+  }
+end
+
+Given /^an existing ([^ ]+) application, verify its namespace can be changed$/ do |cart_name|
+  steps %{
+    Given an existing #{cart_name} application
+    When the application namespace is updated
+    Then the application should be accessible
+  }
+end
+
+Given /^an existing ([^ ]+) application, verify it can be destroyed$/ do |cart_name|
+  steps %{
+    Given an existing #{cart_name} application
+    When the application is destroyed
+    Then the application should not be accessible
+    Then the application should not be accessible via node-web-proxy
+  }
+end
+
+Given /^a new ([^ ]+) application, verify rhcsh$/ do |cart_name|
+  steps %{
+    Given a new #{cart_name} type application
+    And the application is made publicly accessible
+
+    Then I can run "ls / > /dev/null" with exit code: 0
+    And I can run "this_should_fail" with exit code: 127
+    And I can run "true" with exit code: 0
+    And I can run "java -version" with exit code: 0
+    And I can run "scp" with exit code: 1
+  }
+end
+
+Given /^a new ([^ ]+) application, verify tail logs$/ do |cart_name|
+  steps %{
+    Given a new #{cart_name} type application
+    And the application is made publicly accessible
+    Then a tail process will not be running
+
+    When I tail the logs via ssh
+    Then a tail process will be running
+
+    When I stop tailing the logs
+    Then a tail process will not be running
+  }
+end
+
+Given /^a new ([^ ]+) application, obtain disk quota information via SSH$/ do |cart_name|
+  steps %{
+    Given a new #{cart_name} type application
+    And the application is made publicly accessible
+    Then I can obtain disk quota information via SSH
+  }
+end
+
+Given /^a new ([^ ]+) application, use ctl_all to start and stop it, and verify it using ([^ ]+)$/ do |cart_name, proc_name|
+  steps %{
+    Given a new #{cart_name} type application
+    And the application is made publicly accessible
+
+    When I stop the application using ctl_all via rhcsh
+    Then a #{proc_name} process will not be running
+
+    When I start the application using ctl_all via rhcsh
+    Then a #{proc_name} process will be running
+  }
+end
+
+Given /^a new ([^ ]+) application, with ([^ ]+) and ([^ ]+), verify that they are running using ([^ ]+) and ([^ ]+)$/ do |cart_name, db_type, management_app, proc_name, db_proc_name|
+  steps %{
+    Given a new #{type} type application
+    And I embed a #{db_type} cartridge into the application
+    And I embed a #{management_app} cartridge into the application
+    And the application is made publicly accessible
+
+    When I stop the application using ctl_all via rhcsh
+    Then a #{proc_name} process for #{type} will not be running
+    And a #{db_proc_name} process will not be running 
+    And a httpd process for #{management_app} will not be running
+
+    When I start the application using ctl_all via rhcsh
+    Then a #{proc_name} process for #{type} will be running
+    And a #{db_proc_name} process will be running
+    And a httpd process for #{management_app} will be running
+  }
+end
+
+Given /^a new ([^ ]+) application, verify using socket file to connect to database$/ do |cart_name|
+  steps %{  
+    Given a new #{cart_name} type application
+    And I embed a mysql-5.1 cartridge into the application
+    And the application is made publicly accessible
+  
+    When I select from the mysql database using the socket file
+    Then the select result from the mysql database should be valid
+  }
+end
+
+Given /^a new ([^ ]+) application, verify when hot deploy is( not)? enabled, it does( not)? change pid of ([^ ]+) proc$/ do |cart_name, hot_deply_not_enabled, pid_not_changed, proc_name|
+  steps %{
+    Given a new #{cart_name} type application
+    And the application is made publicly accessible
+    And hot deployment is#{hot_deply_not_enabled} enabled for the application
+    And the application cartridge PIDs are tracked
+    When an update is pushed to the application repo
+    Then a #{proc_name} process will be running
+    And the tracked application cartridge PIDs should#{pid_not_changed} be changed
+    When I destroy the application
+    Then a #{proc_name} process will not be running
+  }
+end
+
 # Creates a new account, application, gear, and cartridge in one shot.
 # The cartridge is then configured. After running this step, subsequent
 # steps will have access to three pieces of state:

--- a/controller/test/cucumber/trap-user-extended.feature
+++ b/controller/test/cucumber/trap-user-extended.feature
@@ -1,17 +1,11 @@
 #@runtime_extended_other2
 @runtime_extended2
 Feature: Trap User Shell
-  Scenario Outline: Use ctl_all to start and stop a simple application
-    Given a new <type> type application
-    And the application is made publicly accessible
 
-    When I stop the application using ctl_all via rhcsh
-    Then a <proc_name> process will not be running
+  @rhel-only
+  Scenario Outline: Use ctl_all to start and stop a simple application (RHEL/CentOS)
+    Given a new <type> application, use ctl_all to start and stop it, and verify it using <proc_name>
 
-    When I start the application using ctl_all via rhcsh
-    Then a <proc_name> process will be running
-
-    @rhel-only
     Scenarios: RHEL scenarios
       | type         | proc_name |
       | jbossas-7    | java      |
@@ -22,34 +16,28 @@ Feature: Trap User Shell
       | php-5.3      | httpd     |
       | python-2.6   | httpd     |
 
+
+  Scenario Outline: Use ctl_all to start and stop a simple application (Common)
+    Given a new <type> application, use ctl_all to start and stop it, and verify it using <proc_name>
+
     Scenarios: Common scenarios
       | type         | proc_name |
       | nodejs-0.6   | node      |
       | ruby-1.9     | httpd     |
 
-    @fedora-only
+  @fedora-only
+  Scenario Outline: Use ctl_all to start and stop a simple application (Fedora)
+    Given a new <type> application, use ctl_all to start and stop it, and verify it using <proc_name>
+
     Scenarios: Fedora 18 scenarios
       | type         | proc_name |
       | perl-5.16    | httpd     |
       | php-5.4      | httpd     |
 
-  Scenario Outline: Use ctl_all to start and stop an application with an embedded database
-    Given a new <type> type application
-    And I embed a <db_type> cartridge into the application
-    And I embed a <management_app> cartridge into the application
-    And the application is made publicly accessible
+  @rhel-only
+  Scenario Outline: Use ctl_all to start and stop an application with an embedded database (RHEL/CentOS)
+    Given a new <type> application, with <db_type> and <management_app>, verify that they are running using <proc_name> and <db_proc_name>
 
-    When I stop the application using ctl_all via rhcsh
-    Then a <proc_name> process for <type> will not be running
-    And a <db_proc_name> process will not be running 
-    And a httpd process for <management_app> will not be running
-
-    When I start the application using ctl_all via rhcsh
-    Then a <proc_name> process for <type> will be running
-    And a <db_proc_name> process will be running
-    And a httpd process for <management_app> will be running
-
-    @rhel-only
     Scenarios: RHEL scenarios
       | type         | proc_name | db_type     | db_proc_name | management_app |
       | ruby-1.8     | httpd     | mongodb-2.2 | mongod       | rockmongo-1.1  |
@@ -61,7 +49,10 @@ Feature: Trap User Shell
       | ruby-1.9     | httpd     | mongodb-2.2 | mongod       | rockmongo-1.1  |
       | ruby-1.9     | httpd     | mysql-5.1   | mysqld       | phpmyadmin-3.4 |
 
-    @fedora-only
+  @fedora-only
+  Scenario Outline: Use ctl_all to start and stop an application with an embedded database (Fedora)
+    Given a new <type> application, with <db_type> and <management_app>, verify that they are running using <proc_name> and <db_proc_name>
+    
     Scenarios: Fedora 18 scenarios
       | type         | proc_name | db_type     | db_proc_name | management_app |
       | perl-5.16    | httpd     | mysql-5.1   | mysqld       | phpmyadmin-3.5 |

--- a/controller/test/cucumber/trap-user.feature
+++ b/controller/test/cucumber/trap-user.feature
@@ -7,53 +7,26 @@ Feature: Trap User Shell
   I should be able to limit user login to a defined set of commands
   So that I can ensure the security of the system
 
-  Scenario Outline: Running commands via rhcsh
-    Given a new <php_version> type application
-    And the application is made publicly accessible
+  @rhel-only
+  Scenario: Running commands via rhcsh (RHEL/CentOS)
+    Given a new php-5.3 application, verify rhcsh
+  
+  @fedora-only
+  Scenario: Running commands via rhcsh (Fedora)
+    Given a new php-5.4 application, verify rhcsh
 
-    Then I can run "ls / > /dev/null" with exit code: 0
-    And I can run "this_should_fail" with exit code: 127
-    And I can run "true" with exit code: 0
-    And I can run "java -version" with exit code: 0
-    And I can run "scp" with exit code: 1
-
-    @fedora-only
-    Scenarios: Fedora 18
-     | php_version |
-     |  php-5.4    |
-
-    @rhel-only
-    Scenarios: RHEL
-     | php_version |
-     |  php-5.3    |
-
-  Scenario Outline: Tail Logs
-    Given a new <php_version> type application
-    And the application is made publicly accessible
-    Then a tail process will not be running
-
-    When I tail the logs via ssh
-    Then a tail process will be running
-
-    When I stop tailing the logs
-    Then a tail process will not be running
-
-    @fedora-only
-    Scenarios: Fedora 18
-     | php_version |
-     |  php-5.4    |
-     
-    @rhel-only
-    Scenarios: RHEL
-     | php_version |
-     |  php-5.3    |
-
-  Scenario Outline: Access Quota
-    Given a new <php_version> type application
-    And the application is made publicly accessible
-    Then I can obtain disk quota information via SSH
-
-    @rhel-only
-    Scenarios: RHEL
-     | php_version |
-     |  php-5.3    |
+  @rhel-only
+  Scenario: Tail Logs (RHEL/CentOS)
+    Given a new php-5.3 application, verify tail logs
+  
+  @fedora-only  
+  Scenario: Tail Logs (Fedora)
+    Given a new php-5.4 application, verify tail logs
+  
+  @rhel-only
+  Scenario: Access Quota (RHEL/CentOS)
+    Given a new php-5.3 application, obtain disk quota information via SSH
+    
+  @fedora-only
+  Scenario: Access Quota (Fedora)
+    Given a new php-5.4 application, obtain disk quota information via SSH


### PR DESCRIPTION
The core of the issue is that cucumber ignores tags when line number is specified.
