### PR TITLE
DNS nsupdate plugin: added alternate TSIG key algorithms

### DIFF
--- a/plugins/dns/nsupdate/README.md
+++ b/plugins/dns/nsupdate/README.md
@@ -27,7 +27,8 @@ For TSIG authentication, the configuration file must contain the DNSSEC key name
     # TSIG authentication
     #
     BIND_KEYNAME="example.com"
-    BIND_KEYVALUE="base-64 encoded DNSSEC HMAC TSIG"
+    BIND_KEYVALUE="base-64 encoded DNSSEC HMAC TSIG KEY"
+    BIND_KEYALGORITHM=(HMAC-MD5|HMAC-SHA1|HMAC-SHA256|HMAC-SHA512) - MD5 default
 
 ## GSS-TSIG
 

--- a/plugins/dns/nsupdate/conf/openshift-origin-dns-nsupdate.conf.example
+++ b/plugins/dns/nsupdate/conf/openshift-origin-dns-nsupdate.conf.example
@@ -18,6 +18,7 @@ BIND_ZONE="example.com"
 #
 BIND_KEYNAME="example.com"
 BIND_KEYVALUE="base-64 encoded DNSSEC HMAC TSIG"
+#BIND_KEYVALUE=(HMAC-MD5|HMAC-SHA1|HMAC-SHA256|HMAC-512) # Default: HMAC-MD5
 
 # GSS-TSIG (Kerberos) Authentication
 # BIND_KRB_PRINCIPAL=""

--- a/plugins/dns/nsupdate/config/initializers/openshift-origin-dns-nsupdate.rb
+++ b/plugins/dns/nsupdate/config/initializers/openshift-origin-dns-nsupdate.rb
@@ -22,6 +22,7 @@ Broker::Application.configure do
     # TSIG credentials
     :keyname => conf.get("BIND_KEYNAME", nil),
     :keyvalue => conf.get("BIND_KEYVALUE", nil),
+    :keyalgorithm => conf.get("BIND_KEYALGORITHM", "HMAC-MD5")
 
     # GSS-TSIG (kerberos) credentials
     :krb_principal => conf.get("BIND_KRB_PRINCIPAL", nil),

--- a/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
+++ b/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
@@ -29,6 +29,7 @@ module OpenShift
   #    :port => portnumber,
   #    :keyname => "TSIG key name",
   #    :keyvalue => "TSIG key string",
+  #    :keyalgorithm => ["HMAC-MD5"|"HMAC-SHA1"|"HMAC-SHA256"|"HMAC-SHA512"]
   #    :zone => "zone to update",
   #    # only when configuring with parameters
   #    :domain_suffix => "suffix for application domain names"
@@ -52,6 +53,8 @@ module OpenShift
   #   @return [String] the TSIG key name
   # @!attribute [r] keyvalue
   #   @return [String] the TSIG key value
+  # @!attribute [r] keyalgorithm
+  #   @return [String] the TSIG key algorithm
   # @!attribute [r] krb_principal
   #   @return [String] A Kerberos 5 principal
   # @!attribute [r] krb_keytab
@@ -61,7 +64,7 @@ module OpenShift
     @provider = OpenShift::NsupdatePlugin
 
     attr_reader :server, :port, :zone, :domain_suffix
-    attr_reader :keyname, :keyvalue
+    attr_reader :keyname, :keyvalue, :keyalgorithm
     attr_reader :krb_principal, :krb_keytab
 
     # Establish the parameters for a connection to the DNS update service
@@ -82,6 +85,7 @@ module OpenShift
       @port = access_info[:port].to_i
       @keyname = access_info[:keyname]
       @keyvalue = access_info[:keyvalue]
+      @keyalgorithm = access_info[:keyalgorithm] || "HMAC-MD5"
       @krb_principal = access_info[:krb_principal]
       @krb_keytab = access_info[:krb_keytab]
       @zone = access_info[:zone]
@@ -119,7 +123,7 @@ module OpenShift
       end
 
       # If the config gave a TSIG key, use it
-      keystring = @keyname ? "key #{@keyname} #{keyvalue}" : "gsstsig"
+      keystring = @keyname ? "key #{@keyalgorithm}:#{@keyname} #{keyvalue}" : "gsstsig"
 
       # compose the nsupdate add command
       cmd += %{nsupdate <<EOF

--- a/plugins/dns/nsupdate/spec/unit/openshift-origin-dns-nsupdate_spec.rb
+++ b/plugins/dns/nsupdate/spec/unit/openshift-origin-dns-nsupdate_spec.rb
@@ -31,6 +31,7 @@ module Rails
           :zone => "example.com",
           :keyname => "example.com.key",
           :keyvalue => "examplekeyvalue",
+          :keyalgorithm => "HMAC-MD5",
           :krb_principal => "kerberos_principal",
           :krb_keytab => "kerberos_keytable"
         }
@@ -45,6 +46,8 @@ module Rails
 end
 
 module OpenShift
+
+  class DNSException < Exception ; end
 
   # Make private methods public for testing
   class NsupdatePlugin
@@ -80,7 +83,8 @@ module OpenShift
           :zone => "tsigapp.example.com",
           :domain_suffix => "tsigapp.example.com",
           :keyname => "tsigapp.example.com.key",
-          :keyvalue => "tsigapp_key_value"
+          :keyvalue => "tsigapp_key_value",
+          :keyalgorithm => "HMAC-MD5"
         },
 
         :gss => {
@@ -145,7 +149,7 @@ module OpenShift
       cmdlines.length.should be === 7
 
       cmdlines[0].should be === "nsupdate <<EOF"
-      cmdlines[1].should eq "key #{@config[:tsig][:keyname]} #{@config[:tsig][:keyvalue]}"
+      cmdlines[1].should eq "key #{@config[:tsig][:keyalgorithm]}:#{@config[:tsig][:keyname]} #{@config[:tsig][:keyvalue]}"
       cmdlines[2].should eq "server #{@config[:tsig][:server]} #{@config[:tsig][:port]}"
       cmdlines[3].should eq "update add #{fqdn} 60 CNAME #{value}"
       cmdlines[4].should eq "send"


### PR DESCRIPTION
Per a request, allow nsupdate to use alternate TSIG algorithms.  

Default remains HMAC-MD5.

Added configuration variable: keyalgorithm to plugin config

Values: HMAC-MD5|HMAC-SHA1|HMAC-SHA256|HMAC-SHA512
