### PR TITLE
Bug 917492 fix and rework of labels

### DIFF
--- a/console/app/assets/stylesheets/console/_tile.scss
+++ b/console/app/assets/stylesheets/console/_tile.scss
@@ -3,6 +3,10 @@
   margin-bottom: 20px; 
   background-color: #222;
   color: #b0b0b0;
+  
+  h2 {
+    @include clearfix();
+  }
 
   > p {
     margin-bottom: $baseLineHeight / 1.5;

--- a/console/app/assets/stylesheets/console/_tile.scss
+++ b/console/app/assets/stylesheets/console/_tile.scss
@@ -1,5 +1,5 @@
 .tile {
-  padding: 15px 35px 15px 25px; 
+  padding: 15px 25px; 
   margin-bottom: 20px; 
   background-color: #222;
   color: #b0b0b0;
@@ -59,6 +59,7 @@
 }
 
 .tile-compact {
+  padding-right: 35px;
   h3 {
     display: inline-block;
     margin-right: 10px;
@@ -72,8 +73,13 @@
 }
 
 .tile-dark {
+
   .tile {
     background: #131313;
+  }
+  
+  .tile-featured h3 {
+    margin-right: 20px;
   }
 
   > .tile-click {

--- a/console/app/views/application_types/_application_type.html.haml
+++ b/console/app/views/application_types/_application_type.html.haml
@@ -1,5 +1,5 @@
 - type = application_type
-= div_for type, :class => 'tile tile-click label-tags' do
+= div_for type, :class => 'tile tile-click tile-featured label-tags' do
   %h3
     = link_to type.display_name, application_type_path(type)
 


### PR DESCRIPTION
- Fix for bug 917492 where error msg overlaps at mobile resolution
- Make tile padding equal
  Required restructure of labels
  - moved label inside of h3
  - adjustments of css because of move
