### PR TITLE
OpenShift GSS-TSIG DNS Plugin (Active Directory & IPA)

### DIFF
--- a/plugins/dns/gsstsig/COPYRIGHT
+++ b/plugins/dns/gsstsig/COPYRIGHT
@@ -1,0 +1,1 @@
+Copyright 2013 Red Hat, Inc. and/or its affiliates.

--- a/plugins/dns/gsstsig/Gemfile
+++ b/plugins/dns/gsstsig/Gemfile
@@ -1,0 +1,3 @@
+source "http://rubygems.org"
+
+gemspec

--- a/plugins/dns/gsstsig/LICENSE
+++ b/plugins/dns/gsstsig/LICENSE
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/plugins/dns/gsstsig/README.md
+++ b/plugins/dns/gsstsig/README.md
@@ -1,0 +1,26 @@
+Openshift Origin - DNS Plugin for GSS-TSIG
+============================
+
+This plugin extends OpenShift's ability to integrate with DNS servers that require secure updates via GSS-TSIG, e.g. Microsoft's Active Directory. It provides dynamic DNS updates securely using Kerberos. DNS updates are mandatory for external clients to access gears being instantiated on OpenShift node(s). The most difficult part of getting this plugin to work is the configuration of the Active Directory, the export of a valid Kerberos service principal and the configuration of the broker host to be integrated with the Active Directory.
+
+TODO: Full guide on how to ingegrate plugin. Basic requirements are host with krb5 integration, service principle in AD for DNS mapped to a user and a host and that keytab available to the apache user. There's an applicable configuration file found in /etc/openshift/plugins.d for this specific plugin and is self-explanatory. More to come.
+
+
+Contributing
+----------------------
+
+Visit the [OpenShift Origin Open Source page](https://openshift.redhat.com/community/open-source) for more information on the community process and how you can get involved. Also see our [Contributor Guidelines](CONTRIBUTING.md).
+
+
+Copyright
+----------------------
+
+OpenShift Origin, except where otherwise noted, is released under the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.html). See the LICENSE file located in each component directory.
+
+
+Export Control
+----------------------
+
+Notice of Export Control Law
+
+This software distribution includes cryptographic software that is subject to the U.S. Export Administration Regulations (the "*EAR*") and other U.S. and foreign laws and may not be exported, re-exported or transferred (a) to any country listed in Country Group E:1 in Supplement No. 1 to part 740 of the EAR (currently, Cuba, Iran, North Korea, Sudan & Syria); (b) to any prohibited destination or to any end user who has been prohibited from participating in U.S. export transactions by any federal agency of the U.S. government; or (c) for use in connection with the design, development or production of nuclear, chemical or biological weapons, or rocket systems, space launch vehicles, or sounding rockets, or unmanned air vehicle systems.You may not download this software or technical information if you are located in one of these countries or otherwise subject to these restrictions. You may not provide this software or technical information to individuals or entities located in one of these countries or otherwise subject to these restrictions. You are also responsible for compliance with foreign law requirements applicable to the import, export and use of this software and technical information.

--- a/plugins/dns/gsstsig/Rakefile
+++ b/plugins/dns/gsstsig/Rakefile
@@ -1,0 +1,21 @@
+#require "bundler/gem_tasks"
+require 'rake'
+require 'rake/testtask'
+require 'rspec/core/rake_task'
+require 'rdoc/task'
+
+task :default => [:rdoc]
+
+desc "Run RSpec unit tests"
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = "./spec/*/*_spec.rb" # don't need this, it's default.
+  # make sure ruby can find the superclass and dependencies
+  t.ruby_opts = "-I spec/lib -I ../../../common/lib -I ../../../controller/lib -I lib"
+end
+
+desc "Generate RDoc output"
+Rake::RDocTask.new do |rd|
+  rd.main = "README.rdoc"
+  rd.rdoc_dir = "doc"
+  rd.rdoc_files.include("README.rdoc", "lib/**/*.rb")
+end

--- a/plugins/dns/gsstsig/conf/openshift-origin-dns-gsstsig.conf.example
+++ b/plugins/dns/gsstsig/conf/openshift-origin-dns-gsstsig.conf.example
@@ -1,0 +1,13 @@
+# Settings related to the GSS-TSIG variant of an OpenShift DNS plugin
+
+# The DNS server to update
+SERVER="127.0.0.1"
+
+# Kerberos Pricipal to use
+KRB_PRINCIPAL="DNS/server1.example.com"
+
+# Kerberos keytab to use
+KRB_KEYTAB="/etc/krb5.keytab"
+
+# The base zone for the DNS server
+DNS_ZONE="example.com"

