### PR TITLE
<oo-cgroup-read> bug 924556 pull in native rubygem-open4

### DIFF
--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -33,6 +33,8 @@ Requires:      %{?scl:%scl_prefix}rubygem(parseconfig)
 Requires:      %{?scl:%scl_prefix}rubygem(mocha)
 Requires:      %{?scl:%scl_prefix}rubygem(rspec)
 Requires:      rubygem(openshift-origin-common)
+# non-scl open4 required for oo-cgroup-read bug 924556 until selinux fix for bug 912215 is available
+Requires:      rubygem(open4)
 Requires:      python
 Requires:      libselinux-python
 Requires:      mercurial


### PR DESCRIPTION
oo-cgroup-read was changed from env ruby to /usr/bin/ruby due to
selinux issues (https://bugzilla.redhat.com/show_bug.cgi?id=901449).
Then the implementation was changed from one using cgget to one
using rubygem open4 due to selinux issues
(https://bugzilla.redhat.com/show_bug.cgi?id=912215)
But native rubygem(open4) was not listed as a dependency now that
ruby 1.9.3 is the standard. So, modifying the spec file to ensure
it is present on every system, to prevent JBoss build failures
(https://bugzilla.redhat.com/show_bug.cgi?id=924556)
