### PR TITLE
added krb5 features

### DIFF
--- a/plugins/dns/nsupdate/conf/openshift-origin-dns-nsupdate.conf.example
+++ b/plugins/dns/nsupdate/conf/openshift-origin-dns-nsupdate.conf.example
@@ -6,11 +6,20 @@ BIND_SERVER="127.0.0.1"
 # The DNS server's port
 BIND_PORT=53
 
-# The key name for your zone
-BIND_KEYNAME="example.com"
-
-# base64-encoded key, most likely from /var/named/example.com.key.
-BIND_KEYVALUE=""
-
 # The base zone for the DNS server
 BIND_ZONE="example.com"
+
+#
+# Authentication information
+#
+# Provide either TSIG or GSS-TSIG information, but not both
+
+# TSIG authentication
+#
+BIND_KEYNAME="example.com"
+BIND_KEYVALUE="base-64 encoded DNSSEC HMAC TSIG"
+
+# GSS-TSIG (Kerberos) Authentication
+# BIND_KRB_PRINCIPAL=""
+# BIND_KRB_KEYTAB=""
+

--- a/plugins/dns/nsupdate/config/initializers/openshift-origin-dns-nsupdate.rb
+++ b/plugins/dns/nsupdate/config/initializers/openshift-origin-dns-nsupdate.rb
@@ -15,8 +15,16 @@ Broker::Application.configure do
   config.dns = {
     :server => conf.get("BIND_SERVER", "127.0.0.1"),
     :port => conf.get("BIND_PORT", "53").to_i,
+    :zone => conf.get("BIND_ZONE", "example.com")
+
+    # Authentication information: TSIG or GSS-TSIG (kerberos) but not both
+    #
+    # TSIG credentials
     :keyname => conf.get("BIND_KEYNAME", "example.com"),
     :keyvalue => conf.get("BIND_KEYVALUE", "base64-encoded key, most likely from /var/named/example.com.key."),
-    :zone => conf.get("BIND_ZONE", "example.com")
+
+    # GSS-TSIG (kerberos) credentials
+    :krb_principal => conf.get("BIND_KRB_PRINCIPAL", nil),
+    :krb_keytab => conf.get("BIND_KRB_KEYTAB", nil),
   }
 end

--- a/plugins/dns/nsupdate/rubygem-openshift-origin-dns-nsupdate.spec
+++ b/plugins/dns/nsupdate/rubygem-openshift-origin-dns-nsupdate.spec
@@ -25,6 +25,8 @@ Requires:      %{?scl:%scl_prefix}rubygem(json)
 Requires:      %{?scl:%scl_prefix}rubygem(dnsruby)
 Requires:      rubygem(openshift-origin-common)
 Requires:      bind-utils
+# GSS-API requires kinit
+Requires:      krb-workstation
 Requires:      openshift-origin-broker
 Requires:      selinux-policy-targeted
 Requires:      policycoreutils-python

--- a/plugins/dns/nsupdate/spec/unit/openshift-origin-dns-nsupdate_spec.rb
+++ b/plugins/dns/nsupdate/spec/unit/openshift-origin-dns-nsupdate_spec.rb
@@ -1,7 +1,6 @@
 #Test each of the basic functions of the NsupdateDnsPlugin
 
 require 'rubygems'
-require 'dnsruby'
 
 # the plugin extends classes in the OpenShift::Controller module
 # load the superclass for all DnsService classes: Openshift::DnsService
@@ -30,10 +29,10 @@ module Rails
           :server => "ns1.example.com",
           :port => 2053,
           :zone => "example.com",
-          :config_file => "/etc/dnsmasq.conf",
-          :hosts_dir => "/etc/dnsmasq.d",
-          :system => false,
-          :pid_file => "/var/run/dnsmasq.pid"
+          :keyname => "example.com.key",
+          :keyvalue => "examplekeyvalue",
+          :krb_principal => "kerberos_principal",
+          :krb_keytab => "kerberos_keytable"
         }
       end
 
@@ -47,59 +46,181 @@ end
 
 module OpenShift
 
