### PR TITLE
Bug 957045 - fixing oo-accept-systems for v2 cartridges

### DIFF
--- a/broker-util/oo-accept-systems
+++ b/broker-util/oo-accept-systems
@@ -1,5 +1,4 @@
 #!/usr/bin/env oo-ruby
-#!/usr/bin/env ruby
 
 #--
 # Copyright 2012 Red Hat, Inc.
@@ -21,6 +20,7 @@
 require 'rubygems'
 require 'optparse'
 require 'socket'
+require 'rest-client'
 
 OOAS_OPTIONS = {
     :wait => 5,
@@ -174,12 +174,15 @@ def check_nodes_cartridges
   verbose "checking that broker's cache is not stale"
   begin
     require 'json'
-    require 'rest-client'
     api_carts = JSON.parse(RestClient.get('http://localhost:8080/broker/rest/cartridges.json'))
     api_carts = api_carts["data"].map {|cart| cart["name"]}
     verbose "API reports carts: #{api_carts.join '|'}"
     # remove abstract_carts which don't show in the API
     all_carts.reject! {|cart| cart.start_with? "abstract"}
+
+    cache_clear_command = "bundle exec rake tmp:clear"
+    cache_clear_command = "scl enable ruby193 \"#{cache_clear_command}\"" if ENV["X_SCLS"] =~ /ruby193/
+
     do_fail <<-"MISMATCH" unless api_carts.sort == all_carts.sort
       The broker's list of cartridges does not match what is available on
       the node hosts. The broker probably has cached an old list.
@@ -187,7 +190,7 @@ def check_nodes_cartridges
       Broker has extra: #{(api_carts - all_carts).join ", "}
       Clear the cache by executing:
         # cd /var/www/openshift/broker
-        # bundle exec rake tmp:clear
+        # #{cache_clear_command}
     MISMATCH
   rescue StandardError => e
     do_fail "Couldn't retrieve cartridge list from broker: #{e}"

--- a/broker-util/openshift-origin-broker-util.spec
+++ b/broker-util/openshift-origin-broker-util.spec
@@ -18,7 +18,7 @@ Requires:      ruby(release)
 Requires:      %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
 %endif
 Requires:      openshift-origin-broker
-Requires:      %{?scl:%scl_prefix}rest-client
+Requires:      %{?scl:%scl_prefix}rubygem-rest-client
 # For oo-register-dns
 Requires:      bind-utils
 # For oo-admin-broker-auth

--- a/broker-util/openshift-origin-broker-util.spec
+++ b/broker-util/openshift-origin-broker-util.spec
@@ -18,6 +18,7 @@ Requires:      ruby(release)
 Requires:      %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
 %endif
 Requires:      openshift-origin-broker
+Requires:      %{?scl:%scl_prefix}rest-client
 # For oo-register-dns
 Requires:      bind-utils
 # For oo-admin-broker-auth

--- a/node/misc/bin/oo-cartridge-list
+++ b/node/misc/bin/oo-cartridge-list
@@ -19,6 +19,25 @@ require 'rubygems'
 require 'openshift-origin-node'
 require 'openshift-origin-common'
 
+module OpenShift
+  module NodeLogger
+    def self.logger
+       unless @logger
+          @logger = Logger.new(File.open(File::NULL, "w"))
+       end
+       @logger
+    end
+
+    def self.trace_logger
+       unless @trace_logger
+         @trace_logger = Logger.new(File.open(File::NULL, "w"))
+         @trace_logger.level = Logger::Severity::ERROR
+       end
+       @trace_logger
+    end
+  end
+end
+
 def usage
   puts <<USAGE
 == Synopsis

--- a/plugins/msg-node/mcollective/facts/openshift_facts.rb
+++ b/plugins/msg-node/mcollective/facts/openshift_facts.rb
@@ -131,24 +131,8 @@ end
 #   This is the *full* list.
 #
 Facter.add(:cart_list) do
-    carts = []
-    Dir.glob('/usr/libexec/openshift/cartridges/*/').each do |cart|
-        cart = File.basename(cart).sub(/^(.*)-(\d+)\.(\d+)\.?.*$/, '\1-\2.\3')
-        carts << cart unless cart.nil? || cart == "embedded"
-    end
-    setcode { carts.join('|') }
-end
-
-#
-# List embedded cartridges on the host
-#   Convert from name-m.n.p to name-m.n
-#   This is the *full* list.
-#
-Facter.add(:embed_cart_list) do
-    carts = []
-    Dir.glob('/usr/libexec/openshift/cartridges/embedded/*/').each do |cart|
-        cart = File.basename(cart).sub(/^(.*)-(\d+)\.(\d+)\.?.*$/, '\1-\2.\3')
-        carts << cart unless cart.nil?
-    end
+    carts = `oo-cartridge-list`.split
+    # The first element is the text "Cartridges:"
+    carts.shift
     setcode { carts.join('|') }
 end


### PR DESCRIPTION
- The rest-client dependency needed to be loaded before the rails environment
  because Bundler would prevent it from loading.
- Cartridge lookup is completely different with v2.  I decided to use
  oo-cartridge-list for this in openshift-facts.rb since it supports both v1 and
  v2.  The complication with this is that previously oo-cartridge-list would
  access the platform logs.  Since openshift_facts.rb is ultimately called by a
  cronjob running as openshift_cron_t this would be denied and munge the
  oo-cartridge-list output.  As with other admin cli scripts we decided to stub
  out the logging class to prevent this from happening.
- the embed_cart_list fact did not appear to be used so I removed it.
