### PR TITLE
<oo-accept-broker> Bug 959164 - Fix mongo test with replica sets

### DIFF
--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -513,8 +513,8 @@ function check_datastore_mongo() {
 
     # get the service hostname, port, username, password
 	APP_VALUE_MAP=(
-		["DS_HOST"]="Rails.application.config.datastore[:host_port].split(':')[0]"
-		["DS_PORT"]="Rails.application.config.datastore[:host_port].split(':')[1]"
+		["DS_HOST"]="Rails.application.config.datastore[:host_port].split(',')[0].split(':')[0]"
+		["DS_PORT"]="Rails.application.config.datastore[:host_port].split(',')[0].split(':')[1]"
 		["DS_USER"]="Rails.application.config.datastore[:user]"
 		["DS_PASS"]="Rails.application.config.datastore[:password]"
 		["DS_NAME"]="Rails.application.config.datastore[:db]"
@@ -599,8 +599,8 @@ function check_auth_mongo() {
 
     # get the service hostname, port, username, password
 	APP_VALUE_MAP=(
-		["DS_HOST"]="Rails.application.config.auth[:mongo_host_port].split(':')[0]"
-		["DS_PORT"]="Rails.application.config.auth[:mongo_host_port].split(':')[1]"
+		["DS_HOST"]="Rails.application.config.datastore[:host_port].split(',')[0].split(':')[0]"
+		["DS_PORT"]="Rails.application.config.datastore[:host_port].split(',')[0].split(':')[1]"
 		["DS_USER"]="Rails.application.config.auth[:mongo_user]"
 		["DS_PASS"]="Rails.application.config.auth[:mongo_password]"
 		["DS_NAME"]="Rails.application.config.auth[:mongo_db]"

--- a/broker-util/openshift-origin-broker-util.spec
+++ b/broker-util/openshift-origin-broker-util.spec
@@ -19,6 +19,7 @@ Requires:      %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
 %endif
 Requires:      openshift-origin-broker
 Requires:      %{?scl:%scl_prefix}rubygem-rest-client
+Requires:      mongodb
 # For oo-register-dns
 Requires:      bind-utils
 # For oo-admin-broker-auth


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=959164

Fix mongo db tests in oo-accept-broker when using a mongo replica set.

Added a Require for mongodb (the client package) for
openshift-origin-broker-util, otherwise oo-accept-broker fails when the
mongodb host is not the same as the broker.
