### PR TITLE
<openshift-console> Bug 961888 - Fix SELinux context for httpd run dir

### DIFF
--- a/openshift-console/openshift-origin-console.spec
+++ b/openshift-console/openshift-origin-console.spec
@@ -224,6 +224,7 @@ fi
 /usr/sbin/semanage -i - <<_EOF
 fcontext -a -t httpd_log_t '%{_var}/log/openshift/console(/.*)?'
 fcontext -a -t httpd_log_t '%{_var}/log/openshift/console/httpd(/.*)?'
+fcontext -a -t httpd_var_run_t '%{consoledir}/httpd/run(/.*)?'
 _EOF
 /sbin/restorecon -R %{_var}/log/openshift/console
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=961888

Sets the proper SELinux context on /var/www/openshift/console/httpd/run
(httpd_var_run_t)
