### PR TITLE
Bug 928752: Run threaddump/system-messages only on primary cart

### DIFF
--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -1099,7 +1099,11 @@ module OpenShift
         args = build_base_gear_args(gear)
         args['--cart-name'] = cart
 
-        run_cartridge_command_ignore_components(cart, gear, "threaddump", args)
+        if framework_carts.include?(cart)
+          run_cartridge_command(cart, gear, "threaddump", args)
+        else
+          ResultIO.new
+        end 
       end
 
       #
@@ -1121,7 +1125,11 @@ module OpenShift
         args = build_base_gear_args(gear)
         args['--cart-name'] = cart
 
-        run_cartridge_command_ignore_components(cart, gear, "system-messages", args)
+        if framework_carts.include?(cart)
+          run_cartridge_command(cart, gear, "system-messages", args)
+        else
+          ResultIO.new
+        end 
       end
 
       #


### PR DESCRIPTION
Fix a regression whereby threaddump and system-messages actions were being
sent to non-primary cartridges.

Resolve https://bugzilla.redhat.com/show_bug.cgi?id=928752.
