### PR TITLE
Fix message for threaddump command to avoid confusion.

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/hooks/threaddump
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/hooks/threaddump
@@ -51,4 +51,4 @@ run_as_user "${CARTRIDGE_BASE_PATH}/${cartridge_type}/info/bin/app_ctl.sh thread
 
 client_result "Success"
 client_result ""
-client_result "The thread dump file will be available via: rhc tail $1 -f $cartridge_type/$cartridge_type/standalone/tmp/$cartridge_type.log -o '-n 250'"
+client_result "The thread dump file will be available via: rhc tail $1 -f \"$cartridge_type/$cartridge_type/standalone/tmp/$cartridge_type.log -o '-n 250'\""

--- a/cartridges/openshift-origin-cartridge-jbossews-1.0/info/hooks/threaddump
+++ b/cartridges/openshift-origin-cartridge-jbossews-1.0/info/hooks/threaddump
@@ -51,4 +51,4 @@ run_as_user "${CARTRIDGE_BASE_PATH}/${cartridge_type}/info/bin/app_ctl.sh thread
 
 client_result "Success"
 client_result ""
-client_result "The thread dump file will be available via: rhc tail $1 -f $cartridge_type/$cartridge_type/logs/catalina.out -o '-n 250'"
+client_result "The thread dump file will be available via: rhc tail $1 -f \"$cartridge_type/$cartridge_type/logs/catalina.out -o '-n 250'\""

--- a/cartridges/openshift-origin-cartridge-jbossews-2.0/info/hooks/threaddump
+++ b/cartridges/openshift-origin-cartridge-jbossews-2.0/info/hooks/threaddump
@@ -51,4 +51,4 @@ run_as_user "${CARTRIDGE_BASE_PATH}/${cartridge_type}/info/bin/app_ctl.sh thread
 
 client_result "Success"
 client_result ""
-client_result "The thread dump file will be available via: rhc tail $1 -f $cartridge_type/$cartridge_type/logs/catalina.out -o '-n 250'"
+client_result "The thread dump file will be available via: rhc tail $1 -f \"$cartridge_type/$cartridge_type/logs/catalina.out -o '-n 250'\""

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/control
@@ -97,7 +97,7 @@ function threaddump() {
         kill -3 $java_pid
         client_result "Success"
         client_result ""
-        client_result "The thread dump file will be available via: rhc tail $OPENSHIFT_APP_NAME -f */logs/catalina.out -o '-n 250'"
+        client_result "The thread dump file will be available via: rhc tail $OPENSHIFT_APP_NAME -f \"*/logs/catalina.out -o '-n 250'\""
     else 
         echo "Failed to locate JBOSS PID File"
     fi

--- a/cartridges/openshift-origin-cartridge-ruby-1.8/info/hooks/threaddump
+++ b/cartridges/openshift-origin-cartridge-ruby-1.8/info/hooks/threaddump
@@ -50,7 +50,7 @@ if [ "$result" = "" ]; then
     client_result "Success"
     client_result ""
     # note bz 923405/921537 for why log file name is not more specific
-    client_result "The thread dump file will be available via: rhc tail ${application} -f ${cartridge_type}/logs/error_log-$DATE-* -o '-n 250'"
+    client_result "The thread dump file will be available via: rhc tail ${application} -f \"${cartridge_type}/logs/error_log-$DATE-* -o '-n 250'\""
 else
     client_result " $result"
 fi

--- a/cartridges/openshift-origin-cartridge-ruby-1.9-scl/info/hooks/threaddump
+++ b/cartridges/openshift-origin-cartridge-ruby-1.9-scl/info/hooks/threaddump
@@ -50,7 +50,7 @@ if [ "$result" = "" ]; then
     client_result "Success"
     client_result ""
     # note bz 923405/921537 for why log file name is not more specific
-    client_result "The thread dump file will be available via: rhc tail ${application} -f ${cartridge_type}/logs/error_log-$DATE-* -o '-n 250'"
+    client_result "The thread dump file will be available via: rhc tail ${application} -f \"${cartridge_type}/logs/error_log-$DATE-* -o '-n 250'\""
 else
     client_result " $result"
 fi


### PR DESCRIPTION
As it is written now, the error message can be read as `rhc threaddump` taking a `-o` flag, which is incorrect.
