### PR TITLE
Updating the v2 Jenkins version to match the RPM'd jenkins we use

### DIFF
--- a/cartridges/openshift-origin-cartridge-jenkins-client/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/metadata/manifest.yml
@@ -1,8 +1,8 @@
 Name: jenkins-client
 Cartridge-Short-Name: JENKINS_CLIENT
-Display-Name: Jenkins Client 1.4
+Display-Name: Jenkins Client 1.5
 Description: "The Jenkins client connects to your Jenkins application and enables builds and testing of your application. Requires the Jenkins Application to be created via the new application page."
-Version: '1.4'
+Version: '1.5'
 License: ASL 2.0
 Cartridge-Version: 0.0.1
 Cartridge-Vendor: redhat

--- a/cartridges/openshift-origin-cartridge-jenkins/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jenkins/metadata/manifest.yml
@@ -1,8 +1,8 @@
 Name: jenkins
 Cartridge-Short-Name: JENKINS
-Display-Name: Jenkins Server 1.4
+Display-Name: Jenkins Server 1.5
 Description: "Jenkins is a continuous integration (CI) build server that is deeply integrated into OpenShift. See the Jenkins info page for more."
-Version: '1.4'
+Version: '1.5'
 License: MIT license
 License-Url: http://jenkinsci.org/mitlicense
 Cartridge-Version: 0.0.1


### PR DESCRIPTION
Is there any reason we wouldn't do this now?  Does it require any sort of migration?

I'm assuming test scripts that explicitly use jenkins 1.4 and jenkins-client 1.4 would need to be updated.

I checked and Online, Origin and Enterprise are all using Jenkins 1.5 now.  Makes me wonder if we should go ahead and update our RPM requirements to require 1.5 or greater since that's all we're testing with and I believe the version in the cartridge and the installed jenkins should always match.
