### PR TITLE
WIP Cartridge Refactor - more robust oo-admin-cartridge

### DIFF
--- a/node-util/bin/oo-admin-cartridge
+++ b/node-util/bin/oo-admin-cartridge
@@ -20,22 +20,51 @@ require 'etc'
 require 'optparse'
 require 'ostruct'
 require 'openshift-origin-node/utils/shell_exec'
+require 'openshift-origin-node/model/cartridge_repository'
 
 module OpenShift
-  class AdminCartridge
+  class AdminCartridgeCartridgeRepository
+    def apply(options)
+      repository = OpenShift::CartridgeRepository.instance
+      case options.action
+        when :install
+          dirs = if options.recursive
+                   Dir[File.join(options.source, '/*')].select { |d| File.directory?(d) }
+                 else
+                   [options.source]
+                 end
+
+          dirs.each do |dir|
+            begin
+              repository.install(dir)
+            rescue OpenShift::Utils::ShellExecutionException => e
+              $stderr.puts "install failed for #{dir}: #{e.message}" if options.verbose
+              $stderr.puts e.backtrace.join("\n") if options.verbose
+            end
+          end
+        when :list
+          return repository.to_s
+        when :erase
+          repository.erase(options.name, options.version, options.cartridge_version)
+      end
+      'succeeded'
+    end
+  end
+
+  class AdminCartridgeMcollective
     def apply(options)
       buffer = ''
       case options.action
         when :install
-          if options.recursive
-            Dir[File.join(options.source, '/*')].select { |d| File.directory?(d) }.each do |dir|
-              out, _, _ = Utils::oo_spawn("mco rpc -q openshift cartridge_repository action=install path=#{dir}",
-                                          expected_exitstatus: 0)
-              buffer << out
-            end
-          else
-            buffer, _, _ = Utils::oo_spawn("mco rpc -q openshift cartridge_repository action=install path=#{options.source}",
-                                           expected_exitstatus: 0)
+          dirs = if options.recursive
+                   Dir[File.join(options.source, '/*')].select { |d| File.directory?(d) }
+                 else
+                   [options.source]
+                 end
+
+          dirs.each do |dir|
+            out, _, _ = Utils::oo_spawn("mco rpc -q openshift cartridge_repository action=install path=#{dir}")
+            buffer << out
           end
         when :list
           buffer, _, _ = Utils::oo_spawn('mco rpc -q openshift cartridge_repository action=list',
@@ -47,14 +76,15 @@ module OpenShift
                          cartridge_version="#{options.cartridge_version}"),
                                          expected_exitstatus: 0)
       end
-      buffer
+
+      buffer.squeeze!("\n")
     end
   end
 end
 
 options = OpenStruct.new(verbose: false, recursive: false)
 parser  = OptionParser.new do |opts|
-  opts.banner = 'Usage: --action ACTION [--source] [--name NAME --version VERSION --cartridge-version VERSION]'
+  opts.banner = 'Usage: --action ACTION [--recursive] [--offline] [--source directory] [--name NAME --version VERSION --cartridge-version VERSION]'
   opts.separator ''
   opts.separator 'Options:'
 
@@ -64,6 +94,10 @@ parser  = OptionParser.new do |opts|
 
   opts.on('-s', '--source path', 'Directory of the cartridge to install') do |o|
     options.source = File.expand_path(o)
+  end
+
+  opts.on('--offline', 'Install with mcollective agent not running') do |o|
+    options.offline = o
   end
 
   opts.on('-R', '--recursive', 'Source is assumed to point to a directory containing cartridge directories') do |o|
@@ -108,7 +142,12 @@ unless missing.empty?
 end
 
 begin
-  $stdout.puts OpenShift::AdminCartridge.new.apply(options)
+  output = if options.offline
+             OpenShift::AdminCartridgeCartridgeRepository.new.apply(options)
+           else
+             OpenShift::AdminCartridgeMcollective.new.apply(options)
+           end
+  $stdout.puts output
 rescue OpenShift::Utils::ShellExecutionException => e
   $stderr.puts "\nOperation failed: #{e.stdout}\n#{e.stderr}\n"
   $stderr.puts e.backtrace.join("\n") if options.verbose

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -1023,7 +1023,7 @@ module MCollective
         version           = request[:version]
         cartridge_version = request[:cartridge_version]
 
-        reply[:output] = "#{action}: succeeded"
+        reply[:output] = "#{action} succeeded for #{path}"
         begin
           case action
             when 'install'
@@ -1034,13 +1034,13 @@ module MCollective
               reply[:output] = ::OpenShift::CartridgeRepository.instance.to_s
             else
               reply.fail(
-                  "#{action}: is not implemented. openshift.ddl may be out of date.",
+                  "#{action} is not implemented. openshift.ddl may be out of date.",
                   2)
               return
           end
         rescue Exception => e
           Log.instance.info("cartridge_repository_action(#{action}): failed #{e.message}\n#{e.backtrace}")
-          reply.fail!("#{action}: failed #{e.message}", 4)
+          reply.fail!("#{action} failed for #{path} #{e.message}", 4)
         end
       end
     end


### PR DESCRIPTION
- Add --offline flag
- Do not stop installing cartridges on the first error when recursive flag used
