### PR TITLE
added cgset freeze|thaw user

### DIFF
--- a/node/misc/sbin/oo-admin-ctl-cgroups
+++ b/node/misc/sbin/oo-admin-ctl-cgroups
@@ -128,6 +128,18 @@ function set_blkio() {
     done
 }
 
+#
+# Freeze a user
+#
+freeze_user() {
+    # USERNAME=$1
+    cgset -r freezer.state=FROZEN -g ${OPENSHIFT_CGROUP_ROOT}/$1
+}
+
+thaw_user() {
+    cgset -r freezer.state=THAWED -g ${OPENSHIFT_CGROUP_ROOT}/$1
+}
+
 # List the openshift guest users
 #
 openshift_users() {
@@ -451,31 +463,35 @@ case "$1" in
     ;;
 
   startuser)
-    if (service cgconfig status >/dev/null)
-    then
+    if is_systemd || service cgconfig status >/dev/null 2>&1
+    then 
         startuser $2
-        #service cgred reload
         pkill -USR2 cgrulesengd
     else
         RETVAL=1
-        echo "cgconfig service not running"
+        echo "cgconfig service is not running"
     fi
-    ;;
 
   stopuser)
-    if (service cgconfig status >/dev/null)
+    if is_systemd || service cgconfig status >/dev/null 2>&1
     then
         stopuser $2
-        #service cgred reload
         pkill -USR2 cgrulesengd
     else
         RETVAL=1
-        echo "cgconfig service not running"
+        echo "cgconfig service is not running"
     fi
-    ;;
+
+  freezeuser)
+      freeze_user $2
+      ;;
+
+  thawuser)
+      thaw_user $2
+      ;;
 
   *)
-    echo $"Usage: $0 {startall|stopall|restartall|condrestartall|status|startuser <username>|stopuser <username>}"
+    echo $"Usage: $0 {startall|stopall|restartall|condrestartall|status|startuser <username>|stopuser <username>|freezeuser <username>|thawuser <username>}"
     exit 1
 esac
 

--- a/node/misc/sbin/oo-admin-ctl-cgroups
+++ b/node/misc/sbin/oo-admin-ctl-cgroups
@@ -133,11 +133,11 @@ function set_blkio() {
 #
 freeze_user() {
     # USERNAME=$1
-    cgset -r freezer.state=FROZEN -g ${OPENSHIFT_CGROUP_ROOT}/$1
+    cgset -r freezer.state=FROZEN ${OPENSHIFT_CGROUP_ROOT}/$1
 }
 
 thaw_user() {
-    cgset -r freezer.state=THAWED -g ${OPENSHIFT_CGROUP_ROOT}/$1
+    cgset -r freezer.state=THAWED ${OPENSHIFT_CGROUP_ROOT}/$1
 }
 
 # List the openshift guest users
@@ -471,6 +471,7 @@ case "$1" in
         RETVAL=1
         echo "cgconfig service is not running"
     fi
+    ;;
 
   stopuser)
     if is_systemd || service cgconfig status >/dev/null 2>&1
@@ -481,14 +482,15 @@ case "$1" in
         RETVAL=1
         echo "cgconfig service is not running"
     fi
+    ;;
 
   freezeuser)
-      freeze_user $2
-      ;;
+    freeze_user $2
+    ;;
 
   thawuser)
-      thaw_user $2
-      ;;
+    thaw_user $2
+    ;;
 
   *)
     echo $"Usage: $0 {startall|stopall|restartall|condrestartall|status|startuser <username>|stopuser <username>|freezeuser <username>|thawuser <username>}"


### PR DESCRIPTION
oo-admin-ctl-cgroups had lost the freeze|thaw user functions.

This change restores them, using cgset.

This also checks for is_systemd OR cgconfig service running, but not both.
