### PR TITLE
Corrected the incorrect fix put in for bug 915673 

### DIFF
--- a/broker/test/unit/alias_test.rb
+++ b/broker/test/unit/alias_test.rb
@@ -115,7 +115,7 @@ class AliasTest < ActiveSupport::TestCase
   test "update alias with bad inputs" do
     server_alias = "as#{@random}"
     #non-existent alias
-    assert_raise(OpenShift::UserException){@app.update_alias(server_alias)}
+    assert_raise(Mongoid::Errors::DocumentNotFound){@app.update_alias(server_alias)}
     #no private key
     @app.add_alias(server_alias)
     assert_raise(OpenShift::UserException){@app.update_alias(server_alias, @ssl_certificate)}
@@ -136,7 +136,7 @@ class AliasTest < ActiveSupport::TestCase
   test "remove alias with bad inputs" do
     server_alias = "as#{@random}"
     #non-existent alias
-    assert_raise(OpenShift::UserException){@app.remove_alias(server_alias)}
+    assert_raise(Mongoid::Errors::DocumentNotFound){@app.remove_alias(server_alias)}
   end
 =begin
   test "create alias rollback" do

--- a/controller/app/controllers/alias_controller.rb
+++ b/controller/app/controllers/alias_controller.rb
@@ -139,6 +139,8 @@ class AliasController < BaseController
       messages.push(Message.new(:info, log_msg))
       messages.push(Message.new(:info, reply.resultIO.string, 0, :result))
       return render_success(:ok, "alias", rest_alias, "UPDATE_ALIAS", log_msg, nil, nil, messages)
+    rescue Mongoid::Errors::DocumentNotFound
+      return render_error(:not_found, "Alias #{server_alias} not found for application #{application_id}", 173, "UPDATE_ALIAS")
     rescue OpenShift::UserException => e
       return render_error(:unprocessable_entity, e.message, e.code, "UPDATE_ALIAS", e.field)
     rescue Exception => e
@@ -168,6 +170,8 @@ class AliasController < BaseController
        
     begin
       application.remove_alias(server_alias)
+    rescue Mongoid::Errors::DocumentNotFound
+      return render_error(:not_found, "Alias #{server_alias} not found for application #{application_id}", 173, "DELETE_ALIAS")
     rescue OpenShift::UserException => e
       return render_error(:unprocessable_entity, e.message, e.code, "DELETE_ALIAS", e.field)
     rescue Exception => e

--- a/controller/app/controllers/app_events_controller.rb
+++ b/controller/app/controllers/app_events_controller.rb
@@ -73,7 +73,11 @@ class AppEventsController < BaseController
           msg = "Application #{id} has added alias"
           # msg += ": #{r.resultIO.string.chomp}" if !r.resultIO.string.empty?
         when "remove-alias"
-          r = application.remove_alias(server_alias)
+          begin
+            r = application.remove_alias(server_alias)
+          rescue Mongoid::Errors::DocumentNotFound
+            return render_error(:not_found, "Alias #{server_alias} not found for application #{application.name}", 173, "#{event.sub('-', '_').upcase}_APPLICATION")
+          end
           msg = "Application #{id} has removed alias"
           # msg += ": #{r.resultIO.string.chomp}" if !r.resultIO.string.empty?
         when "scale-up"

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -794,11 +794,7 @@ class Application
   # {PendingAppOps} object which tracks the progress of the operation.
   def remove_alias(fqdn)
     fqdn = fqdn.downcase if fqdn
-    begin
-      al1as = aliases.find_by(fqdn: fqdn)
-    rescue Mongoid::Errors::DocumentNotFound
-      raise OpenShift::UserException.new("Alias '#{fqdn}' does not exist for '#{self.name}'", 173) 
-    end
+    al1as = aliases.find_by(fqdn: fqdn)
     Application.run_in_application_lock(self) do
       if al1as.has_private_ssl_certificate
          op_group = PendingAppOpGroup.new(op_type: :remove_ssl_cert, args: {"fqdn" => al1as.fqdn}, user_agent: self.user_agent)
@@ -817,11 +813,7 @@ class Application
     validate_certificate(ssl_certificate, private_key, pass_phrase)
     
     fqdn = fqdn.downcase if fqdn
-    begin
-      old_alias = aliases.find_by(fqdn: fqdn)
-    rescue Mongoid::Errors::DocumentNotFound
-      raise OpenShift::UserException.new("Alias '#{fqdn}' does not exist for '#{self.name}'", 173) 
-    end
+    old_alias = aliases.find_by(fqdn: fqdn)
     Application.run_in_application_lock(self) do
       #remove old certificate
       if old_alias.has_private_ssl_certificate


### PR DESCRIPTION
The previous fix would return a 422 instead of a 404 if the alias does not exist.
