### PR TITLE
Add erb processing to managed_files.yml

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/metadata/managed_files.yml
@@ -2,3 +2,5 @@
 locked_files:
 - metadata/
 - env/
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-cron/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-cron/metadata/managed_files.yml
@@ -4,3 +4,5 @@ locked_files:
 - cron/metadata/
 - cron/env/
 - cron/conf/
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-diy/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-diy/metadata/managed_files.yml
@@ -5,3 +5,5 @@ locked_files:
 - env/
 - tmp/
 - conf/
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-haproxy/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-haproxy/metadata/managed_files.yml
@@ -1,3 +1,5 @@
 ---
 locked_files:
 - env/
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-jbossas/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-jbossas/metadata/managed_files.yml
@@ -6,3 +6,5 @@ locked_files:
 - env/OPENSHIFT_JBOSSAS_VERSION
 - env/M2_HOME
 - template/
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-jbosseap/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-jbosseap/metadata/managed_files.yml
@@ -3,3 +3,5 @@ locked_files:
 - metadata/
 - env/
 - template/
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-jenkins-client/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/metadata/managed_files.yml
@@ -4,3 +4,5 @@ locked_files:
 - metadata/
 - configuration/
 - env/
+processed_templates:
+- "**/*.erb"

--- a/cartridges/openshift-origin-cartridge-jenkins/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-jenkins/metadata/managed_files.yml
@@ -3,3 +3,5 @@ locked_files:
 - ~/.jenkins_password
 - metadata/
 - env/
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-mock-plugin/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-mock-plugin/metadata/managed_files.yml
@@ -1,3 +1,5 @@
 ---
 locked_files:
 - env/
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-mock/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-mock/metadata/managed_files.yml
@@ -5,3 +5,5 @@ locked_files:
 - ~/.mock_gear_locked_file
 - ~/app-root/data/mock_gear_data_locked_file
 - ~/invalid_mock_locked_file
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-mongodb/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-mongodb/metadata/managed_files.yml
@@ -1,3 +1,5 @@
 ---
 snapshot_exclusions:
 - redhat-mongodb/*
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-mysql/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-mysql/metadata/managed_files.yml
@@ -5,3 +5,5 @@ locked_files:
 - env/OPENSHIFT_MYSQL_DB_USERNAME
 - env/OPENSHIFT_MYSQL_DB_PASSWORD
 - env/OPENSHIFT_MYSQL_DB_URL
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-nodejs/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-nodejs/metadata/managed_files.yml
@@ -3,3 +3,5 @@ locked_files:
 - metadata/
 - env/
 - etc/
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-perl/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-perl/metadata/managed_files.yml
@@ -3,3 +3,5 @@ locked_files:
 - metadata/
 - env/
 - etc/
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-php/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-php/metadata/managed_files.yml
@@ -5,3 +5,5 @@ locked_files:
 - metadata/
 - env/
 - conf/
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/metadata/managed_files.yml
@@ -5,3 +5,5 @@ locked_files:
 - conf.d/
 - phpMyAdmin/
 - env/
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-postgresql/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-postgresql/metadata/managed_files.yml
@@ -6,3 +6,5 @@ locked_files:
 - env/PGDATABASE
 - env/PGDATA
 - env/PGHOST
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-python/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-python/metadata/managed_files.yml
@@ -5,3 +5,5 @@ locked_files:
 - env/
 - etc/
 - template/
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-ruby/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/managed_files.yml
@@ -4,3 +4,5 @@ locked_files:
 - env/
 - etc/
 - template/
+processed_templates:
+- '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-switchyard/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-switchyard/metadata/managed_files.yml
@@ -1,3 +1,5 @@
 ---
 locked_files:
 - env/
+processed_templates:
+- '**/*.erb'

--- a/node/lib/openshift-origin-node/model/v1_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v1_cart_model.rb
@@ -302,8 +302,8 @@ module OpenShift
       raise NotImplementedError.new('V1 snapshot is not implemented via ApplicationContainer')
     end
 
