### PR TITLE
<openshift-console> - Run restorecon on ${consoledir} in %post

### DIFF
--- a/openshift-console/openshift-origin-console.spec
+++ b/openshift-console/openshift-origin-console.spec
@@ -227,6 +227,7 @@ fcontext -a -t httpd_log_t '%{_var}/log/openshift/console/httpd(/.*)?'
 fcontext -a -t httpd_var_run_t '%{consoledir}/httpd/run(/.*)?'
 _EOF
 /sbin/restorecon -R %{_var}/log/openshift/console
+/sbin/restorecon -R %{consoledir}
 
 /sbin/fixfiles -R %{?scl:%scl_prefix}rubygem-passenger restore
 /sbin/fixfiles -R %{?scl:%scl_prefix}mod_passenger restore


### PR DESCRIPTION
Previously set the policy to update the context on
${consoledir}/httpd/run, but didn't do a restorecon in %post to apply
the policy, this fixes that.
