### PR TITLE
Bug 958694: Make .state gear scoped and refactor primary cart concept

### DIFF
--- a/common/lib/openshift-origin-common/models/manifest.rb
+++ b/common/lib/openshift-origin-common/models/manifest.rb
@@ -207,7 +207,7 @@ module OpenShift
         @name                   = @manifest['Name']
         @short_name             = @manifest['Cartridge-Short-Name']
         @categories             = @manifest['Categories'] || []
-        @is_primary             = @categories.include?('web_framework')
+        @is_deployable          = @categories.include?('web_framework')
         @is_web_proxy           = @categories.include?('web_proxy')
         @install_build_required = @manifest.has_key?('Install-Build-Required') ? @manifest['Install-Build-Required'] : true
 
@@ -257,9 +257,12 @@ module OpenShift
         @endpoints.select { |e| e.public_port_name }
       end
 
-      def primary?
-        @is_primary
+      def deployable?
+        @is_deployable
       end
+
+      # For now, these are synonyms
+      alias :buildable? :deployable?
 
       def web_proxy?
         @is_web_proxy

--- a/console/test/integration/rest_api/application_test.rb
+++ b/console/test/integration/rest_api/application_test.rb
@@ -99,11 +99,11 @@ class RestApiApplicationTest < ActiveSupport::TestCase
     with_configured_user
     setup_domain
 
-    assert_create_app({:include => :cartridges, :initial_git_url => 'https://github.com/openshift/wordpress-example', :cartridges => ['php-5.3']}, "Set initial git URL") do |app|
-      assert_equal ['php-5.3'], app.cartridges.map(&:name)
+    assert_create_app({:include => :cartridges, :initial_git_url => 'https://github.com/openshift/nodejs-example', :cartridges => ['nodejs-0.6']}, "Set initial git URL") do |app|
+      assert_equal ['nodejs-0.6'], app.cartridges.map(&:name)
       loaded_app = Application.find(app.name, :params => {:domain_id => @domain.id}, :as => @user)
       omit("No initial_git_url returned") unless loaded_app.initial_git_url
-      assert_equal "https://github.com/openshift/wordpress-example", loaded_app.initial_git_url
+      assert_equal "https://github.com/openshift/nodejs-example", loaded_app.initial_git_url
     end
   end
 

--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -104,13 +104,15 @@ module OpenShift
       if @build_model == :v1
         if template_git_url
           cartridge = @cartridge_model.get_cartridge(cart_name)
-          output = @cartridge_model.resolve_application_dependencies(cart_name) if cartridge.primary?        
+          output = @cartridge_model.resolve_application_dependencies(cart_name) if cartridge.buildable?        
         end
       else
       
         cartridge = @cartridge_model.get_cartridge(cart_name)
 
-        if cartridge.install_build_required || template_git_url
+        # Only perform an initial build if the manifest explicitly specifies a need,
+        # or if a template Git URL is provided and the cart is capable of builds or deploys.
+        if cartridge.install_build_required || (template_git_url && cartridge.buildable?)
           gear_script_log = '/tmp/initial-build.log'
           env             = Utils::Environ.for_gear(@user.homedir)
   

--- a/node/lib/openshift-origin-node/model/v1_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v1_cart_model.rb
@@ -30,7 +30,7 @@ module OpenShift
         # Return a cartridge in the gear; the primary if there is one.
         each_cartridge do |cartridge|
           cartridge_name = cartridge.name
-          break if cartridge.primary?
+          break if cartridge.deployable?
         end
       end
       if cartridge_name.nil?
@@ -75,7 +75,7 @@ module OpenShift
       cart = nil
       each_cartridge do |cartridge|
         cart = cartridge
-        break if cartridge.primary?
+        break if cartridge.deployable?
       end
 
       if cart.nil?

--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -80,15 +80,16 @@ module OpenShift
     end
 
     ##
