### PR TITLE
Bug 955492: Fix rsync command to correct hot deployment

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/bin/deploy.sh
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract-jboss/info/bin/deploy.sh
@@ -14,7 +14,7 @@ CART_NAME=$(get_cartridge_name_from_path)
 if [ ! -h ${OPENSHIFT_REPO_DIR}/deployments ] && [ ! -h ${OPENSHIFT_HOMEDIR}/${CART_NAME}/${CART_NAME}/standalone/deployments ]
 then
   if [ "$(ls ${OPENSHIFT_REPO_DIR}/deployments)" ]; then
-    rsync -r --delete --exclude ".*" ${OPENSHIFT_REPO_DIR}/deployments/ ${OPENSHIFT_HOMEDIR}/${CART_NAME}/${CART_NAME}/standalone/deployments/
+    rsync -r --delete-after --exclude=".*" --exclude='*.deployed' --exclude='*.deploying' --exclude='*.isundeploying' ${OPENSHIFT_REPO_DIR}/deployments/ ${OPENSHIFT_HOMEDIR}/${CART_NAME}/${CART_NAME}/standalone/deployments/
   else
     rm -rf ${OPENSHIFT_HOMEDIR}/${CART_NAME}/${CART_NAME}/standalone/deployments/*
   fi

--- a/cartridges/openshift-origin-cartridge-jbossas-7/info/bin/build.sh
+++ b/cartridges/openshift-origin-cartridge-jbossas-7/info/bin/build.sh
@@ -96,7 +96,7 @@ then
         if [ ! -h ${OPENSHIFT_REPO_DIR}/deployments ] && [ ! -h ${OPENSHIFT_HOMEDIR}/${CART_NAME}/${CART_NAME}/standalone/deployments ]
 		then
 		    if [ "$(ls ${OPENSHIFT_REPO_DIR}/deployments)" ]; then
-  				rsync -r --delete --exclude ".*" ${OPENSHIFT_REPO_DIR}/deployments/ ${OPENSHIFT_HOMEDIR}/${CART_NAME}/${CART_NAME}/standalone/deployments/
+  				rsync -r --delete-after --exclude=".*" --exclude='*.deployed' --exclude='*.deploying' --exclude='*.isundeploying' ${OPENSHIFT_REPO_DIR}/deployments/ ${OPENSHIFT_HOMEDIR}/${CART_NAME}/${CART_NAME}/standalone/deployments/
   			else
     			rm -rf ${OPENSHIFT_HOMEDIR}/${CART_NAME}/${CART_NAME}/standalone/deployments/*
 		    fi

--- a/cartridges/openshift-origin-cartridge-jbosseap-6.0/info/bin/build.sh
+++ b/cartridges/openshift-origin-cartridge-jbosseap-6.0/info/bin/build.sh
@@ -96,7 +96,7 @@ then
         if [ ! -h ${OPENSHIFT_REPO_DIR}/deployments ] && [ ! -h ${OPENSHIFT_HOMEDIR}/${CART_NAME}/${CART_NAME}/standalone/deployments ]
 		then
 		    if [ "$(ls ${OPENSHIFT_REPO_DIR}/deployments)" ]; then
-  				rsync -r --delete --exclude ".*" ${OPENSHIFT_REPO_DIR}/deployments/ ${OPENSHIFT_HOMEDIR}/${CART_NAME}/${CART_NAME}/standalone/deployments/
+  				rsync -r --delete-after --exclude=".*" --exclude='*.deployed' --exclude='*.deploying' --exclude='*.isundeploying' ${OPENSHIFT_REPO_DIR}/deployments/ ${OPENSHIFT_HOMEDIR}/${CART_NAME}/${CART_NAME}/standalone/deployments/
   			else
     			rm -rf ${OPENSHIFT_HOMEDIR}/${CART_NAME}/${CART_NAME}/standalone/deployments/*
     		fi


### PR DESCRIPTION
Make rsync commands consistent when deploying to JBoss to avoid undoing
hot-deployed artifacts by deleting deployment markers.

Resolve https://bugzilla.redhat.com/show_bug.cgi?id=955492
