### PR TITLE
Site should not default to community URL for quickstarts if not specified

### DIFF
--- a/console/app/models/quickstart.rb
+++ b/console/app/models/quickstart.rb
@@ -82,7 +82,7 @@ class Quickstart < RestApi::Base
     end
 
     def site
-      api_links[:site] or Console.config.community_url
+      api_links[:site] or RestApi::Info.site
     end
     def prefix_parameters
       {}


### PR DESCRIPTION
[merge]
