### PR TITLE
Bug 950367 - Handle non-integer values for expires_in

### DIFF
--- a/console/test/integration/rest_api/authorization_test.rb
+++ b/console/test/integration/rest_api/authorization_test.rb
@@ -41,6 +41,11 @@ class RestApiAuthorizationTest < ActiveSupport::TestCase
     assert a.expires_in > 0
   end
 
+  test 'expiration with a string' do
+    assert a = Authorization.create(:expires_in => 'abc', :as => @user)
+    assert a.expires_in > 0
+  end
+
   test 'reuse authorization' do
     assert a = Authorization.create(:as => @user)
     assert b = Authorization.create(:reuse => true, :as => @user)

--- a/controller/app/controllers/authorizations_controller.rb
+++ b/controller/app/controllers/authorizations_controller.rb
@@ -21,7 +21,7 @@ class AuthorizationsController < BaseController
     max_expires = scopes.maximum_expiration
     expires_in =
       if params[:expires_in].present?
-        expires_in = params[:expires_in].to_i
+        expires_in = Integer(params[:expires_in]) rescue -1
         (expires_in < 0 || expires_in > max_expires) ? nil : expires_in
       end || scopes.default_expiration
 


### PR DESCRIPTION
Any param value of expires_in outside the range of 0..max_expires should be
treated as the default value.

@danmcp review
