### PR TITLE
RestApi should defend against poorly formed response bodies

### DIFF
--- a/console/app/models/rest_api/base.rb
+++ b/console/app/models/rest_api/base.rb
@@ -318,7 +318,7 @@ module RestApi
       # :cause => :server_unavailable. As an improvement the broker could return an exit_code
       # for us to handle on translate_api_error. Otherwise throw as ActiveResource would.
       server_unavailable = error.response.present? && 
-        error.response.code.present? && 
+        error.response.respond_to?(:code) && 
         error.response.code.to_i == 503
 
       remote_errors = set_remote_errors(error, true)

--- a/console/test/unit/rest_api_test.rb
+++ b/console/test/unit/rest_api_test.rb
@@ -216,6 +216,11 @@ class RestApiTest < ActiveSupport::TestCase
     assert_equal [125, 'test', 'hello'], errors[0]
   end
 
+  def test_save_handles_invalid_error
+    Key.any_instance.expects(:save_without_change_tracking).raises(ActiveResource::ConnectionError.new(stub(:response => '')))
+    assert_raises(ActiveResource::ConnectionError){ Key.new(:name => 'test', :raw_content => 'bar', :as => @user).save }
+  end
+
   def test_serialization
     app = Application.new :name => 'test1', :cartridge => 'cool', :application_type => 'diy-0.1', :as => @user
     #puts app.class.send('known_attributes').inspect


### PR DESCRIPTION
It's possible for ActiveResource::ConnectionError#response to return a string.

@fabianofranz Review
