### PR TITLE
Add yard documentation markup to DNS plugins

### DIFF
--- a/controller/.gitignore
+++ b/controller/.gitignore
@@ -1,2 +1,2 @@
-doc
 .yardoc
+doc

--- a/controller/lib/openshift/dns_service.rb
+++ b/controller/lib/openshift/dns_service.rb
@@ -1,30 +1,85 @@
 module OpenShift
+
+  # Abstract DNS update plugin interface
+  #
+  # The DNS update plugin communicates with a dynamic DNS service to publish
+  # the locations of new applications.
+  #
+  # This class defines the abstract interface that will be implemented by
+  # plugins which interact with real services.
+  #
+  # This class also acts as a factory for the plugin service objects.
+  #
+  # @abstract
   class DnsService
     @oo_dns_provider = OpenShift::DnsService
 
+    # Set the concrete provider class for the plugin object factory
+    # @param [Class <DnsService>] provider_class
+    #   The class to instantiate when an instance is requested
+    # @return [Class <DnsService>]
+    #   The class which has been set in the factory
     def self.provider=(provider_class)
       @oo_dns_provider = provider_class
     end
 
+    # Factory method for plugin implementation objects
+    # @return [DnsService] 
+    #   an object which implements the DnsService interface
     def self.instance
       @oo_dns_provider.new
     end
 
-    def initialize
-    end
+    #def initialize
+    #end
 
+    # Publish an application - create DNS record
+    #
+    # @param [String] app_name
+    #   The name of the application to publish
+    # @param [String] namespace
+    #   The namespace which contains the application
+    # @param [String] public_hostname
+    #   The name of the location where the application resides
+    # @return [Object]
+    #   The response from the service provider in what ever form
+    #   that takes
     def register_application(app_name, namespace, public_hostname)
     end
 
+    # Unpublish an application - remove DNS record
+    #
+    # @param [String] app_name
+    #   The name of the application to publish
+    # @param [String] namespace
+    #   The namespace which contains the application
+    # @return [Object]
+    #   The response from the service provider in what ever form
+    #   that takes    
     def deregister_application(app_name, namespace)
     end
-    
+
+    # Change the published location of an application - Modify DNS record
+    #
+    # @param [String] app_name
+    #   The name of the application to publish
+    # @param [String] namespace
+    #   The namespace which contains the application
+    # @param [String] public_hostname
+    #   The name of the location where the application resides
+    # @return [Object]
+    #   The response from the service provider in what ever form
+    #   that takes
     def modify_application(app_name, namespace, public_hostname)
     end
 
+    # Send any queued update requests to the DNS update service
+    # @return [nil]
     def publish
     end
 
+    # Terminate any open connection to the DNS update service
+    # @return [nil]
     def close
     end
   end

--- a/plugins/dns/bind/.gitignore
+++ b/plugins/dns/bind/.gitignore
@@ -1,2 +1,2 @@
-doc
 .yardoc
+doc

--- a/plugins/dns/bind/config/initializers/openshift-origin-dns-bind.rb
+++ b/plugins/dns/bind/config/initializers/openshift-origin-dns-bind.rb
@@ -1,5 +1,10 @@
 require 'openshift-origin-common'
 
+# Add DNS plugin configuration information to the Rails::application.config
+# object
+#
+# @see OpenShift::BindPlugin
+#
 Broker::Application.configure do
   conf_file = File.join(OpenShift::Config::PLUGINS_DIR, File.basename(__FILE__, '.rb') + '.conf')
   if Rails.env.development?

--- a/plugins/dns/bind/lib/openshift/bind_plugin.rb
+++ b/plugins/dns/bind/lib/openshift/bind_plugin.rb
@@ -5,16 +5,59 @@ require 'rubygems'
 require 'dnsruby'
 
 module OpenShift
-  class BindPlugin < OpenShift::DnsService
-    @oo_dns_provider = OpenShift::BindPlugin
 
