### PR TITLE
Hide the passphrase in the custom SSL alias settings

### DIFF
--- a/console/app/views/aliases/_form.html.haml
+++ b/console/app/views/aliases/_form.html.haml
@@ -55,7 +55,7 @@
         %label.control-label{:for => 'certificate_pass_phrase'} 
           Certificate pass phrase
         .controls
-          = f.text_field :certificate_pass_phrase, :id => 'certificate_pass_phrase', :disabled => !@custom_certificates_supported 
+          = f.password_field :certificate_pass_phrase, :id => 'certificate_pass_phrase', :disabled => !@custom_certificates_supported
           %p.help-block Optional pass phrase for the certificate private key.
 
   = f.buttons do

--- a/console/app/views/aliases/index.html.haml
+++ b/console/app/views/aliases/index.html.haml
@@ -64,7 +64,7 @@
           %label.control-label{:for => 'certificate_pass_phrase'} 
             Private Key Pass Phrase
           .controls
-            = f.text_field :certificate_pass_phrase, :id => 'certificate_pass_phrase', :disabled => !@private_ssl_certificates_supported 
+            = f.password_field :certificate_pass_phrase, :id => 'certificate_pass_phrase', :disabled => !@private_ssl_certificates_supported
             %p.help-block Pass phrase for the certificate private key, required if the provided private key is encrypted.
 
     = f.buttons do

--- a/console/app/views/aliases/show.html.haml
+++ b/console/app/views/aliases/show.html.haml
@@ -105,7 +105,7 @@
         %label.control-label{:for => 'certificate_pass_phrase'} 
           Private Key Pass Phrase
         .controls
-          = f.text_field :certificate_pass_phrase, :id => 'certificate_pass_phrase', :disabled => !@private_ssl_certificates_supported 
+          = f.password_field :certificate_pass_phrase, :id => 'certificate_pass_phrase', :disabled => !@private_ssl_certificates_supported
           %p.help-block Pass phrase for the certificate private key, required if the provided private key is encrypted.
 
       = f.buttons do


### PR DESCRIPTION
When creating a custom alias and uploading its SSL certificate the passphrase is shown as plain text right now. This is a quick fix to use the password field instead of the text field for increased security.
