### PR TITLE
Use rhcsh for psql commands

### DIFF
--- a/controller/test/cucumber/support/sql_helper.rb
+++ b/controller/test/cucumber/support/sql_helper.rb
@@ -22,7 +22,7 @@ module SQLHelper
       '-d' => '$OPENSHIFT_APP_NAME' # always use proper db name
     }
 
-    cmd = @psql_helper ? "psql" : "/usr/bin/psql"
+    cmd = "rhcsh #{@psql_helper ? "psql" : "/usr/bin/psql"}"
 
     # SCP the file so we don't have to worry about escaping SQL
     if @app.respond_to?(:scp_content)


### PR DESCRIPTION
Due to a bug in trap user, `rhcsh` isn't used when executing these commands directly. This fix only affects cucumber tests.
