### PR TITLE
Bug 927614: Fix action hook execution during v2 control ops

### DIFF
--- a/cartridges/openshift-origin-cartridge-mock/bin/control
+++ b/cartridges/openshift-origin-cartridge-mock/bin/control
@@ -6,15 +6,17 @@ cartridge_instance_dir=$OPENSHIFT_MOCK_DIR
 source $cartridge_instance_dir/mock.conf
 
 case "$1" in
-  start)     touch $MOCK_STATE/control_start ;;
-  stop)      touch $MOCK_STATE/control_stop ;;
-  restart)   touch $MOCK_STATE/control_restart ;;
-  status)    touch $MOCK_STATE/control_status ;;
-  reload)    touch $MOCK_STATE/control_reload ;;
-  tidy)      touch $MOCK_STATE/control_tidy ;;
-  build)     touch $MOCK_STATE/control_build;;
-  deploy)    touch $MOCK_STATE/control_deploy;;
-  *)         exit 0
+  start)       touch $MOCK_STATE/control_start ;;
+  stop)        touch $MOCK_STATE/control_stop ;;
+  restart)     touch $MOCK_STATE/control_restart ;;
+  status)      touch $MOCK_STATE/control_status ;;
+  reload)      touch $MOCK_STATE/control_reload ;;
+  tidy)        touch $MOCK_STATE/control_tidy ;;
+  pre-build)   touch $MOCK_STATE/control_pre_build ;;
+  build)       touch $MOCK_STATE/control_build ;;
+  deploy)      touch $MOCK_STATE/control_deploy ;;
+  post-deploy) touch $MOCK_STATE/control_post_deploy ;;
+  *)           exit 0
 esac
 
 exit 0

--- a/cartridges/openshift-origin-cartridge-mock/template/.openshift/action_hooks/build
+++ b/cartridges/openshift-origin-cartridge-mock/template/.openshift/action_hooks/build
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+PATH=/bin/:/usr/bin:$PATH
+
+MOCK_STATE=$OPENSHIFT_DATA_DIR/.mock_cartridge_state
+
+touch $MOCK_STATE/action_hook_build

--- a/cartridges/openshift-origin-cartridge-mock/template/.openshift/action_hooks/deploy
+++ b/cartridges/openshift-origin-cartridge-mock/template/.openshift/action_hooks/deploy
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+PATH=/bin/:/usr/bin:$PATH
+
+MOCK_STATE=$OPENSHIFT_DATA_DIR/.mock_cartridge_state
+
+touch $MOCK_STATE/action_hook_deploy

--- a/cartridges/openshift-origin-cartridge-mock/template/.openshift/action_hooks/post-deploy
+++ b/cartridges/openshift-origin-cartridge-mock/template/.openshift/action_hooks/post-deploy
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+PATH=/bin/:/usr/bin:$PATH
+
+MOCK_STATE=$OPENSHIFT_DATA_DIR/.mock_cartridge_state
+
+touch $MOCK_STATE/action_hook_post_deploy

--- a/cartridges/openshift-origin-cartridge-mock/template/.openshift/action_hooks/pre-build
+++ b/cartridges/openshift-origin-cartridge-mock/template/.openshift/action_hooks/pre-build
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+PATH=/bin/:/usr/bin:$PATH
+
+MOCK_STATE=$OPENSHIFT_DATA_DIR/.mock_cartridge_state
+
+touch $MOCK_STATE/action_hook_pre_build

--- a/controller/test/cucumber/cartridge-mock.feature
+++ b/controller/test/cucumber/cartridge-mock.feature
@@ -37,6 +37,10 @@ Feature: V2 SDK Mock Cartridge
     And the mock control_build marker will exist
     And the mock control_deploy marker will exist
     And the mock control_start marker will exist
+    And the mock action_hook_pre_build marker will exist
+    And the mock action_hook_build marker will exist
+    And the mock action_hook_deploy marker will exist
+    And the mock action_hook_post_deploy marker will exist
     And the application repo has been updated
 
     When I call tidy on the application

--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -752,9 +752,9 @@ module OpenShift
     #                                        'pre' and 'post' depending on their execution order.
     def do_control_with_directory(action, options={})
       cartridge_dir             = options[:cartridge_dir]
-      pre_action_hooks_enabled  = options[:pre_action_hooks_enabled] || true
-      post_action_hooks_enabled = options[:post_action_hooks_enabled] || true
-      prefix_action_hooks       = options[:prefix_action_hooks] || true
+      pre_action_hooks_enabled  = options.has_key?(:pre_action_hooks_enabled)  ? options[:pre_action_hooks_enabled]  : true
+      post_action_hooks_enabled = options.has_key?(:post_action_hooks_enabled) ? options[:post_action_hooks_enabled] : true
+      prefix_action_hooks       = options.has_key?(:prefix_action_hooks)       ? options[:prefix_action_hooks]       : true
 
       logger.debug { "#{@user.uuid} #{action} against '#{cartridge_dir}'" }
       buffer       = ''
@@ -804,12 +804,7 @@ module OpenShift
     # Executes the named +action+ from the user repo +action_hooks+ directory and returns the
     # stdout of the execution, or raises a +ShellExecutionException+ if the action returns a
     # non-zero return code.
-    #
-    # If +env+ is not specified, the environment from +Environment.for_gear+ will be used for
-    # the execution.
-    def do_action_hook(action, env=nil)
-      env = env ||= Utils::Environ.for_gear(@user.homedir)
-
+    def do_action_hook(action, env)
       action_hooks_dir = File.join(@user.homedir, %w{app-root runtime repo .openshift action_hooks})
       action_hook = File.join(action_hooks_dir, action)
       out = ''
@@ -822,7 +817,7 @@ module OpenShift
                                       uid:             @user.uid)
         raise Utils::ShellExecutionException.new(
                   "Failed to execute action hook '#{action}' for #{@user.uuid} application #{@user.app_name}",
-                  rc, buffer, err
+                  rc, out, err
               ) if rc != 0
       end
 


### PR DESCRIPTION
Fix action hook execution during v2 do_control calls, and add cucumber
test coverage for the build cycle to exercise action hooks.
