### PR TITLE
Bug 876746 - oo-cartridge-info errors when no parameters are passed

### DIFF
--- a/node/misc/bin/oo-cartridge-info
+++ b/node/misc/bin/oo-cartridge-info
@@ -56,6 +56,11 @@ end
 $oo_debug = true if args['--debug']
 $porcelain = args['--porcelain'] ? true : false
 
+if ARGV[0].nil?
+  $stderr.write(usage())
+  exit(1)
+end
+
 cart_name = ARGV.shift
 cart_found = false
 


### PR DESCRIPTION
[merge]
