### PR TITLE
<openshift-console> - Bug 957818 Update boot.rb to default to production...

### DIFF
--- a/openshift-console/config/boot.rb
+++ b/openshift-console/config/boot.rb
@@ -1,5 +1,13 @@
 require 'rubygems'
 
+unless ENV["RAILS_ENV"] == "test"
+  if File.exist?('/etc/openshift/development')
+    ENV["RAILS_ENV"] = "development"
+  else
+    ENV["RAILS_ENV"] = "production"
+  end
+end
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 


### PR DESCRIPTION
... env

https://bugzilla.redhat.com/show_bug.cgi?id=957818

This is similar to the logic in the boot.rb file for broker, and makes
it so that clearing the console cache via bundle exec "rails runner
Rails.cache.clear" does not require specifying the environment.
