### PR TITLE
Bug fixes

### DIFF
--- a/node-util/bin/oo-restorer
+++ b/node-util/bin/oo-restorer
@@ -67,7 +67,7 @@ fi
 # code copied from node/lib/util_ext
 runuser --shell /bin/sh "$uuid" -c "echo started >$OPENSHIFT_HOMEDIR/app-root/runtime/.state"
 
-/usr/bin/timeout -s USR1 120s /usr/sbin/oo-admin-ctl-gears startgear "${uuid}"
+/usr/bin/timeout -s USR1 200s /usr/sbin/oo-admin-ctl-gears startgear "${uuid}"
 
 # Enable proxy setup
 oo-ruby /usr/bin/oo-frontend-unidle --with-container-uuid $uuid

--- a/node/lib/openshift-origin-node/utils/selinux.rb
+++ b/node/lib/openshift-origin-node/utils/selinux.rb
@@ -181,12 +181,15 @@ module OpenShift
         context = Selinux.matchpathcon(path, mode)
         if context == -1
           context = Selinux.lgetfilecon(path)
+          if context == -1
+            raise Errno::EINVAL.new("lgetfilecon: #{path}")
+          end
         end
         context = Selinux.context_new(context[1])
         Selinux.context_range_set(context, label)
         context = Selinux.context_str(context)
         if Selinux.lsetfilecon(path, context) == -1
-          raise Errno::EINVAL.new(path)
+          raise Errno::EINVAL.new("lsetfilecon: #{context} #{path}")
         end
       end
 

--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -27,7 +27,6 @@ Requires:      ruby(release)
 %else
 Requires:      %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
 %endif
-Requires:      %{?scl:%scl_prefix}ruby(selinux)
 Requires:      %{?scl:%scl_prefix}rubygems
 Requires:      %{?scl:%scl_prefix}rubygem(json)
 Requires:      %{?scl:%scl_prefix}rubygem(parseconfig)


### PR DESCRIPTION
Bug 950711 - Apps taking longer than 120s fail to restore; bump to 200s to cover the few apps affected.

Bug 951994 - Underlying ruby selinux library appears to be unstable.  Rewrite to call the command line.
