### PR TITLE
Do not validate vendor and cartridge names when instantiating Manifest from filesystem

### DIFF
--- a/common/lib/openshift-origin-common/models/manifest.rb
+++ b/common/lib/openshift-origin-common/models/manifest.rb
@@ -172,7 +172,7 @@ module OpenShift
       #
       #   Cartridge.new('/var/lib/openshift/.cartridge_repository/php/1.0/metadata/manifest.yml', '3.5', '.../.cartridge_repository') -> Cartridge
       #   Cartridge.new('Name: ...', '3.5') -> Cartridge
-      def initialize(manifest, version=nil, repository_base_path='')
+      def initialize(manifest, version=nil, repository_base_path='', check_names=true)
 
         if File.exist? manifest
           @manifest      = YAML.load_file(manifest)
@@ -220,9 +220,11 @@ module OpenShift
         raise MissingElementError.new(nil, 'Name') unless @name
         #raise InvalidElementError.new(nil, 'Name') if @name.include?('-')
 
-        validate_vendor_name
-        validate_cartridge_name
-        check_reserved_cartridge_name
+        if check_names
+          validate_vendor_name
+          validate_cartridge_name
+          check_reserved_cartridge_name
+        end
 
         if @manifest.has_key?('Source-Url')
           raise InvalidElementError.new(nil, 'Source-Url') unless @manifest['Source-Url'] =~ URI::ABS_URI

--- a/node/lib/openshift-origin-node/model/cartridge_repository.rb
+++ b/node/lib/openshift-origin-node/model/cartridge_repository.rb
@@ -113,9 +113,11 @@ module OpenShift
     #   CartridgeRepository.instance.load("/var/lib/openshift/.cartridge_repository")  #=> 24
     def load(directory = nil)
       @semaphore.synchronize do
+        load_via_url = directory.nil?
         find_manifests(directory || @path) do |manifest_path|
           logger.debug { "Loading cartridge from #{manifest_path}" }
-          c = insert(OpenShift::Runtime::Manifest.new(manifest_path, nil, @path))
+          # we check the vendor and cartridge names only when loading via URL
+          c = insert(OpenShift::Runtime::Manifest.new(manifest_path, nil, @path, load_via_url))
           logger.debug { "Loaded cartridge (#{c.name}, #{c.version}, #{c.cartridge_version})" }
         end
       end


### PR DESCRIPTION
This addresses Bug 959843.
