### PR TITLE
Fix gemspec for missing and incorrect requirement

### DIFF
--- a/plugins/auth/remote-user/openshift-origin-auth-remote-user.gemspec
+++ b/plugins/auth/remote-user/openshift-origin-auth-remote-user.gemspec
@@ -26,7 +26,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('openshift-origin-controller')
-  s.add_dependency('json')
+  s.add_dependency('openshift-origin-common')
+  s.add_dependency('rails')
+  s.add_development_dependency('json')
   s.add_development_dependency('rake', '>= 0.8.7', '<= 0.9.6')
   s.add_development_dependency('bundler')
   s.add_development_dependency('mocha')


### PR DESCRIPTION
- json is only used for tests
- rails is used in ./lib/remote_user_auth_engine.rb
- openshift-origin-common in ./config/initializers/openshift-origin-auth-remote-user.rb
