### PR TITLE
<broker> Bug 956351 - Add mongo rubygem dependency, docs

### DIFF
--- a/broker/Gemfile
+++ b/broker/Gemfile
@@ -15,6 +15,15 @@ gem 'bson_ext'
 gem 'pry', :require => 'pry' if ENV['PRY']
 gem 'minitest'
 
+# For performance reasons, the following scripts will not be
+# refactored to use mongoid exclusively:
+#  * broker-util/oo-admin-chk
+#  * broker-util/oo-admin-fix-sshkeys
+#  * broker-util/oo-stats
+# These scripts use the OpenShift::DataStore API, and thus depend on
+# the mongo rubygem:
+gem 'mongo'
+
 if ENV['SOURCE']
   gem 'openshift-origin-common', :path => '../common'
   gem 'openshift-origin-controller', :path => '../controller'

--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -39,6 +39,9 @@ Requires:      %{?scl:%scl_prefix}rubygem(bson_ext)
 Requires:      %{?scl:%scl_prefix}rubygem(json)
 Requires:      %{?scl:%scl_prefix}rubygem(json_pure)
 Requires:      %{?scl:%scl_prefix}rubygem(minitest)
+# This gem is required by oo-admin-chk, oo-admin-fix-sshkeys, and
+# oo-stats, for OpenShift::DataStore API support
+Requires:      %{?scl:%scl_prefix}rubygem(mongo)
 # The mongoid gem doesn't exist in Fedora yet
 %if 0%{?scl:1}
 Requires:      %{?scl:%scl_prefix}rubygem(mongoid)


### PR DESCRIPTION
At least three scripts - broker-util/oo-admin-chk, broker-util/oo-admin-fix-sshkeys, and broker-util/oo-stats - use the OpenShift::DataStore API for performance reasons, and so still depend on the mongo rubygem. This change adds the gem dependency back to the broker Gemfile and specfile.

@abhgupta
