### PR TITLE
Match exactly on root username

### DIFF
--- a/cartridges/openshift-origin-cartridge-mongodb/bin/control
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/control
@@ -2,7 +2,7 @@
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 export STOPTIMEOUT=20
 
-if whoami | grep -q root
+if whoami | grep -q -w root
 then
     client_result "Please don't run script as root, try:"
     client_result "runuser --shell /bin/sh $OPENSHIFT_GEAR_UUID ${OPENSHIFT_MONGODB_DIR}/bin/control"


### PR DESCRIPTION
So if someone decide to have a user called "noroot", or anything, this
doesn't trigger the warning by error.
