### PR TITLE
Bug 922650: Fix default ROOT.war for JBoss carts

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/hooks/configure
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/hooks/configure
@@ -186,7 +186,9 @@ populate_repo_dir
 
 # Copy the example WAR to the deployments directories
 #cp ${JBOSS_CARTRIDGE_ROOT}/info/data/ROOT.war $APP_REPO_DIR/deployments
-jar cvf $APP_REPO_DIR/deployments/ROOT.war ${JBOSS_CARTRIDGE_ROOT}/template/*
+pushd ${JBOSS_CARTRIDGE_ROOT}/template/src/main/webapp
+jar cvf $APP_REPO_DIR/deployments/ROOT.war ./*
+popd
 
 chmod +x "$APP_JBOSS_BIN_DIR/standalone.sh" || error "Failed to chmod new application scripts" 122
 secure_app_dir

--- a/cartridges/openshift-origin-cartridge-jbossews-1.0/info/hooks/configure
+++ b/cartridges/openshift-origin-cartridge-jbossews-1.0/info/hooks/configure
@@ -174,7 +174,9 @@ populate_repo_dir
 
 # Copy the example WAR to the webapps directories
 #cp ${JBOSS_CARTRIDGE_ROOT}/info/data/ROOT.war $APP_REPO_DIR/webapps
-jar cvf $APP_REPO_DIR/webapps/ROOT.war ${JBOSS_CARTRIDGE_ROOT}/template/*
+pushd ${JBOSS_CARTRIDGE_ROOT}/template/src/main/webapp
+jar cvf $APP_REPO_DIR/webapps/ROOT.war ./*
+popd
 
 secure_app_dir
 secure_cart_instance_dir

--- a/cartridges/openshift-origin-cartridge-jbossews-2.0/info/hooks/configure
+++ b/cartridges/openshift-origin-cartridge-jbossews-2.0/info/hooks/configure
@@ -173,7 +173,9 @@ populate_repo_dir
 
 # Copy the example WAR to the webapps directories
 #cp ${JBOSS_CARTRIDGE_ROOT}/info/data/ROOT.war $APP_REPO_DIR/webapps
-jar cvf $APP_REPO_DIR/webapps/ROOT.war ${JBOSS_CARTRIDGE_ROOT}/template/*
+pushd ${JBOSS_CARTRIDGE_ROOT}/template/src/main/webapp
+jar cvf $APP_REPO_DIR/webapps/ROOT.war ./*
+popd
 
 secure_app_dir
 secure_cart_instance_dir


### PR DESCRIPTION
Fix erroneous absolute paths introduced into the default ROOT.war for
new JBoss cartridge applications.
