### PR TITLE
broker messaging does not require mcollective server

### DIFF
--- a/plugins/msg-broker/mcollective/rubygem-openshift-origin-msg-broker-mcollective.spec
+++ b/plugins/msg-broker/mcollective/rubygem-openshift-origin-msg-broker-mcollective.spec
@@ -23,7 +23,6 @@ Requires:      %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
 Requires:      %{?scl:%scl_prefix}rubygems
 Requires:      %{?scl:%scl_prefix}rubygem(json)
 Requires:      rubygem(openshift-origin-common)
-Requires:      mcollective
 Requires:      mcollective-client
 Requires:      selinux-policy-targeted
 Requires:      policycoreutils-python


### PR DESCRIPTION
Remove installation requirement.  The broker does not require the mcollective server (the mcollective package)
