### PR TITLE
Improve console rest api memory usage by reducing copies

### DIFF
--- a/console/app/controllers/capability_aware.rb
+++ b/console/app/controllers/capability_aware.rb
@@ -16,7 +16,10 @@ module CapabilityAware
   # Call this with :refresh => true to force a
   # refresh of the values stored in session
   def user_capabilities(args = {})
-    @user_capabilities = nil if args[:refresh]
+    if args[:refresh]
+      @user_capabilities = nil
+      session[:caps] = nil
+    end
     model = Console.config.capabilities_model_class
     @user_capabilities ||=
       (model.from(session[:caps]) rescue nil) ||

--- a/console/app/models/application.rb
+++ b/console/app/models/application.rb
@@ -24,7 +24,7 @@ class Application < RestApi::Base
   has_many :cartridges
   has_many :gears
   has_many :gear_groups
-  has_one  :embedded, :class_name => 'rest_api/base/attribute_hash'
+  has_one  :embedded, :class_name => as_indifferent_hash
 
   attr_accessible :name, :scale, :gear_profile, :cartridges, :cartridge_names, :initial_git_url, :initial_git_branch
 

--- a/console/app/models/capabilities.rb
+++ b/console/app/models/capabilities.rb
@@ -3,7 +3,7 @@ module Capabilities
   extend ActiveSupport::Concern
 
   included do
-    has_one :capabilities, :class_name => 'rest_api/base/attribute_hash'
+    has_one :capabilities, :class_name => as_indifferent_hash
     def capabilities
       attributes[:capabilities] || {}
     end
@@ -37,10 +37,12 @@ module Capabilities
     # Raise if the values cannot be converted
     #
     def self.from(obj)
-      case obj
-      when Array then new(*obj)
-      when Hash then  new(*attrs.map{ |s| obj[s] || obj[s.to_s] })
-      else            new(*attrs.map{ |s| obj.send(s) })
+      if obj.is_a? Array
+        new(*obj)
+      elsif obj.respond_to? :[]
+        new(*attrs.map{ |s| obj[s] || obj[s.to_s] })
+      else            
+        new(*attrs.map{ |s| obj.send(s) })
       end if obj
     end
 

--- a/console/app/models/cartridge.rb
+++ b/console/app/models/cartridge.rb
@@ -21,10 +21,10 @@ class Cartridge < RestApi::Base
 
   belongs_to :application
   has_one    :cartridge_type
-  has_many   :collocated_with, :class_name => 'string'
-  has_many   :properties, :class_name => 'rest_api/base/attribute_hash'
-  has_one    :help_topics, :class_name => 'rest_api/base/attribute_hash'
-  has_one    :links, :class_name => 'rest_api/base/attribute_hash'
+  has_many   :collocated_with, :class_name => String
+  has_many   :properties, :class_name => as_indifferent_hash
+  has_one    :help_topics, :class_name => as_indifferent_hash
+  has_one    :links, :class_name => as_indifferent_hash
 
   delegate :display_name, :tags, :priority, :to => :cartridge_type, :allow_nil => false
 

--- a/console/app/models/cartridge_type.rb
+++ b/console/app/models/cartridge_type.rb
@@ -23,8 +23,8 @@ class CartridgeType < RestApi::Base
   attr_accessor :priority
   attr_accessor :usage_rates
 
-  has_many :properties, :class_name => 'rest_api/base/attribute_hash'
-  has_many :usage_rate, :class_name => 'rest_api/base/attribute_hash'
+  has_many :properties, :class_name => as_indifferent_hash
+  has_many :usage_rate, :class_name => as_indifferent_hash
 
   self.element_name = 'cartridges'
 

--- a/console/app/models/gear.rb
+++ b/console/app/models/gear.rb
@@ -5,7 +5,7 @@ class Gear < RestApi::Base
   #custom_id :id
 
   belongs_to :application
-  has_many :components, :class_name => 'rest_api/base/attribute_hash'
+  has_many :components, :class_name => as_indifferent_hash
 
   def state
     (super || :unknown).to_sym

