### PR TITLE
Included missing gem ci_reporter

### DIFF
--- a/openshift-console/Gemfile
+++ b/openshift-console/Gemfile
@@ -2,6 +2,7 @@ source 'http://rubygems.org'
 
 gem 'minitest'
 gem 'openshift-origin-console', :require => 'console', :path => ENV['CONSOLE_PATH']
+gem 'ci_reporter'
 group :assets do
         gem 'compass-rails', '~> 1.0.3'
         gem 'coffee-rails',  '~> 3.2.2'


### PR DESCRIPTION
This seems to fix an error we're currently getting during vagrant deployment:

"Notice: /Stage[main]/Openshift_origin::Console/Exec[Console gem dependencies]/returns: cannot load such file -- ci/reporter/rake/minitest"
