### PR TITLE
Moved the call of exec "app_ctl.sh reload" into a forked child process

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy-1.4/info/bin/haproxy_ctld.rb
+++ b/cartridges/openshift-origin-cartridge-haproxy-1.4/info/bin/haproxy_ctld.rb
@@ -85,7 +85,9 @@ class HAProxyUtils
         if repaired
             @@log.info("GEAR_INFO - validate: Configuration was modified, reloading haproxy")
             ENV["CARTRIDGE_TYPE"] = "haproxy-1.4"
-            exec "app_ctl.sh reload"
+            fork do
+              exec "app_ctl.sh reload"
+            end
         end
     end
 end


### PR DESCRIPTION
The reload triggered by app_ctl.sh was killing haproxy_ctld
