### PR TITLE
<oo-accept-broker> Bug 958437 - Making CONSOLE_SECRET check dependent on...

### DIFF
--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -206,12 +206,14 @@ function check_missing_and_insecure_secrets() {
       fail "SESSION_SECRET must be set in $BROKER_CONF (Hint: use 'openssl rand -hex 64' to generate a unique secret."
     fi
 
-    CONSOLE_SECRET=`fetch_config ${CONSOLE_CONF} SESSION_SECRET`
-    if [ "$CONSOLE_SECRET" = "nil" -o "$CONSOLE_SECRET" = "" ]
+    if [ -f ${CONSOLE_CONF} ]
     then
-      fail "SESSION_SECRET must be set in ${CONSOLE_CONF} (Hint: use 'openssl rand -hex 64' to generate a unique secret."
+      CONSOLE_SECRET=`fetch_config ${CONSOLE_CONF} SESSION_SECRET`
+      if [ "$CONSOLE_SECRET" = "nil" -o "$CONSOLE_SECRET" = "" ]
+      then
+        fail "SESSION_SECRET must be set in ${CONSOLE_CONF} (Hint: use 'openssl rand -hex 64' to generate a unique secret."
+      fi
     fi
-
 }
 
 # This is another way to parse the config settings.  You could argue that it's


### PR DESCRIPTION
... existence of CONSOLE_CONF

https://bugzilla.redhat.com/show_bug.cgi?id=958437

Only check CONSOLE_SECRET if the Console config is present on the
system, since there is no dependency on openshift-origin-console being
installed for broker-utils