--- a/plugins/dns/gsstsig/config/initializers/openshift-origin-dns-gsstsig.rb
+++ b/plugins/dns/gsstsig/config/initializers/openshift-origin-dns-gsstsig.rb
@@ -1,0 +1,21 @@
+require 'openshift-origin-common'
+
+Broker::Application.configure do
+  conf_file = File.join(OpenShift::Config::PLUGINS_DIR, File.basename(__FILE__, '.rb') + '.conf')
+  if Rails.env.development?
+    dev_conf_file = File.join(OpenShift::Config::PLUGINS_DIR, File.basename(__FILE__, '.rb') + '-dev.conf')
+    if File.exist? dev_conf_file
+      conf_file = dev_conf_file
+    else
+      Rails.logger.info "Development configuration for #{File.basename(__FILE__, '.rb')} not found. Using production configuration."
+    end
+  end
+  conf = OpenShift::Config.new(conf_file)
+
+  config.dns = {
+    :server => conf.get("SERVER", "127.0.0.1"),
+    :krb_principal => conf.get("KRB_PRINCIPAL", "Kerberos principal to use"),
+    :krb_keytab => conf.get("KRB_KEYTAB", "Kerberos keytab to use"),
+    :dns_zone => conf.get("DNS_ZONE", "example.com")
+  }
+end

--- a/plugins/dns/gsstsig/lib/gsstsig_dns_engine.rb
+++ b/plugins/dns/gsstsig/lib/gsstsig_dns_engine.rb
@@ -1,0 +1,7 @@
+require 'openshift-origin-controller'
+require 'rails'
+
+module OpenShift
+  class GSSTSIGDnsEngine < Rails::Engine
+  end
+end

--- a/plugins/dns/gsstsig/lib/openshift-origin-dns-gsstsig.rb
+++ b/plugins/dns/gsstsig/lib/openshift-origin-dns-gsstsig.rb
@@ -1,0 +1,10 @@
+require "openshift-origin-common"
+
+module OpenShift
+  module GSSTSIGDnsModule
+    require 'gsstsig_dns_engine' if defined?(Rails) && Rails::VERSION::MAJOR == 3
+  end
+end
+
+require "openshift/gsstsig_plugin.rb"
+OpenShift::DnsService.provider=OpenShift::GSSTSIGPlugin

--- a/plugins/dns/gsstsig/lib/openshift/gsstsig_plugin.rb
+++ b/plugins/dns/gsstsig/lib/openshift/gsstsig_plugin.rb
@@ -1,0 +1,70 @@
+#
+# Make Openshift
+#
+require 'rubygems'
+
+module OpenShift
+
+  # 
+  class GSSTSIGPlugin < OpenShift::DnsService
+    @provider = OpenShift::GSSTSIGPlugin
+
+    attr_reader :server, :krb_keytab, :krb_principal, :dns_zone
+
+    def initialize(access_info = nil)
+      if access_info != nil
+        @domain_suffix = access_info[:domain_suffix]
+      elsif defined? Rails
+        access_info = Rails.application.config.dns
+        @domain_suffix = Rails.application.config.openshift[:domain_suffix]
+      else
+        raise Exception.new("GSS-TSIG DNS updates are not initialized")
+      end
+
+      @server = access_info[:server]
+      @krb_keytab = access_info[:krb_keytab]
+      @krb_principal = access_info[:krb_principal]
+      @dns_zone = access_info[:dns_zone]
+    end
+
+    def register_application(app_name, namespace, public_hostname)
+      # create an A record for the application in the domain
+      fqdn = "#{app_name}-#{namespace}.#{@domain_suffix}"
+      raise DNSException.new unless system %{
+kinit -kt #{@krb_keytab} #{@krb_principal} && nsupdate -g <<EOF
+server #{@server} 53
+update add #{fqdn} 60 CNAME #{public_hostname}
+send
+quit
+EOF
+      }
+    end
+
+    def deregister_application(app_name, namespace)
+      # delete the CNAME record for the application in the domain
+      fqdn = "#{app_name}-#{namespace}.#{@domain_suffix}"
+  
+      #raise ::OpenShift::DNSNotFoundException.new unless dns_entry_exists?(fqdn, Dnsruby::Types::CNAME)
+      raise DNSException.new unless system %{
+kinit -kt #{@krb_keytab} #{@krb_principal} && nsupdate -g <<EOF
+server #{@server} 53
+update delete #{fqdn} CNAME
+send
+quit
+EOF
+      }
+    end
+
+    def modify_application(app_name, namespace, public_hostname)
+      deregister_application(app_name, namespace)
+      register_application(app_name, namespace, public_hostname)
+    end
+
+    def publish
+    end
+
+    def close
+    end
+
+  end
+end

