### PR TITLE
WIP Cartridge Refactor - Roll out old threaddump support

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -77,6 +77,5 @@ case "$1" in
   tidy)      tidy ;;
   build)     build ;;
   deploy)    deploy ;;
-  threaddump) exit 69;;
   *)         exit 0
 esac

--- a/controller/test/cucumber/cartridge-phpv2.feature
+++ b/controller/test/cucumber/cartridge-phpv2.feature
@@ -8,6 +8,5 @@ Feature: V2 SDK PHP Cartridge
   And the platform-created default environment variables will exist
   And the php-5.3 cartridge private endpoints will be exposed
   And the php-5.3 PHP_VERSION env entry will exist
-  And the php-5.3 cartridge will not support threaddump
   When I destroy the application
   Then the application git repo will not exist

--- a/controller/test/cucumber/step_definitions/runtime_steps.rb
+++ b/controller/test/cucumber/step_definitions/runtime_steps.rb
@@ -809,15 +809,8 @@ Then /^the "(.*)" content does( not)? exist(s)? for ([^ ]+)$/ do |path, negate, 
   end
 end
 
-Then /^the ([^ ]+) cartridge will( not)? support threaddump/ do |cartridge_name, negate|
-  if negate
-    e = assert_raise(OpenShift::Utils::ShellExecutionError)  do
-      @gear.container.threaddump(cartridge_name)
-    end
-    assert_equal 69, e.rc
-  else
+Then /^the ([^ ]+) cartridge will support threaddump/ do |cartridge_name|
     @gear.container.threaddump(cartridge_name)
-  end
 end
 
 Then /^the ([^ ]+) cartridge instance directory will( not)? exist$/ do |cartridge_name, negate|

--- a/node/README.writing_cartridges.md
+++ b/node/README.writing_cartridges.md
@@ -216,10 +216,17 @@ The `Version` element is the default or only version of the software packaged by
 
     Versions: [5.3]
 
+### TBD Element
+
+The `TBD` element is a TBD of optional hooks supported by your cartridge.  `threaddump` is an example of
+one such hook. OpenShift will only call optional hooks if they are included in this element.
+Supported optional hooks:
+
+    threaddump
+
+
 ### Endpoints Element
 See below.
-
-*jwh: How do we want to cover the other manifest.yml features?*
 
 ## Cartridge Locking
 
@@ -669,8 +676,6 @@ The list of operations your cartridge may be called to perform:
       cartridge has packaged this may equate to a restart.
    * `restart` stop current process and start a new one for the code your cartridge packages
    * `threaddump` if applicable, your cartridge should signal the packaged software to perform a thread dump.
-     An exit status of `69` signals OpenShift that your cartridge or packaged software does not support this
-     operation.
    * `tidy` all unused resources should be released. It is at your discretion to
      determine what should be done. Be frugal, on some systems resources may be
      very limited. Some possible behaviors: 

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -870,12 +870,8 @@ module MCollective
           container = get_app_container_from_args(args)
           output    = container.threaddump(cart_name)
         rescue OpenShift::Utils::ShellExecutionException => e
-          if 69 == e.rc
-            return 127, "CLIENT_ERROR: The threaddump command is not supported by this application type."
-          else
-            Log.instance.info "#{e.message}\n#{e.backtrace}\n#{e.stderr}"
-            return -1, "CLIENT_ERROR: action 'threaddump' #{e.message} #{e.stderr}"
-          end
+          Log.instance.info "#{e.message}\n#{e.backtrace}\n#{e.stderr}"
+          return -1, "CLIENT_ERROR: action 'threaddump' failed #{e.message} #{e.stderr}"
         rescue Exception => e
           Log.instance.info "#{e.message}\n#{e.backtrace}"
           return -1, e.message


### PR DESCRIPTION
- New manifest-driven documented
- Any threaddump call on un-supported cartridges will return success
