### PR TITLE
Updated nsupdate config to grab/use GSSTSIG/DNS Kerberos info when given

### DIFF
--- a/plugins/dns/nsupdate/config/initializers/openshift-origin-dns-nsupdate.rb
+++ b/plugins/dns/nsupdate/config/initializers/openshift-origin-dns-nsupdate.rb
@@ -20,8 +20,8 @@ Broker::Application.configure do
     # Authentication information: TSIG or GSS-TSIG (kerberos) but not both
     #
     # TSIG credentials
-    :keyname => conf.get("BIND_KEYNAME", "example.com"),
-    :keyvalue => conf.get("BIND_KEYVALUE", "base64-encoded key, most likely from /var/named/example.com.key."),
+    :keyname => conf.get("BIND_KEYNAME", nil),
+    :keyvalue => conf.get("BIND_KEYVALUE", nil),
 
     # GSS-TSIG (kerberos) credentials
     :krb_principal => conf.get("BIND_KRB_PRINCIPAL", nil),


### PR DESCRIPTION
If DNS kerberos credentials are given in `/etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf` for GSS-TSIG, TSIG information would be wrongly populated with dummy information when initializing `OpenShift::DnsService` for nsupdate. 