--- a/plugins/dns/gsstsig/openshift-origin-dns-gsstsig.gemspec
+++ b/plugins/dns/gsstsig/openshift-origin-dns-gsstsig.gemspec
@@ -1,0 +1,36 @@
+# -*- encoding: utf-8 -*-
+config_dir  = File.join(File.join("config", "**"), "*")
+$:.push File.expand_path("../lib", __FILE__)
+lib_dir  = File.join(File.join("lib", "**"), "*")
+test_dir  = File.join(File.join("test", "**"), "*")
+bin_dir  = File.join("bin", "*")
+doc_dir  = File.join(File.join("doc", "**"), "*")
+conf_dir  = File.join(File.join("conf", "**"), "*")
+spec_file = "rubygem-openshift-origin-dns-gsstsig.spec"
+
+Gem::Specification.new do |s|
+  s.name        = "openshift-origin-dns-gsstsig"
+  s.version     = `rpm -q --define 'rhel 7' --qf "%{version}\n" --specfile #{spec_file}`.split[0]
+  s.license     = `rpm -q --define 'rhel 7' --qf "%{license}\n" --specfile #{spec_file}`.split[0]
+  s.authors     = ["Rhys Oxenham"]
+  s.email       = ["roxenham@redhat.com"]
+  s.homepage    = `rpm -q --define 'rhel 7' --qf "%{url}\n" --specfile #{spec_file}`.split[0]
+  s.summary     = `rpm -q --define 'rhel 7' --qf "%{description}\n" --specfile #{spec_file}`.split[0]
+  s.description = `rpm -q --define 'rhel 7' --qf "%{description}\n" --specfile #{spec_file}`.split[0]
+
+  s.rubyforge_project = "openshift-origin-dns-gsstsig"
+
+  s.files       = Dir[lib_dir] + Dir[doc_dir] + Dir[conf_dir] + Dir[config_dir]
+  s.test_files  = Dir[test_dir]
+  s.executables   = Dir[bin_dir]
+  s.files       += %w(README.md Rakefile Gemfile rubygem-openshift-origin-dns-gsstsig.spec openshift-origin-dns-gsstsig.gemspec LICENSE COPYRIGHT)
+  s.require_paths = ["lib"]
+
+  s.add_dependency('openshift-origin-controller')
+  s.add_dependency('json')  
+  s.add_dependency('dnsruby')
+  s.add_development_dependency('rake', '>= 0.8.7', '<= 0.9.2.2')  
+  s.add_development_dependency('rspec')
+  s.add_development_dependency('bundler')
+  s.add_development_dependency('mocha')
+end

