### PR TITLE
Bug 918966 - Routes in broker should handle IDs more generically

### DIFF
--- a/controller/config/routes.rb
+++ b/controller/config/routes.rb
@@ -1,25 +1,27 @@
 Rails.application.routes.draw do
+  id_with_format = OpenShift::Controller::Routing::ID_WITH_FORMAT
+
   scope "/rest" do
     resource :api, :only => :show, :controller => :api
     resource :environment, :only => [:show], :controller => :environment
     resource :user, :only => [:show, :destroy], :controller => :user do
-      resources :keys, :controller => :keys, :constraints => { :id => /[\w\.\-@+]+?(?=(\.(xml|json|yml|yaml|xhtml))?\z)/ }
-      resources :authorizations, :controller => :authorizations, :constraints => { :id => /[\w]+/ }, :only => [:index, :show, :destroy, :create, :update]
+      resources :keys, :controller => :keys, :constraints => { :id => id_with_format }
+      resources :authorizations, :controller => :authorizations, :constraints => { :id => id_with_format }, :only => [:index, :show, :destroy, :create, :update]
       match 'authorizations' => 'authorizations#destroy_all', :via => :delete
     end
     resources :cartridges, :only => [:index, :show], :constraints => { :id => /standalone|embedded/ }
     resources :quickstarts, :only => [:index, :show]
-    resources :estimates, :constraints => { :id => /[\w]+/ }, :only => [:index, :show]
+    resources :estimates, :constraints => { :id => id_with_format }, :only => [:index, :show]
 
     # Allow restful update of the domain name via the standard id parameter
-    match "domains/:existing_id" => "domains#update", :via => :put, :existing_id => /[A-Za-z0-9]+/
-    resources :domains, :constraints => { :id => /[A-Za-z0-9]+/ } do
-      resources :applications, :constraints => { :id => /[A-Za-z0-9]+/ } do
+    match "domains/:existing_id" => "domains#update", :via => :put, :existing_id => id_with_format
+    resources :domains, :constraints => { :id => id_with_format } do
+      resources :applications, :constraints => { :id => id_with_format } do
         resource :descriptor, :only => :show
-        resources :gear_groups, :constraints => { :id => /[A-Za-z0-9]+/ }, :only => [:index, :show]
+        resources :gear_groups, :constraints => { :id => id_with_format }, :only => [:index, :show]
         #added back the gears URL so we can return an appropriate message instead of a routing error
         resources :gears, :only => [:index, :show]
-        resources :cartridges, :controller => :emb_cart, :only => [:index, :show, :create, :update, :destroy], :constraints => { :id => /([\w\-]+(-)([\d]+(\.[\d]+)*)+)/ } do
+        resources :cartridges, :controller => :emb_cart, :only => [:index, :show, :create, :update, :destroy], :constraints => { :id => id_with_format } do
             resources :events, :controller => :emb_cart_events, :only => :create
         end
         resources :events, :controller => :app_events, :only => :create

--- a/controller/lib/openshift-origin-controller.rb
+++ b/controller/lib/openshift-origin-controller.rb
@@ -10,6 +10,7 @@ module OpenShift
     autoload :ApiResponses,            'openshift/controller/api_responses'
     autoload :Configuration,           'openshift/controller/configuration'
     autoload :OAuth,                   'openshift/controller/oauth'
+    autoload :Routing,                 'openshift/controller/routing'
     autoload :ScopeAuthorization,      'openshift/controller/scope_authorization'
   end
 

--- a/controller/lib/openshift/controller/routing.rb
+++ b/controller/lib/openshift/controller/routing.rb
@@ -1,0 +1,7 @@
+module OpenShift
+  module Controller
+    module Routing
+      ID_WITH_FORMAT = /[^\/]+(?=\.xml\z|\.json\z)|[^\/]+/
+    end
+  end
+end


### PR DESCRIPTION
Rails automatically applies a (.:format) qualifier to restful routes. The
broker is using a set of very arbitrary regexes - instead we should be looking
for SPECIFICALLY .json or .xml as an extension, and everything else becomes
the ID.

Includes: https://github.com/openshift/li/pull/985
