### PR TITLE
Bug 874442

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/README.md
+++ b/cartridges/openshift-origin-cartridge-nodejs/README.md
@@ -4,16 +4,17 @@ The `nodejs` cartridge provides [Node.js](http://nodejs.org/) on OpenShift.
 
 ## Template Repository Layout
 
-    node_modules/            Any Node modules packaged with the app
+    node_modules/            Any Node modules packaged with the app [1]
     deplist.txt              Deprecated.
     package.json             npm package descriptor.
     npm_global_module_list   List of globally installed node modules (on OpenShift)
     .openshift/              Location for OpenShift specific files
-      action_hooks/          See the Action Hooks documentation [1]
-      markers/               See the Markers section [2]
+      action_hooks/          See the Action Hooks documentation [2]
+      markers/               See the Markers section [3]
 
-\[1\] [Action Hooks documentation](https://github.com/openshift/origin-server/blob/master/node/README.writing_applications.md#action-hooks)
-\[2\] [Markers](#markers)
+\[1\] [`node_modules`](#node_modules-directory)
+\[2\] [Action Hooks documentation](https://github.com/openshift/origin-server/blob/master/node/README.writing_applications.md#action-hooks)
+\[3\] [Markers](#markers)
 
 ### Layout Notes
 
@@ -25,6 +26,15 @@ Note: Every time you push, everything in your remote repo dir gets recreated
       data directory, which will persist between pushes of your repo.
       The OpenShift data directory is accessible relative to the remote repo
       directory (`../data`) or via an environment variable `$OPENSHIFT_DATA_DIR`.
+
+#### `node_modules` directory
+The `node_modules` directory allows you to package any Node module on which
+your application depends along with your application.
+
+If you just wish to install module(s) from the npm registry
+([npmjs.org](https://npmjs.org/)), you
+can specify the module name(s) and versions in your application's
+`package.json` file.
 
 
 #### deplist.txt

--- a/cartridges/openshift-origin-cartridge-nodejs/versions/0.6/template/node_modules/read.me
+++ b/cartridges/openshift-origin-cartridge-nodejs/versions/0.6/template/node_modules/read.me
@@ -1,8 +1,0 @@
-
-This directory allows you to package any Node modules (that your application
-depends on) along with your application.
-
-If you just wish to install module(s) from the npm registry (npmjs.org), you
-can specify the module name(s) and versions in your application's
-package.json file (../package.json).
-


### PR DESCRIPTION
Avoid confusion arising from app-root/repo/node_modules/read.me implying that read.me file should not be removed when force_clean_build marker is present.

app-root/repo/node_modules/read.me is now removed, and app-root/repo/README.md will point to updated documentation at https://github.com/openshift/origin-server/blob/master/cartridges/openshift-origin-cartridge-nodejs/README.md, which explains the purpose of the node_modules directory.
