### PR TITLE
Bug 959123: Suppress output from psql command during start/stop

### DIFF
--- a/cartridges/openshift-origin-cartridge-postgresql/bin/control
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/control
@@ -8,7 +8,7 @@ function _pg_stop {
 
 function _is_running {
   # Can't use pg_ctl status here because it doesn't mean the db is done starting up
-  psql -l -U postgres 2>&1 > /dev/null
+  psql -l -U postgres &> /dev/null
   return $?
 }
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=959123

The command that runs when checking for psql status was very verbose and
this came through to the user's terminal when using `rhc
start|stop|restart`