--- a/console/app/models/quickstart.rb
+++ b/console/app/models/quickstart.rb
@@ -111,7 +111,7 @@ class Quickstart < RestApi::Base
             :list => (info.link("LIST_QUICKSTARTS").path rescue nil),
             :get => (info.link("SHOW_QUICKSTART").path rescue nil),
             :search => (info.link("SEARCH_QUICKSTARTS").path rescue nil),
-            :search_param => (info.required_params('SEARCH_QUICKSTARTS').first[:name] rescue nil),
+            :search_param => (info.required_params('SEARCH_QUICKSTARTS').first['name'] rescue nil),
           }
         end
       end

--- a/console/app/models/rest_api/base.rb
+++ b/console/app/models/rest_api/base.rb
@@ -64,7 +64,7 @@ class ActiveResource::Base
   private
     def find_or_create_resource_for_collection(name)
       return reflections[name.to_sym].klass if reflections.key?(name.to_sym)
-      find_or_create_resource_for(ActiveSupport::Inflector.singularize(name.to_s))
+      nil
     end
 
     alias_method :original_find_or_create_resource_for, :find_or_create_resource_for
@@ -74,7 +74,7 @@ class ActiveResource::Base
       name = name.to_s.gsub(/[^\w\:]/, '_')
       # association support
       return reflections[name.to_sym].klass if reflections.key?(name.to_sym)
-      original_find_or_create_resource_for(name)
+      nil
     end
 end
 
@@ -206,16 +206,27 @@ module RestApi
       resource
     end
 
+    class HashWithSimpleIndifferentAccess < Hash
+      def [](s)
+        super s.to_s
+      end
+      def []=(s, v)
+        super s.to_s, v
+      end
+    end
+
     def initialize(attributes = {}, persisted=false)
       @as = attributes.delete :as
-      super attributes, persisted
+      @attributes     = HashWithSimpleIndifferentAccess.new
+      @prefix_options = {}
+      @persisted = persisted
+      load(attributes)
     end
 
     def load(attributes, remove_root=false)
       raise ArgumentError, "expected an attributes Hash, got #{attributes.inspect}" unless attributes.is_a?(Hash)
       self.prefix_options, attributes = split_options(attributes)
 
-      attributes = attributes.dup
       aliased = self.class.aliased_attributes
       calculated = self.class.calculated_attributes
       known = self.class.known_attributes
@@ -229,25 +240,34 @@ module RestApi
         if !known.include? key.to_s and !calculated.include? key and self.class.method_defined?("#{key}=")
           send("#{key}=", value)
         else
-          self.attributes[key.to_s] =
+          @attributes[key.to_s] =
             case value
               when Array
-                resource = nil
-                value.map do |attrs|
-                  if attrs.is_a?(Hash)
-                    resource ||= find_or_create_resource_for_collection(key)
-                    attrs[:as] = as if resource.method_defined? :as=
-                    resource.new(attrs)
+                if value.length > 0
+                  if resource = find_or_create_resource_for_collection(key)
+                    value.map do |attrs|
+                      if attrs.is_a?(Hash)
+                        attrs[:as] = as if resource.method_defined? :as=
+                        resource.new(attrs)
+                      else
+                        attrs
+                      end
+                    end
                   else
-                    attrs.duplicable? ? attrs.dup : attrs
+                    value
                   end
+                else
+                  value
                 end
               when Hash
-                resource = find_or_create_resource_for(key)
-                value[:as] = as if resource.method_defined? :as=
-                resource.new(value)
+                if resource = find_or_create_resource_for(key)
+                  value[:as] = as if resource.method_defined? :as=
+                  resource.new(value)
+                else
+                  value
+                end
               else
-                value.duplicable? ? value.dup : value
+                value
             end
         end
       end
@@ -461,7 +481,23 @@ module RestApi
         hash.each_pair{ |k,v| self[k] = v }
       end
     end
-    has_many :messages, :class_name => 'rest_api/base/attribute_hash'
+    #
+    # Provides indifferent access to a backing Hash with String keys.
+    #
+    class IndifferentAccess < SimpleDelegator
+      def [](s)
+        v = __getobj__[s.to_s]
+        v = __getobj__[s] if v.nil? && !(String === s)
+        v
+      end
+      def []=(s, v)
+        __getobj__[s.to_s] = v
+      end
+    end
+    def self.as_indifferent_hash
+      IndifferentAccess
+    end
+    has_many :messages, :class_name => as_indifferent_hash
 
     #FIXME may be refactored
     def remote_results
