### PR TITLE
Add rake tasks to resolve dependencies, build RPMs and generate docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 .*.swp
 .sass-cache
 .rvmrc
+.yardoc
+doc
+pkg

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,287 @@
+# Building OpenShift Origin Packages
+
+The OpenShift Origin build tree uses Rake to automate the package and
+documentation build process.  A small set of task files are stored in
+the _tasks_ directory at the root of the source tree.  These can be
+included in the Rakefile in each sub-directory and in the root
+directory for each package.
+
+# <a id="Prerequisites">Prerequisites</a>
+
+Before you can start building the software you need to have a build
+host (a computer set up to run the builds) and the software which is
+used to orchestrate the process.
+
+The [OpenShift](http://openshift.redhat.com) project
+[source code](https://github.com/openshift/origin-server) is hosted on
+[Github](https://github.com) and the source code is managed with
+[git](http://git-scm.com/). The software is packaged in RPM format
+(with some as [Rubygems](http://rubygems.org) as an intermediate
+format). The package building program is _rpmbuild_. The packaging is
+managed by [Tito](https://github.com/dwoodson/tito). Repository
+management is done by _yum_ (using yum-utils). The build tasks
+are defined by [Rake](http://rubygems.org/gems/rake). The
+documentation is compiled with [Yard](http://yardoc.org) (another
+rubygem). Testing is done with
+[Rspec 2.x](https://www.relishapp.com/rspec) and
+[Cucumber](http://cukes.info/).
+
+All of these must be installed on the build system before the
+OpenShift Origin software can be built.
+
+    yum install git rubygem-rake rubygem-yard rubygem-redcarpet \
+        rpm-build tito yum-utils rubygem-bundler \
+        rubygem-rspec-core rubygem-rspec-mocks \
+        rubygem-rspec-expectations rubygem-rspec-rails \
+        rubygem-cucumber
+
+# <a id="Standard Tasks">Standard Tasks</a>
+
+You can check at any level what tasks are available using the _rake_
+command.  This is a sample of the tasks at the top of the source
+tree. Not all of these will be available in any other location.
+
+    $ rake --tasks
+    rake all:builddep[answer]      # install all build requirements
+    rake all:yard[docdir]          # generate comprehensive documentation
+    rake all:rpm[repodir,test,yum] # generate all RPMs and create yum repo
+    rake all:testrpm[repodir,yum]  # generate all RPMs and create yum repo
+    rake builddep[answer]          # install build requirements from subdirs
+    rake rpm[repodir,test,yum]     # generate RPM packages in subdirectories
+    rake testrpm[repodir,yum]      # generate test RPM packages in subdirs
+    rake yard[docdir]              # generate yard docs in subdirectories
+    rake yard_sources              # report doc sources
+    
+There are three files in ```tasks/``` in the top of the source
+tree. These define a set of standard tasks.
+
+te markup docs
+* **build_tasks.rb** - tasks for building or preparing to build packages
+ * _builddep_ - install packages needed to build this package
+ * _rpm[repodir,test,yum]_ - build the release version of this package
+ * _testrpm[repodir,yum]_ - build the test version of this package
+
+
+* **yard_tasks.rb** - tasks for generating markup documentation 
+ * _yard_ - generate markup documentation
+ * *yard_sources* - list the source subdirectories and files for markup
+
+
+* **dir_tasks.rb** - tasks for a directory containing other packages.
+ * _rpm[repodir,test,yum]_ - pass down the rpm task to children
+ * _testrpm[repodir,yum]_ - pass down the testrpm task to children
+ * _yard_ - pass down the yard task to children
+ * *yard_sources* - list the source subdirectories for all children
+
+You can ```require``` one or more of these in a Rakefile to enable the
+standard tasks.
+
+## Install Package Build Requirements
+
+When the [prerequisites](#Prerequisites) have been installed you can
+start using the build tasks.  The first task is to insure that all of
+the build requirements for the packages are in place.
+
+Each package directory should have a Rake task named _builddep_.  You
+can run that task in the package directory.  You can also run it from
+the root of the source tree. It will walk the source tree examining
+each package and installing the build requirements.
+
+The first time you're installing you can run a special target
+*all:builddep* at the root of the source tree.  This target is more
+efficient at installing all of the requirements at once.
+
+    rake all:builddep # install all build requirements
+    rake builddep     # install the build requirements for one package
+    
+The _yum-builddep_ program that is used must be run as root.  If you
+are not the root user when you run this target it will use _sudo_.
+You will need to have sudo enabled and enter your password once.
+    
+## Generate Software Packages and Repository
+
+Once all of the build requirements for all of the software have been
+installed you can proceed to creating the software packages. There are
+two tasks to generate packages.
+
+* _rpm_ - generate release (tagged) packages
+* _testrpm_ - generate test package from the most recent commit
+
+Both tasks can take arguments (presented in square brackets suffixed
+to the task name).
+
+* _repodir_ - the destination for packaging artifacts and a _yum_
+  repository.
+
+* _test_ - rpm only - create test RPMs instead of release packages.
+
+* _yum_ -  both - run createrepo in the destination after building.
+
+  __NOTE__: Rake doesn't read ```.titorc``` so you must specify the
+  location of the RPM destination to properly generate the yum metadata.
+
+### Release (tagged) Packages
+
+Each package will have a target named _rpm_ which will invoke _tito_
+to execute the build and place the RPM in to a repository. The _rpm_
+task will generate the most recent tagged release of the package.
+
+    rake all:rpm[/var/www/httpd/yum] # build all RPMs and create repo
+    rake rpm # build one (or all) packages in the default destination
+    rake rpm[/var/cache/yumrepo] # build packages in alternate destination
+    
+    
+
+### Test Packages
+
+You can use the _rpm_ task to build test RPMs but a shortcut has been
+provided. The _testrpm_ task is used in the same way as the _rpm_ task
+but will generate test RPMs with versions which allow them to be
+installed and updated with ```yum update``` as development proceeds.
+
+    rake testrpm # build one or all packages to the default location
+    rake testrpm[/home/devuser/yumrepo] # build to alternate location
+
+## Generate Code Markup Documentation
+
+It has become fairly common practice to automatically generate
+function and class documentation using some form of markup in comments
+in-line with source code.  Ruby has a number of tools that will do
+this. The OpenShift project is using the [Yard](http://yardoc.org)
+documentation generator.  All of the ruby code should be marked up to
+provide useful documentation.
+
+A set of tasks have been provided to trigger the generation of markup
+documentation. Each package should have a _yard_ target to generate a
+local copy of the documentation for that package alone.  This can be
+integrated with the package build process so that the documentation
+can be included in the package.
+
+At the top of the software tree a custom _yard_ target will build a
+comprehensive documentation set for all of the packages included in
+the tree.  By default the _yard_ target places the resulting output in
+the a subdirectory of the current working directory. The output
+location is named named ```./doc``` .
+
+Like the _rpm_ and _testrpm_ targets, the top level _yard_
+target can take an argument to place the output in a custom location.
+
+    rake all:yard[/var/www/html/osdocs] # place docs where apached can see
+    rake yard # generate documentation and place it in the default location.
+   
+_NOTE_ : due to a peculiarity in the default _yard_ rake target, the
+alternate location argument is only available for the comprehensive
+build target at the root of the source tree. 
+
+# Adding Software
+
+When you add a new package to the source tree you should add a
+Rakefile to your package root directory and to any parent directory
+which doesn't already have one.  You can use one of the existing ones
+as a sample.  If you include any of the
+[Standard Tasks](#Standard Tasks) you will need to adjust the _require_
+line to refer to the right number of parent directories.
+
+## Including the [Standard Tasks](#Standard Tasks)
+
+* Create a Rakefile
+* add _require_ lines
+* adjust for the depth
+* add custom tasks as needed
+
+### Directory Rakefiles
+
+Rake tasks can walk the entire source repository, executing the task
+in each package root.  To do this each directory must have a set of
+tasks which will look down into their children and pass the task down.
+The directories which contain children must have a set of tasks to do that.
+
+Example:
+
+    cat plugins/Rakefile 
+    #
+    # A Rakefile for a parent directory with no custom tasks
+    #
+    require "../tasks/dir_tasks"
+
+This file sits one level below the root of the source tree.  It is a
+directory which contains nothing but subdirectories.  The
+subdirectories may contain packages or other children which contain
+their own Rakefile.
+
+### Package Rakefiles
+
+The Rakefile in the root directory of a package will need to include
+at least the *build_tasks.rb* file.  If the package contains Ruby code
+with markup commentary it should also include the *yard_tasks.rb* file
+as well.  Remember to adjust the path to reach the ```tasks```
+directory at the root of the source tree.
+
+Example:
+
+    cat plugins/dns/bind/Rakefile
+    # 
+    # Standard Tasks
+    #
+    require "../../../tasks/build_tasks"
+    require "../../../tasks/yard_tasks" 
+    
+    # Define these to allow generation of comprehensive yard docs
+    YARD_SOURCEROOT = File.dirname(__FILE__)
+    YARD_SOURCES = ['lib']
+    
+    # Custom test task
+    require 'rake/testtask'
+    
+    Rake::TestTask.new(:test) do |t|
+      t.libs << 'test'
+      t.test_files = FileList['test/**/*_test.rb']
+      t.verbose = true
+    end
+
+Note first that the ```require``` lines for the OpenShift standard
+tasks have been adjusted for the depth of the Rakefile in the source
+tree.
+
+Second, note the *YARD_SOURCEROOT* and *YARD_SOURCES* constants.
+These are used by the *yard_sources* target.  They tell the *all:yard*
+target at the root what source files and directories to include in the
+comprehensive documentation output.
+
+Finally this file defines a custom _test_ task using the Rake testtask module.
+
+## Adding Custom Tasks
+
+If you need custom tasks for a given package, feel free to add them to
+the local Rakefile.  Be aware of the standard tasks so you can avoid
+accidentally overriding them.
+
+See the example above.
+
+## Adding "Standard" Tasks
+
+Because the [Standard Tasks](#Standard Tasks) are defined in one place
+in the source tree, it is possible to add new "standard" tasks without
+editing all of the Rakefiles in the tree.
+
+You need to be sure that the new task will not conflict with any
+existing tasks.  If you want the top level Rakefile task to walk the
+entire source tree, you will need to add a matching task to the
+*dir_tasks.rb* file.
+
+If you want to create a new *class* of standard tasks (tasks that do
+not fall into "build", "yard" or "dir", you __will__ have to create a
+new task definition file at the top level and add that to each of the
+appropriate Rakefiles in the source tree.  The only obvious class I
+can think of is __test__. This should not happen often after this
+system has been in use for a while.
+
+# References
+
+* __Git__: The [Git](http://git-scm.com/) software revision control system
+* __Github__: (https://github.com) - The hosting site for OpenShift Origin
+* __Rake__: [Ruby Make](http://rake.rubyforge.org/) - development tasks
+* __Yard__: [Generate API documentation from code markup](http://yardoc.org/)
+* __Tito__: [Generate RPM packages and repository](http://github.com/dgoodwin/tito)
+* __Rspec__: [Unit testing framework for test driven development](https://www.relishapp.com/rspec)
+* __Cucumber__: [Behavior driven functional and integration testing framework](http://cukes.info)

--- a/Rakefile
+++ b/Rakefile
@@ -1,25 +1,101 @@
 require 'rake'
+require 'yard'
 
-begin
-  require 'yard'
+# use recursive tasks
+#require "./tasks/dir_tasks"
 
-  namespace :doc do
-    desc 'Create Ruby docs for all components'
-    task :gen do
-      doc_dir = File.join(File.dirname(__FILE__), "doc")
-      FileUtils.rm_rf(doc_dir)
-      gems = Dir.glob("**/*.gemspec")
-      gems.each do |gem_file|
-        gem_src_dir = File.dirname(gem_file)
-        FileUtils.mkdir_p File.join(doc_dir, gem_src_dir)
-        
-        args = ['--protected', '--private', '--no-yardopts', "--output-dir #{File.join(doc_dir, gem_src_dir)}"] #, File.join(gem_src_dir, "**/*")
-        system "cd #{gem_src_dir}; yardoc #{args.join(" ")}\n"
-        system "yardoc README.md"
+namespace :all do
+  # ============================================================================
+  # Custom top-level tasks for efficiency
+  #
+  # While these tasks can be done recursively, they're much faster this way.
+  # ============================================================================
+
+  #
+  # Generate and combine Yard documentation from all sources
+  #
+  desc "generate comprehensive documentation"
+  task :yard, :destdir do | t, args |
+
+    puts "collecting source locations"
+
+    # include manually created markdown documentation
+    readme_files = FileList["*.md", "documentation/*.md"]
+
+    # find the source locations indicated in each package
+    srclist = `rake yard_sources`.split("\n")
+    puts "sourcelist = #{srclist}"
+
+    # Generate docs with standard parameters
+    cmd = 'yard doc '
+    yardargs = ['--protected', '--private', '--no-yardopts']
+    cmd += yardargs.join(' ') + ' '
+
+    # Set the destination for docs if provided
+    if not args[:destdir] == nil then
+      cmd += "--output-dir #{args[:destdir]} " 
+    end
+
+    # compose the doc generation command
+    cmd += srclist.join(' ')
+    cmd += " - " + readme_files.join(' ')
+
+    # Generate documentation
+    system cmd
+  end
+
+  #
+  # Install all RPM build requirements
+  #
+  require 'find'
+  desc "install all build requirements"
+  task :builddep, :answer do |t, args|
+    cmd = "yum-builddep "
+
+    answer = args[:answer] || ""
+    cmd += " --assume#{answer} " if ['yes', 'no'].include? answer
+
+    speclist = []
+    Find.find(".") do | f |
+      speclist << f if /\.spec$/.match f
+    end
+    specfiles = speclist.join(' ')
+
+    cmd += specfiles
+    cmd = "sudo " + cmd if not Process.uid == 0
+    system cmd
+  end
+
+  #
+  # Build all RPMs and generate a yum repository
+  #
+  desc "generate all RPMs and create yum repository"
+  task :rpm, :repodir, :test, :yum do |t, args|
+
+    repodir = args[:repodir] || ""
+    testflag = args[:test] || "/tmp/tito"
+
+    Find.find(".") do |f|
+      if /.spec$/.match f then
+        pkgdir = File.dirname f
+        system "cd #{pkgdir} ; rake rpm[#{repodir},#{testflag}]"
       end
     end
+
+    # generate the repo metadata    
+    system "createrepo #{repodir}" if args[:yum] and File.directory? repodir
   end
-rescue LoadError => e
-  print e.message
-  # YARD is not available
+
+  #
+  # Create test RPMs from source tree and spec files
+  #
+  # repodir: destination for artifacts and packages
+  #
+  desc "generate all test RPMs and create yum repository"
+  task :testrpm, :repodir, :yum do |t, args|
+    repodir = args[:repodir] || ""
+    yum = args[:yum] || ""
+    Rake.application.invoke_task("all:rpm[#{repodir},true,#{yum}]")
+  end
+
 end

--- a/broker-util/Rakefile
+++ b/broker-util/Rakefile
@@ -1,0 +1,1 @@
+require "../tasks/build_tasks"

--- a/broker/Rakefile
+++ b/broker/Rakefile
@@ -1,7 +1,21 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
-require 'rake'
+if defined? Rails then
+  #
+  # When running the broker application...
+  #
 
-Broker::Application.load_tasks
+  require File.expand_path('config/application', File.dirname(__FILE__))
+
+  require 'rake'
+
+  Broker::Application.load_tasks
+else
+  # include standard build/doc tasks
+  require "../tasks/yard_tasks"
+  require "../tasks/build_tasks"
+
+  YARD_SOURCEROOT = File.dirname(__FILE__)
+  YARD_SOURCES = ['app', 'config', 'lib']
+end

--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent-0.1/Rakefile
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent-0.1/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-abstract/Rakefile
+++ b/cartridges/openshift-origin-cartridge-abstract/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-community-python-2.7/Rakefile
+++ b/cartridges/openshift-origin-cartridge-community-python-2.7/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-community-python-3.3/Rakefile
+++ b/cartridges/openshift-origin-cartridge-community-python-3.3/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-cron-1.4/Rakefile
+++ b/cartridges/openshift-origin-cartridge-cron-1.4/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-diy-0.1/Rakefile
+++ b/cartridges/openshift-origin-cartridge-diy-0.1/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-haproxy-1.4/Rakefile
+++ b/cartridges/openshift-origin-cartridge-haproxy-1.4/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-jbossas-7/Rakefile
+++ b/cartridges/openshift-origin-cartridge-jbossas-7/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-jbosseap-6.0/Rakefile
+++ b/cartridges/openshift-origin-cartridge-jbosseap-6.0/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-jbossews-1.0/Rakefile
+++ b/cartridges/openshift-origin-cartridge-jbossews-1.0/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-jbossews-2.0/Rakefile
+++ b/cartridges/openshift-origin-cartridge-jbossews-2.0/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-jenkins-1.4/Rakefile
+++ b/cartridges/openshift-origin-cartridge-jenkins-1.4/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-jenkins-client-1.4/Rakefile
+++ b/cartridges/openshift-origin-cartridge-jenkins-client-1.4/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-mock-plugin/Rakefile
+++ b/cartridges/openshift-origin-cartridge-mock-plugin/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-mock/Rakefile
+++ b/cartridges/openshift-origin-cartridge-mock/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-mongodb-2.2/Rakefile
+++ b/cartridges/openshift-origin-cartridge-mongodb-2.2/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-mysql-5.1/Rakefile
+++ b/cartridges/openshift-origin-cartridge-mysql-5.1/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-nodejs-0.6/Rakefile
+++ b/cartridges/openshift-origin-cartridge-nodejs-0.6/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-perl-5.10/Rakefile
+++ b/cartridges/openshift-origin-cartridge-perl-5.10/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-php-5.3/Rakefile
+++ b/cartridges/openshift-origin-cartridge-php-5.3/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-phpmyadmin-3.4/Rakefile
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin-3.4/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-postgresql-8.4/Rakefile
+++ b/cartridges/openshift-origin-cartridge-postgresql-8.4/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-python-2.6/Rakefile
+++ b/cartridges/openshift-origin-cartridge-python-2.6/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-ruby-1.8/Rakefile
+++ b/cartridges/openshift-origin-cartridge-ruby-1.8/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-ruby-1.9-scl/Rakefile
+++ b/cartridges/openshift-origin-cartridge-ruby-1.9-scl/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/cartridges/openshift-origin-cartridge-switchyard-0.6/Rakefile
+++ b/cartridges/openshift-origin-cartridge-switchyard-0.6/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/common/Rakefile
+++ b/common/Rakefile
@@ -1,8 +1,5 @@
-require 'rubygems'
-require 'rake'
 require 'rake/clean'
 require 'rake/testtask'
-require "bundler/gem_tasks"
 
 desc "Print environment to run from checkout - eval $( rake local_env | tail -n +1 )"
 task :local_env do
@@ -22,3 +19,10 @@ desc "Generate RDoc"
 task :doc do
   sh "rdoc ."
 end
+
+# include standard build and doc tasks
+require "../tasks/yard_tasks"
+require "../tasks/build_tasks"
+
+YARD_SOURCEROOT = File.dirname(__FILE__)
+YARD_SOURCES = ['lib']

--- a/console/Rakefile
+++ b/console/Rakefile
@@ -1,44 +1,62 @@
 #!/usr/bin/env rake
-begin
-  require 'bundler/setup'
-rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+
+if defined? Rails then
+  begin
+   require 'bundler/setup'
+  rescue LoadError
+    puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+  end
+
+  APP_RAKEFILE = File.expand_path(
+    "test/rails_app/Rakefile", 
+    File.dirname(__FILE__))
+
+  load 'rails/tasks/engine.rake'
+
+  Bundler::GemHelper.install_tasks
+  #
+  # Bundler has an older vendored version of net/http/persistent in /vendor. 
+  # If this remains on the path, then calling require 'net/http/persistent'
+  # will load the vendored version rather than the one on our path.
+  #
+  $LOAD_PATH.delete_if{ |p| p =~ %r(/lib/bundler/vendor) }
+
+else
+  require 'rake/testtask'
+
+
+  begin
+    require 'rdoc/task'
+  rescue LoadError
+    require 'rdoc/rdoc'
+    require 'rake/rdoctask'
+    RDoc::Task = Rake::RDocTask
+  end
+
+  RDoc::Task.new(:rdoc) do |rdoc|
+    rdoc.rdoc_dir = 'rdoc'
+    rdoc.title    = 'Testblah'
+    rdoc.options << '--line-numbers'
+    rdoc.rdoc_files.include('README.rdoc')
+    rdoc.rdoc_files.include('lib/**/*.rb')
+  end
+
+
+  Rake::TestTask.new(:test) do |t|
+    t.libs << 'lib'
+    t.libs << 'test'
+    t.pattern = 'test/**/*_test.rb'
+    t.verbose = false
+  end
+
+  # include standard build and documentation tasks
+  require "../tasks/build_tasks"
+  require "../tasks/yard_tasks"
+
+  YARD_SOURCEROOT = File.dirname(__FILE__)
+  # Define these to allow generation of comprehensive yard docs
+  YARD_SOURCES = ['app', 'config', 'lib']  
+  
+
+  task :default => :test
 end
-begin
-  require 'rdoc/task'
-rescue LoadError
-  require 'rdoc/rdoc'
-  require 'rake/rdoctask'
-  RDoc::Task = Rake::RDocTask
-end
-
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'Testblah'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.rdoc')
-  rdoc.rdoc_files.include('lib/**/*.rb')
-end
-
-APP_RAKEFILE = File.expand_path("../test/rails_app/Rakefile", __FILE__)
-load 'rails/tasks/engine.rake'
-
-Bundler::GemHelper.install_tasks
-#
-# Bundler has an older vendored version of net/http/persistent in /vendor. 
-# If this remains on the path, then calling require 'net/http/persistent'
-# will load the vendored version rather than the one on our path.
-#
-$LOAD_PATH.delete_if{ |p| p =~ %r(/lib/bundler/vendor) }
-
-require 'rake/testtask'
-
-Rake::TestTask.new(:test) do |t|
-  t.libs << 'lib'
-  t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
-  t.verbose = false
-end
-
-
-task :default => :test

--- a/controller/Rakefile
+++ b/controller/Rakefile
@@ -1,9 +1,20 @@
-#require "bundler/gem_tasks"
-require 'rake'
-require 'rake/testtask'
+#
+# Standard Tasks
+#
+require "../tasks/build_tasks"
+require "../tasks/yard_tasks"
 
+YARD_SOURCEROOT = File.dirname(__FILE__)
+YARD_SOURCES = ['app', 'config', 'lib']
+
+
+#
+# Custom test task
+#
+require 'rake/testtask'
 Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
   t.test_files = FileList['test/**/*_test.rb']
   t.verbose = true
 end
+

--- a/extras/avahi-cname-manager/Rakefile
+++ b/extras/avahi-cname-manager/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/msg-common/Rakefile
+++ b/msg-common/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../tasks/build_tasks'

--- a/node-proxy/Rakefile
+++ b/node-proxy/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/node-util/Rakefile
+++ b/node-util/Rakefile
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/node/Rakefile
+++ b/node/Rakefile
@@ -38,3 +38,10 @@ desc "Generate RDoc"
 task :doc do
   sh "rdoc ."
 end
+
+require "../tasks/yard_tasks"
+require "../tasks/build_tasks"
+
+YARD_SOURCEROOT = File.dirname(__FILE__)
+# Define these to allow generation of comprehensive yard docs
+YARD_SOURCES = ['lib']  

--- a/openshift-console/Rakefile
+++ b/openshift-console/Rakefile
@@ -2,9 +2,20 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+if defined? Rails then
+  # if running the application
+  require File.expand_path('../config/application', __FILE__)
 
-OpenshiftConsole::Application.load_tasks
-namespace :console do
-  Console::Engine.load_tasks
+  OpenshiftConsole::Application.load_tasks
+  namespace :console do
+    Console::Engine.load_tasks
+  end
+
+else
+  # if building the application
+  require "../tasks/yard_tasks"
+  require "../tasks/build_tasks"
+
+  YARD_SOURCEROOT = File.dirname(__FILE__)
+  YARD_SOURCES = ['app', 'config', 'lib']
 end

--- a/pam_openshift/Rakefile
+++ b/pam_openshift/Rakefile
@@ -1,0 +1,1 @@
+require "../tasks/build_tasks"

--- a/plugins/auth/kerberos/Rakefile
+++ b/plugins/auth/kerberos/Rakefile
@@ -1,11 +1,7 @@
-#require "bundler/gem_tasks"
-require 'rake'
-require 'rake/testtask'
+require "rake/testtask"
+require "bundler/gem_tasks"
 
-Rake::TestTask.new(:test) do |t|
-  sh "/usr/bin/mongo localhost/openshift_origin_broker_test --eval 'db.addUser(\"openshift\", \"mooo\")'"
-  t.libs << 'test'
-  t.warning = false
-  t.verbose = true
-  t.test_files = FileList['test/**/*_test.rb']
-end
+require "../../../tasks/yard_tasks"
+require "../../../tasks/build_tasks"
+
+

--- a/plugins/auth/mongo/Rakefile
+++ b/plugins/auth/mongo/Rakefile
@@ -1,11 +1,13 @@
 #require "bundler/gem_tasks"
-require 'rake'
 require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
-  sh "/usr/bin/mongo localhost/openshift_origin_broker_test --eval 'db.addUser(\"openshift\", \"mooo\")'"
+  #sh "/usr/bin/mongo localhost/openshift_origin_broker_test --eval 'db.addUser(\"openshift\", \"mooo\")'"
   t.libs << 'test'
   t.warning = false
   t.verbose = true
   t.test_files = FileList['test/**/*_test.rb']
 end
+
+require "../../../tasks/yard_tasks"
+require "../../../tasks/build_tasks"

--- a/plugins/auth/mongo/test/functional/account_controller_test.rb
+++ b/plugins/auth/mongo/test/functional/account_controller_test.rb
@@ -2,6 +2,9 @@ require 'test_helper'
 
 class AccountControllerTest < ActionController::TestCase
   def setup
+
+    initialize_database
+
     @auth_service = OpenShift::MongoAuthService.new 
     @auth_service.register_user("admin","admin")
     @request.env["HTTP_AUTHORIZATION"] = "Basic " + Base64.encode64('admin:admin')

--- a/plugins/auth/mongo/test/test_helper.rb
+++ b/plugins/auth/mongo/test/test_helper.rb
@@ -3,3 +3,7 @@ require "dummy/config/environment"
 require "rails/test_help"
 require "rubygems"
 require "mocha"
+
+def initialize_database() 
+  sh "/usr/bin/mongo localhost/openshift_origin_broker_test --eval 'db.addUser(\"openshift\", \"mooo\")'"
+end

--- a/plugins/auth/remote-user/Rakefile
+++ b/plugins/auth/remote-user/Rakefile
@@ -3,9 +3,12 @@ require 'rake'
 require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
-  sh "/usr/bin/mongo localhost/openshift_origin_broker_test --eval 'db.addUser(\"openshift\", \"mooo\")'"
   t.libs << 'test'
   t.warning = false
   t.verbose = true
   t.test_files = FileList['test/**/*_test.rb']
 end
+
+require "../../../tasks/yard_tasks"
+require "../../../tasks/build_tasks"
+

--- a/plugins/dns/avahi/Rakefile
+++ b/plugins/dns/avahi/Rakefile
@@ -19,3 +19,11 @@ Rake::RDocTask.new do |rd|
   rd.rdoc_dir = "doc"
   rd.rdoc_files.include("README.rdoc", "lib/**/*.rb")
 end
+
+require "../../../tasks/build_tasks"
+require "../../../tasks/yard_tasks"
+
+# Define these to allow generation of comprehensive yard docs
+YARD_SOURCEROOT = File.dirname(__FILE__)
+YARD_SOURCES = ['lib']
+

--- a/plugins/dns/bind/Rakefile
+++ b/plugins/dns/bind/Rakefile
@@ -1,5 +1,14 @@
-#require "bundler/gem_tasks"
-require 'rake'
+#
+# Standard Tasks
+#
+require "../../../tasks/build_tasks"
+require "../../../tasks/yard_tasks"
+
+# Define these to allow generation of comprehensive yard docs
+YARD_SOURCEROOT = File.dirname(__FILE__)
+YARD_SOURCES = ['lib']
+
+# Custom test task
 require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
@@ -7,3 +16,4 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/**/*_test.rb']
   t.verbose = true
 end
+

--- a/plugins/dns/nsupdate/Rakefile
+++ b/plugins/dns/nsupdate/Rakefile
@@ -19,3 +19,10 @@ Rake::RDocTask.new do |rd|
   rd.rdoc_dir = "doc"
   rd.rdoc_files.include("README.rdoc", "lib/**/*.rb")
 end
+
+require "../../../tasks/build_tasks"
+require "../../../tasks/yard_tasks"
+
+# Define these to allow generation of comprehensive yard docs
+YARD_SOURCEROOT = File.dirname(__FILE__)
+YARD_SOURCES = ['lib']

--- a/plugins/dns/route53/.gitignore
+++ b/plugins/dns/route53/.gitignore
@@ -1,3 +1,4 @@
 AWSCONFIG
 doc
 .yardoc
+pkg

--- a/plugins/msg-broker/mcollective/Rakefile
+++ b/plugins/msg-broker/mcollective/Rakefile
@@ -7,3 +7,6 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/**/*_test.rb']
   t.verbose = true
 end
+
+require "../../../tasks/build_tasks"
+require "../../../tasks/yard_tasks"

--- a/plugins/msg-node/mcollective/Rakefile
+++ b/plugins/msg-node/mcollective/Rakefile
@@ -1,0 +1,1 @@
+require "../../../tasks/build_tasks"

--- a/port-proxy/Rakefile
+++ b/port-proxy/Rakefile
@@ -1,0 +1,1 @@
+require "../tasks/build_tasks"

--- a/tasks/Rakefile.build_only
+++ b/tasks/Rakefile.build_only
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for packages with no ruby markup
+#
+# Adjust path for package depth as needed
+require '../../tasks/build_tasks'

--- a/tasks/Rakefile.directory
+++ b/tasks/Rakefile.directory
@@ -1,0 +1,5 @@
+#
+# Standard Rakefile for a directory with children
+#
+# Adjust the path as needed for depth
+require "../tasks/dir_tasks"

--- a/tasks/Rakefile.rubygem
+++ b/tasks/Rakefile.rubygem
@@ -1,5 +1,16 @@
-require "bundler/gem_tasks"
-require 'rake'
+#
+# Standard tasks
+#
+require "../../../tasks/yard_tasks"
+require "../../../tasks/build_tasks"
+
+# Define these to allow generation of comprehensive yard docs
+YARD_SOURCEROOT = File.dirname(__FILE__)
+YARD_SOURCES = ['lib']
+
+#
+# Custom Rspec test task
+#
 require 'rake/testtask'
 require 'rspec/core/rake_task'
 
@@ -10,12 +21,6 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.ruby_opts = "-I spec/lib -I ../../../common/lib -I ../../../controller/lib -I lib"
 end
 
-require "../../../tasks/yard_tasks"
-require "../../../tasks/build_tasks"
-
-# Define these to allow generation of comprehensive yard docs
-YARD_SOURCEROOT = File.dirname(__FILE__)
-YARD_SOURCES = ['lib']
 
 
 

--- a/tasks/build_tasks.rb
+++ b/tasks/build_tasks.rb
@@ -1,0 +1,62 @@
+#
+# Tasks to build packages from source trees
+#
+
+#
+# Install build requirements.
+# Use sudo(1) if caller is not root
+#
+# answer: "yes" or "no" - assume yes or no to yum questions
+#
+desc "Install build dependencies for this package"
+task :builddep, :answer do |t, args|
+  specfiles = Dir.glob("*.spec")
+  if specfiles.length != 1 then
+    raise Exception.new("there must be exactly one specfile") 
+  end
+  builddep_cmd = "yum-builddep #{specfiles[0]}"
+  if not args[:answer] == nil then
+    if not ['yes', 'no'].include? args[:answer]
+      raise Exception.new("builddep answer must be 'yes' or 'no'")
+    end
+    builddep_cmd += " --assume#{args[:answer]}"
+  end
+  builddep_cmd = "sudo " + builddep_cmd if not Process.uid == 0
+  system builddep_cmd
+end
+
+#
+# Build an RPM from the source tree and spec file using tito
+#
+# repodir: the destination for artifacts and packages
+# test: boolean - build test packages if set
+#
+desc "Create installable RPM package"
+task :rpm, :repodir, :test, :yum do |t, args|
+  build_cmd = "tito build --rpm"
+
+  repodir = args[:repodir] || ""
+  if not repodir == "" then
+    sh "mkdir -p #{repodir}" if not Dir.exists? repodir
+    build_cmd += " --output #{repodir}"
+  end
+
+  if args[:test] then
+    build_cmd += " --test"
+  end
+  system build_cmd
+
+  system "createrepo #{repodir}" if args[:yum] and File.directory? repodir
+end
+
+#
+# Create test RPMs from source tree and spec files
+#
+# repodir: destination for artifacts and packages
+#
+desc "Create installable RPM package for testing"
+task :testrpm, :repodir, :yum do |t, args|
+  repodir = args[:repodir] || ""
+  yum = args[:yum] || ""
+  Rake.application.invoke_task("rpm[#{repodir},true,#{yum}]")
+end

--- a/tasks/dir_tasks.rb
+++ b/tasks/dir_tasks.rb
@@ -1,0 +1,106 @@
+#
+# Rake tasks for traversing directories containing package trees.
+#
+# @author Mark Lamourine <markllama@redhat.com>
+#
+
+#
+# Walk the source tree finding and installing build requirements for
+# each package as it is found
+#
+desc "install build requirements from subdirectories"
+task :builddep, :answer do |t, args|
+  subdirs = FileList["*/Rakefile"].each do |rf|
+    dirname = File.dirname(rf)
+    begin
+      cmd = "cd #{dirname} ; rake #{t.name}"
+      cmd += "[" + args[:answer] + "]" if ['yes', 'no'].include? args[:answer]
+      system cmd
+    rescue
+      puts "failed to #{t.name} in #{dirname}"
+    end
+  end
+end
+
+#
+# Walk the source tree finding an generating documentation for each
+# package as it is found
+#
+desc "generate yard documentation in subdirectories"
+task :yard, :docdir do |t, args|
+  
+  subdirs = FileList["*/Rakefile"].each do |rf|
+    dirname = File.dirname(rf)
+    cmd = "cd #{dirname} ; rake #{t.name}"
+    docdir = args[:docdir]
+    cmd += "[#{docdir}]" if not docdir == nil
+    begin
+      system cmd
+    rescue
+      puts "failed to #{t.name} in #{dirname}"
+    end
+  end
+end
+
+#
+# Walk the source tree finding package directories and emitting
+# the location of each directory to use as input
+# 
+desc "report doc sources"
+task :yard_sources do |t|
+  subdirs = FileList["*/Rakefile"].each do |rf|
+    dirname = File.dirname(rf)
+    begin
+      system "cd #{dirname} ; rake #{t.name} 2>/dev/null"
+    rescue
+      ""
+    end
+  end
+end
+
+#
+# Walk the source tree finding package directories and
+# generate RPM for each one
+#
+# repodir: the destination for build artifacts and RPMs
+# test: boolean - if set, generate test RPM
+#
+desc "generate RPM packages in subdirectories"
+task :rpm, :repodir, :test, :yum do |t, args|
+  subdirs = FileList["*/Rakefile"].each do |rf|
+    dirname = File.dirname(rf)
+    cmd = "cd #{dirname} ; rake #{t.name}"
+    repodir = args[:repodir] || ""
+    testflag = args[:test] || ""
+    yum = args[:yum] || ""
+    cmd += "[#{repodir},#{testflag},${yum}]"
+    begin
+      system cmd
+    rescue
+      puts "failed to #{t.name} in #{dirname}"
+    end
+  end
+end
+
+#
+# Walk the source tree finding package directories
+# Generate test RPM for each one located
+#
+# repodir: destination for build artifacts and RPMs
+#
+desc "generate test RPM packages in subdirectories"
+task :testrpm, :repodir, :yum do |t, args|
+  subdirs = FileList["*/Rakefile"].each do |rf|
+    dirname = File.dirname(rf)
+    cmd = "cd #{dirname} ; rake #{t.name}"
+    repodir = args[:repodir] || ""
+    yum = args[:yum] || ""
+    cmd += "[#{repodir},#{yum}]"
+    begin
+      system cmd
+    rescue
+      puts "failed to #{t.name} in #{dirname}"
+    end
+  end
+end
+

--- a/tasks/yard_tasks.rb
+++ b/tasks/yard_tasks.rb
@@ -1,0 +1,45 @@
+#
+# Rake tasks to generate markup documentation
+#
+
+#
+# Generate markup documentation from Ruby source code
+# 
+# ENV['docdir'] - target location for the output 
+#
+require 'yard'
+desc "Generate documentation"
+YARD::Rake::YardocTask.new() do |t|
+  t.options = ['--protected', '--private', '--no-yardopts']
+  docdir = ENV['docdir']
+  if not docdir == nil
+    t.options += ["--output-dir", docdir]
+  end
+end
+
+#
+# Remove the output results from yard document generation
+#
+require 'fileutils'
+desc "remove yardoc artifacts"
+task :clean_yard do
+  FileUtils.rm_rf 'doc'
+  FileUtils.rm_rf '.yardoc'
+end
+
+#
+# Generate a list of source directories to scan.
+# The directories are absolute paths.
+# This is used to generate comprehensive documentation in a single
+# output location.
+#
+# Define YARD_SOURCES and YARD_SOURCEROOT in your Rakefile to allow
+# generation of comprehensive documentation
+#
+desc "report doc sources"
+task :yard_sources do
+  # source list defaults to the 'lib' subdirectory
+  sourcelist = (defined? YARD_SOURCES) ? YARD_SOURCES : ['lib']
+  here = (defined? YARD_SOURCEROOT) ? YARD_SOURCEROOT + "/" : "."
+  puts YARD_SOURCES.map {|d| here + d }.join(' ')
+end

--- a/util-scl/Rakefile
+++ b/util-scl/Rakefile
@@ -1,0 +1,1 @@
+require "../tasks/build_tasks"

--- a/util/Rakefile
+++ b/util/Rakefile
@@ -1,0 +1,1 @@
+require "../tasks/build_tasks"


### PR DESCRIPTION
See [BUILD.md](https://github.com/markllama/origin-server/blob/features/build/rake_tasks/BUILD.md) at the root of this branch for explanation and documentation

As a developer I would like to be able to build, test and document the OpenShift Origin server source code using only tools which reside within the source tree.

This patch adds a set of template Rake tasks and Rakefiles to the source tree to introduce several standard _rake_ tasks to prepare, build and generate documentation for the packages contained in the source tree.  When executed from the root of the source tree these tasks will walk the source code tree and execute for each package.

This patch includes documentation for the new tasks, including how to prepare, run and extend them.
