### PR TITLE
Adding SESSION_SECRET settings to the broker and console

### DIFF
--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -156,6 +156,19 @@ function check_missing_and_insecure_secrets() {
     then
       fail "Default AUTH_SALT detected in ${BROKER_CONF}! Change the the value and use oo-admin-broker-auth to regenerate authentication tokens. (Hint: use 'openssl rand -base64 64' to generate a unique salt)"
     fi
+
+    BROKER_SECRET=`fetch_config ${BROKER_CONF} SESSION_SECRET`
+    if [ $BROKER_SECRET == "nil" ]
+    then
+      fail "SESSION_SECRET must be set in $BROKER_CONF (Hint: use 'openssl rand -hex 64' to generate a unique secret."
+    fi
+
+    CONSOLE_SECRET=`fetch_config ${CONSOLE_CONF} SESSION_SECRET`
+    if [ $CONSOLE_SECRET == "nil" ]
+    then
+      fail "SESSION_SECRET must be set in ${CONSOLE_CONF} (Hint: use 'openssl rand -hex 64' to generate a unique secret."
+    fi
+
 }
 
 # This is another way to parse the config settings.  You could argue that it's

--- a/broker/conf/broker.conf
+++ b/broker/conf/broker.conf
@@ -42,6 +42,14 @@ AUTH_RSYNC_KEY_FILE="/etc/openshift/rsync_id_rsa"
 
 AUTH_SCOPE_TIMEOUTS="session=1.days|7.days, *=1.months|6.months"
 
+
+# This session must be shared amongst all Brokers but otherwise secret.  If
+# this value is changed sessions will be dropped.  This value is used for
+# setting the rails secret_token (or the secret_key_base for Rails 4.0).
+# "openssl rand -hex 64" can be use to generate a unique value.
+#
+# SESSION_SECRET=
+
 #Enable/disable maintenance mode
 ENABLE_MAINTENANCE_MODE="false"
 MAINTENANCE_NOTIFICATION_FILE="/etc/openshift/outage_notification.txt"

--- a/broker/config/initializers/secret_token.rb
+++ b/broker/config/initializers/secret_token.rb
@@ -1,11 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
-# Your secret key for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-Broker::Application.config.secret_token = 'be714beb6a20e3bb1ac7fb915d963fce18c58ea8fe983f2ca000d0cb962ab925e342486727a5196b09da8b380371b0934b03bbf6197d6a252afda7710e5a7118'
-
 conf_file = if Rails.env.development?
   File.join(OpenShift::Config::CONF_DIR, 'broker-dev.conf')
 else
@@ -17,5 +11,22 @@ auth_salt = conf.get("AUTH_SALT")
 if auth_salt.blank?
   raise "\nYou must set AUTH_SALT in #{conf_file}."
 elsif auth_salt == "ClWqe5zKtEW4CJEMyjzQ"
-  Rails.logger.error "\nERROR: You are using the default value for for AUTH_SALT in #{conf_file}!"
+  Rails.logger.error "\nWARNING: You are using the default value for for AUTH_SALT in #{conf_file}!"
 end
+
+rails_secret = conf.get("SESSION_SECRET")
+if rails_secret.blank?
+  Rails.logger.error "\nWARNING: Please configure SESSION_SECRET in #{conf_file}.  " +
+                     "Run oo-accept-broker for details."
+
+  # We don't want to prevent an application from starting if this new setting
+  # is missing.  In that case we will use the AUTH_SALT since we know that it
+  # exists and is the same across all Brokers.
+  rails_secret = auth_salt
+end
+
+# Your secret key for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+Broker::Application.config.secret_token = Digest::SHA512.hexdigest(rails_secret)

--- a/openshift-console/config/initializers/secret_token.rb
+++ b/openshift-console/config/initializers/secret_token.rb
@@ -1,7 +1,22 @@
 # Be sure to restart your server when you modify this file.
+require 'console/config_file'
 
-# Your secret key for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-OpenshiftConsole::Application.config.secret_token = 'bc09e1f022b83b744a16e72d92dc2bb5b6778e1526617e5bee8e89c13e80edb208335823a456773827f62b3b91392f36c6c264006a49a2ed96baea9c7a599fd0'
+file = "/etc/openshift/console.conf"
+conf = Console::ConfigFile.new(file)
+
+session_secret = conf[:SESSION_SECRET]
+if session_secret.blank?
+  Rails.logger.error "\nWARNING: Please configure SESSION_SECRET in #{file}.  " +
+                     "Run oo-accept-broker for details."
+
+  # We don't want to prevent an application from starting if this new setting
+  # is missing.  In that case we will use the previously hardcoded value.
+  OpenshiftConsole::Application.config.secret_token = 'bc09e1f022b83b744a16e72d92dc2bb5b6778e1526617e5bee8e89c13e80edb208335823a456773827f62b3b91392f36c6c264006a49a2ed96baea9c7a599fd0'
+else
+
+  # Your secret key for verifying the integrity of signed cookies.
+  # If you change this key, all old signed cookies will become invalid!
+  # Make sure the secret is at least 30 characters and all random,
+  # no regular words or you'll be exposed to dictionary attacks.
+  OpenshiftConsole::Application.config.secret_token = Digest::SHA512.hexdigest(session_secret)
+end


### PR DESCRIPTION
These aren't really used today but we need to get users to stop using the
default rails secrets.

If these settings are missing a WARNING will be displayed in the log files.  oo-accept-broker will also report errors and show the user how to resolve the issue.
