### PR TITLE
[TO_STAGE] Bug 963048 - the old oo-admin-ctl-gear script was setting/exporting APP_...

### DIFF
--- a/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/util
+++ b/cartridges/openshift-origin-cartridge-abstract/abstract/info/lib/util
@@ -696,9 +696,12 @@ function setup_basic_vars {
 
 function setup_app_dir_vars {
     APP_HOME="$GEAR_BASE_DIR/$uuid/"
+    OPENSHIFT_HOMEDIR="$APP_HOME"
     APP_DIR=`echo $APP_HOME/$cartridge_type | tr -s /`
     APP_REPO_DIR="$APP_HOME/app-root/repo"
     APP_DATA_DIR="$APP_HOME/app-root/data"
+
+    export APP_HOME OPENSHIFT_HOMEDIR
 }
 
 function force_kill {


### PR DESCRIPTION
...HOME and OPENSHIFT_HOME_DIR but the new version assumed that the start hook did that itself through setup_user_vars.
