### PR TITLE
Removing the MongoDB dependency from the Broker rpm spec

### DIFF
--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -27,7 +27,6 @@ Requires:      httpd
 # requirements.
 Requires:      mod_ssl
 Requires:      %{?scl:%scl_prefix}mod_passenger
-Requires:      mongodb-server
 %if 0%{?scl:1}
 Requires:      openshift-origin-util-scl
 %else


### PR DESCRIPTION
I verified that both the Origin puppet code and the OSE installation script explicitly install the mongodb-server package.
