### PR TITLE
Bug 958617 - Add missing env var

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossews/env/OPENSHIFT_JBOSSEWS_LOG_DIR.erb
+++ b/cartridges/openshift-origin-cartridge-jbossews/env/OPENSHIFT_JBOSSEWS_LOG_DIR.erb
@@ -1,0 +1,1 @@
+<%= ENV['OPENSHIFT_JBOSSEWS_DIR'] %>logs/


### PR DESCRIPTION
- control tidy required OPENSHIFT_JBOSSEWS_LOG_DIR
