### PR TITLE
No longer matching the comment on ssh_key_remove.  

### DIFF
--- a/node/lib/openshift-origin-node/model/unix_user.rb
+++ b/node/lib/openshift-origin-node/model/unix_user.rb
@@ -285,11 +285,7 @@ Dir(after)    #{@uuid}/#{@uid} => #{list_home_dir(@homedir)}
       self.class.notify_observers(:before_remove_ssh_key, self, key)
 
       modify_ssh_keys do |keys|
-        if comment
-          keys.delete_if{ |k, v| v.include?(key) && v.include?(comment)}
-        else
-          keys.delete_if{ |k, v| v.include?(key)}
-        end
+        keys.delete_if{ |k, v| v.include?(key)}
       end
 
       self.class.notify_observers(:after_remove_ssh_key, self, key)


### PR DESCRIPTION
Matching all keys which match the actual key payload is the same instead.
