### PR TITLE
added config doc and checks for files in GSS-TSIG

### DIFF
--- a/plugins/dns/nsupdate/README.md
+++ b/plugins/dns/nsupdate/README.md
@@ -1,3 +1,46 @@
-Notice of Export Control Law
+# Notice of Export Control Law
 
 This software distribution includes cryptographic software that is subject to the U.S. Export Administration Regulations (the "*EAR*") and other U.S. and foreign laws and may not be exported, re-exported or transferred (a) to any country listed in Country Group E:1 in Supplement No. 1 to part 740 of the EAR (currently, Cuba, Iran, North Korea, Sudan & Syria); (b) to any prohibited destination or to any end user who has been prohibited from participating in U.S. export transactions by any federal agency of the U.S. government; or (c) for use in connection with the design, development or production of nuclear, chemical or biological weapons, or rocket systems, space launch vehicles, or sounding rockets, or unmanned air vehicle systems.You may not download this software or technical information if you are located in one of these countries or otherwise subject to these restrictions. You may not provide this software or technical information to individuals or entities located in one of these countries or otherwise subject to these restrictions. You are also responsible for compliance with foreign law requirements applicable to the import, export and use of this software and technical information.
+
+# Configuration
+
+This plugin can authenticate updates using either TSIG or GSS-TSIG request signatires. The DNS server must be configured to accept update requests from the broker host.
+
+The configuration file for the plugin is ```/etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf```
+
+Three variables in the configuration file define the location of the update server:
+    # The DNS server
+    BIND_SERVER="127.0.0.1"
+    
+    # The DNS server's port
+    BIND_PORT=53
+
+    # The base zone for the DNS server
+    BIND_ZONE="example.com"
+
+Change the server and zone to match your environment.  You should not generally need to change the port number.
+
+## TSIG (RFC 2136)
+
+For TSIG authentication, the configuration file must contain the DNSSEC key name and the base-64 encoded signing key string.  These are set using the *BIND_KEYNAME* and *BIND_KEYVALUE* variables in the configuration file.
+
+    # TSIG authentication
+    #
+    BIND_KEYNAME="example.com"
+    BIND_KEYVALUE="base-64 encoded DNSSEC HMAC TSIG"
+
+## GSS-TSIG
+
+For GSS-TSIG authentication the administrator must provide the name of the Kerberos principal that will be used for authentication, and the file name of the keytab file which contains the user credentials.
+
+    # GSS-TSIG (Kerberos) Authentication
+    # BIND_KRB_PRINCIPAL="" 
+    # BIND_KRB_KEYTAB=""
+    
+Note that the keytab file must be readable by the ```apache``` user that is the user which runs the broker processes.
+
+
+ 
+
+
+

--- a/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
+++ b/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
@@ -75,7 +75,7 @@ module OpenShift
         access_info = Rails.application.config.dns
         @domain_suffix = Rails.application.config.openshift[:domain_suffix]
       else
-        raise Exception.new("Nsupdate DNS updates are not initialized")
+        raise DNSException.new("Nsupdate DNS updates are not initialized")
       end
 
       @server = access_info[:server]
@@ -85,6 +85,19 @@ module OpenShift
       @krb_principal = access_info[:krb_principal]
       @krb_keytab = access_info[:krb_keytab]
       @zone = access_info[:zone]
+
+      # verify that the plugin can read the keytab file, if specified
+      if @krb_keytab
+        if not File.exists? @krb_keytab
+          raise DNSException.new "missing GSS keytab file: #{@krb_keytab}"
+        
+        elsif not File.readable? @krb_keytab
+          raise DNSException.new(
+              "keytab file #{@krb_keytab} is not readable by UID #{Process.uid}"
+              )
+        end
+      end
+         
     end
 
     private


### PR DESCRIPTION
When the broker attempts to create a Nsupdate plugin DNSService object using GSS-TSIG it must specify and be able to read the KRB5 keytab file.

This patch causes the DNS plugin to check for the presence and permissions of the keytab file if it is specified.

This will provide better diagnostics for broker setup.
