### PR TITLE
The v2 cartridge needs to pull in the ruby-1.8 dependencies as well

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/openshift-origin-cartridge-ruby.spec
+++ b/cartridges/openshift-origin-cartridge-ruby/openshift-origin-cartridge-ruby.spec
@@ -14,22 +14,46 @@ Group:         Development/Languages
 License:       ASL 2.0
 URL:           https://openshift.redhat.com
 Source0:       http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
-Requires:      rubygem(openshift-origin-node)
-Requires:      openshift-origin-node-util
-Requires:      sqlite-devel
+Requires:      gcc-c++
 Requires:      libev
 Requires:      libev-devel
-Requires:      %{?scl:%scl_prefix}rubygems
+Requires:      libxml2
+Requires:      libxml2-devel
+Requires:      libxslt
+Requires:      libxslt-devel
+Requires:      mod_bw
+Requires:      mysql-devel
+Requires:      openshift-origin-cartridge-abstract
+Requires:      openshift-origin-node-util
+Requires:      rubygem(openshift-origin-node)
+Requires:      sqlite-devel
+
+# For the ruby 1.8 cartridge
+%if 0%{?rhel}
+Requires:      js
+Requires:      mod_passenger
+Requires:      ruby-devel
+Requires:      rubygem-bson_ext
+Requires:      rubygem-bundler
+Requires:      rubygem(openshift-origin-node)
+Requires:      rubygem-passenger
+Requires:      rubygem-passenger-native
+Requires:      rubygem-passenger-native-libs
+Requires:      rubygem-rack >= 1.1.0
+Requires:      rubygems
+Requires:      rubygem-sqlite3
+Requires:      rubygem-thread-dump
+Requires:      ruby-mysql
+Requires:      ruby-sqlite3
+%endif
+
 Requires:      %{?scl:%scl_prefix}js
 Requires:      %{?scl:%scl_prefix}js-devel
 Requires:      %{?scl:%scl_prefix}libyaml
 Requires:      %{?scl:%scl_prefix}libyaml-devel
+Requires:      %{?scl:%scl_prefix}mod_passenger
 Requires:      %{?scl:%scl_prefix}ruby
 Requires:      %{?scl:%scl_prefix}ruby-devel
-Requires:      %{?scl:%scl_prefix}ruby-irb
-Requires:      %{?scl:%scl_prefix}ruby-libs
-Requires:      %{?scl:%scl_prefix}ruby-tcltk
-Requires:      %{?scl:%scl_prefix}rubygem-ZenTest
 Requires:      %{?scl:%scl_prefix}rubygem-actionmailer
 Requires:      %{?scl:%scl_prefix}rubygem-actionpack
 Requires:      %{?scl:%scl_prefix}rubygem-activemodel
@@ -46,10 +70,12 @@ Requires:      %{?scl:%scl_prefix}rubygem-builder
 Requires:      %{?scl:%scl_prefix}rubygem-bundler
 Requires:      %{?scl:%scl_prefix}rubygem-coffee-rails
 Requires:      %{?scl:%scl_prefix}rubygem-coffee-script
+Requires:      %{?scl:%scl_prefix}rubygem-daemon_controller
 Requires:      %{?scl:%scl_prefix}rubygem-diff-lcs
 Requires:      %{?scl:%scl_prefix}rubygem-erubis
 Requires:      %{?scl:%scl_prefix}rubygem-execjs
 Requires:      %{?scl:%scl_prefix}rubygem-fakeweb
+Requires:      %{?scl:%scl_prefix}rubygem-fastthread
 Requires:      %{?scl:%scl_prefix}rubygem-fssm
 Requires:      %{?scl:%scl_prefix}rubygem-hike
 Requires:      %{?scl:%scl_prefix}rubygem-http_connection
@@ -67,6 +93,12 @@ Requires:      %{?scl:%scl_prefix}rubygem-minitest
 Requires:      %{?scl:%scl_prefix}rubygem-mocha
 Requires:      %{?scl:%scl_prefix}rubygem-mongo
 Requires:      %{?scl:%scl_prefix}rubygem-multi_json
+Requires:      %{?scl:%scl_prefix}rubygem-open4
+Requires:      %{?scl:%scl_prefix}rubygem-passenger
+Requires:      %{?scl:%scl_prefix}rubygem-passenger-devel
+Requires:      %{?scl:%scl_prefix}rubygem-passenger-native
+Requires:      %{?scl:%scl_prefix}rubygem-passenger-native-libs
+Requires:      %{?scl:%scl_prefix}rubygem-pg
 Requires:      %{?scl:%scl_prefix}rubygem-polyglot
 Requires:      %{?scl:%scl_prefix}rubygem-rack
 Requires:      %{?scl:%scl_prefix}rubygem-rack-cache
@@ -79,6 +111,7 @@ Requires:      %{?scl:%scl_prefix}rubygem-rdoc
 Requires:      %{?scl:%scl_prefix}rubygem-rspec
 Requires:      %{?scl:%scl_prefix}rubygem-ruby2ruby
 Requires:      %{?scl:%scl_prefix}rubygem-ruby_parser
+Requires:      %{?scl:%scl_prefix}rubygems
 Requires:      %{?scl:%scl_prefix}rubygem-sass
 Requires:      %{?scl:%scl_prefix}rubygem-sass-rails
 Requires:      %{?scl:%scl_prefix}rubygem-sexp_processor
@@ -92,27 +125,23 @@ Requires:      %{?scl:%scl_prefix}rubygem-treetop
 Requires:      %{?scl:%scl_prefix}rubygem-tzinfo
 Requires:      %{?scl:%scl_prefix}rubygem-uglifier
 Requires:      %{?scl:%scl_prefix}rubygem-xml-simple
-Requires:      %{?scl:%scl_prefix}runtime
-Requires:      %{?scl:%scl_prefix}rubygem-daemon_controller
-Requires:      %{?scl:%scl_prefix}rubygem-fastthread
-Requires:      %{?scl:%scl_prefix}rubygem-passenger
-Requires:      %{?scl:%scl_prefix}rubygem-passenger-devel
-Requires:      %{?scl:%scl_prefix}rubygem-passenger-native
-Requires:      %{?scl:%scl_prefix}rubygem-passenger-native-libs
-Requires:      %{?scl:%scl_prefix}mod_passenger
+Requires:      %{?scl:%scl_prefix}rubygem-ZenTest
+Requires:      %{?scl:%scl_prefix}ruby-irb
+Requires:      %{?scl:%scl_prefix}ruby-libs
 Requires:      %{?scl:%scl_prefix}ruby-mysql
-Requires:      %{?scl:%scl_prefix}rubygem-pg
-Requires:      %{?scl:%scl_prefix}rubygem-open4
-Requires:      mysql-devel
-Requires:      libxml2
-Requires:      libxml2-devel
-Requires:      libxslt
-Requires:      libxslt-devel
-Requires:      gcc-c++
-Requires:      js
+Requires:      %{?scl:%scl_prefix}ruby-tcltk
+Requires:      %{?scl:%scl_prefix}runtime
+
 # Deps for users
 Requires:      ImageMagick-devel
 Requires:      ruby-RMagick
+%if 0%{?rhel}
+Requires:      ruby-nokogiri
+%endif
+%if 0%{?fedora}
+Requires:      rubygem-nokogiri
+%endif
+
 BuildRequires: git
 BuildRoot:     %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch:     noarch


### PR DESCRIPTION
Also, I sorts these more alphabetically by section.

A problem existed with Origin on RHEL in that the ruby 1.8 cartridge would not have the rubygem-passenger and mod_passenger dependencies.