-    # Returns the +Cartridge+ in the gear whose +primary+ flag is set to true,
-    #
-    # Raises an exception if no such cartridge is present.
+    # Returns the primary +Cartridge+ in the gear as specified by the
+    # +OPENSHIFT_PRIMARY_CARTRIDGE_DIR+ environment variable, or +Nil+ if
+    # no primary cartridge is present.
     def primary_cartridge
-      each_cartridge do |cartridge|
-        return cartridge if cartridge.primary?
-      end
+      env              = Utils::Environ.for_gear(@user.homedir)
+      primary_cart_dir = env['OPENSHIFT_PRIMARY_CARTRIDGE_DIR']
 
-      raise "No primary cartridge found on gear #{@user.uuid}"
+      raise "No primary cartridge detected in gear #{@user.uuid}" unless primary_cart_dir
+      
+      return get_cartridge_from_directory(File.basename(primary_cart_dir))
     end
 
     ##
@@ -149,6 +150,8 @@ module OpenShift
 
     # Load cartridge's local manifest from cartridge directory name
     def get_cartridge_from_directory(directory)
+      raise "Directory name is required" if (directory == nil || directory.empty?)
+
       unless @cartridges.has_key? directory
         cartridge_path = PathUtils.join(@user.homedir, directory)
         manifest_path  = PathUtils.join(cartridge_path, 'metadata', 'manifest.yml')
@@ -251,7 +254,7 @@ module OpenShift
             output << cartridge_action(cartridge, 'setup', software_version, true)
             process_erb_templates(c.directory)
             output << cartridge_action(cartridge, 'install', software_version)
-            populate_gear_repo(c.directory, template_git_url) if cartridge.primary?
+            populate_gear_repo(c.directory, template_git_url) if cartridge.deployable?
           end
 
         end
@@ -415,7 +418,14 @@ module OpenShift
 
       envs.clear
       envs['namespace'] = @user.namespace if @user.namespace
-      envs['primary_cartridge_dir'] = target + File::SEPARATOR if cartridge.primary?
+
+      # If there's not already a primary cartridge on the gear, assume
+      # the new cartridge is the primary.
+      current_gear_env = Utils::Environ.for_gear(@user.homedir)
+      unless current_gear_env['OPENSHIFT_PRIMARY_CARTRIDGE_DIR']
+        envs['primary_cartridge_dir'] = target + File::SEPARATOR
+        logger.info("Cartridge #{cartridge.name} recorded as primary within gear #{@user.uuid}")
+      end
 
       unless envs.empty?
         write_environment_variables(File.join(@user.homedir, '.env'), envs)
@@ -1045,8 +1055,8 @@ module OpenShift
 
       buffer = ''
       each_cartridge do |cartridge|
-        next if options[:primary_only] and not cartridge.primary?
-        next if options[:secondary_only] and cartridge.primary?
+        next if options[:primary_only] and cartridge.name != primary_cartridge.name
+        next if options[:secondary_only] and cartridge.name == primary_cartridge.name
 
         buffer << start_cartridge('start', cartridge, options)
       end
@@ -1087,7 +1097,7 @@ module OpenShift
         return "Not starting cartridge #{cartridge.name} because the application was explicitly stopped by the user"
       end
 
-      if cartridge.primary?
+      if cartridge.name == primary_cartridge.name
         FileUtils.rm_f(stop_lock) if options[:user_initiated]
         @state.value = OpenShift::State::STARTED
       end
@@ -1138,7 +1148,7 @@ module OpenShift
         return "Not stopping cartridge #{cartridge.name} because the application was explicitly stopped by the user"
       end
 
-      if cartridge.primary?
+      if cartridge.name == primary_cartridge.name
         create_stop_lock if options[:user_initiated]
         @state.value = OpenShift::State::STOPPED
       end


### PR DESCRIPTION
Make the .state file represent the state of a gear rather than the application
as a whole. Redefine the concept of the 'primary' cartridge as the first cartridge
installed on the gear. Add state to Runtime::Manifest to flag a cartridge as
'buildable' or 'deployable' in order to make more granular decisions related
to the build process which are unrelated to the primary cartridge concept.

Move the platform closer to cartridge level state management.

Resolve bug 958694.
