### PR TITLE
Fix for bug 953035

### DIFF
--- a/controller/app/rest_models/rest_application.rb
+++ b/controller/app/rest_models/rest_application.rb
@@ -91,7 +91,7 @@ class RestApplication < OpenShift::Model
     self.uuid = app.uuid
     self.aliases = []
     app.aliases.each do |a|
-      self.aliases << RestAlias.new(app, domain, a, url, true)
+      self.aliases << RestAlias.new(app, domain, a, url, nolinks)
     end
     self.gear_count = app.num_gears
     self.domain_id = domain.namespace


### PR DESCRIPTION
Including the links for aliases embedded in application response if nolinks was not specified
