### PR TITLE
Create ~/.gemrc for the application user so that '--no-rdoc --no-ri' is ...

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby-1.8/info/hooks/configure
+++ b/cartridges/openshift-origin-cartridge-ruby-1.8/info/hooks/configure
@@ -110,3 +110,11 @@ export CART_INFO_DIR
 $CARTRIDGE_BASE_PATH/abstract/info/bin/deploy_httpd_proxy.sh $application $namespace $uuid $IP
 
 enable_cgroups
+
+## Set up '--no-rdoc --no-ri' as default
+gemrc=$APP_HOME/.gemrc
+test -f $gemrc || cat << EOF > $gemrc
+--- 
+gem: --no-rdoc --no-ri
+EOF
+chown $user_id:$group_id $gemrc

--- a/cartridges/openshift-origin-cartridge-ruby-1.9-scl/info/hooks/configure
+++ b/cartridges/openshift-origin-cartridge-ruby-1.9-scl/info/hooks/configure
@@ -118,3 +118,11 @@ export CART_INFO_DIR
 $CARTRIDGE_BASE_PATH/abstract/info/bin/deploy_httpd_proxy.sh $application $namespace $uuid $IP
 
 enable_cgroups
+
+## Set up '--no-rdoc --no-ri' as default
+gemrc=$APP_HOME/.gemrc
+test -f $gemrc || cat << EOF > $gemrc
+--- 
+gem: --no-rdoc --no-ri
+EOF
+chown $user_id:$group_id $gemrc


### PR DESCRIPTION
...the default.

This should speed up subsequent gem installation. The user can override
this with '--rdoc' '--ri' if desired.
