### PR TITLE
Split v2 configure into configure/post-configure

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/metadata/manifest.yml
@@ -29,3 +29,4 @@ Scaling:
 Configure-Order:
   - mongodb
   - 10gen-mms-agent
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-cron/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-cron/metadata/manifest.yml
@@ -29,3 +29,4 @@ Subscribes:
 Scaling:
   Min: 1
   Max: 1
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-diy/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-diy/metadata/manifest.yml
@@ -75,3 +75,4 @@ Endpoints:
       - Frontend:      ""
         Backend:       ""
         Options:       { websocket: true }
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-haproxy/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-haproxy/metadata/manifest.yml
@@ -2,11 +2,11 @@ Name: haproxy
 Cartridge-Short-Name: HAPROXY
 Display-Name: OpenShift Web Balancer
 Description: "Acts as a load balancer for your web cartridge and will automatically scale up to handle incoming traffic. Is automatically added to scaled applications when they are created and cannot be removed or added to an application after the fact."
-Version: 1.4
+Version: '1.4'
 License: GPLv2+
 License-Url: http://www.gnu.org/licenses/gpl-2.0.html
 Vendor: http://haproxy.1wt.eu/
-Cartridge-Version: 0.0.1
+Cartridge-Version: '0.0.1'
 Cartridge-Vendor: redhat
 Categories:
   - web_proxy
@@ -56,3 +56,4 @@ Endpoints:
     Mappings:
       - Frontend:      "/haproxy-status"
         Backend:       "/"
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-jbossas/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jbossas/metadata/manifest.yml
@@ -122,3 +122,4 @@ Endpoints:
     Public-Port-Name:  REMOTING_PROXY_PORT
 Additional-Control-Actions:
     - threaddump
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-jbosseap/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jbosseap/metadata/manifest.yml
@@ -119,3 +119,4 @@ Endpoints:
     Public-Port-Name:  REMOTING_PROXY_PORT
 Additional-Control-Actions:
     - threaddump
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-jbossews/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jbossews/metadata/manifest.yml
@@ -93,3 +93,4 @@ Endpoints:
     Private-Port:      8787
 Additional-Control-Actions:
     - threaddump
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-jenkins-client/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/metadata/manifest.yml
@@ -24,3 +24,4 @@ Group-Overrides:
 Scaling:
   Min: 1
   Max: 1
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-jenkins/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jenkins/metadata/manifest.yml
@@ -71,3 +71,4 @@ Endpoints:
     Mappings:
       - Frontend:      ""
         Backend:       ""
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-mock-plugin/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mock-plugin/metadata/manifest.yml
@@ -28,3 +28,4 @@ Endpoints:
     Private-Port-Name: EXAMPLE_PORT1
     Private-Port:      8080
     Public-Port-Name:  EXAMPLE_PUBLIC_PORT1
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-mock/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mock/metadata/manifest.yml
@@ -3,6 +3,7 @@ Cartridge-Short-Name: MOCK
 Display-Name: Mock Cartridge 0.1
 Description: "A mock cartridge for development use only."
 Version: '0.1'
+Versions: ['0.1', '0.2']
 License: ASL 2.0
 Vendor: Red Hat
 Cartridge-Version: 0.0.1
@@ -59,3 +60,14 @@ Endpoints:
 Scaling:
   Min: 1
   Max: -1
+Install-Build-Required: false
+Version-Overrides:
+  '0.2':
+    Install-Build-Required: true
+    Provides:
+      - mock-0.2
+      - "mock"
+    Group-Overrides:
+      - components:
+        - mock-0.2
+        - web_proxy

--- a/cartridges/openshift-origin-cartridge-mongodb/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mongodb/metadata/manifest.yml
@@ -50,3 +50,4 @@ Endpoints:
     Private-Port-Name: DB_PORT
     Private-Port:      27017
     Public-Port-Name:  DB_PROXY_PORT
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-mysql/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mysql/metadata/manifest.yml
@@ -48,3 +48,4 @@ Endpoints:
     Private-Port-Name: DB_PORT
     Private-Port:      3306
     Public-Port-Name:  DB_PROXY_PORT
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml
@@ -96,3 +96,4 @@ Endpoints:
       - Frontend:      ""
         Backend:       ""
         Options:       { websocket: true }
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-perl/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-perl/metadata/manifest.yml
@@ -84,3 +84,4 @@ Endpoints:
       - Frontend:      ""
         Backend:       ""
         Options:       { websocket: true }
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml.fedora
+++ b/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml.fedora
@@ -86,3 +86,4 @@ Endpoints:
       - Frontend:      ""
         Backend:       ""
         Options:       { websocket: true }
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml.rhel
@@ -86,3 +86,4 @@ Endpoints:
       - Frontend:      ""
         Backend:       ""
         Options:       { websocket: true }
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/metadata/manifest.yml
@@ -41,3 +41,4 @@ Endpoints:
     Mappings:
       - Frontend:      "/phpmyadmin"
         Backend:       "/phpmyadmin"
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-postgresql/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-postgresql/metadata/manifest.yml
@@ -47,3 +47,4 @@ Endpoints:
     Private-Port-Name: DB_PORT
     Private-Port:      5432
     Public-Port-Name:  DB_PROXY_PORT
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-python/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-python/metadata/manifest.yml
@@ -108,3 +108,4 @@ Version-Overrides:
        - components:
          - python-3.3
          - web_proxy
+Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml
@@ -98,3 +98,4 @@ Version-Overrides:
       - components:
         - ruby-1.8
         - web_proxy
+Install-Build-Required: false

--- a/controller/test/cucumber/platform-basic.feature
+++ b/controller/test/cucumber/platform-basic.feature
@@ -27,13 +27,12 @@ Feature: V2 SDK Mock Cartridge
     And the "mock/mock_cart_locked_file" content does exist for mock-0.1
     And the "app-root/data/mock_gear_data_locked_file" content does exist for mock-0.1
     And the "invalid_locked_file" content does not exist for mock-0.1
-
-    When I start the newfangled application
-    Then the mock control_start marker will exist
+    And the mock control_start marker will exist
     And the mock action_hook_pre_start marker will exist
     And the mock action_hook_pre_start_mock marker will exist
     And the mock action_hook_post_start marker will exist
     And the mock action_hook_post_start_mock marker will exist
+    And the mock control_build marker will not exist
 
     When I status the mock-0.1 cartridge
     Then the mock control_status marker will exist
@@ -84,4 +83,3 @@ Feature: V2 SDK Mock Cartridge
 
     When I destroy the application
     Then the application git repo will not exist
-

--- a/controller/test/cucumber/platform-builds.feature
+++ b/controller/test/cucumber/platform-builds.feature
@@ -41,4 +41,43 @@ Feature: V2 SDK Mock Cartridge Build Tests
     Then the mock control_stop marker will exist
     Then the mock control_start marker will exist
     And the mock control_build marker will exist
-    
+
+  Scenario: Exercise basic platform functionality in isolation with install builds enabled
+    Given a v2 default node
+    Given a new mock-0.2 type application
+    Then the application git repo will exist
+    And the platform-created default environment variables will exist
+    And the mock-0.2 cartridge private endpoints will be exposed
+    And the mock setup_called marker will exist
+    And the mock setup_version marker will exist
+    And the mock setup_failure marker will not exist
+    And the mock install_called marker will exist
+    And the mock install_version marker will exist
+    And the mock install_failure marker will not exist
+    And the mock post_setup_called marker will exist
+    And the mock post_setup_version marker will exist
+    And the mock post_setup_failure marker will not exist
+    And the mock post_install_called marker will exist
+    And the mock post_install_version marker will exist
+    And the mock post_install_failure marker will not exist
+    And the mock-0.2 MOCK_VERSION env entry will exist
+    And the mock-0.2 MOCK_EXAMPLE env entry will exist
+    And the mock-0.2 MOCK_SERVICE_URL env entry will exist
+    And the "app-root/runtime/repo/.openshift/README.md" content does exist for mock-0.2
+    And the ".mock_gear_locked_file" content does exist for mock-0.2
+    And the "mock/mock_cart_locked_file" content does exist for mock-0.2
+    And the "app-root/data/mock_gear_data_locked_file" content does exist for mock-0.2
+    And the "invalid_locked_file" content does not exist for mock-0.2
+    And the mock control_start marker will exist
+    And the mock action_hook_pre_start marker will exist
+    And the mock action_hook_pre_start_mock marker will exist
+    And the mock action_hook_post_start marker will exist
+    And the mock action_hook_post_start_mock marker will exist
+    And the mock control_pre_receive marker will exist
+    And the mock control_build marker will exist
+    And the mock control_deploy marker will exist
+    And the mock control_start marker will exist
+    And the mock action_hook_pre_build marker will exist
+    And the mock action_hook_build marker will exist
+    And the mock action_hook_deploy marker will exist
+    And the mock action_hook_post_deploy marker will exist

--- a/controller/test/cucumber/support/runtime_support.rb
+++ b/controller/test/cucumber/support/runtime_support.rb
@@ -281,8 +281,9 @@ module OpenShift
       if cli
         output = `oo-cartridge -a add -c #{@gear.uuid} -n #{@name} -v`
       else