-    # DEPENDENCIES
-    # Rails.application.config.openshift[:domain_suffix]
-    # Rails.application.config.dns[...]
+  #
+  # OpenShift DNS Plugin to interact with dynamic DNS using 
+  # {https://www.ietf.org/rfc/rfc2136 RFC 2136} update protocol and
+  # {https://www.ietf.org/rfc/rfc2845 RFC 2845} DNS TSIG
+  #
+  # Implements the OpenShift::DnsService interface
+  #
+  # This service uses the Ruby Dnsruby package to communicate with the
+  # DNS service.
+  #
+  # The object can be configured either by providing the access_info
+  # parameter or by pulling the settings from the Rails.application.config
+  # object (if it exists).
+  #
+  # When pulling from the Rails configuration this plugin expects to find
+  # the domain_suffix in 
+  #   Rails.application.config.openshift[:domain_suffix]
+  # and the rest of the parameters in a hash at
+  #   Rails.application.config.dns
+  #
+  # @example Bind plugin configuration hash
+  #   {:server => "myserver",
+  #    :port => portnumber,
+  #    :keyname => "TSIG key name",
+  #    :keyvalue => "TSIG key string",
+  #    :zone => "zone to update",
+  #    # only when configuring with parameters
+  #    :domain_suffix => "suffix for application domain names"
+  #    }
+  #
+  # @!attribute [r] server
+  #   @return [String] IP address of the DNS update server
+  # @!attribute [r] port
+  #   @return [Fixnum] UDP port for the DNS update server
+  # @!attribute [r] keyname
+  #   @return [String] the TSIG key name
+  # @!attribute [r] keyvalue
+  #   @return [String] the TSIG key value
+  class BindPlugin < OpenShift::DnsService
 
     attr_reader :server, :port, :keyname, :keyvalue
 
+    # class variable: 
+    @oo_dns_provider = OpenShift::BindPlugin
+
+
+    # Establish the parameters for a connection to the DNS update service
+    #
+    # @param access_info [Hash] communication configuration settings
+    # @see BindPlugin BindPlugin class Examples
     def initialize(access_info = nil)
+
       if access_info != nil
         @domain_suffix = access_info[:domain_suffix]
       elsif defined? Rails
@@ -32,6 +75,11 @@ module OpenShift
       @zone = access_info[:zone]
     end
 
+    private
+
+    # create a resolver object - connection to the update server
+    #
+    # @return [Dnsruby::Resolver] a resolver object for the update service
     def dns
       if not @dns_con
         @dns_con = Dnsruby::Resolver.new(:nameserver => @server, :port => @port)
@@ -40,6 +88,20 @@ module OpenShift
       @dns_con
     end
 
+    public
+
+
+    # Publish an application - create DNS record
+    #
+    # @param [String] app_name
+    #   The name of the application to publish
+    # @param [String] namespace
+    #   The namespace which contains the application
+    # @param [String] public_hostname
+    #   The name of the location where the application resides
+    # @return [Object]
+    #   The response from the service provider in what ever form
+    #   that takes
     def register_application(app_name, namespace, public_hostname)
       # create an A record for the application in the domain
       fqdn = "#{app_name}-#{namespace}.#{@domain_suffix}"
@@ -51,6 +113,15 @@ module OpenShift
       dns.send_message(update)
     end
 
+    # Unpublish an application - remove DNS record
+    #
+    # @param [String] app_name
+    #   The name of the application to publish
+    # @param [String] namespace
+    #   The namespace which contains the application
+    # @return [Object]
+    #   The response from the service provider in what ever form
+    #   that takes    
     def deregister_application(app_name, namespace)
       begin
         # delete the CNAME record for the application in the domain
@@ -72,14 +143,29 @@ module OpenShift
       end
     end
   
+    # Change the published location of an application - Modify DNS record
+    #
+    # @param [String] app_name
+    #   The name of the application to publish
+    # @param [String] namespace
+    #   The namespace which contains the application
+    # @param [String] public_hostname
+    #   The name of the location where the application resides
+    # @return [Object]
+    #   The response from the service provider in what ever form
+    #   that takes
     def modify_application(app_name, namespace, public_hostname)
       deregister_application(app_name, namespace)
       register_application(app_name, namespace, public_hostname)
     end
 
+    # send any queued requests to the update server
+    # @return [nil]
     def publish
     end
 
+    # close any persistent connection to the update server
+    # @return [nil]
     def close
     end
     

--- a/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
+++ b/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
@@ -5,12 +5,52 @@ require 'rubygems'
 
 module OpenShift
 
