### PR TITLE
Broker changes for supporting unsubscribe connection event.

### DIFF
--- a/controller/app/models/pending_app_op_group.rb
+++ b/controller/app/models/pending_app_op_group.rb
@@ -255,6 +255,8 @@ class PendingAppOpGroup
             application.set_connections(op.args["connections"])
           when :execute_connections
             application.execute_connections
+          when :unsubscribe_connections
+            application.unsubscribe_connections(op.args["sub_pub_info"])
           when :set_gear_additional_filesystem_gb
             gear.set_addtl_fs_gb(op.args["additional_filesystem_gb"], handle)
             use_parallel_job = true

--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -978,7 +978,7 @@ module OpenShift
         end
         [nil, nil]
       end
-      
+
       #
       # Start cartridge services within a gear
       #
@@ -1548,7 +1548,7 @@ module OpenShift
       #
       # NOTES:
       # * uses RemoteJob
-      #         
+      # 
       def get_execute_connector_job(gear, cart, connector_name, connection_type, input_args, pub_cart=nil)
         args = build_base_gear_args(gear)
         args['--cart-name'] = cart
@@ -1562,6 +1562,28 @@ module OpenShift
           args['--input-args'] = input_args.join(" ")
         end
         job = RemoteJob.new('openshift-origin-node', 'connector-execute', args)
+        job
+      end
+
+      #
+      # Create a job to unsubscribe
+      #
+      # INPUTS:
+      # * gear: a Gear object
+      # * cart: a Cartridge object
+      # * publish_cart_name: a Cartridge object
+      #
+      # RETURNS:
+      # * a RemoteJob object
+      #
+      # NOTES:
+      # * uses RemoteJob
+      # 
+      def get_unsubscribe_job(gear, cart, publish_cart_name)
+        args = build_base_gear_args(gear)
+        args['--cart-name'] = cart
+        args['--publishing-cart-name'] = publish_cart_name
+        job = RemoteJob.new('openshift-origin-node', 'unsubscribe', args)
         job
       end
 

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -617,7 +617,7 @@ module MCollective
         pub_cart_name = args['--publishing-cart-name']
 
         with_container_from_args(args) do |container, output|
-          output << container.unsubscribe(cart_name, pub_cart_name)
+          output << container.unsubscribe(cart_name, pub_cart_name).to_s
         end
       end
 


### PR DESCRIPTION
Details: When one of the component is removed from the app and if it has published
some content to other components located on different gears, we issue
unsubscribe event on all the subscribing gears to cleanup the published content.
