### PR TITLE
<oo-accept-broker> more rhel/fedora reconciliation, cleanup

### DIFF
--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -146,8 +146,13 @@ function check_ruby_requirements() {
     verbose checking ruby requirements
     if [ -z "${USE_SCL}" -a ! -x /usr/bin/ruby ]
     then
-	fail ruby is not installed or not executable
-	return
+	  fail ruby is not installed or not executable
+	  return
+    fi
+    if ! /usr/bin/which oo-ruby 1> /dev/null 2> /dev/null
+    then
+      fail oo-ruby wrapper is not in path
+      return
     fi
     for OSO_RUBY_LIB in $*
     do

--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -42,9 +42,6 @@ MESG_PLUGINS="mcollective"
 
 DEFAULT_PACKAGES="
   ruby
-  rubygems
-  rubygem-rails
-  rubygem-passenger
   rubygem-openshift-origin-common
   rubygem-openshift-origin-controller
   openshift-origin-broker 
@@ -96,8 +93,18 @@ if which scl 1> /dev/null 2> /dev/null && scl -l | grep -q '^ruby193$' ; then
     }
 
     function safe_ruby() {
-        scl enable ruby193 "ruby $@"
+#        scl enable ruby193 "ruby \"$@\""
+        oo-ruby "$@"
     }
+    PACKAGES+="  ruby193-rubygem-rails
+  ruby193-rubygem-passenger
+  ruby193-rubygems
+"
+else
+    PACKAGES+="  rubygem-rails
+  rubygem-passenger
+  rubygems
+"
 fi
 
 

--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -80,10 +80,6 @@ function safe_bundle() {
     bundle exec "$@"
 }
 
-function safe_ruby() {
-    ruby "$@"
-}
-
 USE_SCL=""
 
 if which scl 1> /dev/null 2> /dev/null && scl -l | grep -q '^ruby193$' ; then
@@ -92,10 +88,6 @@ if which scl 1> /dev/null 2> /dev/null && scl -l | grep -q '^ruby193$' ; then
         scl enable ruby193 "bundle exec \"$@\""
     }
 
-    function safe_ruby() {
-#        scl enable ruby193 "ruby \"$@\""
-        oo-ruby "$@"
-    }
     PACKAGES+="  ruby193-rubygem-rails
   ruby193-rubygem-passenger
   ruby193-rubygems
@@ -160,7 +152,7 @@ function check_ruby_requirements() {
     for OSO_RUBY_LIB in $*
     do
 	verbose checking ruby requirements for $OSO_RUBY_LIB
-        GEM_ERROR=`safe_ruby -I ${OSO_BROKER_ROOT} -r rubygems -- <<EOF
+        GEM_ERROR=`oo-ruby -I ${OSO_BROKER_ROOT} -r rubygems -- <<EOF
             require 'bundler'
             begin
               require '$OSO_RUBY_LIB'


### PR DESCRIPTION
Modify packages list for check_packages since these are divergent
between rhel and fedora

use oo-ruby instead of inline ruby wrapper, since it already exists
and will be updated independent of this script

@brenton
