### PR TITLE
<controller,broker-util> Bug 961255 - DataStore fixes for mongo ssl

### DIFF
--- a/broker-util/oo-analytics-import
+++ b/broker-util/oo-analytics-import
@@ -44,11 +44,12 @@ end
 def analytics_db(read_preference=:secondary, session_name='default')
   config = Mongoid::Config.sessions[session_name]
   hosts = config['hosts']
+  ssl = config['options']['ssl']
   if hosts.length > 1
-    con = Mongo::ReplSetConnection.new(hosts, {:read => read_preference})
+    con = MongoReplicaSetClient.new(hosts, :read => read_preference, :ssl => ssl)
   else
     host_port = hosts[0].split(':')
-    con = Mongo::Connection.new(host_port[0], host_port[1].to_i)
+    con = MongoClient.new(host_port[0], host_port[1].to_i, :ssl => ssl)
   end
   adb = con.db('analytics')
   adb.authenticate(config['username'], config['password'])

--- a/controller/lib/openshift/data_store.rb
+++ b/controller/lib/openshift/data_store.rb
@@ -1,14 +1,17 @@
 module OpenShift
   class DataStore
 
+    include Mongo
+
     def self.db(read_preference=:secondary, session_name='default')
       config = Mongoid::Config.sessions[session_name]
       hosts = config['hosts']
+      ssl = config['options']['ssl']
       if hosts.length > 1
-        con = Mongo::ReplSetConnection.new(hosts, {:read => read_preference})
+        con = MongoReplicaSetClient.new(hosts, :read => read_preference, :ssl => ssl)
       else
         host_port = hosts[0].split(':')
-        con = Mongo::Connection.new(host_port[0], host_port[1].to_i)
+        con = MongoClient.new(host_port[0], host_port[1].to_i, :ssl => ssl)
       end
       db = con.db(config['database'])
       db.authenticate(config['username'], config['password'])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=961255

Switching Mongo::Connection references to MongoClient and MongoReplicaSetClient to allow ssl connections if enabled
