### PR TITLE
Bug 959123: Modify postgres dump on restore to connect to proper database

### DIFF
--- a/cartridges/openshift-origin-cartridge-postgresql/bin/control
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/control
@@ -102,7 +102,7 @@ function post_restore {
     zcat $dump_file | \
       sed "s#$rexp#\\1 DATABASE $new_db#g;           \
       s#$owner_rexp#\\1 \\2 OWNER = \"$new_user\"#g; \
-      s#\\connect $old_db#\\connect $new_db#g;       \
+      s#\\\\connect $old_db#\\\\connect $new_db#g;   \
       s#$old_user#$new_user#g;" |  \
       psql -U postgres -d postgres
 

--- a/cartridges/openshift-origin-cartridge-postgresql/bin/install
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/install
@@ -9,7 +9,7 @@ env_dir="${OPENSHIFT_POSTGRESQL_DIR}/env"
 echo 'Generating username and password'
 
 # Force the username to be all lowercase and not include o,O,0
-username=$(generate_username admin 12 'a-np-z1-9')
+username=$(generate_username)
 password=$(generate_password)
 
 set_env_var 'OPENSHIFT_POSTGRESQL_DB_USERNAME' $username $env_dir

--- a/node/misc/usr/lib/cartridge_sdk/bash/sdk
+++ b/node/misc/usr/lib/cartridge_sdk/bash/sdk
@@ -114,9 +114,10 @@ function random_string {
 
   local len=${1-$DEFAULT_LEN}
   local space=${2-"${DEFAULT_SPACE}"}
+  local omit=${3-""}
 
   local rnd=$(head -n 50 /dev/urandom | tr -dc $space | fold -w $len)
-  [ "$3" ] && rnd=$(echo "${rnd}" | grep -v "${3}")
+  [ -n "${omit}" ] && rnd=$(echo "${rnd}" | grep -v "${omit}")
   echo $(echo "${rnd}" | head -n1)
 }
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=959123

When restoring the database, the `\connect` option was not being properly changed due to escaping "\" in the `sed` command.
Also, the username was not properly being generated due to a bug in the Bash SDK when using `set -u`.
