### PR TITLE
<cartridge-jbossews> Bug 961628 - Fix Categories listed

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossews/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jbossews/metadata/manifest.yml
@@ -15,7 +15,6 @@ Categories:
   - jboss
   - tomcat
   - tomcat7
-  - tomcat6
   - web_framework
 Website: http://www.redhat.com/products/jbossenterprisemiddleware/web-server/
 Help-Topics:
@@ -107,6 +106,13 @@ Version-Overrides:
       - "jbossews(version) >= 1.0"
       - "jboss-ews-1.0"
       - "jboss-ews-1.0.0"
+    Categories:
+      - service
+      - java
+      - jboss
+      - tomcat
+      - tomcat6
+      - web_framework
     Group-Overrides:
       - components:
         - "jbossews-1.0"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=961628

Update the Categories, so that the EWS 1.0 cartridge does not advertise
tomcat7 and the EWS 2.0 cartridge does not advertise tomcat6
