### PR TITLE
<haproxy_ctld> Bug 920990 - fix p_usage showing usage message twice

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy-1.4/info/bin/haproxy_ctld.rb
+++ b/cartridges/openshift-origin-cartridge-haproxy-1.4/info/bin/haproxy_ctld.rb
@@ -334,7 +334,7 @@ Notes:
 1. To start/stop auto scaling in daemon mode run:
     haproxy_watcher (start|stop|restart|run|)
 USAGE
-    exit 255
+    exit! 255
 end
 
 def help_marker


### PR DESCRIPTION
updated p_usage method to drop straight out of program (via exit!) after
displaying usage instead of raising the "exit" exception

https://bugzilla.redhat.com/show_bug.cgi?id=920990

[test]
