### PR TITLE
Support arbitrary cache stores in Origin

### DIFF
--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -39,6 +39,9 @@ Broker::Application.configure do
   ############################################
 
   conf = OpenShift::Config.new(File.join(OpenShift::Config::CONF_DIR, 'broker-dev.conf'))
+
+  config.send(:cache_store=, eval("[#{conf.get("CACHE_STORE")}]")) if conf.get("CACHE_STORE")
+
   config.datastore = {
     :host_port => conf.get("MONGO_HOST_PORT", "localhost:27017"),
     :user => conf.get("MONGO_USER", "openshift"),

--- a/broker/config/environments/production.rb
+++ b/broker/config/environments/production.rb
@@ -39,6 +39,8 @@ Broker::Application.configure do
 
   conf = OpenShift::Config.new(File.join(OpenShift::Config::CONF_DIR, 'broker.conf'))
 
+  config.send(:cache_store=, eval("[#{conf.get("CACHE_STORE")}]")) if conf.get("CACHE_STORE")
+
   config.datastore = {
     :host_port => conf.get("MONGO_HOST_PORT", "localhost:27017"),
     :user => conf.get("MONGO_USER", "openshift"),

--- a/console/config/initializers/cache_silence.rb
+++ b/console/config/initializers/cache_silence.rb
@@ -1,0 +1,1 @@
+Rails.cache.silence! if Rails.cache.respond_to? :silence!

--- a/console/lib/console/configuration.rb
+++ b/console/lib/console/configuration.rb
@@ -36,6 +36,7 @@ module Console
     config_accessor :include_helpers
 
     config_accessor :community_url
+    config_accessor :cache_store
 
     #
     # A class that represents the capabilities object
@@ -124,6 +125,10 @@ module Console
         self.community_url = config[:COMMUNITY_URL]
         if self.community_url && !self.community_url.end_with?('/')
           raise InvalidConfiguration, "COMMUNITY_URL must end in '/'"
+        end
+
+        if cache_store = config[:CACHE_STORE]
+          Rails.configuration.send(:cache_store=, eval("[#{cache_store}]"))
         end
 
         case config[:CONSOLE_SECURITY]

--- a/controller/config/initializers/cache_silence.rb
+++ b/controller/config/initializers/cache_silence.rb
@@ -1,0 +1,1 @@
+Rails.cache.silence! if Rails.cache.respond_to? :silence!


### PR DESCRIPTION
Allow cache stores to be configured in the broker and console via the "CACHE_STORE" config value.  Clients wishing to use a specific cache store may have to ensure the Gem is loaded by adding a plugins.d/<gemname> file corresponding to their desired client.

Example config is Dalli:

```
CACHE_STORE=:dalli_store, 'localhost:11211', {:namespace => 'console', :failover => true, :expires_in => 1.day, :compress => true}
```

and you would create an empty file at

```
/etc/openshift/plugins.d/dalli.conf
```

so that the broker loads Dalli.  For the console, you'd need to change the Gemfile (we don't have a gem extension method for the console yet).
