### PR TITLE
node scripts Bug 920477 - replace -? short option with documented -h

### DIFF
--- a/node/misc/bin/oo-app-create
+++ b/node/misc/bin/oo-app-create
@@ -62,7 +62,7 @@ opts = GetoptLong.new(
     ["--with-container-name",       GetoptLong::OPTIONAL_ARGUMENT],
     ["--porcelain",           "-q", GetoptLong::NO_ARGUMENT],
     ["--debug",               "-d", GetoptLong::NO_ARGUMENT],
-    ["--help",                "-?", GetoptLong::NO_ARGUMENT]
+    ["--help",                "-h", GetoptLong::NO_ARGUMENT]
 )
 
 args = {}

--- a/node/misc/bin/oo-cartridge-info
+++ b/node/misc/bin/oo-cartridge-info
@@ -39,7 +39,7 @@ require 'openshift-origin-common'
 opts = GetoptLong.new(
     ["--porcelain",         "-q", GetoptLong::NO_ARGUMENT],
     ["--debug",             "-d", GetoptLong::NO_ARGUMENT],
-    ["--help",              "-?", GetoptLong::NO_ARGUMENT]
+    ["--help",              "-h", GetoptLong::NO_ARGUMENT]
 )
 
 args = {}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=920477

Both scripts show "-h" as the short option for "--help" in their usage
output - updated code to match docs.

[test]
