### PR TITLE
use correct exception class on update fail

### DIFF
--- a/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
+++ b/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
@@ -170,7 +170,7 @@ EOF
 
       success = system cmd
       if not success
-        raise DnsException.new("error adding app record #{fqdn}")
+        raise DNSException.new("error adding app record #{fqdn}")
       end
     end
 
@@ -195,7 +195,7 @@ EOF
 
       success = system cmd
       if not success
-        raise DnsException.new("error deleting app record #{fqdn}")
+        raise DNSException.new("error deleting app record #{fqdn}")
       end  
     end
 


### PR DESCRIPTION
The nsupdate plugin was raising DnsException when the correct class name is DNSException.

BZ 955602

https://bugzilla.redhat.com/show_bug.cgi?id=955602