@@ -688,8 +724,7 @@ module RestApi
 
       # supports presence of AttributeMethods and Dirty
       def attribute(s)
-        #puts "attribute[#{s}] #{caller.join("  \n")}"
-        attributes[s]
+        attributes[s.to_s]
       end
 
       def method_missing(method_symbol, *arguments) #:nodoc:

--- a/console/app/models/rest_api/info.rb
+++ b/console/app/models/rest_api/info.rb
@@ -19,8 +19,8 @@ module RestApi
     schema do
       string :version, :status
     end
-    has_many :supported_api_versions, :class_name => 'string'
-    has_one :data, :class_name => 'rest_api/base/attribute_hash'
+    has_many :supported_api_versions, :class_name => String
+    has_one :data, :class_name => as_indifferent_hash
 
     def url
       self.class.site

--- a/console/lib/active_resource/reflection.rb
+++ b/console/lib/active_resource/reflection.rb
@@ -71,7 +71,7 @@ module ActiveResource
 
       private
         def derive_class_name
-          return (options[:class_name] ? options[:class_name].to_s : name.to_s).classify
+          options[:class_name] ? options[:class_name].to_s : name.to_s.classify
         end
     end
   end

--- a/console/test/unit/capability_aware_test.rb
+++ b/console/test/unit/capability_aware_test.rb
@@ -21,6 +21,12 @@ class CapabilityAwareTest < ActiveSupport::TestCase
     args
   end
 
+  test 'user capabilities handle wrapped hashes' do
+    assert caps = Console.config.capabilities_model_class.from(Class.new(SimpleDelegator).new(:max_gears => 2, :consumed_gears => 0))
+    assert_equal 2, caps.max_gears
+    assert_equal 0, caps.consumed_gears
+  end
+
   test 'user capabilities handles defaults' do
     User.expects(:find).returns(User.new(:capabilities => {}))
     assert cap = obj.user_capabilities

--- a/console/test/unit/rest_api_test.rb
+++ b/console/test/unit/rest_api_test.rb
@@ -365,10 +365,24 @@ class RestApiTest < ActiveSupport::TestCase
     self.site = "http://localhost"
   end
 
-  def test_create_safe_reflected_name
+  def test_dont_reflect_code
     base = ReflectedTest.new
     r = base.send("find_or_create_resource_for", 'mysql-5.1')
-    assert_equal 'RestApiTest::ReflectedTest::Mysql51', r.name, r.pretty_inspect
+    assert_nil r
+  end
+
+  def test_load_ignores_classes
+    args = {:foo => 1, :bar => 2, :arr => [], :arr2 => [{:a => 1}], :arr3 => [1], :obj => {:b => 1}}
+    o = RestApi::Base.new(args)
+    assert_equal 1, o.foo
+    assert_equal 2, o.bar
+    assert_same args[:arr], o.arr
+    #assert_not_same args[:arr], o.arr # HashWithIndifferentAccess dup's all arrays and hashes, not ideal
+    assert_same args[:arr2], o.arr2
+    assert_same args[:arr3], o.arr3
+    assert o.arr2[0].is_a? Hash
+    assert_same args[:arr2][0], o.arr2[0]
+    assert_same args[:obj], o.obj
   end
 
   def test_create_cookie


### PR DESCRIPTION
ActiveResource + RestApi + HashWithIndifferentAcesss make too many copies of the data retrieved from the server or received from #new.  Also, the default RestApi class creation behavior for nested resources is too error prone and results in difficult to debug errors.  This pull request:
- Changes the default behavior for nested objects to expose them as a raw hash (string keys).
- Adds a new HashWithSimpleIndifferentAccess for use with the default hash-like objects we get back - it avoids an extra copy of the contents
- Avoids extra copies during creation - this does introduce the possibility that an object passed to the resource may be mutated after creation.  The answer in that scenario is - don't do that.

Should reduce memory allocation on REST API calls by 3-6 times.