-  # 
+  # OpenShift DNS Plugin to interact with dynamic DNS using 
+  # {https://www.ietf.org/rfc/rfc2136 RFC 2136} update protocol and
+  # {https://www.ietf.org/rfc/rfc2845 RFC 2845} DNS TSIG
+  #
+  # Implements the OpenShift::DnsService interface
+  #
+  # This class uses the nsupdate(8) program to communicate with the
+  # DNS service.
+  #
+  # The object can be configured either by providing the access_info
+  # parameter or by pulling the settings from the Rails.application.config
+  # object (if it exists).
+  #
+  # When pulling from the Rails configuration this plugin expects to find
+  # the domain_suffix in 
+  #   Rails.application.config.openshift[:domain_suffix]
+  # and the rest of the parameters in a hash at
+  #   Rails.application.config.dns
+  #
+  # @example Bind plugin configuration hash
+  #   {:server => "myserver",
+  #    :port => portnumber,
+  #    :keyname => "TSIG key name",
+  #    :keyvalue => "TSIG key string",
+  #    :zone => "zone to update",
+  #    # only when configuring with parameters
+  #    :domain_suffix => "suffix for application domain names"
+  #    }
+  #
+  # @!attribute [r] server
+  #   @return [String] IP address of the DNS update server
+  # @!attribute [r] port
+  #   @return [Fixnum] UDP port for the DNS update server
+  # @!attribute [r] keyname
+  #   @return [String] the TSIG key name
+  # @!attribute [r] keyvalue
+  #   @return [String] the TSIG key value
   class NsupdatePlugin < OpenShift::DnsService
     @provider = OpenShift::NsupdatePlugin
 
     attr_reader :server, :port, :keyname, :keyvalue
 
+    # Establish the parameters for a connection to the DNS update service
+    #
+    # @param access_info [Hash] communication configuration settings
+    # @see BindPlugin BindPlugin class Examples
     def initialize(access_info = nil)
       if access_info != nil
         @domain_suffix = access_info[:domain_suffix]
@@ -28,6 +68,17 @@ module OpenShift
       @zone = access_info[:zone]
     end
 
+    # Publish an application - create DNS record
+    #
+    # @param [String] app_name
+    #   The name of the application to publish
+    # @param [String] namespace
+    #   The namespace which contains the application
+    # @param [String] public_hostname
+    #   The name of the location where the application resides
+    # @return [Object]
+    #   The response from the service provider in what ever form
+    #   that takes
     def register_application(app_name, namespace, public_hostname)
       # create an A record for the application in the domain
       fqdn = "#{app_name}-#{namespace}.#{@domain_suffix}"
@@ -42,6 +93,15 @@ EOF
       }
     end
 
+    # Unpublish an application - remove DNS record
+    #
+    # @param [String] app_name
+    #   The name of the application to publish
+    # @param [String] namespace
+    #   The namespace which contains the application
+    # @return [Object]
+    #   The response from the service provider in what ever form
+    #   that takes    
     def deregister_application(app_name, namespace)
       # delete the CNAME record for the application in the domain
       fqdn = "#{app_name}-#{namespace}.#{@domain_suffix}"
@@ -58,14 +118,29 @@ EOF
       }
     end
 
+   # Change the published location of an application - Modify DNS record
+    #
+    # @param [String] app_name
+    #   The name of the application to publish
+    # @param [String] namespace
+    #   The namespace which contains the application
+    # @param [String] public_hostname
+    #   The name of the location where the application resides
+    # @return [Object]
+    #   The response from the service provider in what ever form
+    #   that takes
     def modify_application(app_name, namespace, public_hostname)
       deregister_application(app_name, namespace)
       register_application(app_name, namespace, public_hostname)
     end
 
+    # send any queued requests to the update server
+    # @return [nil]
     def publish
     end
 
+    # close any persistent connection to the update server
+    # @return [nil]
     def close
     end
 

--- a/plugins/dns/route53/.gitignore
+++ b/plugins/dns/route53/.gitignore
@@ -1,2 +1,3 @@
 AWSCONFIG
 doc
+.yardoc


### PR DESCRIPTION
This should change NO CODE.

This change adds yard documentation markup to the DnsService abstract base class and the existing DNS plugin implementation classes.
