### PR TITLE
card#559 changes

### DIFF
--- a/broker-util/man/oo-admin-ctl-user.8
+++ b/broker-util/man/oo-admin-ctl-user.8
@@ -8,6 +8,8 @@
 .fam C
 \fBoo-admin-ctl-user\fP [\fB-h\fP|\fB--help\fP] [\fB-l\fP|\fB--login\fP \fIlogin_name\fP] 
 [\fB--setmaxgears\fP \fImax_gears\fP] [\fB--setconsumedgears\fP \fIconsumed_gears\fP]
+[\fB--setmaxuntrackedstorage\fP \fImax_untracked_storage\fP]
+[\fB--setmaxtrackedstorage\fP \fImax_tracked_storage\fP]
 [\fB--listsubaccounts\fP] [\fB--addsubaccount\fP \fIsubaccount_login\fP]
 [\fB--removesubaccount\fP \fIsubaccount_login\fP] [\fB--allowsubaccounts\fP true|false]
 [\fB--addgearsize\fP \fIgear_size\fP] [\fB--removegearsize\fP \fIgear_size\fP]
@@ -36,6 +38,14 @@ Set the maximum number of gears an user is allowed to consume.
 .B
 \fB--setconsumedgears\fP \fIconsumed_gears\fP
 Set the number of gears an user has consumed. Use with caution.
+.TP
+.B
+\fB--setmaxuntrackedstorage\fP \fImax_untracked_storage\fP
+Set the maximum amount of untracked additional file-system storage.
+.TP
+.B
+\fB--setmaxtrackedstorage\fP \fImax_tracked_storage\fP
+Set the maximum amount of tracked additional file-system storage.
 .TP
 .B
 \fB--listsubaccounts\fP

--- a/broker-util/man/oo-admin-ctl-user.txt2man
+++ b/broker-util/man/oo-admin-ctl-user.txt2man
@@ -4,6 +4,8 @@ NAME
 SYNOPSIS
   oo-admin-ctl-user [-h|--help] [-l|--login login_name] 
   [--setmaxgears max_gears] [--setconsumedgears consumed_gears]
+  [--setmaxuntrackedstorage max_untracked_storage]
+  [--setmaxtrackedstorage max_tracked_storage]
   [--listsubaccounts] [--addsubaccount subaccount_login]
   [--removesubaccount subaccount_login] [--allowsubaccounts true|false]
   [--addgearsize gear_size] [--removegearsize gear_size]
@@ -25,6 +27,12 @@ OPTIONS
   --setconsumedgears consumed_gears  
     Set the number of gears an user has consumed. Use with caution.
 
+  --setmaxuntrackedstorage max_untracked_storage 
+    Set the maximum amount of untracked additional file-system storage.
+
+  --setmaxtrackedstorage max_tracked_storage 
+    Set the maximum amount of tracked additional file-system storage.
+ 
   --listsubaccounts  
     List the subaccounts that have been created under this parent account.
     (login)

--- a/broker-util/oo-admin-ctl-user
+++ b/broker-util/oo-admin-ctl-user
@@ -26,8 +26,10 @@ Options:
     Login with OpenShift access (required)
   --setmaxgears <number>
     Set the maximum number of gears a user is allowed to use
-  --setmaxstorage <number>
-    Set the maximum storage additional storage per gear for a user
+  --setmaxtrackedstorage <number>
+    Set the maximum additional storage per gear that will be tracked for a user
+  --setmaxuntrackedstorage <number>
+    Set the maximum additional storage per gear that will be untracked for a user
   --setconsumedgears <number>
     Set the number of gears a user has consumed (use carefully)
   --listsubaccounts
@@ -87,15 +89,33 @@ def set_max_gears(user, maxgears)
     end
 end
 
-def set_max_storage(user, maxstorage)
+def set_max_tracked_storage(user, maxtrackedstorage)
     user_capabilities = user.get_capabilities
-    if user_capabilities["max_storage_per_gear"] == maxstorage
-        puts "User already has max_storage_per_gear set to #{user_capabilities['max_storage_per_gear']}"
+    if user_capabilities["max_tracked_addtl_storage_per_gear"] == maxtrackedstorage
+        puts "User already has max_tracked_addtl_storage_per_gear set to #{user_capabilities['max_tracked_addtl_storage_per_gear']}"
         return
     end
 
