### PR TITLE
<haproxy_ctld.rb> Bug 962714 - Fix p_usage method to exit immediately

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/haproxy_ctld.rb
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/haproxy_ctld.rb
@@ -327,7 +327,7 @@ Notes:
 1. To start/stop auto scaling in daemon mode run:
     haproxy_watcher (start|stop|restart|run|)
 USAGE
-    exit 255
+    exit! 255
 end
 
 begin


### PR DESCRIPTION
p_usage was run twice when haproxy_ctld was run with -h, since call to
"exit" didn't bypass exit handlers. Changed to "exit!" which drops
straight out of process.

Clone of bug https://bugzilla.redhat.com/show_bug.cgi?id=920990
