### PR TITLE
Bug 963981 - Fix app events controller

### DIFF
--- a/broker-util/oo-admin-ctl-domain
+++ b/broker-util/oo-admin-ctl-domain
@@ -82,7 +82,7 @@ when "env_add"
     exit 1
   end
   begin
-    domain = Domain.with(consistency: :eventual).find_by(owner: user, namespace: namespace)
+    domain = Domain.with(consistency: :eventual).find_by(owner: user, canonical_namespace: namespace.downcase)
   rescue Mongoid::Errors::DocumentNotFound
     puts "Domain with namespace: #{namespace} not found for user #{user.login}"
     exit 1
@@ -109,7 +109,7 @@ when "env_del"
     exit 1
   end
   begin
-    domain = Domain.with(consistency: :eventual).find_by(owner: user, namespace: namespace)
+    domain = Domain.with(consistency: :eventual).find_by(owner: user, canonical_namespace: namespace.downcase)
   rescue Mongoid::Errors::DocumentNotFound
     puts "Domain with namespace: #{namespace} not found for user #{user.login}"
     exit 1

--- a/broker/test/unit/application_test.rb
+++ b/broker/test/unit/application_test.rb
@@ -29,7 +29,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest #ActiveSupport::TestCas
   test "create and destroy embedded application" do
     @appname = "test"
     app = Application.create_app(@appname, ["php-5.3", "mysql-5.1"], @domain, "small")
-    app = Application.find_by(name: @appname, domain_id: @domain._id) rescue nil
+    app = Application.find_by(canonical_name: @appname.downcase, domain_id: @domain._id) rescue nil
 
     app.destroy_app
   end
@@ -37,7 +37,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest #ActiveSupport::TestCas
   test "create and destroy embedded scalable application" do
     @appname = "test"
     app = Application.create_app(@appname, ["php-5.3", "mysql-5.1"], @domain, "small", true)
-    app = Application.find_by(name: @appname, domain_id: @domain._id) rescue nil
+    app = Application.find_by(canonical_name: @appname.downcase, domain_id: @domain._id) rescue nil
 
     app.destroy_app
   end
@@ -45,7 +45,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest #ActiveSupport::TestCas
   test "scalable application events" do
     @appname = "test"
     app = Application.create_app(@appname, ["php-5.3", "mysql-5.1"], @domain, "small", true)
-    app = Application.find_by(name: @appname, domain_id: @domain._id) rescue nil
+    app = Application.find_by(canonical_name: @appname.downcase, domain_id: @domain._id) rescue nil
     app.restart
     app.stop
     app.start
@@ -62,7 +62,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest #ActiveSupport::TestCas
   test "threaddump application events" do
     @appname = "test"
     app = Application.create_app(@appname, ["ruby-1.9", "mysql-5.1"], @domain, "small", true)
-    app = Application.find_by(name: @appname, domain_id: @domain._id) rescue nil
+    app = Application.find_by(canonical_name: @appname.downcase, domain_id: @domain._id) rescue nil
     app.threaddump
     app.destroy_app
   end
@@ -70,7 +70,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest #ActiveSupport::TestCas
   test "scaling and storage events on application" do
     @appname = "test"
     app = Application.create_app(@appname, ["php-5.3", "mysql-5.1"], @domain, "small", true)
-    app = Application.find_by(name: @appname, domain_id: @domain._id) rescue nil
+    app = Application.find_by(canonical_name: @appname.downcase, domain_id: @domain._id) rescue nil
 
     @user.capabilities["max_untracked_addtl_storage_per_gear"] = 5
     @user.save
@@ -101,7 +101,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest #ActiveSupport::TestCas
   test "application events through internal rest" do
     @appname = "test"
     app = Application.create_app(@appname, ["ruby-1.9", "mysql-5.1"], @domain, "small", true)
-    app = Application.find_by(name: @appname, domain_id: @domain._id) rescue nil
+    app = Application.find_by(canonical_name: @appname.downcase, domain_id: @domain._id) rescue nil
 
     resp = rest_check(:get, "", {})
     assert_equal resp.status, 200

--- a/broker/test/unit/domain_test.rb
+++ b/broker/test/unit/domain_test.rb
@@ -40,7 +40,7 @@ class DomainTest < ActiveSupport::TestCase
     @domain = Domain.new(namespace: namespace, owner:@user)
     @domain.save
     
-    @domain = Domain.find_by(owner: @user, canonical_namespace: namespace)
+    @domain = Domain.find_by(owner: @user, canonical_namespace: namespace.downcase)
     assert_equal(namespace, @domain.namespace)
     
     domains = Domain.where(owner: @user)
@@ -78,6 +78,7 @@ class DomainTest < ActiveSupport::TestCase
   
   test "add and remove ssh keys to domain" do
     namespace = "ns#{@random}"
+    namespace.downcase!
     @domain = Domain.new(namespace: namespace, owner:@user)
     @domain.save
     
@@ -105,6 +106,7 @@ class DomainTest < ActiveSupport::TestCase
   
   test "add and remove env variables to domain" do
     namespace = "ns#{@random}"
+    namespace.downcase!
     @domain = Domain.new(namespace: namespace, owner:@user)
     @domain.save
     
@@ -129,6 +131,7 @@ class DomainTest < ActiveSupport::TestCase
   
   test "update domain" do
     namespace = "ns#{@random}"
+    namespace.downcase!
     @domain = Domain.new(namespace: namespace, owner:@user)
     @domain.save
     

--- a/controller/app/controllers/app_events_controller.rb
+++ b/controller/app/controllers/app_events_controller.rb
@@ -106,7 +106,7 @@ class AppEventsController < BaseController
       return render_exception(e)
     end
 
-    @application = Application.find_by(domain: @domain, canonical_name: @application.name)
+    @application.with(consistency: :strong).reload
     app = get_rest_application(@application)
     @reply = new_rest_reply(:ok, "application", app)
     message = Message.new("INFO", msg, 0)

--- a/controller/app/models/domain.rb
+++ b/controller/app/models/domain.rb
@@ -80,7 +80,7 @@ class Domain
     if Application.with(consistency: :strong).where(domain_id: self._id).count > 0
       raise OpenShift::UserException.new("Domain contains applications. Delete applications first before changing the domain namespace.", 128)
     end
-    if Domain.with(consistency: :strong).where(canonical_namespace: new_namespace).count > 0 
+    if Domain.with(consistency: :strong).where(canonical_namespace: new_namespace.downcase).count > 0 
       raise OpenShift::UserException.new("Namespace '#{new_namespace}' is already in use. Please choose another.", 103, "id") 
     end
     self.namespace = new_namespace


### PR DESCRIPTION
Use canonical_name/canonical_namespace for application/domain respectively when using find_by op.
