### PR TITLE
Never use the Puppetlabs repos

### DIFF
--- a/documentation/install_origin_using_puppet.md
+++ b/documentation/install_origin_using_puppet.md
@@ -17,20 +17,9 @@ The OpenShift Origin RPMs can be available from:
 
 ## Installing Puppet
 
-You will also need to install the latest puppet and facter RPMS from [PuppetLabs](https://puppetlabs.com/).
-Create the following on each host:
+  Note: For RHEL systems you will need to include the [EPEL repository](http://fedoraproject.org/wiki/EPEL) to install puppet. To do so install the latest `epel-release` package found [here](http://download.fedoraproject.org/pub/epel/6/i386/repoview/epel-release.html)
 
-File: /etc/yum.repos.d/puppetlabs-products.repo
-
-Contents:
-
-    [puppetlabs-products]
-    name=puppetlabs-products
-    baseurl=http://yum.puppetlabs.com/fedora/f17/products/x86_64/
-    gpgkey=http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
-    exclude=mcollective*
-    gpgcheck=1
-    enabled=1
+    yum install -y --nogpgcheck ${url_of_the_latest_epel-release_rpm}
 
 Run the following to install puppet and facter
 


### PR DESCRIPTION
The Puppetlabs repositories are unsafe for use on any RHEL system.  They replace system / EPEL packages and upgrade to backwards incompatible versions of their own packages without warning.
