### PR TITLE
Allow clients to recognize downloadable cart parameters

### DIFF
--- a/broker/test/functional/application_controller_test.rb
+++ b/broker/test/functional/application_controller_test.rb
@@ -35,6 +35,10 @@ class ApplicationControllerTest < ActionController::TestCase
     assert_response :created
     get :show, {"id" => @app_name, "domain_id" => @domain.namespace}
     assert_response :success
+    assert json = JSON.parse(response.body)
+    assert link = json['data']['links']['ADD_CARTRIDGE']
+    assert_equal Rails.configuration.openshift[:download_cartridges_enabled], link['optional_params'].one?{ |p| p['name'] == 'url' }
+
     get :index , {"domain_id" => @domain.namespace}
     assert_response :success
     delete :destroy , {"id" => @app_name, "domain_id" => @domain.namespace}

--- a/broker/test/functional/domains_controller_test.rb
+++ b/broker/test/functional/domains_controller_test.rb
@@ -31,8 +31,13 @@ class DomiansControllerTest < ActionController::TestCase
     namespace = "ns#{@random}"
     post :create, {"id" => namespace}
     assert_response :created
+
     get :show, {"id" => namespace}
     assert_response :success
+    assert json = JSON.parse(response.body)
+    assert link = json['data']['links']['ADD_APPLICATION']
+    assert_equal Rails.configuration.openshift[:download_cartridges_enabled], link['optional_params'].one?{ |p| p['name'] == 'cartridges[][url]' }
+
     get :index , {}
     assert_response :success
     new_namespace = "xns#{@random}"

--- a/controller/app/rest_models/rest_application.rb
+++ b/controller/app/rest_models/rest_application.rb
@@ -193,7 +193,8 @@ class RestApplication < OpenShift::Model
             OptionalParam.new("scales_from", "integer", "Minimum number of gears to run the component on."),
             OptionalParam.new("scales_to", "integer", "Maximum number of gears to run the component on."),
             OptionalParam.new("additional_storage", "integer", "Additional GB of space to request on all gears running this component."),
-          ]
+            (OptionalParam.new("url", "string", "A URL to a downloadable cartridge.") if Rails.application.config.openshift[:download_cartridges_enabled]),
+          ].compact
         ),
         "LIST_CARTRIDGES" => Link.new("List embedded cartridges", "GET", URI::join(url, "domains/#{@domain_id}/applications/#{@name}/cartridges")),
         "DNS_RESOLVABLE" => Link.new("Resolve DNS", "GET", URI::join(url, "domains/#{@domain_id}/applications/#{@name}/dns_resolvable")),

--- a/controller/app/rest_models/rest_domain.rb
+++ b/controller/app/rest_models/rest_domain.rb
@@ -41,7 +41,8 @@ class RestDomain < OpenShift::Model
           OptionalParam.new("scale", "boolean", "Mark application as scalable", [true, false], false),
           OptionalParam.new("gear_profile", "string", "The size of the gear", valid_sizes, valid_sizes[0]),
           OptionalParam.new("initial_git_url", "string", "A URL to a Git source code repository that will be the basis for this application."),
-        ]),
+          (OptionalParam.new("cartridges[][url]", "string", "A URL to a downloadable cartridge. You may an array of urls via {'cartridges' : [{'url':'http://...'}]}") if Rails.application.config.openshift[:download_cartridges_enabled]),
+        ].compact),
         "UPDATE" => Link.new("Update domain", "PUT", URI::join(url, "domains/#{id}"),[
           Param.new("id", "string", "Name of the domain")
         ]),

--- a/controller/app/rest_models/rest_domain.rb
+++ b/controller/app/rest_models/rest_domain.rb
@@ -41,7 +41,7 @@ class RestDomain < OpenShift::Model
           OptionalParam.new("scale", "boolean", "Mark application as scalable", [true, false], false),
           OptionalParam.new("gear_profile", "string", "The size of the gear", valid_sizes, valid_sizes[0]),
           OptionalParam.new("initial_git_url", "string", "A URL to a Git source code repository that will be the basis for this application."),
-          (OptionalParam.new("cartridges[][url]", "string", "A URL to a downloadable cartridge. You may an array of urls via {'cartridges' : [{'url':'http://...'}]}") if Rails.application.config.openshift[:download_cartridges_enabled]),
+          (OptionalParam.new("cartridges[][url]", "string", "A URL to a downloadable cartridge. You may specify an multiple urls via {'cartridges' : [{'url':'http://...'}, ...]}") if Rails.application.config.openshift[:download_cartridges_enabled]),
         ].compact),
         "UPDATE" => Link.new("Update domain", "PUT", URI::join(url, "domains/#{id}"),[
           Param.new("id", "string", "Name of the domain")


### PR DESCRIPTION
Add 'cartridges[][url]' as an optional parameter on ADD_APPLICATION and 'url'
as an optional parameter on ADD_CARTRIDGE

@rajatchopra this covers the remaining item on the UI side to close, please review
