### PR TITLE
Validate cartridge and vendor names under certain conditions

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossews/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jbossews/metadata/manifest.yml
@@ -1,6 +1,6 @@
 Name: jbossews
 Cartridge-Short-Name: JBOSSEWS
-Cartridge-Vendor: Red Hat
+Cartridge-Vendor: redhat
 Cartridge-Version: 0.0.1
 Display-Name: Tomcat 7 (JBoss EWS 2.0)
 Description: "JBoss Enterprise Web Server is the enterprise-class Java web container for large-scale lightweight web applications based on Tomcat 7. Build and deploy JSPs and Servlets in the cloud."

--- a/cartridges/openshift-origin-cartridge-postgresql/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-postgresql/metadata/manifest.yml
@@ -4,7 +4,7 @@ Architecture: noarch
 Cartridge-Short-Name: POSTGRESQL
 Cartridge-Version:    '0.2.0'
 Cartridge-Versions:   [0.2.0]
-Cartridge-Vendor:     Red Hat
+Cartridge-Vendor:     redhat
 Display-Name: PostgreSQL Database 8.4
 Description: "PostgreSQL is an advanced Object-Relational database management system"
 Version:   '8.4'

--- a/common/test/unit/manifest_test.rb
+++ b/common/test/unit/manifest_test.rb
@@ -81,7 +81,7 @@ class ManifestTest < Test::Unit::TestCase
 Name: mock
 Cartridge-Short-Name: MOCK
 Cartridge-Version: '1.0'
-Cartridge-Vendor: Unit Test
+Cartridge-Vendor: unit_test
 Display-Name: Mock
 Description: "A mock cartridge for development use only."
 Version: '0.1'

--- a/node/README.writing_cartridges.md
+++ b/node/README.writing_cartridges.md
@@ -96,7 +96,7 @@ Name: PHP
 Cartridge-Short-Name: PHP
 Cartridge-Version: '1.0.1'
 Cartridge-Versions: ['1.0.1']
-Cartridge-Vendor: Red Hat
+Cartridge-Vendor: redhat
 Display-Name: PHP 5.3
 Description: "PHP is a general-purpose server-side scripting language..."
 Version: '5.3'

--- a/node/lib/openshift-origin-node/model/cartridge_repository.rb
+++ b/node/lib/openshift-origin-node/model/cartridge_repository.rb
@@ -122,8 +122,9 @@ module OpenShift
     def load(directory = nil)
       @semaphore.synchronize do
         find_manifests(directory || @path) do |manifest_path|
+          logger.debug { "Loading cartridge from #{manifest_path}" }
           c = insert(OpenShift::Runtime::Manifest.new(manifest_path, nil, @path))
-          logger.debug { "Loaded cartridge (#{c.name}, #{c.version}, #{c.cartridge_version}) from #{manifest_path}" }
+          logger.debug { "Loaded cartridge (#{c.name}, #{c.version}, #{c.cartridge_version})" }
         end
       end
 
@@ -269,7 +270,7 @@ module OpenShift
     #
     # Insert cartridge into index
     #
-    #   CartridgeRepository.instance.instance(cartridge) -> Cartridge
+    #   CartridgeRepository.instance.insert(cartridge) -> Cartridge
     def insert(cartridge) # :nodoc:
       cartridge.versions.each do |version|
         @index[cartridge.name][version][cartridge.cartridge_version] = cartridge
@@ -329,6 +330,8 @@ module OpenShift
       if :url == cartridge.manifest_path
         uri       = URI(cartridge.source_url)
         temporary = PathUtils.join(File.dirname(target), File.basename(cartridge.source_url))
+        cartridge.validate_vendor_name
+        cartridge.validate_cartridge_name
 
         case
           when 'git' == uri.scheme || cartridge.source_url.end_with?('.git')

--- a/node/test/functional/node_func_test.rb
+++ b/node/test/functional/node_func_test.rb
@@ -29,7 +29,7 @@ class NodeTest < OpenShift::V2SdkTestCase
     OpenShift::CartridgeRepository.
         any_instance.
         stubs(:find_manifests).