-    def lock_files(cartridge)
-      raise NotImplementedError.new('V1 lock_files is not implemented via ApplicationContainer')
+    def locked_files(cartridge)
+      raise NotImplementedError.new('V1 locked_files is not implemented via ApplicationContainer')
     end
 
     def snapshot_exclusions(cartridge)
@@ -318,8 +318,8 @@ module OpenShift
       raise NotImplementedError.new('V1 restore_transforms is not implemented via ApplicationContainer')
     end
 
-    def process_templates(cartridge)
-      raise NotImplementedError.new('V1 process_templates is not implemented via ApplicationContainer')
+    def processed_templates(cartridge)
+      raise NotImplementedError.new('V1 processed_templates is not implemented via ApplicationContainer')
     end
   end
 end

--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -252,7 +252,7 @@ module OpenShift
         Dir.chdir(@user.homedir) do
           unlock_gear(cartridge) do |c|
             output << cartridge_action(cartridge, 'setup', software_version, true)
-            process_erb_templates(c.directory)
+            process_erb_templates(c)
             output << cartridge_action(cartridge, 'install', software_version)
             populate_gear_repo(c.directory, template_git_url) if cartridge.deployable?
           end
@@ -326,7 +326,7 @@ module OpenShift
     #
     #   v2_cart_model.unlock_gear('php-5.3')
     def unlock_gear(cartridge, relock = true)
-      files = lock_files(cartridge)
+      files = locked_files(cartridge)
       begin
         do_unlock(files)
         yield cartridge
@@ -509,12 +509,13 @@ module OpenShift
     # process_erb_templates(cartridge_name) -> nil
     #
     # Search cartridge for any remaining <code>erb</code> files render them
-    def process_erb_templates(cartridge_name)
-      directory = File.join(@user.homedir, cartridge_name)
-      logger.info "Processing ERB templates for #{directory}/**"
+    def process_erb_templates(cartridge)
+      directory = PathUtils.join(@user.homedir, cartridge.name)
+      logger.info "Processing ERB templates for #{cartridge}"
 
       env = Utils::Environ.for_gear(@user.homedir, directory)
-      render_erbs(env, File.join(directory, '**'))
+      erbs = processed_templates(cartridge).map { |x| PathUtils.join(@user.homedir, x) }
+      render_erbs(env, erbs)
     end
 
     #  cartridge_action(cartridge, action, software_version, render_erbs) -> buffer
@@ -536,7 +537,8 @@ module OpenShift
 
       cartridge_env = gear_env.merge(Utils::Environ.load(cartridge_env_home))
       if render_erbs
-        render_erbs(cartridge_env, cartridge_env_home)
+        erbs = Dir.glob(cartridge_env_home + '/*.erb', File::FNM_DOTMATCH).select { |f| File.file?(f) }
+        render_erbs(cartridge_env, erbs)
         cartridge_env = gear_env.merge(Utils::Environ.load(cartridge_env_home))
       end
 
@@ -551,14 +553,13 @@ module OpenShift
       out
     end
 
-    # render_erbs(program environment as a hash, erb_path_glob) -> nil
+    # render_erbs(program environment as a hash, erbs) -> nil
     #
-    # Using the path globbing provided + '/*.erb', run <code>erb</code> against each template tile.
-    # See <code>Dir.glob</code> and <code>OpenShift::Utils.oo_spawn</code>
+    # Run <code>erb</code> against each template file submitted
     #
