### PR TITLE
Bug 947010: Exclude grep when checking for existing process

### DIFF
--- a/cartridges/openshift-origin-cartridge-diy/versions/0.1/template/.openshift/action_hooks/stop
+++ b/cartridges/openshift-origin-cartridge-diy/versions/0.1/template/.openshift/action_hooks/stop
@@ -2,7 +2,7 @@
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 # The logic to stop your application should be put in this script.
-if [ -z "$(ps -ef | grep testrubyserver.rb)" ]
+if [ -z "$(ps -ef | grep testrubyserver.rb | grep -v grep)" ]
    then
        client_result "Application is already stopped"
    else


### PR DESCRIPTION
Resolve https://bugzilla.redhat.com/show_bug.cgi?id=947010