-        multiple_yields(["#{@path}/redhat-CRTest/1.2/metadata/manifest.yml"])
+        multiple_yields(["#{@path}/redhat-crtest/1.2/metadata/manifest.yml"])
 
     OpenShift::CartridgeRepository.instance.clear
     OpenShift::CartridgeRepository.instance.load
@@ -39,33 +39,33 @@ class NodeTest < OpenShift::V2SdkTestCase
     buffer = OpenShift::Node.get_cartridge_list(true, true, true)
     refute_nil buffer
 
-    assert_equal %Q(CLIENT_RESULT: [\"---\\nName: CRTest-0.1\\nDisplay-Name: CRTest Unit Test\\nVersion: '0.1'\\nVersions:\\n- '0.1'\\n- '0.2'\\n- '0.3'\\nCartridge-Vendor: Red Hat\\nGroup-Overrides:\\n- components:\\n  - CRTest-0.1\\n  - web_proxy\\n\",\"---\\nName: CRTest-0.2\\nDisplay-Name: CRTest Unit Test\\nVersion: '0.2'\\nVersions:\\n- '0.1'\\n- '0.2'\\n- '0.3'\\nCartridge-Vendor: Red Hat\\nGroup-Overrides:\\n- components:\\n  - CRTest-0.2\\n  - web_proxy\\n\",\"---\\nName: CRTest-0.3\\nDisplay-Name: CRTest Unit Test\\nVersion: '0.3'\\nVersions:\\n- '0.1'\\n- '0.2'\\n- '0.3'\\nCartridge-Vendor: Red Hat\\nGroup-Overrides:\\n- components:\\n  - CRTest-0.2\\n  - web_proxy\\n\"]),
+    assert_equal %Q(CLIENT_RESULT: [\"---\\nName: crtest-0.1\\nDisplay-Name: crtest Unit Test\\nVersion: '0.1'\\nVersions:\\n- '0.1'\\n- '0.2'\\n- '0.3'\\nCartridge-Vendor: redhat\\nGroup-Overrides:\\n- components:\\n  - crtest-0.1\\n  - web_proxy\\n\",\"---\\nName: crtest-0.2\\nDisplay-Name: crtest Unit Test\\nVersion: '0.2'\\nVersions:\\n- '0.1'\\n- '0.2'\\n- '0.3'\\nCartridge-Vendor: redhat\\nGroup-Overrides:\\n- components:\\n  - crtest-0.2\\n  - web_proxy\\n\",\"---\\nName: crtest-0.3\\nDisplay-Name: crtest Unit Test\\nVersion: '0.3'\\nVersions:\\n- '0.1'\\n- '0.2'\\n- '0.3'\\nCartridge-Vendor: redhat\\nGroup-Overrides:\\n- components:\\n  - crtest-0.2\\n  - web_proxy\\n\"]),
                  buffer
   end
 
   MANIFESTS = [
       %q{#
-        Name: CRTest
-        Display-Name: CRTest Unit Test
+        Name: crtest
+        Display-Name: crtest Unit Test
         Cartridge-Short-Name: CRTEST
         Version: '0.3'
         Versions: ['0.1', '0.2', '0.3']
         Cartridge-Version: '1.2'
-        Cartridge-Vendor: Red Hat
+        Cartridge-Vendor: redhat
         Group-Overrides:
           - components:
-            - CRTest-0.3
+            - crtest-0.3
             - web_proxy
         Version-Overrides:
           '0.1':
             Group-Overrides:
               - components:
-                - CRTest-0.1
+                - crtest-0.1
                 - web_proxy
           '0.2':
             Group-Overrides:
               - components:
-                - CRTest-0.2
+                - crtest-0.2
                 - web_proxy
       },
   ]

--- a/node/test/unit/application_container_test.rb
+++ b/node/test/unit/application_container_test.rb
@@ -67,7 +67,7 @@ class ApplicationContainerTest < Test::Unit::TestCase
         Name: mock
         Cartridge-Short-Name: MOCK
         Cartridge-Version: 1.0
-        Cartridge-Vendor: Unit Test
+        Cartridge-Vendor: unit_test
         Display-Name: Mock
         Description: "A mock cartridge for development use only."
         Version: 0.1

--- a/node/test/unit/cartridge_repository_test.rb
+++ b/node/test/unit/cartridge_repository_test.rb
@@ -39,21 +39,21 @@ class CartridgeRepositoryTest < Test::Unit::TestCase
     cr.load(@path)
 
     refute_nil cr
-    e = cr.select('CRTest', '0.1', '1.0')
+    e = cr.select('crtest', '0.1', '1.0')
     refute_nil e
     assert_equal '0.1', e.version
-    assert_equal "#{@path}/redhat-CRTest/1.0", e.repository_path
-    assert_equal 'RedHat', e.cartridge_vendor
+    assert_equal "#{@path}/redhat-crtest/1.0", e.repository_path
+    assert_equal 'redhat', e.cartridge_vendor
 
-    e = cr.select('CRTest', '0.1')
-    refute_nil e
-    assert_equal '0.1', e.version
-
-    e = cr.select('CRTest')
+    e = cr.select('crtest', '0.1')
     refute_nil e
     assert_equal '0.1', e.version
 
-    assert_equal "#{@path}/redhat-CRTest/1.0", e.repository_path
+    e = cr.select('crtest')
+    refute_nil e
+    assert_equal '0.1', e.version
+
+    assert_equal "#{@path}/redhat-crtest/1.0", e.repository_path
   end
 
   def test_each
@@ -68,9 +68,9 @@ class CartridgeRepositoryTest < Test::Unit::TestCase
         any_instance.
         stubs(:find_manifests).
         with(@path).
-        multiple_yields(["#{@path}/RedHat-CRTest/1.0/metadata/manifest.yml"],
-                        ["#{@path}/RedHat-CRTest/1.1/metadata/manifest.yml"],
-                        ["#{@path}/RedHat-CRTest/1.2/metadata/manifest.yml"],)
+        multiple_yields(["#{@path}/RedHat-crtest/1.0/metadata/manifest.yml"],
+                        ["#{@path}/RedHat-crtest/1.1/metadata/manifest.yml"],
+                        ["#{@path}/RedHat-crtest/1.2/metadata/manifest.yml"],)
 
     cr = OpenShift::CartridgeRepository.instance
     cr.clear
@@ -88,32 +88,32 @@ class CartridgeRepositoryTest < Test::Unit::TestCase
         any_instance.
         stubs(:find_manifests).
         with(@path).
-        multiple_yields(["#{@path}/redhat-CRTest/1.0/metadata/manifest.yml"],
-                        ["#{@path}/redhat-CRTest/1.1/metadata/manifest.yml"],
-                        ["#{@path}/redhat-CRTest/1.2/metadata/manifest.yml"],)
+        multiple_yields(["#{@path}/redhat-crtest/1.0/metadata/manifest.yml"],
+                        ["#{@path}/redhat-crtest/1.1/metadata/manifest.yml"],
+                        ["#{@path}/redhat-crtest/1.2/metadata/manifest.yml"],)
 
     cr = OpenShift::CartridgeRepository.instance
     cr.clear
     cr.load(@path)
 
-    e = cr.select('CRTest')
+    e = cr.select('crtest')
     refute_nil e
     assert_equal '0.3', e.version
     assert_equal '1.2', e.cartridge_version
 
     cr = OpenShift::CartridgeRepository.instance
-    e  = cr.select('CRTest', '0.3')
+    e  = cr.select('crtest', '0.3')
     refute_nil e
     assert_equal '0.3', e.version
     assert_equal '1.2', e.cartridge_version
 
-    e = cr['CRTest']
+    e = cr['crtest']
     refute_nil e
     assert_equal '0.3', e.version
     assert_equal '1.2', e.cartridge_version
 
     cr = OpenShift::CartridgeRepository.instance
-    e  = cr['CRTest', '0.3']
+    e  = cr['crtest', '0.3']
     refute_nil e
     assert_equal '0.3', e.version
     assert_equal '1.2', e.cartridge_version
@@ -129,45 +129,45 @@ class CartridgeRepositoryTest < Test::Unit::TestCase
         any_instance.
         stubs(:find_manifests).
         with(@path).
-        multiple_yields(["#{@path}/redhat-CRTest/1.0/metadata/manifest.yml"],
-                        ["#{@path}/tests/redhat-CRTest/1.1/metadata/manifest.yml"],
-                        ["#{@path}/tests/redhat-CRTest/1.2/metadata/manifest.yml"],)
+        multiple_yields(["#{@path}/redhat-crtest/1.0/metadata/manifest.yml"],
+                        ["#{@path}/tests/redhat-crtest/1.1/metadata/manifest.yml"],
+                        ["#{@path}/tests/redhat-crtest/1.2/metadata/manifest.yml"],)
 
     cr = OpenShift::CartridgeRepository.instance
     cr.clear
     cr.load(@path)
 
     assert_raise(KeyError) do
-      cr.select('CRTest', '0.4')
+      cr.select('crtest', '0.4')
     end
   end
 
   MANIFESTS = [
       %q{#
-        Name: CRTest
+        Name: crtest
         Cartridge-Short-Name: CRTEST
         Version: '0.1'
         Versions: ['0.1']
         Cartridge-Version: '1.0'
         Cartridge-Versions: ['1.0']
-        Cartridge-Vendor: RedHat
+        Cartridge-Vendor: redhat
       },
       %q{#
-        Name: CRTest
+        Name: crtest
         Cartridge-Short-Name: CRTEST
         Version: '0.2'
         Versions: ['0.1', '0.2']
         Cartridge-Version: '1.1'
         Cartridge-Versions: ['1.0', '1.1']
-        Cartridge-Vendor: RedHat
+        Cartridge-Vendor: redhat
       },
       %q{#
-        Name: CRTest
+        Name: crtest
         Cartridge-Short-Name: CRTEST
         Version: '0.3'
         Versions: ['0.1', '0.2', '0.3']
         Cartridge-Version: '1.2'
-        Cartridge-Vendor: Red Hat
+        Cartridge-Vendor: redhat
       },
   ]
 end

--- a/node/test/unit/v2_cart_model_test.rb
+++ b/node/test/unit/v2_cart_model_test.rb
@@ -68,7 +68,7 @@ module OpenShift
         Name: mock
         Cartridge-Short-Name: MOCK
         Cartridge-Version: 1.0
-        Cartridge-Vendor: Unit Test
+        Cartridge-Vendor: unit_test
         Display-Name: Mock
         Description: "A mock cartridge for development use only."
         Version: '0.1'
@@ -140,9 +140,9 @@ module OpenShift
     def test_get_cartridge_error_loading
       local_model = OpenShift::V2CartridgeModel.new(@config, @user, mock())
 
-      YAML.stubs(:load_file).with("#{@homedir}/redhat-CRTest/metadata/manifest.yml").raises(ArgumentError.new('bla'))
+      YAML.stubs(:load_file).with("#{@homedir}/redhat-crtest/metadata/manifest.yml").raises(ArgumentError.new('bla'))
 
-      assert_raise(RuntimeError, "Failed to load cart manifest from #{@homedir}/redhat-CRTest/metadata/manifest.yml for cart mock in gear : bla") do
+      assert_raise(RuntimeError, "Failed to load cart manifest from #{@homedir}/redhat-crtest/metadata/manifest.yml for cart mock in gear : bla") do
         local_model.get_cartridge("mock-0.1")
       end
     end


### PR DESCRIPTION
online_runtime_245 online_runtime_288

CartridgeRepository functional tests need to be adjusted so that the vendor name is not a reserved one.
