### PR TITLE
Provision for supporting supplementary groups for generated gear users

### DIFF
--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -12,6 +12,11 @@ CLOUD_DOMAIN="example.com"                                  # Domain suffix to u
 # INTERNAL_ETH_DEV='eth1'                                    # Specify the internal cluster facing ethernet device
 INSTANCE_ID="localhost"                                      # Set by RH EC2 automation
 
+# Uncomment and use the following line if you want to gear users to be members of
+# additional groups besides the one with the same id as the uid. The other group
+# should be an existing group.
+#GEAR_SUPL_GRPS="another_group"  # Supplementary groups for gear UIDs (comma separated list)
+
 # Generally the following should not be changed:
 ENABLE_CGROUPS=1                                             # constrain gears in cgroups (1=yes, 0=no)
 GEAR_BASE_DIR="/var/lib/openshift"                           # gear root directory

--- a/node/lib/openshift-origin-node/model/unix_user.rb
+++ b/node/lib/openshift-origin-node/model/unix_user.rb
@@ -95,6 +95,7 @@ module OpenShift
       gecos    = @config.get("GEAR_GECOS")     || "OO application container"
       notify_observers(:before_unix_user_create)
       basedir = @config.get("GEAR_BASE_DIR")
+      supplementary_groups = @config.get("GEAR_SUPL_GRPS")
 
       # lock to prevent race condition between create and delete of gear
       uuid_lock_file = "/var/lock/oo-create.#{@uuid}"
@@ -124,6 +125,9 @@ module OpenShift
                   -m \
                   -k #{skel_dir} \
                   #{@uuid}}
+          if supplementary_groups != ""
+            cmd << %{ -G "#{supplementary_groups}"}
+          end
           out,err,rc = shellCmd(cmd)
           raise UserCreationException.new(
                   "ERROR: unable to create user account(#{rc}): #{cmd.squeeze(" ")} stdout: #{out} stderr: #{err}"


### PR DESCRIPTION
The changes basically add `-G <supplementary groups>` to the `useradd` call.

Signed-off-by: K.C. Wong kcwong@paypal.com
