### PR TITLE
<broker><oo-accept-broker> Bug 958674 - Fix Mongo SSL support

### DIFF
--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -488,9 +488,10 @@ function check_mongo_login() {
     # $DB=$2
     # $USER=$3
     # $PASS=$4
+    # $SSL=$5
     verbose checking mongo db login access
     ssl_opt=""
-    if [ "${APP_VALUES[DS_SSL]}" == "true" ]
+    if [ "$5" == "true" ]
     then
         ssl_opt="--ssl"
     fi
@@ -590,7 +591,7 @@ function check_datastore_mongo() {
     fi
 
     # check OpenShift Origin user (username/password)
-    check_mongo_login "${APP_VALUES[DS_HOST]}:${APP_VALUES[DS_PORT]}" ${APP_VALUES[DS_NAME]} ${APP_VALUES[DS_USER]} ${APP_VALUES[DS_PASS]}
+    check_mongo_login "${APP_VALUES[DS_HOST]}:${APP_VALUES[DS_PORT]}" ${APP_VALUES[DS_NAME]} ${APP_VALUES[DS_USER]} ${APP_VALUES[DS_PASS]} ${APP_VALUES[DS_SSL]}
 }
 
 function check_auth_mongo() {
@@ -656,7 +657,7 @@ function check_auth_mongo() {
     fi
 
     # check OpenShift Origin user (username/password)
-    check_mongo_login "${APP_VALUES[DS_HOST]}:${APP_VALUES[DS_PORT]}" ${APP_VALUES[DS_NAME]} ${APP_VALUES[DS_USER]} ${APP_VALUES[DS_PASS]}
+    check_mongo_login "${APP_VALUES[DS_HOST]}:${APP_VALUES[DS_PORT]}" ${APP_VALUES[DS_NAME]} ${APP_VALUES[DS_USER]} ${APP_VALUES[DS_PASS]} ${APP_VALUES[DS_SSL]}
 }
 
 function get_http_response_code() {

--- a/broker/config/mongoid.yml
+++ b/broker/config/mongoid.yml
@@ -12,10 +12,10 @@ production:
         <% end %>
       username: "<%= config[:user] %>"
       password: "<%= config[:password] %>"
-      ssl: <%= config[:ssl] %>
       options:
         consistency: :strong
         safe: true
+        ssl: <%= config[:ssl] %>
   options:
     raise_not_found_error: true
 development:
@@ -32,10 +32,10 @@ development:
         <% end %>
       username: "<%= config[:user] %>"
       password: "<%= config[:password] %>"
-      ssl: <%= config[:ssl] %>
       options:
         consistency: :strong
         safe: true
+        ssl: <%= config[:ssl] %>
   options:
     raise_not_found_error: true
 test:
@@ -52,9 +52,9 @@ test:
         <% end %>
       username: "<%= config[:user] %>"
       password: "<%= config[:password] %>"
-      ssl: <%= config[:ssl] %>
       options:
         consistency: :strong
         safe: true
+        ssl: <%= config[:ssl] %>
   options:
     raise_not_found_error: true


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=958674

Update Broker mongoid config to properly support SSL connections to
mongo.

Update oo-accept-broker to not fail when attempting auth to mongo over
an SSL connection
