### PR TITLE
origin-node Bug 963336 - Add 'Requires' of mod_ssl so httpd can start

### DIFF
--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -41,6 +41,7 @@ Requires:      python
 Requires:      libselinux-python
 Requires:      mercurial
 Requires:      httpd
+Requires:      mod_ssl
 %if 0%{?fedora}%{?rhel} <= 6
 Requires:      libcgroup
 %else


### PR DESCRIPTION
Fixes httpd failing to start on node servers due to missing ssl module required by 000001_openshift_origin_node.conf

Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=963336
