### PR TITLE
Fix 'No such file' bug.

### DIFF
--- a/broker-util/oo-setup-broker
+++ b/broker-util/oo-setup-broker
@@ -412,7 +412,7 @@ run "/usr/sbin/lokkit -p 53:tcp"
 run "/usr/sbin/lokkit -p 53:udp"
 
 $log.info "Updating broker hostname in apache"
-find_and_replace( "/etc/httpd/conf.d/000000_openshift_origin_broker_proxy.conf", /  ServerName.*$/, "  ServerName broker.#{node_domain}" )
+find_and_replace( "/etc/httpd/conf.d/000002_openshift_origin_broker_proxy.conf", /  ServerName.*$/, "  ServerName broker.#{node_domain}" )
 
 $log.info "Updating system wide OpenShift CLI configuration to use local broker"
 File.open("/etc/openshift/express.conf", "w") do |f|


### PR DESCRIPTION
File 000000_openshift_origin_broker_proxy.conf was deleted, the new is 000002_openshift_origin_broker_proxy.conf.