-        with_ex_handling do
-          output = @gear.container.configure(@name)
+        with_container do |container|
+          output = container.configure(@name)
+          output << container.post_configure(@name)
         end
       end
 
@@ -296,49 +297,51 @@ module OpenShift
     end
 
     def deconfigure
-      with_ex_handling do
-        @gear.container.deconfigure(@name)
+      with_container do |container|
+        container.deconfigure(@name)
       end
     end
 
     def start
-      with_ex_handling do
-        @gear.container.start(@name)
+      with_container do |container|
+        container.start(@name)
       end
     end
 
     def stop
-      with_ex_handling do
-        @gear.container.stop(@name)
+      with_container do |container|
+        container.stop(@name)
       end
     end
 
     def status()
-      with_ex_handling do
-        @gear.container.status(@name)
+      with_container do |container|
+        container.status(@name)
       end
     end
 
     def restart()
-      with_ex_handling do
-        @gear.container.restart(@name)
+      with_container do |container|
+        container.restart(@name)
       end
     end
 
     def tidy()
-      with_ex_handling do 
-        @gear.container.tidy
+      with_container do |container|
+        container.tidy
       end
     end
 
-    def with_ex_handling
+    def with_container
       begin
-        yield
+        yield @gear.container
       rescue Utils::ShellExecutionException => e
-        $logger.error("Caught ShellExecutionException (#{e.rc}): #{e.message}; output: #{e.stdout} #{e.stderr}\n#{e.backtrace}")
+        $logger.error "Caught ShellExecutionException (#{e.rc}): #{e.message}; output: #{e.stdout} #{e.stderr}"
+        $logger.error e.backtrace.join("\n")
         raise
       rescue => e
-        $logger.error("Caught an Exception, #{e.message}\n#{e.backtrace}")
+        $logger.error "Caught an Exception, #{e.message}"
+        $logger.error e.backtrace.join("\n")
         raise
       end
     end

--- a/node-util/bin/oo-cartridge
+++ b/node-util/bin/oo-cartridge
@@ -104,6 +104,7 @@ begin
   case action
     when 'add'
       output = container.configure(c, template_url)
+      output << container.post_configure(c, template_url)
     when 'delete'
       container.deconfigure(c)
     else

--- a/node/lib/openshift-origin-node/model/cartridge.rb
+++ b/node/lib/openshift-origin-node/model/cartridge.rb
@@ -133,7 +133,8 @@ module OpenShift
                   :short_name,
                   :categories,
                   :version,
-                  :source
+                  :source,
+                  :install_build_required
 
       # :call-seq:
       #   Cartridge.new(manifest_path) -> Cartridge
@@ -166,13 +167,14 @@ module OpenShift
           @manifest.merge!(vtree) if vtree
         end
 
-        @cartridge_vendor  = @manifest['Cartridge-Vendor']
-        @cartridge_version = @manifest['Cartridge-Version'] && @manifest['Cartridge-Version'].to_s
-        @name              = @manifest['Name']
-        @short_name        = @manifest['Cartridge-Short-Name']
-        @categories        = @manifest['Categories'] || []
-        @is_primary        = @categories.include?('web_framework')
-        @is_web_proxy      = @categories.include?('web_proxy')
+        @cartridge_vendor       = @manifest['Cartridge-Vendor']
+        @cartridge_version      = @manifest['Cartridge-Version'] && @manifest['Cartridge-Version'].to_s
+        @name                   = @manifest['Name']
+        @short_name             = @manifest['Cartridge-Short-Name']
+        @categories             = @manifest['Categories'] || []
+        @is_primary             = @categories.include?('web_framework')
+        @is_web_proxy           = @categories.include?('web_proxy')
+        @install_build_required = @manifest.has_key?('Install-Build-Required') ? @manifest['Install-Build-Required'] : true
 
         #FIXME: reinstate code after manifests are updated
         #raise MissingElementError.new(nil, 'Cartridge-Vendor') unless @cartridge_vendor

--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -83,12 +83,8 @@ def do_command
     exit 1
   rescue OpenShift::Utils::ShellExecutionException => e
     $stderr.puts "#{e.message}: rc(#{e.rc})"
-
-    if 
-      $stderr.puts "stdout: #{e.stdout}\nstderr#{e.stderr}"
-      $stderr.puts e.backtrace.join("\n")
-    end
-
+    $stderr.puts "stdout: #{e.stdout}\nstderr#{e.stderr}"
+    $stderr.puts e.backtrace.join("\n")
     exit -1
   rescue Exception => e
     $stderr.puts e.message


### PR DESCRIPTION
Separate configure into configure/post-configure and support initial builds
during setup, controllable via a new 'Install-Build-Required' manifest key.

Trello: https://trello.com/c/UCTKH4LA (online_runtime_241)
