### PR TITLE
Bug 922689: Fix for not showing proper cartridge errors

### DIFF
--- a/console/app/views/cartridge_types/show.html.haml
+++ b/console/app/views/cartridge_types/show.html.haml
@@ -10,7 +10,7 @@
 
 = semantic_form_for @cartridge, :url => application_cartridges_path(@application), :html => {:class => 'form'} do |f|
   = f.hidden_field :name, :value => @cartridge_type.name
-  = f.semantic_errors :except => [:name, :cartridge]
+  = f.semantic_errors
   %p
     Do you want to add the
     %strong


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=922689

We were suppressing the cartridge error messages, but since there was no input associated with the cartridge, we never saw them in the semantic_errors
