### PR TITLE
Bug 949844

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/README.md
+++ b/cartridges/openshift-origin-cartridge-ruby/README.md
@@ -65,3 +65,19 @@ of use:
 
 For more information about environment variables, consult the
 [OpenShift Application Author Guide](https://github.com/openshift/origin-server/blob/master/node/README.writing_applications.md).
+
+## `threaddump` command
+
+OpenShift's CLI tool, [`rhc`](https://rubygems.org/gems/rhc), has a subcommand
+`threaddump`.
+Applications created by this cartridge respond to this command by looking
+for the appropriate `Rack` process, and sending `ABRT` signal to it.
+As explained in [Passenger User Guide](http://www.modrails.com/documentation/Users%20guide%20Apache.html#debugging_frozen),
+this signal will dump the current thread backtraces but also terminates
+the processes.
+
+Note that `Rack` process may not exist if the application had just started
+and not been accessed.
+
+Note also that scaled applications are not supported by the `threaddump`
+command.

--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -142,7 +142,7 @@ function threaddump() {
       client_result "Success"
       client_result ""
       # note bz 923405/921537 for why log file name is not more specific
-      client_result "The thread dump file will be available via: rhc tail ${OPENSHIFT_APP_NAME} -f \"${OPENSHIFT_RUBY_LOG_DIR}/error_log-$DATE-* -o '-n 250'\""
+      client_result "The thread dump file will be available via: rhc tail ${OPENSHIFT_APP_NAME} -f ${OPENSHIFT_RUBY_LOG_DIR}/error_log-$DATE-* -o '-n 250'"
   else
       client_result " $result"
   fi
@@ -159,7 +159,7 @@ function _threaddump() {
 
   PID=$(ps -u $(id -u $1) -o pid,command | grep -v grep | grep 'Rack:.*'$1 | awk 'BEGIN {FS=" "}{print $1}')
 
-  if [ ! "$PID" = "" ]; then
+  if [ -z "$PID" ]; then
     echo "Unable to detect application PID. Check the application's availability by accessing http://${OPENSHIFT_GEAR_DNS}"
   else
     if ! kill -s ABRT $PID; then


### PR DESCRIPTION
Fix the logic in PID detection. If $PID is empty, warn and abort operation.
At the moment PID detection relies on the presence of a process with "Rack:" in it. This may fail if the application had just been started.
