### PR TITLE
Bug 956670 - Fix static references to small gear size

### DIFF
--- a/broker-util/oo-admin-ctl-district
+++ b/broker-util/oo-admin-ctl-district
@@ -145,7 +145,8 @@ begin
     district.remove_capacity(size)
     reply.resultIO << "Success!"
   when "create"
-    puts "node_profile not specified.  Using default: small" unless node_profile
+    default_gear_size = Rails.application.config.openshift[:default_gear_size]
+    puts "node_profile not specified.  Using default: #{default_gear_size}" unless node_profile
     district = District::create_district(name, node_profile)
     uuid = district.uuid
     reply.resultIO << "Successfully created district: #{district.uuid}" if reply.resultIO.string.empty?

--- a/broker/test/unit/district_test.rb
+++ b/broker/test/unit/district_test.rb
@@ -162,7 +162,16 @@ class DistrictTest < ActiveSupport::TestCase
     # assert that the available_uids array is not sorted
     assert_nil(district.available_uids.reduce{|prev,l| break unless l >= prev; l}, "The UIDs are not randomized")
   end
-  
+
+  test "district gear_size matches DEFAULT_GEAR_SIZE" do
+    o_default_gear_size = Rails.application.config.openshift[:default_gear_size]
+    new_default_gear_size = "newsize"
+    Rails.application.config.openshift[:default_gear_size] = new_default_gear_size
+    new_d = District.create_district("a")
+    assert_equal(new_default_gear_size, new_d.gear_size)
+    Rails.application.config.openshift[:default_gear_size] = o_default_gear_size
+  end
+ 
 =begin
   test "district nodes" do
     orig_d = get_district_obj

--- a/controller/app/models/district.rb
+++ b/controller/app/models/district.rb
@@ -18,7 +18,8 @@ class District
 #  attr_accessor :server_identities, :active_server_identities_size, :uuid, :creation_time, :available_capacity, :available_uids, :max_uid, :max_capacity, :externally_reserved_uids_size, :node_profile, :name
 
   def self.create_district(name, gear_size=nil)
-    profile = gear_size ? gear_size : "small"
+    
+    profile = gear_size ? gear_size : Rails.application.config.openshift[:default_gear_size]
     if District.where(name: name).count > 0
       raise OpenShift::OOException.new("District by name #{name} already exists")
     end
@@ -47,7 +48,7 @@ class District
   end
 
   def self.find_available(gear_size=nil)
-    gear_size = gear_size ? gear_size : 'small'
+    gear_size = gear_size ? gear_size : Rails.application.config.openshift[:default_gear_size]
     valid_district = District.where(:available_capacity.gt => 0, :gear_size => gear_size, :active_server_identities_size.gt => 0).desc(:available_capacity).first
     valid_district
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=956670

Creating a new district would default to small gear size even if
DEFAULT_GEAR_SIZE has been updated.  This updates the static references
to use the DEFAULT_GEAR_SIZE instead.
