### PR TITLE
Bug 950823

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -75,6 +75,7 @@ function tidy() {
 
 function pre-build() {
   # to be implemented
+  true
 }
 
 function build() {
@@ -124,10 +125,12 @@ function build() {
 
 function post-deploy() {
   # to be implemented
+  true
 }
 
 function threaddump() {
   # to be determined
+  true
 }
 
 


### PR DESCRIPTION
Bash cannot stomach a function with empty body; this caused syntax
error, and the failure to create Ruby applications.
