### PR TITLE
Added :autocomplete option to inputs/input

### DIFF
--- a/console/lib/console/formtastic/bootstrap_form_builder.rb
+++ b/console/lib/console/formtastic/bootstrap_form_builder.rb
@@ -136,6 +136,11 @@ module Console
         html_options[:class] ||= "inputs"
         html_options[:name] = title
 
+        if html_options[:autocomplete]
+          @old_autocomplete_section = @autocomplete_section
+          @autocomplete_section = html_options[:autocomplete]
+        end
+
         if html_options[:for] # Nested form
           inputs_for_nested_attributes(*(args << html_options), &block)
         elsif html_options[:inline]
@@ -161,6 +166,9 @@ module Console
 
           field_set_and_list_wrapping(*((args << html_options) << contents))
         end
+
+      ensure
+        @autocomplete_section = @old_autocomplete_section
       end
 
       def inline_fields_and_wrapping(*args, &block)
@@ -206,6 +214,14 @@ module Console
 
         options[:required] = method_required?(method) unless options.key?(:required)
         options[:as]     ||= default_input_type(method, options)
+
+        if (field = options[:autocomplete])
+          if (section = @autocomplete_section)
+            field = "#{section} #{field}"
+          end
+          options[:input_html] ||= {}
+          options[:input_html][:autocomplete] = field
+        end
 
         html_class = [ 
           options[:as], 


### PR DESCRIPTION
This adds a helper option to `inputs` and `input` fields to create the correct `autocomplete` html_options.

Based on [this spec](http://www.whatwg.org/specs/web-apps/current-work/multipage/association-of-controls-and-forms.html#autofilling-form-controls:-the-autocomplete-attribute), if a user passes `:autocomplete => 'billing'` to an `inputs` call, it will set the section (such as billing or shipping) for subsequent autocompletes.

If a user passes `:autocomplete => 'given-name'` to an input field, it will combine that with a previous section to make an input like:

```
<input autocomplete="billing given-name" ...>
```
