### PR TITLE
Bug 949518

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/bin/setup
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/setup
@@ -30,7 +30,7 @@ pushd $OPENSHIFT_NODEJS_DIR > /dev/null
 	npmgl=$OPENSHIFT_NODEJS_DIR/versions/$version/configuration/npm_global_module_list
 	module_list=$(perl -ne 'print if /^\s*[^#\s]/' "$npmgl" | tr '\n' ' ')
 	npm link $module_list >/dev/null 2>&1
-	mv node_modules $OPENSHIFT_HOMEDIR/.node_modules
+	ln -fs $OPENSHIFT_NODEJS_DIR/node_modules $OPENSHIFT_REPO_DIR/../node_modules
 popd > /dev/null
 
 # npm keeps per-user config in ~/.npmrc and cache in ~/.npm/  and


### PR DESCRIPTION
Create symlink to `$OPENSHIFT_NODEJS_DIR/node_modules` in `$OPENSHIFT/..`.

This directory should survive deployments, and is searched by npm when the application is started.