+  # Make private methods public for testing
+  class NsupdatePlugin
+    def test_add_cmd(fqdn, value)
+      add_cmd(fqdn, value)
+    end
+
+    def test_del_cmd(fqdn)
+      del_cmd(fqdn)
+    end
+
+  end
+
   describe NsupdatePlugin do
 
    before do
-      # create a DnsMasq service to work with
-      #@service = DnsMasqService.new
-
-      #puts "new service = @service"
-
       #
       # Set the assumed service file configuration
       #
       @dns = {
-        :service => "dnsmasq",
+        :service => "nsupdate",
         :server => "127.0.0.1",
         :port => "2053",
         :zone => "example.com",
         :domain_suffix => "example.com",
-        #:config_file => @service.config_file,
-        #:hosts_dir => @service.hosts_dir,
-        #:pid_file => @service.pid_file
+      }
+
+      # Sample Configurations
+      @config = {
+        :tsig => {
+          :server => "4.5.6.7",
+          :port => 3053,
+          :zone => "tsigapp.example.com",
+          :domain_suffix => "tsigapp.example.com",
+          :keyname => "tsigapp.example.com.key",
+          :keyvalue => "tsigapp_key_value"
+        },
+
+        :gss => {
+          :server => "9.8.7.6",
+          :port => 4053,
+          :zone => "krbapp.example.com",
+          :domain_suffix => "krbapp.example.com",
+          :krb_principal => "krbuser",
+          :krb_keytab => "/krb/keytab/filename"
+        }
       }
 
       @plugin = NsupdatePlugin.new(@dns)
 
-      @resolver = 
-        Dnsruby::Resolver.new({
-                                :nameservers => [@dns[:server]], 
-                                :port => @dns[:port].to_s,
-                                :do_caching => false
-                              })
-    end
-
-    after do
-      # Stop and clean the DnsMasq service workspaces
-      #@service.stop if @service.pid
-      #@service.clean
     end
 
     it "can be configured using an input hash" do
-      uplift = OpenShift::NsupdatePlugin.new @dns
-      #uplift.config_file.should be @dns[:config_file]
-      #uplift.hosts_dir.should be @dns[:hosts_dir]
-      #uplift.pid.should be @dns[:pid]
+      tsig_dns = OpenShift::NsupdatePlugin.new @config[:tsig]
+      tsig_dns.server.should be @config[:tsig][:server]
+      tsig_dns.port.should be @config[:tsig][:port]
+      tsig_dns.keyname.should be @config[:tsig][:keyname]
+      tsig_dns.keyvalue.should be @config[:tsig][:keyvalue]
+      tsig_dns.krb_principal.should be nil
+      tsig_dns.krb_keytab.should be nil
+
+      gss_dns = OpenShift::NsupdatePlugin.new @config[:gss]
+      gss_dns.server.should be @config[:gss][:server]
+      gss_dns.port.should be @config[:gss][:port]
+      gss_dns.keyname.should be nil
+      gss_dns.keyvalue.should be nil
+      gss_dns.krb_principal.should be @config[:gss][:krb_principal]
+      gss_dns.krb_keytab.should be @config[:gss][:krb_keytab]
+
     end
 
     it "can be configured using the Rails Application::Configuration object" do
       
+      dns = OpenShift::NsupdatePlugin.new
 
-      uplift = OpenShift::NsupdatePlugin.new
+      cfg = Rails.application.config.dns
+
+      dns.server.should eq cfg[:server]
+      dns.port.should eq cfg[:port]
+      dns.keyname.should eq cfg[:keyname]
+      dns.keyvalue.should eq cfg[:keyvalue]
+      dns.krb_principal.should eq cfg[:krb_principal]
+      dns.krb_keytab.should eq cfg[:krb_keytab]
+
 
     end
 
 
