### PR TITLE
Fix for bug 959178

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -577,7 +577,11 @@ module OpenShift
 
     # reload gear as supported by cartridges
     def reload(cart_name)
-      @cartridge_model.do_control('reload', cart_name) if State::STARTED == state.value
+      if State::STARTED == state.value
+        return @cartridge_model.do_control('reload', cart_name)
+      else
+        return "Application or component not running. Cannot reload."
+      end
     end
 
     ##


### PR DESCRIPTION
reload was returning nil for stopped cartridges/applications and << was exploding.
