### PR TITLE
Bug 952161

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/metadata/jenkins_shell_command.erb
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/jenkins_shell_command.erb
@@ -4,7 +4,7 @@ upstream_ssh="<%= ENV['OPENSHIFT_GEAR_UUID'] %>@<%= ENV['OPENSHIFT_APP_NAME'] %>
 
 if [ -f Gemfile ]
 then
-  if [ ! -f .openshift/markers/force_clean_build ] && ! [ -d .bundle ] && ! git show master~1:.bundle > /dev/null 2>&1
+  if [ ! -f .openshift/markers/force_clean_build ] &#038;&#038; ! [ -d .bundle ] &#038;&#038; ! git show master~1:.bundle > /dev/null 2>&#038;1
   then
     rsync --include='.bundle/' --include='.bundle/***' --include='vendor/' --include='vendor/***' --exclude='*' $upstream_ssh:~/app-root/repo/ ~/$WORKSPACE
   fi


### PR DESCRIPTION
Ruby v2 cartridge can add Jenkins client. Ampersands caused XML stream to be malformed, and jenkins_create_job to fail.