--- a/plugins/dns/gsstsig/rubygem-openshift-origin-dns-gsstsig.spec
+++ b/plugins/dns/gsstsig/rubygem-openshift-origin-dns-gsstsig.spec
@@ -1,0 +1,86 @@
+%if 0%{?fedora}%{?rhel} <= 6
+    %global scl ruby193
+    %global scl_prefix ruby193-
+%endif
+%{!?scl:%global pkg_name %{name}}
+%{?scl:%scl_package rubygem-%{gem_name}}
+%global gem_name openshift-origin-dns-gsstsig
+%global rubyabi 1.9.1
+
+Summary:       OpenShift plugin for DNS update service using GSS-TSIG (RFC 3645)
+Name:          rubygem-%{gem_name}
+Version:       0.0.1
+Release:       1%{?dist}
+Group:         Development/Languages
+License:       ASL 2.0
+URL:           http://openshift.redhat.com
+Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/rubygem-%{gem_name}-%{version}.tar.gz
+Requires:      %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
+Requires:      %{?scl:%scl_prefix}ruby
+Requires:      %{?scl:%scl_prefix}rubygems
+Requires:      %{?scl:%scl_prefix}rubygem(json)
+Requires:      %{?scl:%scl_prefix}rubygem(dnsruby)
+Requires:      rubygem(openshift-origin-common)
+Requires:      bind-utils
+Requires:      openshift-origin-broker
+Requires:      selinux-policy-targeted
+Requires:      policycoreutils-python
+%if 0%{?fedora}%{?rhel} <= 6
+BuildRequires: %{?scl:%scl_prefix}build
+BuildRequires: scl-utils-build
+%endif
+BuildRequires: %{?scl:%scl_prefix}ruby(abi) = %{rubyabi}
+BuildRequires: %{?scl:%scl_prefix}ruby 
+BuildRequires: %{?scl:%scl_prefix}rubygems
+BuildRequires: %{?scl:%scl_prefix}rubygems-devel
+BuildArch:     noarch
+Provides:      rubygem(%{gem_name}) = %version
+
+%description
+Provides a DNS service update plugin using GSS-TSIG
+
+%prep
+%setup -q
+
+%build
+%{?scl:scl enable %scl - << \EOF}
+mkdir -p ./%{gem_dir}
+# Create the gem as gem install only works on a gem file
+gem build %{gem_name}.gemspec
+export CONFIGURE_ARGS="--with-cflags='%{optflags}'"
+# gem install compiles any C extensions and installs into a directory
+# We set that to be a local directory so that we can move it into the
+# buildroot in %%install
+gem install -V \
+        --local \
+        --install-dir ./%{gem_dir} \
+        --bindir ./%{_bindir} \
+        --force \
+        --rdoc \
+        %{gem_name}-%{version}.gem
+%{?scl:EOF}
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -a ./%{gem_dir}/* %{buildroot}%{gem_dir}/
+
+# Add documents/examples
+mkdir -p %{buildroot}%{_docdir}/%{name}-%{version}/
+#cp -r doc/* %{buildroot}%{_docdir}/%{name}-%{version}/
+
+#Config file
+mkdir -p %{buildroot}/etc/openshift/plugins.d
+cp %{buildroot}/%{gem_dir}/gems/%{gem_name}-%{version}/conf/openshift-origin-dns-gsstsig.conf.example %{buildroot}/etc/openshift/plugins.d/openshift-origin-dns-gsstsig.conf.example
+
+%files
+%doc %{gem_docdir}
+%doc %{_docdir}/%{name}-%{version}
+%{gem_instdir}
+%{gem_spec}
+%{gem_cache}
+/etc/openshift/plugins.d/openshift-origin-dns-gsstsig.conf.example
+
+
+%changelog
+* Thu Mar 07 2013 Rhys Oxenham <roxenham@redhat.com> 0.0.1-1
+- Took base nsupdate code and modified for GSS-TSIG DNS integration, e.g. Active Directory

--- a/plugins/dns/gsstsig/spec/unit/openshift-origin-dns-gss-tsig_spec.rb.todo
+++ b/plugins/dns/gsstsig/spec/unit/openshift-origin-dns-gss-tsig_spec.rb.todo
@@ -1,0 +1,97 @@
+#Test each of the basic functions of the gsstsigDnsPlugin
+
+require 'rubygems'
+require 'dnsruby'
+
+# the plugin extends classes in the OpenShift::Controller module
+# load the superclass for all DnsService classes: Openshift::DnsService
+require 'openshift/dns_service'
+
+# Now load the plugin code itself (not the wrapper!)
+require 'openshift/gsstsigPlugin'
+
+#
+# Define the Rails config structure for testing
+#
+
+module Rails
+  def self.application()
+    Application.new
+  end
+
+  class Application
+
+    class Configuration
+      attr_accessor :openshift, :dns
+
+      def initialize()
+        @openshift = { :domain_suffix => "example.com" }
+        @dns = {
+          :server => "ad.example.com",
+          :secure => true,
+          :dns_zone => "example.com",
+          :krb_keytab => "/etc/krb5.keytab",
+          :krb_principal => "DNS/server1.example.com",
+        }
+      end
+
+    end
+   def config()
+      Configuration.new
+    end
+  end
+
+end
+
+module OpenShift
+
+  describe gsstsigPlugin do
+
+   before do
+      # create a DnsMasq service to work with
+      #@service = DnsMasqService.new
+
+      #puts "new service = @service"
+
+      #
+      # Set the assumed service file configuration
+      #
+      @dns = {
+          :server => "ad.example.com",
+          :dns_zone => "example.com",
+          :krb_keytab => "/etc/krb5.keytab",
+          :krb_principal => "DNS/server1.example.com",
+      }
+
+      @plugin = gsstsigPlugin.new(@dns)
+
+      @resolver = 
+        Dnsruby::Resolver.new({
+                                :nameservers => [@dns[:server]], 
+                                :port => @dns[:port].to_s,
+                                :do_caching => false
+                              })
+    end
+
+    after do
+      # Stop and clean the DnsMasq service workspaces
+      #@service.stop if @service.pid
+      #@service.clean
+    end
+
+    it "can be configured using an input hash" do
+      uplift = OpenShift::gsstsigPlugin.new @dns
+      #uplift.config_file.should be @dns[:config_file]
+    end
+
+    it "can be configured using the Rails Application::Configuration object" do
+      
+
+      uplift = OpenShift::gsstsigPlugin.new
+
+    end
+
+
+  end
+
+end


### PR DESCRIPTION
Based on the nsupdate plugin (ruby193) I've created a new separate GSS-TSIG specific plugin that I've tested and works (RHEL 6 + OSE with Windows 2008 R2 x64 AD as well as RHEL 6 IPA/IdM).

There are a few caveats:
- when testing against OpenShift Enterprise I had to ensure that the gem was installed manually (gem install --local /path/to/gem)
- the sources need to be manually placed into the rpmbuild/SOURCES directory as they don't currently exist within the OpenShift repo.

Rebased & squashed https://github.com/openshift/origin-server/pull/1550
