### PR TITLE
<broker> Updated spec file for correct user_action.log location

### DIFF
--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -30,6 +30,9 @@ OSO_HTTPD_CONF_DIR=${OSO_HTTPD_DIR}/conf.d
 OSO_ENV_DIR=${OSO_CFG_DIR}/environments
 OSO_INI_DIR=${OSO_CFG_DIR}/initializers
 
+BROKER_CONF="/etc/openshift/broker.conf"
+CONSOLE_CONF="/etc/openshift/console.conf"
+
 if [ -e '/etc/openshift/development' ] ; then
   OSO_ENVIRONMENT=${OSO_ENVIRONMENT:=development}
 else
@@ -173,10 +176,24 @@ EOF`
     done
 }
 
-function check_missing_and_insecure_secrets() {
-    BROKER_CONF="/etc/openshift/broker.conf"
-    CONSOLE_CONF="/etc/openshift/console.conf"
+function check_logfile_perms() {
+    ENABLE_USER_ACTION_LOG=`fetch_config ${BROKER_CONF} ENABLE_USER_ACTION_LOG`
+    if [ $ENABLE_USER_ACTION_LOG = "true" ]
+    then 
+      USER_ACTION_LOG_FILE=`fetch_config ${BROKER_CONF} USER_ACTION_LOG_FILE`
+      if [ ! -f $USER_ACTION_LOG_FILE ]
+      then
+        fail "Rest API Logging enabled but the log file does not exist -- run touch ${USER_ACTION_LOG_FILE} && chown apache:apache ${USER_ACTION_LOG_FILE} && chmod 640 ${USER_ACTION_LOG_FILE}"
+      else
+        if [ `ls -l ${USER_ACTION_LOG_FILE} | awk '{print $3$4}'` != 'apacheapache' ]
+        then
+          fail "Rest API Logging enabled but the log file has wrong owner -- run chown apache:apache ${USER_ACTION_LOG_FILE}"
+        fi
+      fi
+    fi
+}
 
+function check_missing_and_insecure_secrets() {
     AUTH_SALT=`fetch_config ${BROKER_CONF} AUTH_SALT`
     if [ "$AUTH_SALT" = "ClWqe5zKtEW4CJEMyjzQ" ]
     then
@@ -899,6 +916,7 @@ STATUS=0
 probe_version
 
 check_missing_and_insecure_secrets
+check_logfile_perms
 check_packages $PACKAGES
 check_ruby_requirements $OSO_RUBY_LIBS
 check_selinux_enforcing

--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -108,7 +108,7 @@ mv %{buildroot}%{brokerdir}/httpd/000002_openshift_origin_broker_proxy.conf %{bu
 mv %{buildroot}%{brokerdir}/httpd/000002_openshift_origin_broker_servername.conf %{buildroot}%{_sysconfdir}/httpd/conf.d/
 
 mkdir -p %{buildroot}%{_var}/log/openshift/broker/httpd
-touch %{buildroot}%{_var}/log/openshift/user_action.log
+touch %{buildroot}%{_var}/log/openshift/broker/user_action.log
 touch %{buildroot}%{_var}/log/openshift/broker/production.log
 touch %{buildroot}%{_var}/log/openshift/broker/development.log
 
@@ -137,7 +137,7 @@ rm %{buildroot}%{brokerdir}/httpd/broker-scl-ruby193.conf
 %attr(0750,-,-) %{_var}/log/openshift/broker/httpd
 %attr(0640,-,-) %ghost %{_var}/log/openshift/broker/production.log
 %attr(0640,-,-) %ghost %{_var}/log/openshift/broker/development.log
-%attr(0640,-,-) %ghost %{_var}/log/openshift/user_action.log
+%attr(0640,-,-) %ghost %{_var}/log/openshift/broker/user_action.log
 %attr(0750,-,-) %{brokerdir}/script
 %attr(0750,-,-) %{brokerdir}/tmp
 %attr(0750,-,-) %{brokerdir}/tmp/cache
@@ -182,7 +182,7 @@ systemctl --system daemon-reload
 # command line tools that will load the Rails environment and create the logs
 # as root.  We need the files labeled %ghost because we don't want these log
 # files overwritten on RPM upgrade.
-for l in %{_var}/log/openshift/user_action.log %{_var}/log/openshift/broker/{development,production}.log; do
+for l in %{_var}/log/openshift/broker/{development,production,user_action}.log; do
   if [ ! -f $l ]; then
     touch $l
   fi
@@ -199,7 +199,6 @@ boolean -m --on httpd_enable_homedirs
 fcontext -a -t httpd_var_run_t '%{brokerdir}/httpd/run(/.*)?'
 fcontext -a -t httpd_tmp_t '%{brokerdir}/tmp(/.*)?'
 fcontext -a -t httpd_log_t '%{_var}/log/openshift/broker(/.*)?'
-fcontext -a -t httpd_log_t '%{_var}/log/openshift/user_action.log'
 _EOF
 
 chcon -R -t httpd_log_t %{_var}/log/openshift/broker
@@ -210,7 +209,7 @@ chcon -R -t httpd_var_run_t %{brokerdir}/httpd/run
 /sbin/restorecon -R -v /var/run
 #/sbin/restorecon -rv %{_datarootdir}/rubygems/gems/passenger-*
 /sbin/restorecon -rv %{brokerdir}/tmp
-/sbin/restorecon -v '%{_var}/log/openshift/user_action.log'
+/sbin/restorecon -v '%{_var}/log/openshift/broker/user_action.log'
 
 %postun
 /sbin/fixfiles -R %{?scl:%scl_prefix}rubygem-passenger restore


### PR DESCRIPTION
Spec was still referencing /var/log/openshift/user_action.log instead of
/var/log/openshift/broker/user_action.log this was causing the logfile
to be created with the wrong permissions when oo-accept-broker is run

user_action.log for the broker was moved from /var/log/openshift to /var/log/openshift/broker/ a while back, but there were still references to the original location.
