### PR TITLE
Call cart pre-receive hook during default build lifecycle

### DIFF
--- a/cartridges/openshift-origin-cartridge-mock/bin/control
+++ b/cartridges/openshift-origin-cartridge-mock/bin/control
@@ -48,6 +48,7 @@ case "$1" in
   post-snapshot) touch $MOCK_STATE/control_post_snapshot ;;
   pre-restore)   touch $MOCK_STATE/control_pre_restore ;;
   post-restore)  touch $MOCK_STATE/control_post_restore ;;
+  pre-receive)   touch $MOCK_STATE/control_pre_receive ;;
   *)           exit 0
 esac
 

--- a/controller/test/cucumber/cartridge-mock.feature
+++ b/controller/test/cucumber/cartridge-mock.feature
@@ -37,6 +37,7 @@ Feature: V2 SDK Mock Cartridge
     And the mock control_stop marker is removed
     And a simple update is pushed to the application repo
     Then the mock control_stop marker will exist
+    And the mock control_pre_receive marker will exist
     And the mock control_build marker will exist
     And the mock control_deploy marker will exist
     And the mock control_start marker will exist

--- a/node/README.writing_cartridges.md
+++ b/node/README.writing_cartridges.md
@@ -1006,6 +1006,7 @@ Note: User action hooks are assumed to reside in
 During the `build` phase:
 
 1. The application is stopped
+1. The primary cartridge `pre-receive` control action is executed
 1. The newly committed application source code is copied to `$OPENSHIFT_REPO_DIR`
    **Note**: This step is the only time the application source code is copied by 
    OpenShift during this lifecycle.

--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -343,6 +343,13 @@ module OpenShift
       else
         DefaultBuilder.new(self).pre_receive(out: options[:out],
                                              err: options[:err])
+
+        @cartridge_model.do_control('pre-receive',
+                                    @cartridge_model.primary_cartridge,
+                                    out:                       options[:out],
+                                    err:                       options[:err],
+                                    pre_action_hooks_enabled:  false,
+                                    post_action_hooks_enabled: false)
       end
     end
 

--- a/node/test/unit/build_lifecycle_test.rb
+++ b/node/test/unit/build_lifecycle_test.rb
@@ -66,8 +66,17 @@ class BuildLifecycleTest < Test::Unit::TestCase
 
   def test_pre_receive_default_builder
     @cartridge_model.expects(:builder_cartridge).returns(nil)
+    
+    primary = mock()
+    @cartridge_model.expects(:primary_cartridge).returns(primary)
 
     @container.expects(:stop_gear).with(user_initiated: true, out: $stdout, err: $stderr)
+    @cartridge_model.expects(:do_control).with('pre-receive',
+                                               primary,
+                                               out:                       $stdout,
+                                               err:                       $stderr,
+                                               pre_action_hooks_enabled:  false,
+                                               post_action_hooks_enabled: false)
 
     @container.pre_receive(out: $stdout, err: $stderr)
   end


### PR DESCRIPTION
Give cartridges an opportunity to perform actions before the default builder
post-receive is invoked and the Git repository is commited/archived to the
OPENSHIFT_REPO_DIR directory.
