### PR TITLE
Bug 952161

### DIFF
--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_create_job
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_create_job
@@ -19,8 +19,11 @@ STDERR.sync = true
 @openshift_domain = ARGV[0]
 @job_erb = "#{ENV['OPENSHIFT_JENKINS_CLIENT_DIR']}/configuration/jenkins_job_template.xml.erb"
 @builder_type = ARGV[1]
-file = File.open(ARGV[2], "rb")
-@shell_command = file.read
+## https://bugzilla.redhat.com/show_bug.cgi?id=952161
+# Encode XML entites in jenkins_shell_command.erb template *after*
+# processing ERB directives.
+shell_command_erb = ERB.new( File.open(ARGV[2], "rb").read)
+@shell_command = shell_command_erb.result(binding).encode(:xml => :text)
 file = File.open(ARGV[3], "rb")
 @artifacts = file.read
 


### PR DESCRIPTION
Encode XML entities in jenkins_shell_command.rb template after processing ERB directives.

This supersedes #2092.

Here, we will assume that things the ERB directives will emit will not interfere XML processing.