+    it "generates add commands for TSIG credentials" do
+      dns = OpenShift::NsupdatePlugin.new(@config[:tsig])
+
+      fqdn = "testapp1-testns1." + dns.domain_suffix
+      value = "node.example.com"
+
+      cmd = dns.send(:add_cmd, fqdn, value)
+      
+      cmdlines = cmd.split "\n"
+      cmdlines.length.should be === 7
+
+      cmdlines[0].should be === "nsupdate <<EOF"
+      cmdlines[1].should eq "key #{@config[:tsig][:keyname]} #{@config[:tsig][:keyvalue]}"
+      cmdlines[2].should eq "server #{@config[:tsig][:server]} #{@config[:tsig][:port]}"
+      cmdlines[3].should eq "update add #{fqdn} 60 CNAME #{value}"
+      cmdlines[4].should eq "send"
+      cmdlines[5].should eq "quit"
+      cmdlines[6].should eq "EOF"
+    end
+
+    it "generates delete commands for GSS credentials" do
+      dns = OpenShift::NsupdatePlugin.new(@config[:tsig])
+
+      fqdn = "testapp1-testns1." + dns.domain_suffix
+
+      cmd = dns.send(:del_cmd, fqdn)
+     
+      cmdlines = cmd.split "\n"
+      cmdlines.length.should be === 7
+
+      cmdlines[0].should be === "nsupdate <<EOF"
+      cmdlines[1].should eq "key #{@config[:tsig][:keyname]} #{@config[:tsig][:keyvalue]}"
+      cmdlines[2].should eq "server #{@config[:tsig][:server]} #{@config[:tsig][:port]}"
+      cmdlines[3].should eq "update delete #{fqdn}"
+      cmdlines[4].should eq "send"
+      cmdlines[5].should eq "quit"
+      cmdlines[6].should eq "EOF"
+
+    end
+
+    it "generates add commands for GSS credentials" do
+
+      cfg = @config[:gss]
+      dns = OpenShift::NsupdatePlugin.new(cfg)
+
+      fqdn = "testapp1-testns1." + dns.domain_suffix
+      value = "node.example.com"
+
+      cmd = dns.send(:add_cmd, fqdn, value)
+      
+      cmdlines = cmd.split "\n"
+      cmdlines.length.should be === 8
+
+      cmdlines[0].should eq "kinit -kt #{cfg[:krb_keytab]} #{cfg[:krb_principal]} && \\"
+      cmdlines[1].should be === "nsupdate <<EOF"
+      cmdlines[2].should eq ""
+      cmdlines[3].should eq "server #{cfg[:server]} #{cfg[:port]}"
+      cmdlines[4].should eq "update add #{fqdn} 60 CNAME #{value}"
+      cmdlines[5].should eq "send"
+      cmdlines[6].should eq "quit"
+      cmdlines[7].should eq "EOF"
+
+    end
+
+    it "generates delete commands for GSS credentials" do
+
+      cfg = @config[:gss]
+      dns = OpenShift::NsupdatePlugin.new(cfg)
+
+      fqdn = "testapp1-testns1." + dns.domain_suffix
+
+      cmd = dns.send(:del_cmd, fqdn)
+      
+      cmdlines = cmd.split "\n"
+      cmdlines.length.should be === 8
+
+      cmdlines[0].should eq "kinit -kt #{cfg[:krb_keytab]} #{cfg[:krb_principal]} && \\"
+      cmdlines[1].should eq "nsupdate <<EOF"
+      cmdlines[2].should eq ""
+      cmdlines[3].should eq "server #{cfg[:server]} #{cfg[:port]}"
+      cmdlines[4].should eq "update delete #{fqdn}"
+      cmdlines[5].should eq "send"
+      cmdlines[6].should eq "quit"
+      cmdlines[7].should eq "EOF"
+
+    end
+
+    
   end
 
 end


### PR DESCRIPTION
This request would add the ability for the nsupdate plugin to use GSS-TSIG to authenticate DNS update requests.

There are still questions: This now requires krb5-workstation even if it doesn't use it.

Is it possible to use rubygem-krb5-auth?  Looking into it.

To use TSIG, set BIND_KEYNAME and BIND_KEYVALUE
To use GSS-TSIG set BIND_KRB_PRINCIPAL and BIND_KRB_KEYTAB
