### PR TITLE
Provide overrides based on Ruby version so that a Ruby-1.8 app can scale

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml
@@ -13,6 +13,25 @@ Categories:
   - service
   - ruby
   - web_framework
+Version-Overrides:
+  '1.8':
+    Provides:
+      - ruby-1.8
+      - "ruby"
+      - "ruby(version) = 1.8"
+    Group-Overrides:
+      - components:
+        - ruby-1.8
+        - web_proxy
+  '1.9':
+    Provides:
+      - ruby-1.9
+      - "ruby"
+      - "ruby(version) = 1.9"
+    Group-Overrides:
+      - components:
+        - ruby-1.9
+        - web_proxy
 Website: http://www.ruby.org
 Help-Topics:
   "Developer Center": https://openshift.redhat.com/community/developers
@@ -44,10 +63,6 @@ Cart-Data:
   - Key: OPENSHIFT_GEAR_UUID
     Type: environment
     Description: "Unique ID which identified the gear. This value changes between gears."
-Provides:
-  - ruby-1.9
-  - "ruby"
-  - "ruby(version) = 1.9"
 Publishes:
   publish-http-url:
     Type: "NET_TCP:httpd-proxy-info"
@@ -72,10 +87,6 @@ Subscribes:
 Scaling:
   Min: 1
   Max: -1
-Group-Overrides:
-  - components:
-    - ruby-1.9
-    - web_proxy
 Endpoints:
   - Private-IP-Name:   IP
     Private-Port-Name: PORT


### PR DESCRIPTION
This addresses Bug 951389.
