### PR TITLE
Bug 957453 - enable unidle from v2 app builder

### DIFF
--- a/node-util/bin/oo-admin-ctl-gears
+++ b/node-util/bin/oo-admin-ctl-gears
@@ -120,14 +120,15 @@ module OpenShift
     def unidle
       p_runner(false) do |gear|
         output_pass_fail("Unidling", gear) do
+          out = ""
           if gear.stop_lock? and (gear.state.value == State::IDLE)
-            frontend = FrontendHttpServer.new(gear.uuid)
-            if frontend.idle?
-              out = gear.start_gear
-              frontend.unidle
-              out
-            end
+            out = gear.start_gear
           end
+          frontend = FrontendHttpServer.new(gear.uuid)
+          if frontend.idle?
+            frontend.unidle
+          end
+          out
         end
       end
     end

--- a/node/lib/openshift-origin-node/model/default_builder.rb
+++ b/node/lib/openshift-origin-node/model/default_builder.rb
@@ -52,6 +52,8 @@ module OpenShift
                             out:            options[:out],
                             err:            options[:err])
 
+      FrontendHttpServer.new(@container.uuid).unprivileged_unidle
+
       @container.post_deploy(out: options[:out],
                              err: options[:err])
     end

--- a/node/test/unit/build_lifecycle_test.rb
+++ b/node/test/unit/build_lifecycle_test.rb
@@ -53,6 +53,9 @@ class BuildLifecycleTest < Test::Unit::TestCase
 
     @container = OpenShift::ApplicationContainer.new(@gear_uuid, @gear_uuid, @user_uid,
         @app_name, @gear_uuid, @namespace, nil, nil, nil)
+
+    @frontend = mock('OpenShift::FrontendHttpServer')
+    OpenShift::FrontendHttpServer.stubs(:new).returns(@frontend)
   end
 
   def test_pre_receive_default_builder
@@ -84,6 +87,8 @@ class BuildLifecycleTest < Test::Unit::TestCase
     @container.expects(:deploy).with(out: $stdout, err: $stderr)
     @container.expects(:start_gear).with(primary_only: true, user_initiated: true, hot_deploy: nil, out: $stdout, err: $stderr)
     @container.expects(:post_deploy).with(out: $stdout, err: $stderr)
+
+    @frontend.expects(:unprivileged_unidle)
 
     @container.post_receive(out: $stdout, err: $stderr)
   end


### PR DESCRIPTION
The v2 build process triggered by a git push tries to start the gear.  If the gear was idled, that start needs to include marking the gear as no longer idle in the front-end Apache server.  That is a root operation.  Since the gear build runs as the gear user, it doesn't have privileges to do that so a Net::HTTP call is made instead to wake up the app.
