### PR TITLE
<node/httpd conf> Bug 962938 - Set ProxyTimeout for node HTTPD config

### DIFF
--- a/node/httpd/000001_openshift_origin_node.conf
+++ b/node/httpd/000001_openshift_origin_node.conf
@@ -37,6 +37,9 @@
   RequestHeader set X-Forwarded-Port  "443"
   RequestHeader set X-Forwarded-SSL-Client-Cert %{SSL_CLIENT_CERT}e
 
+  # Should match broker 000002_openshift_origin_broker_proxy.conf:
+  ProxyTimeout 300
+
   # Access the OpenShift mod_rewrite router
   include conf.d/openshift_route.include
 


### PR DESCRIPTION
Add ProxyTimeout setting to override server config default (picked up
from TimeOut, which is 60 in httpd.conf). Also add comment referencing
broker-specific setting for future reference.

@rmillner 