-    print "Setting max_storage_per_gear to #{maxstorage}... "
-    user_capabilities["max_storage_per_gear"]=maxstorage
+    print "Setting max_tracked_addtl_storage_per_gear to #{maxtrackedstorage}... "
+    user_capabilities["max_tracked_addtl_storage_per_gear"]=maxtrackedstorage
+    user.set_capabilities(user_capabilities)
+    if user.save
+        puts "Done."
+    else
+        puts "An error occurred saving the user."
+        exit 6
+    end
+end
+
+def set_max_untracked_storage(user, maxuntrackedstorage)
+    user_capabilities = user.get_capabilities
+    if user_capabilities["max_untracked_addtl_storage_per_gear"] == maxuntrackedstorage
+        puts "User already has max_untracked_addtl_storage_per_gear set to #{user_capabilities['max_untracked_addtl_storage_per_gear']}"
+        return
+    end
+
+    print "Setting max_untracked_addtl_storage_per_gear to #{maxuntrackedstorage}... "
+    user_capabilities["max_untracked_addtl_storage_per_gear"]=maxuntrackedstorage
     user.set_capabilities(user_capabilities)
     if user.save
         puts "Done."
@@ -311,7 +331,8 @@ end
 opts = GetoptLong.new(
     ["--login",          "-l", GetoptLong::REQUIRED_ARGUMENT],
     ["--setmaxgears",      GetoptLong::REQUIRED_ARGUMENT],
-    ["--setmaxstorage",    GetoptLong::REQUIRED_ARGUMENT],
+    ["--setmaxtrackedstorage", GetoptLong::REQUIRED_ARGUMENT],
+    ["--setmaxuntrackedstorage", GetoptLong::REQUIRED_ARGUMENT],
     ["--setconsumedgears", GetoptLong::REQUIRED_ARGUMENT],
     ["--listsubaccounts",  GetoptLong::NO_ARGUMENT],
     ["--addsubaccount",    GetoptLong::REQUIRED_ARGUMENT],
@@ -345,12 +366,20 @@ if args["--setmaxgears"]
   maxgears = args["--setmaxgears"].to_i
 end
 
-if args["--setmaxstorage"]
-  unless args["--setmaxstorage"] =~ /^[0-9]+$/
-    puts "ERROR: Max storage must be a positive integer"
+if args["--setmaxtrackedstorage"]
+  unless args["--setmaxtrackedstorage"] =~ /^[0-9]+$/
+    puts "ERROR: Max tracked storage must be a positive integer"
     exit 1
   end
-  maxstorage = args["--setmaxstorage"].to_i
+  maxtrackedstorage = args["--setmaxtrackedstorage"].to_i
+end
+
+if args["--setmaxuntrackedstorage"]
+  unless args["--setmaxuntrackedstorage"] =~ /^[0-9]+$/
+    puts "ERROR: Max untracked storage must be a positive integer"
+    exit 1
+  end
+  maxuntrackedstorage = args["--setmaxuntrackedstorage"].to_i
 end
 
 if args["--setconsumedgears"]
@@ -392,8 +421,13 @@ unless maxgears.nil?
     changed_user = true
 end
 
-unless maxstorage.nil?
-    set_max_storage(user,maxstorage)
+unless maxtrackedstorage.nil?
+    set_max_tracked_storage(user,maxtrackedstorage)
+    changed_user = true
+end
+
+unless maxuntrackedstorage.nil?
+    set_max_untracked_storage(user,maxuntrackedstorage)
     changed_user = true
 end
 
@@ -454,14 +488,15 @@ user_capabilities = user.get_capabilities
 
 # print out the user's current settings
 puts "User #{user.login}:"
-puts "      consumed gears: #{user.consumed_gears}"
-puts "           max gears: #{user_capabilities['max_gears']}"
-puts "max storage per gear: #{user_capabilities['max_storage_per_gear'] || 0}"
-puts "plan upgrade enabled: #{user_capabilities['plan_upgrade_enabled']}"
-puts "          gear sizes: #{user_capabilities['gear_sizes'].join(', ')}" if user_capabilities.has_key?('gear_sizes')
-puts "sub accounts allowed: #{user_capabilities['subaccounts']}" if user_capabilities.has_key?('subaccounts')
+puts "                  consumed gears: #{user.consumed_gears}"
+puts "                       max gears: #{user_capabilities['max_gears']}"
+puts "    max tracked storage per gear: #{user_capabilities['max_tracked_addtl_storage_per_gear'] || 0}"
+puts "  max untracked storage per gear: #{user_capabilities['max_untracked_addtl_storage_per_gear'] || 0}"
+puts "            plan upgrade enabled: #{user_capabilities['plan_upgrade_enabled']}"
+puts "                      gear sizes: #{user_capabilities['gear_sizes'].join(', ')}" if user_capabilities.has_key?('gear_sizes')
+puts "            sub accounts allowed: #{user_capabilities['subaccounts']}" if user_capabilities.has_key?('subaccounts')
 puts "private SSL certificates allowed: #{user_capabilities['private_ssl_certificates']}" if user_capabilities.has_key?('private_ssl_certificates')
-puts "  inherit gear sizes: #{user_capabilities['inherit_on_subaccounts'].include?('gear_sizes')}" if user_capabilities.has_key?('inherit_on_subaccounts')
+puts "              inherit gear sizes: #{user_capabilities['inherit_on_subaccounts'].include?('gear_sizes')}" if user_capabilities.has_key?('inherit_on_subaccounts')
 puts 
 if args["--listsubaccounts"] and (not subaccount_list.nil?) and (not subaccount_list.empty?)
     puts "Sub Accounts: #{subaccount_list.length}"

--- a/broker/test/unit/application_test.rb
+++ b/broker/test/unit/application_test.rb
@@ -75,7 +75,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest #ActiveSupport::TestCas
     app = Application.create_app(@appname, ["php-5.3", "mysql-5.1"], @domain, "small", true)
     app = Application.find_by(name: @appname, domain_id: @domain._id) rescue nil
 
-    @user.capabilities["max_storage_per_gear"] = 10
+    @user.capabilities["max_untracked_addtl_storage_per_gear"] = 5
     @user.save
     app.reload
     component_instance = app.component_instances.find_by(cartridge_name: "php-5.3")

--- a/console/app/controllers/storage_controller.rb
+++ b/console/app/controllers/storage_controller.rb
@@ -22,7 +22,7 @@ class StorageController < ConsoleController
   def user_information
     user_default_domain
     @user = User.find :one, :as => current_user
-    @max_storage = @user.capabilities[:max_storage_per_gear] || 0
+    @max_storage = (@user.capabilities[:max_untracked_addtl_storage_per_gear] || 0) + (@user.capabilities[:max_tracked_addtl_storage_per_gear] || 0)
     @can_modify_storage = @max_storage > 0
   end
 

--- a/console/test/functional/storage_controller_test.rb
+++ b/console/test/functional/storage_controller_test.rb
@@ -1,13 +1,13 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class StorageControllerTest < ActionController::TestCase
-  test "should show with max_storage_per_gear" do
+  test "should show with max storage per gear" do
     get :show, {:application_id => with_storage_app.to_param}
 
     assert_response :success
   end
 
-  test "should not be able to set storage higher than user's max_storage_per_gear" do
+  test "should not be able to set storage higher than user's max storage per gear" do
     set_storage(with_storage_app,'ruby-1.8',100,false)
 
     assert flash[:error].length == 1, "Should only get one error"

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -557,8 +557,8 @@ class Application
   # @raise [OpenShift::UserException] Exception raised if request cannot be completed
   def update_component_limits(component_instance, scale_from, scale_to, additional_filesystem_gb)
     if additional_filesystem_gb && additional_filesystem_gb != 0
-      max_storage = self.domain.owner.capabilities['max_storage_per_gear']
-      raise OpenShift::UserException.new("You are not allowed to request additional gear storage", 164) unless max_storage
+      max_storage = self.domain.owner.max_storage
+      raise OpenShift::UserException.new("You are not allowed to request additional gear storage", 164) if max_storage == 0
       raise OpenShift::UserException.new("You have requested more additional gear storage than you are allowed (max: #{max_storage} GB)", 166) if additional_filesystem_gb > max_storage
     end
     Application.run_in_application_lock(self) do    

--- a/controller/app/models/cloud_user.rb
+++ b/controller/app/models/cloud_user.rb
@@ -87,6 +87,13 @@ class CloudUser
     set_capabilities(user_capabilities)
   end
 
+  def max_storage
+    user_capabilities = get_capabilities
+    max_untracked_storage = user_capabilities["max_untracked_addtl_storage_per_gear"] || 0
+    max_tracked_storage = user_capabilities["max_tracked_addtl_storage_per_gear"] || 0
+    (max_untracked_storage + max_tracked_storage)
+  end
+
   def save(options = {})
     res = false
     notify = !self.persisted?


### PR DESCRIPTION
Removed 'setmaxstorage' option for oo-admin-ctl-user script.
Added 'setmaxtrackedstorage' and 'setmaxuntrackedstorage' options for oo-admin-ctl-user script.
Updated oo-admin-ctl-user man page.
Max allowed additional fs storage for user will be 'max_untracked_addtl_storage_per_gear' capability + 'max_tracked_addtl_storage_per_gear' capability.
Don't record usage for additional fs storage if it is less than 'max_untracked_addtl_storage_per_gear' limit.
Fixed unit tests and models to accommodate the above change.
