### PR TITLE
Moving openshift-icon to a partial and including in common so that mixin...

### DIFF
--- a/console/app/assets/stylesheets/_iconfont.scss
+++ b/console/app/assets/stylesheets/_iconfont.scss
@@ -5,12 +5,14 @@
     position: absolute;
     left: 0;
     top: 0;
+    text-shadow: none;
   }
 }
 
 .font-icon {
   display: inline-block;
   top: 0;
+  @include icon-text-shadow();
   &.font-icon-inline  {
     position: relative;
   }
@@ -68,16 +70,9 @@ h5[class*="icon-"]:before {
   margin-left: 6px;
 }
 
-h1, h2, h3 {
+h1, h2, h3, h4, h5, h6 {
   .font-icon-block {
     margin-right: .2em;
-    bottom: 5px;
-  }
-}
-h4, h5, h6 {
-  .font-icon-block {
-    margin-right: .15em;
-    bottom: 3px;
   }
 }
 

--- a/console/app/assets/stylesheets/_mixins.scss
+++ b/console/app/assets/stylesheets/_mixins.scss
@@ -119,3 +119,18 @@
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
+
+
+@mixin icon-text-shadow($color: rgba(0, 0, 0, 0.75)) {
+  text-shadow: 0 1px 0 $color;
+}
+
+// Requires inline-block or block
+@mixin truncate() {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.truncate {
+  @include truncate();
+}

--- a/console/app/assets/stylesheets/_openshift-icon.css.scss
+++ b/console/app/assets/stylesheets/_openshift-icon.css.scss
@@ -40,6 +40,7 @@ you can use the generic selector below, but it's slower:
 	 left: -4px;
    margin-left: 4px;
    position: relative;
+   @include icon-text-shadow();
 }
 .icon-lock:before {
 	content: "\e000";

--- a/console/app/assets/stylesheets/_type.scss
+++ b/console/app/assets/stylesheets/_type.scss
@@ -100,7 +100,7 @@ footer h3 {
 // ASIDE
 // -----
 aside, aside p {
-    font-size: $baseFontSize - 1.5;
+    font-size: $baseFontSize - 1;
 }
 
 

--- a/console/app/assets/stylesheets/_variables.scss
+++ b/console/app/assets/stylesheets/_variables.scss
@@ -66,6 +66,7 @@ $linkColorHover:                $openshiftDarkRed;
 $linkColorBlue:                 #069;
 $linkColorBlueHover:            $openshiftBrightRed;
 $linkColorBlueOnDark:           #42a0bf;
+$buttonBlueHover:               #B1E5F2;
 
 $textColor:                     #404040;
 
@@ -80,6 +81,7 @@ $grayLighter:										#ededed;
 $grayLight:                     #999;
 $grayMedium:                    #505050;
 $grayDark:                      #2f2f2f;
+$grayDarker:                    #202020;
 $primaryButtonBackground:       #B1E5F2;
 $orange:                        #ffb02e;
 $linkColor:                     #0069d6;

--- a/console/app/assets/stylesheets/common.css.scss
+++ b/console/app/assets/stylesheets/common.css.scss
@@ -80,4 +80,5 @@
 @import "responsive";
 
 @import "custom";
+@import "openshift-icon";
 @import "iconfont";

--- a/console/app/assets/stylesheets/console/_application.scss
+++ b/console/app/assets/stylesheets/console/_application.scss
@@ -80,6 +80,12 @@
   margin-bottom: 10px;
 }
 
+#aliases li > a {
+  @include truncate();
+  max-width: 65%;
+  display: inline-block;
+}
+
 @media (max-width: 480px) {
   .application-info {
     > .url,

--- a/console/app/assets/stylesheets/console/_core.scss
+++ b/console/app/assets/stylesheets/console/_core.scss
@@ -257,9 +257,83 @@ figure {
   margin-top: 25px;
 }
 
+
+.header-bar {
+  display: table;
+  width: 100%;
+  @include box-sizing(border-box);
+  height: 34px;
+  h3,h4,h5 {
+    display:table-cell;
+    vertical-align:middle;
+    margin: 0;
+  }
+  .header-btn {
+    display:table-cell;
+    vertical-align:middle;
+    text-align:right;
+    width: 50%;
+    background: $grayDarker;
+    .header-btn-title {
+      display: table-cell;
+      vertical-align: middle;
+      text-align: right;
+      padding-right: 20px;
+      font-family: $headerFontFamily;
+      border-right: 1px solid rgba(255, 255, 255, 0.075);
+    }
+    a {
+      color: #9A9B9C;
+      vertical-align:middle;
+      display: table;
+      height: 100%;
+      width: 100%;
+      font-size: $baseFontSize - 3;
+      text-transform: uppercase;
+      &:hover {
+        text-decoration: none;
+        color: $linkTextDarkBackground;
+        .font-icon {
+          background: $buttonBlueHover;
+          color: $grayDarker;
+          @include icon-text-shadow(rgba(255, 255, 255, 0.75));
+        }
+      }
+      .font-icon {
+        display: table-cell;
+        vertical-align: middle;
+        text-align: center;
+        font-size: 11px;
+        width: 34px;
+        border-left: 1px solid rgba(0, 0, 0, 0.3);
+      }
+    }
+  }
+}
+
+
+aside .header-bar {
+  margin-bottom: $baseLineHeight / 3;
+  height: 26px;
+  .header-btn {
+    a {
+      font-size: $baseFontSize - 3;
+      .header-btn-title {
+        padding: 0;
+        text-align: center;
+      }
+      .font-icon {
+        font-size: 9.5px;
+        width: 24px;
+      }
+    }
+  }
+}
+
+
 .sidebar {
-  border-top: 1px dotted $grayMedium;
-  padding-top: $baseLineHeight; 	
+  border-bottom: 1px dotted $grayMedium;
+  margin-bottom: $baseLineHeight; 	
 }
 
 @media (max-width: 767px) {
@@ -612,14 +686,6 @@ $cartridgeBorderWidth: 10px;
 #assistance ul,
 #app-unique-info ul {
   margin-bottom: 25px;
-  }
-#app-unique-info h5 {
-  border-bottom: 1px solid #222222;
-  }
-#aliases {
-  a, span {
-    font-size: $baseFontSize;
-  }
 }
 
 .section-console h6 {

--- a/console/app/assets/stylesheets/console/_tile.scss
+++ b/console/app/assets/stylesheets/console/_tile.scss
@@ -89,21 +89,17 @@
       .tile-target {
         color: #f0f0f0;
       }
-      i.tile-arrow {
-        background-position: 0 -30px;
+      .font-icon.tile-arrow {
+        color: $buttonBlueHover;
       }
     }
-    /*i.tile-arrow {
-      background-position: 0 0;
+    .font-icon.tile-arrow {
       position: absolute;
-      overflow: hidden;
-      display: block;
-      height: 20px;
-      width: 10px;
-      right: 5px;
-      top: 19px;
-      width: 25px;
-    }*/
+      font-size: 13.5px;
+      position: absolute;
+      right: 25px;
+      top: 25px;
+    }
     .font-icon-block {
       position: absolute;
       right: 25px;
@@ -126,9 +122,6 @@
   .section-body .row > .tile-click {
     @include expand_for_phone();
 
-    i.tile-arrow {
-      right: -15px;
-    }
   }
 }
 

--- a/console/app/views/applications/index.html.haml
+++ b/console/app/views/applications/index.html.haml
@@ -22,7 +22,7 @@
           .url
             %strong @
             = link_to application.web_url, application.web_url
-          %i.sprite.tile-arrow
+          %span.tile-arrow.font-icon{"aria-hidden" => "true", "data-icon" => "\ue007"}
 
   .btn-toolbar.base.right
     = link_to application_types_path, :class => 'btn btn-primary btn-large' do

--- a/console/app/views/applications/show.html.haml
+++ b/console/app/views/applications/show.html.haml
@@ -24,12 +24,18 @@
 
 %section#app-specifics
 %section#app-cartridges.span9
-  %header.clearfix
-    %h3.pull-left Cartridges
-    .pull-right
-      = link_to application_cartridge_types_path(@application), :class => 'btn-add-cart' do
-        Add Cartridge
-        %span.sprite
+  %header.clearfix.header-bar
+    %h3
+      Cartridges
+    .header-btn
+      = link_to application_cartridge_types_path(@application) do
+        %span.header-btn-title add cartridge
+        %span.font-icon{"aria-hidden" => "true", "data-icon" => "\uee16"}
+    -#%h3.pull-left Cartridges
+      .pull-right
+        = link_to application_cartridge_types_path(@application), :class => 'btn-add-cart' do
+          Add Cartridge
+          %span.sprite
 
   - @gear_groups.each_with_index do |group,g|
     .gear-group
@@ -115,14 +121,15 @@
       %i.icon-add
 
 %aside#app-unique-info.span3
-  %section#aliases
-    -#%h5 Visibility
-    -#%ul.unstyled
-      %li External
-    .pull-right
-      = link_to 'add alias', application_aliases_path(@application)
-    %h5 
-      Aliases
+  %section#aliases.sidebar
+    %header.clearfix.header-bar
+      %h5
+        Aliases
+      .header-btn
+        = link_to application_aliases_path(@application) do
+          %span.header-btn-title add alias
+          %span.font-icon{"aria-hidden" => "true", "data-icon" => "\uee16"}
+          
     %ul.unstyled
       - if @application.aliases.empty?
         %li 
@@ -133,11 +140,11 @@
         - @application.aliases.sort.each do |a|
           %li
             - if a.has_private_ssl_certificate?
-              %span.icon-lock.font-icon-size-12.font-icon-white{'aria-hidden' => true, :title => 'SSL certificate attached'}
+              %span.icon-lock.font-icon-size-12.font-icon-white.pull-left{'aria-hidden' => true, :title => 'SSL certificate attached'}
             - else
-              %span.icon-unlock.font-icon-size-12.font-icon-grey{'aria-hidden' => true, :title => 'No SSL certificate'}
+              %span.icon-unlock.font-icon-size-12.font-icon-grey.pull-left{'aria-hidden' => true, :title => 'No SSL certificate'}
             = link_to a.name, application_alias_path(@application, a)
-            .pull-right
+            .pull-right.icon-pencil.font-icon-grey
               = link_to 'edit', application_alias_path(@application, a)
 
     - if @application.initial_git_url.present?


### PR DESCRIPTION
... can be applied and other styling changes

Created a mixin for text-overflow .truncate and used with aliases list
Created markup for header button usage of add/create function
Switched individual application page from using sprite images to icon font
Swiched application list to use right arrow icon instead of sprite
Removed bottom positioning of icons with h1,h2 b/c when used with truncate the overflow:hidden cut the tops off.
A couple of variables added for colors
