### PR TITLE
abstract requires tar but that is no longer in @base

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/openshift-origin-cartridge-abstract.spec
+++ b/cartridges/openshift-origin-cartridge-abstract/openshift-origin-cartridge-abstract.spec
@@ -16,6 +16,7 @@ Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%
 Requires:      facter
 Requires:      git
 Requires:      make
+Requires:      tar
 Requires:      mod_ssl
 # abstract/info/connection-hooks/publish-http-url
 Requires:      python


### PR DESCRIPTION
Add tar to the requirements list for the abstract cartridge package.

Tar used to be required by the base group but it is not in Fedora 18.
