### PR TITLE
Bug 955463: Move hot deploy logic into the v2 model

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -403,26 +403,20 @@ module OpenShift
     end
 
     def remote_deploy(options={})
-      if options[:hot_deploy]
-        options[:out].puts "Skipping secondary gear start due to presence of hot deploy marker" if options[:out]
-      else
-        start_gear(secondary_only: true,
-                   user_initiated: true,
-                   out:            options[:out],
-                   err:            options[:err])
-      end
+      start_gear(secondary_only: true,
+                 user_initiated: true,
+                 hot_deploy:     options[:hot_deploy],
+                 out:            options[:out],
+                 err:            options[:err])
 
       deploy(out: options[:out],
              err: options[:err])
 
-      if options[:hot_deploy]
-        options[:out].puts "Skipping primary gear start due to presence of hot deploy marker" if options[:out]
-      else
-        start_gear(primary_only:  true,
-                  user_initiated: true,
-                  out:            options[:out],
-                  err:            options[:err])
-      end
+      start_gear(primary_only:   true,
+                 user_initiated: true,
+                 hot_deploy:     options[:hot_deploy],
+                 out:            options[:out],
+                 err:            options[:err])
 
       post_deploy(out: options[:out],
                   err: options[:err])

--- a/node/lib/openshift-origin-node/model/default_builder.rb
+++ b/node/lib/openshift-origin-node/model/default_builder.rb
@@ -25,13 +25,10 @@ module OpenShift
     end
 
     def pre_receive(options)
-      if options[:hot_deploy]
-        options[:out].puts "Skipping gear stop due to presence of hot deploy marker" if options[:out]
-      else
-        @container.stop_gear(user_initiated: true,
-                             out: options[:out],
-                             err: options[:err])
-      end
+      @container.stop_gear(user_initiated: true,
+                           hot_deploy:     options[:hot_deploy],
+                           out:            options[:out],
+                           err:            options[:err])
     end
 
     def post_receive(options)
@@ -40,26 +37,20 @@ module OpenShift
       @container.build(out: options[:out],
                        err: options[:err])
 
-      if options[:hot_deploy]
-        options[:out].puts "Skipping secondary gear start due to presence of hot deploy marker" if options[:out]
-      else
-        @container.start_gear(secondary_only: true,
-                              user_initiated: true,
-                              out:            options[:out],
-                              err:            options[:err])
-      end
+      @container.start_gear(secondary_only: true,
+                            user_initiated: true,
+                            hot_deploy:     options[:hot_deploy],
+                            out:            options[:out],
+                            err:            options[:err])
 
       @container.deploy(out: options[:out],
                         err: options[:err])
 
-      if options[:hot_deploy]
-        options[:out].puts "Skipping primary gear start due to presence of hot deploy marker" if options[:out]
-      else
-        @container.start_gear(primary_only:   true,
-                              user_initiated: true,
-                              out:            options[:out],
-                              err:            options[:err])
-      end
+      @container.start_gear(primary_only:   true,
+                            user_initiated: true,
+                            hot_deploy:     options[:hot_deploy],
+                            out:            options[:out],
+                            err:            options[:err])
 
       @container.post_deploy(out: options[:out],
                              err: options[:err])

--- a/node/test/unit/build_lifecycle_test.rb
+++ b/node/test/unit/build_lifecycle_test.rb
@@ -61,7 +61,7 @@ class BuildLifecycleTest < Test::Unit::TestCase
     primary = mock()
     @cartridge_model.expects(:primary_cartridge).returns(primary)
 
-    @container.expects(:stop_gear).with(user_initiated: true, out: $stdout, err: $stderr)
+    @container.expects(:stop_gear).with(user_initiated: true, hot_deploy: nil, out: $stdout, err: $stderr)
     @cartridge_model.expects(:do_control).with('pre-receive',
                                                primary,
                                                out:                       $stdout,
@@ -80,9 +80,9 @@ class BuildLifecycleTest < Test::Unit::TestCase
 
     repository.expects(:deploy)
     @container.expects(:build).with(out: $stdout, err: $stderr)
-    @container.expects(:start_gear).with(secondary_only: true, user_initiated: true, out: $stdout, err: $stderr)
+    @container.expects(:start_gear).with(secondary_only: true, user_initiated: true, hot_deploy: nil, out: $stdout, err: $stderr)
     @container.expects(:deploy).with(out: $stdout, err: $stderr)
-    @container.expects(:start_gear).with(primary_only: true, user_initiated: true, out: $stdout, err: $stderr)
+    @container.expects(:start_gear).with(primary_only: true, user_initiated: true, hot_deploy: nil, out: $stdout, err: $stderr)
     @container.expects(:post_deploy).with(out: $stdout, err: $stderr)
 
     @container.post_receive(out: $stdout, err: $stderr)
@@ -200,9 +200,9 @@ class BuildLifecycleTest < Test::Unit::TestCase
   end
 
   def test_remote_deploy_success
-    @container.expects(:start_gear).with(secondary_only: true, user_initiated: true, out: $stdout, err: $stderr)
+    @container.expects(:start_gear).with(secondary_only: true, user_initiated: true, hot_deploy: nil, out: $stdout, err: $stderr)
     @container.expects(:deploy).with(out: $stdout, err: $stderr)
-    @container.expects(:start_gear).with(primary_only: true, user_initiated: true, out: $stdout, err: $stderr)
+    @container.expects(:start_gear).with(primary_only: true, user_initiated: true, hot_deploy: nil, out: $stdout, err: $stderr)
     @container.expects(:post_deploy).with(out: $stdout, err: $stderr)
 
     @container.remote_deploy(out: $stdout, err: $stderr)


### PR DESCRIPTION
Consolidate all hot deploy logic into the v2 model to enforce consistency
of application state.
