### PR TITLE
Set sync on STDOUT/STDERR in gear script

### DIFF
--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -27,6 +27,9 @@ program :name, "OpenShift Gear Control"
 program :version, "1.0.0"
 program :description, "An assortment gear utilities"
 
+STDOUT.sync = true
+STDERR.sync = true
+
 module OpenShift
   module NodeLogger
     def self.logger


### PR DESCRIPTION
The gear script is assumed to be interactive. Enable sync on the STDOUT/STDERR
objects to ensure output is line-buffered.
