### PR TITLE
Minor EWS spec fix to avoid gcj issues

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossews/openshift-origin-cartridge-jbossews.spec
+++ b/cartridges/openshift-origin-cartridge-jbossews/openshift-origin-cartridge-jbossews.spec
@@ -12,6 +12,7 @@ Requires:      rubygem(openshift-origin-node)
 Requires:      tomcat7
 Requires:      lsof
 Requires:      java-1.7.0-openjdk
+Requires:      java-1.7.0-openjdk-devel
 %if 0%{?rhel}
 Requires:      maven3
 %endif
@@ -19,7 +20,6 @@ Requires:      maven3
 Requires:      maven
 %endif
 BuildRequires: git
-BuildRequires: java-devel >= 1:1.6.0
 BuildRequires: jpackage-utils
 BuildArch:     noarch
 


### PR DESCRIPTION
I don't believe java-devel is an actual build time requirement for this
package.  Also, I think we need to be explicity about which java-devel we
actually want to avoid being broken by gcj.  See the following for more
details:

java-1.7.0-openjdk-devel is likely what needs to be installed since
java-1.7.0-openjdk is explicitly labeled as a requirement.  However, it does
not provide java-devel:

[root@broker yum.repos.d]# rpm -q --provides java-1.7.0-openjdk-devel
java7-1.7.0-devel = 1:1.7.0.11
java7-devel = 1:1.7.0
java7-devel-openjdk = 1:1.7.0.11
java7-sdk = 1:1.7.0
java7-sdk-1.7.0 = 1:1.7.0.11
java7-sdk-1.7.0-openjdk = 1:1.7.0.11
java7-sdk-openjdk = 1:1.7.0.11
lib.so()(64bit)
lib.so(SUNWprivate_1.1)(64bit)
libunpack.so()(64bit)
libunpack.so(SUNWprivate_1.1)(64bit)
java-1.7.0-openjdk-devel = 1:1.7.0.11-2.4.0.2.el6
java-1.7.0-openjdk-devel(x86-64) = 1:1.7.0.11-2.4.0.2.el6

java-1.6.0-openjdk-devel does provide java-devel = 1:1.6.0 but unfortunately on
a RHEL6.4 system if java-1.5.0-gcj-devel is already installed 'yum update
java-devel' will not find java-1.6.0-openjdk-devel.

[root@broker yum.repos.d]# rpm -q --provides java-1.6.0-openjdk-devel
java-1.6.0-devel = 1:1.6.0.0
java-devel = 1:1.6.0
java-devel-openjdk = 1:1.6.0.0
java-sdk = 1:1.6.0
java-sdk-1.6.0 = 1:1.6.0.0
java-sdk-1.6.0-openjdk = 1:1.6.0.0
java-sdk-openjdk = 1:1.6.0.0
lib.so()(64bit)
libunpack.so()(64bit)
java-1.6.0-openjdk-devel = 1:1.6.0.0-1.57.1.11.9.el6_4
java-1.6.0-openjdk-devel(x86-64) = 1:1.6.0.0-1.57.1.11.9.el6_4
