### PR TITLE
Bug 956667 - Updated MySQL v2 cart to install with oo-admin-cartridge in...

### DIFF
--- a/cartridges/openshift-origin-cartridge-mysql/openshift-origin-cartridge-mysql.spec
+++ b/cartridges/openshift-origin-cartridge-mysql/openshift-origin-cartridge-mysql.spec
@@ -34,6 +34,8 @@ mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges/v2
 cp -r * %{buildroot}%{cartridgedir}/
 ln -s %{cartridgedir}/conf/ %{buildroot}/%{_sysconfdir}/openshift/cartridges/v2/%{name}
 
+%post
+%{_sbindir}/oo-admin-cartridge --action install --offline --source /usr/libexec/openshift/cartridges/v2/mysql
 
 %clean
 rm -rf %{buildroot}


### PR DESCRIPTION
... %post

https://bugzilla.redhat.com/show_bug.cgi?id=956667

Updated cartridges/openshift-origin-cartridge-mysql/openshift-origin-cartridge-mysql.spec
to install the cartridge with oo-admin-cartridge in %post, this
replicates identical behavior in the other v2 cartridges.
