### PR TITLE
correct openshift-node-web-proxy logrotate to match all log files.

### DIFF
--- a/node-proxy/config/logrotate.d/openshift-node-web-proxy
+++ b/node-proxy/config/logrotate.d/openshift-node-web-proxy
@@ -1,4 +1,4 @@
-/var/log/node-web-proxy/*.log {
+/var/log/node-web-proxy/*log {
     daily
     missingok
     notifempty
@@ -8,5 +8,7 @@
     size 20M
     rotate 5
     sharedscripts
+    postrotate
+        /sbin/service openshift-node-web-proxy reload > /dev/null 2>/dev/null || true
+    endscript
 }
-

--- a/node-proxy/config/logrotate.d/openshift-node-web-proxy
+++ b/node-proxy/config/logrotate.d/openshift-node-web-proxy
@@ -9,6 +9,6 @@
     rotate 5
     sharedscripts
     postrotate
-        /sbin/service openshift-node-web-proxy reload > /dev/null 2>/dev/null || true
+        /sbin/service openshift-node-web-proxy restart > /dev/null 2>/dev/null || true
     endscript
 }


### PR DESCRIPTION
This ensures logrotate correctly rotates all node-web-proxy log files, including supervisor_log.