-    #   v2_cart_model.render_erbs({HOMEDIR => '/home/no_place_like'}, '/var/lib/...cartridge/env')
-    def render_erbs(env, path_glob)
-      Dir.glob(path_glob + '/*.erb', File::FNM_DOTMATCH).select { |f| File.file?(f) }.each do |file|
+    #   v2_cart_model.render_erbs({HOMEDIR => '/home/no_place_like'}, ['/var/lib/openshift/user/cart/foo.erb', ...])
+    def render_erbs(env, erbs)
+      erbs.each do |file|
         begin
           Utils.oo_spawn(%Q{/usr/bin/oo-erb -S 2 -- #{file} > #{file.chomp('.erb')}},
                          env:                 env,

--- a/node/test/unit/managed_files_test.rb
+++ b/node/test/unit/managed_files_test.rb
@@ -22,6 +22,7 @@ require_relative '../test_helper'
 module OpenShift
   class ManagedFilesTest < OpenShift::V2SdkTestCase
     include ManagedFiles
+
     def setup
       @user = OpenStruct.new({
         :homedir =>  "#{Dir.mktmpdir}/"
@@ -32,48 +33,86 @@ module OpenShift
         :directory =>  'mock'
       })
       FileUtils.mkdir_p(File.join(@user.homedir,@cartridge.directory))
+    end
 
-      # TODO: Don't actually need to create the files until we want to test globbing
-=begin
-      %w(
-        .good
-        bad
-        app-root/good
-        mock/good
-        .ssh/bad
-        ../bad
-      ).each do |path|
-        full_path = File.join(@user.homedir,path)
-        dir = File.dirname(full_path)
-        FileUtils.mkdir_p(dir)
-        FileUtils.touch(full_path)
-      end
-=end
-
-      good_files = %w(~/.good ~/app-root/good good ~/app-root/foo/good/) << "~/#{@cartridge.directory}/good"
-      blacklist_files = %w(~/.ssh/bad)
-      oob_files = %w(~/../bad)
-      @managed_files = {
-        :locked_files => good_files | blacklist_files | oob_files
-      }
-
+    # Set the managed_files hash
+    def set_managed_files(hash)
       File.join(@user.homedir,@cartridge.directory,'metadata','managed_files.yml').tap do |manifest_file|
         FileUtils.mkdir_p(File.dirname(manifest_file))
         File.open(manifest_file,'w') do |f|
-          f.write(@managed_files.to_yaml)
+          f.write(hash.to_yaml)
         end
       end
     end
 
-    def test_get_managed_files
-      assert_equal @managed_files[:locked_files], managed_files(@cartridge, :locked_files, @user.homedir, false)
+    # Create files for globbing
+    def touch_files(files)
+      files.each do |path|
+        full_path = File.join(@user.homedir,@cartridge.directory,path)
+        dir = File.dirname(full_path)
+        FileUtils.mkdir_p(dir)
+        FileUtils.touch(full_path)
+      end
     end
 
-    def test_get_locked_files
-      # The lock_files are returned relative to the homedir without the ~/
-      expected_files = %w(.good app-root/good mock/good mock/good).map{|x| File.join(@user.homedir,x) }
-      expected_files << "#{File.join(@user.homedir,'app-root','foo','good')}/"
-      assert_equal expected_files.sort, lock_files(@cartridge).sort
+    # Transform relative file paths
+    def chroot_files(files)
+      files.map do |x|
+        x = "~/#{@cartridge.name}/#{x}" unless x.start_with?("~")
+        x.sub(/^~\//,@user.homedir)
+      end
+    end
+
+    def test_missing_managed_files
+      logger = mock()
+      logger.expects(:info).with { |x| x =~ /.yml is missing$/ }
+      NodeLogger.expects(:logger).returns(logger)
+      assert_empty managed_files(@cartridge, :foo, @user.homedir)
+    end
+
+    # Ensure that managed_files does not attempt to render the values in any way
+    def test_get_managed_files
+      %w(a ./b /c ~/d e/f/g).tap do |expected|
+        set_managed_files({:foo => expected})
+        assert_equal expected, managed_files(@cartridge, :foo, @user.homedir, false)
+      end
+    end
+
+    # Ensure locked_files does not return bad entries
+    def test_get_locked_files_static
+      good_files = %w(~/.good ~/app-root/good good ~/app-root/foo/good/) << "~/#{@cartridge.directory}/good"
+      blacklist_files = %w(~/.ssh/bad)
+      oob_files = %w(~/../bad)
+      set_managed_files({:locked_files => good_files | blacklist_files | oob_files })
+
+      expected_files = chroot_files(good_files)
+      assert_equal expected_files.sort, locked_files(@cartridge).sort
+    end
+
+    # Ensure the glob doesn't return unexpected files
+    def test_get_locked_files_glob
+      files = %w(
+        glob/foo/bar/good
+        glob/foo/good
+        glob/bar/baz/good
+        glob/bar/bad/bad
+        conf/foo/bar/good.erb
+      )
+      touch_files(files)
+      expected_files = chroot_files(files).select{|x| x =~ /good/ }
+
+      glob_files = %w(glob/foo/**/* glob/bar/baz/* conf/**/*.erb)
+
+      set_managed_files({:locked_files => glob_files})
+      assert_equal expected_files.sort, locked_files(@cartridge).sort
+    end
+
+    # Ensure that the restore transforms are returned verbatim
+    def test_restore_transforms
+      ['s|${OPENSHIFT_GEAR_NAME}/data|app-root/data|'].tap do |expected|
+        set_managed_files({:restore_transforms => expected})
+        assert_equal expected, restore_transforms(@cartridge)
+      end
     end
   end
 end

--- a/node/test/unit/v2_cart_model_test.rb
+++ b/node/test/unit/v2_cart_model_test.rb
@@ -294,7 +294,7 @@ module OpenShift
     # Flow control for unlock_gear success - block is yielded to
     # with cartridge name, do_unlock_gear and do_lock_gear bound the call.
     def test_unlock_gear_success
-      @model.expects(:lock_files).with('mock-0.1').returns(%w(file1 file2 file3))
+      @model.expects(:locked_files).with('mock-0.1').returns(%w(file1 file2 file3))
       @model.expects(:do_unlock).with(%w(file1 file2 file3))
       @model.expects(:do_lock).with(%w(file1 file2 file3))
 
@@ -309,7 +309,7 @@ module OpenShift
     # even when the block raises and exception.  Exception bubbles
     # out to caller.
     def test_unlock_gear_block_raises
-      @model.expects(:lock_files).with('mock-0.1').returns(%w(file1 file2 file3))
+      @model.expects(:locked_files).with('mock-0.1').returns(%w(file1 file2 file3))
       @model.expects(:do_unlock).with(%w(file1 file2 file3))
       @model.expects(:do_lock).with(%w(file1 file2 file3))
 
@@ -340,7 +340,7 @@ module OpenShift
       cartridge = mock()
       files = %w(a b c)
 
-      @model.expects(:lock_files).with(cartridge).returns(files)
+      @model.expects(:locked_files).with(cartridge).returns(files)
       @model.expects(:do_unlock).with(files)
       @model.expects(:do_lock).never
 
@@ -353,7 +353,7 @@ module OpenShift
       cartridge = mock()
       files = %w(a b c)
 
-      @model.expects(:lock_files).with(cartridge).returns(files)
+      @model.expects(:locked_files).with(cartridge).returns(files)
       @model.expects(:do_unlock).with(files)
       @model.expects(:do_lock).with(files)
 
@@ -366,7 +366,7 @@ module OpenShift
       cartridge = mock()
       files = %w(a b c)
 
-      @model.expects(:lock_files).with(cartridge).returns(files)
+      @model.expects(:locked_files).with(cartridge).returns(files)
       @model.expects(:do_unlock).with(files)
       @model.expects(:do_lock).with(files)
 
@@ -381,7 +381,7 @@ module OpenShift
       cartridge = mock()
       files = %w(a b c)
 
-      @model.expects(:lock_files).with(cartridge).returns(files)
+      @model.expects(:locked_files).with(cartridge).returns(files)
       @model.expects(:do_unlock).with(files)
       @model.expects(:do_lock).never()
 


### PR DESCRIPTION
Continuation of https://trello.com/c/k9b9aqbH

This adds `processed_templates` to the list of `managed_files`
It also adds test cases and fixes `restore_transforms`

Depends on https://github.com/openshift/li/pull/1367 for additional cartridges.
