### PR TITLE
Bug 961661 - Limit scalability of Jenkins v2 cart

### DIFF
--- a/cartridges/openshift-origin-cartridge-jenkins/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jenkins/metadata/manifest.yml
@@ -74,4 +74,7 @@ Endpoints:
       - Frontend:      "/health"
         Backend:       ""
         Options:       { health: true }
+Scaling:
+  Min: 1
+  Max: 1
 Install-Build-Required: false


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=961661

Adding scaling limitation of 1 gear for
openshift-origin-cartridge-jenkins
