### PR TITLE
Turned out to be unnecessary.

### DIFF
--- a/cartridges/openshift-origin-cartridge-mongodb-2.2/info/hooks/configure
+++ b/cartridges/openshift-origin-cartridge-mongodb-2.2/info/hooks/configure
@@ -125,10 +125,13 @@ client_result "   Root Password: $password"
 client_result "   Database Name: $DB_NAME"
 client_result ""
 
-client_result 'Connection URL: mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/'
-client_result ""
-
-if ! is_a_scalable_app; then
+if is_a_scalable_app; then
+    client_result 'Connection URL: mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/'
+    client_result 'MongoDB gear-local connection URL: mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/'
+    client_result ""
+else
+    client_result 'Connection URL: mongodb://$OPENSHIFT_MONGODB_DB_HOST:$OPENSHIFT_MONGODB_DB_PORT/'
+    client_result ""
     client_result "You can manage your new MongoDB by also embedding rockmongo-1.1"
     client_result "The rockmongo username and password will be the same as the MongoDB credentials above."
 fi


### PR DESCRIPTION
Revert "Bug 901445 - Clean up scaled app output."

This reverts commit 2a391695f00bae35580843075f9a2fc13b294c06.
