### PR TITLE
<threaddump> fix bug 923405 so ruby thread dump reports useful log file

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby-1.8/info/hooks/threaddump
+++ b/cartridges/openshift-origin-cartridge-ruby-1.8/info/hooks/threaddump
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Creates a thread dump from a jboss-as7 instance
+# Creates a thread dump from a ruby-1.8 instance
 
 # Exit on any errors
 # set -e
@@ -47,10 +47,10 @@ result=`run_as_user "$CARTRIDGE_BASE_PATH/ruby-1.8/info/bin/threaddump.sh $1 $3"
 
 if [ "$result" = "" ]; then
     DATE=`date -u '+%Y%m%d'`
-    ZONE=`date +%Z`
     client_result "Success"
     client_result ""
-    client_result "The thread dump file will be available via: rhc tail ${application} -f ${cartridge_type}/logs/error_log-$DATE-000000-$ZONE -o '-n 250'"
+    # note bz 923405/921537 for why log file name is not more specific
+    client_result "The thread dump file will be available via: rhc tail ${application} -f ${cartridge_type}/logs/error_log-$DATE-* -o '-n 250'"
 else
     client_result " $result"
 fi

--- a/cartridges/openshift-origin-cartridge-ruby-1.9-scl/info/hooks/threaddump
+++ b/cartridges/openshift-origin-cartridge-ruby-1.9-scl/info/hooks/threaddump
@@ -47,10 +47,10 @@ result=`run_as_user "$CARTRIDGE_BASE_PATH/ruby-1.9/info/bin/threaddump.sh $1 $3"
 
 if [ "$result" = "" ]; then
     DATE=`date -u '+%Y%m%d'`
-    ZONE=`date +%Z`
     client_result "Success"
     client_result ""
-    client_result "The thread dump file will be available via: rhc tail ${application} -f ${cartridge_type}/logs/error_log-$DATE-000000-$ZONE -o '-n 250'"
+    # note bz 923405/921537 for why log file name is not more specific
+    client_result "The thread dump file will be available via: rhc tail ${application} -f ${cartridge_type}/logs/error_log-$DATE-* -o '-n 250'"
 else
     client_result " $result"
 fi


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=923405 thread dumps report the wrong log file name due to timezone

When ruby does a thread dump it goes in the httpd server log. This is
rotated via rotatelogs and the name includes the timezone in it. Due to
various complications this does not always match the TZ from `date`.
Rather than try to give the exact file name, we now just give a glob
that is good enough.
