### PR TITLE
We don't want test dependencies required at runtime

### DIFF
--- a/broker/Gemfile.fedora
+++ b/broker/Gemfile.fedora
@@ -1,0 +1,57 @@
+source 'http://rubygems.org'
+
+gem 'rails', '~> 3.2.8'
+gem 'json'
+gem 'json_pure'
+gem 'parseconfig'
+gem 'xml-simple'
+gem 'rack'
+gem 'regin'
+gem 'open4'
+gem 'systemu'
+gem 'mongoid'
+gem 'bson'
+gem 'bson_ext'
+gem 'pry', :require => 'pry' if ENV['PRY']
+
+# For performance reasons, the following scripts will not be
+# refactored to use mongoid exclusively:
+#  * broker-util/oo-admin-chk
+#  * broker-util/oo-admin-fix-sshkeys
+#  * broker-util/oo-stats
+# These scripts use the OpenShift::DataStore API, and thus depend on
+# the mongo rubygem:
+gem 'mongo'
+
+if ENV['BROKER_SOURCE']
+  gem 'openshift-origin-common', :path => '../common'
+  gem 'openshift-origin-controller', :path => '../controller'
+  gem 'netrc' # rest-client has an undeclared prereq on netrc
+
+  # Optionally load plugins from source
+  eval((IO.read(File.expand_path('~/.openshift/broker_plugins.rb')) rescue ''))
+else
+  gem 'openshift-origin-controller'
+end
+
+# Load plugin gems.
+Dir["/etc/openshift/plugins.d/*.conf"].delete_if{ |x| x.end_with? "-dev.conf" }.map{|x| File.basename(x, ".conf")}.each {|plugin| gem plugin}
+
+# Bundle edge Rails instead:
+# gem 'rails', :git => 'git://github.com/rails/rails.git'
+
+# Use unicorn as the web server
+# gem 'unicorn'
+
+# Deploy with Capistrano
+# gem 'capistrano'
+
+# To use debugger (ruby-debug for Ruby 1.8.7+, ruby-debug19 for Ruby 1.9.2+)
+# gem 'ruby-debug'
+# gem 'ruby-debug19', :require => 'ruby-debug'
+
+# Bundle the extra gems:
+# gem 'bj'
+# gem 'nokogiri'
+# gem 'sqlite3-ruby', :require => 'sqlite3'
+# gem 'aws-s3', :require => 'aws/s3'

--- a/broker/Gemfile.rhel
+++ b/broker/Gemfile.rhel
@@ -1,0 +1,57 @@
+source 'http://rubygems.org'
+
+gem 'rails', '~> 3.2.8'
+gem 'json'
+gem 'json_pure'
+gem 'parseconfig'
+gem 'xml-simple'
+gem 'rack'
+gem 'regin'
+gem 'open4'
+gem 'systemu'
+gem 'mongoid'
+gem 'bson'
+gem 'bson_ext'
+gem 'pry', :require => 'pry' if ENV['PRY']
+
+# For performance reasons, the following scripts will not be
+# refactored to use mongoid exclusively:
+#  * broker-util/oo-admin-chk
+#  * broker-util/oo-admin-fix-sshkeys
+#  * broker-util/oo-stats
+# These scripts use the OpenShift::DataStore API, and thus depend on
+# the mongo rubygem:
+gem 'mongo'
+
+if ENV['BROKER_SOURCE']
+  gem 'openshift-origin-common', :path => '../common'
+  gem 'openshift-origin-controller', :path => '../controller'
+  gem 'netrc' # rest-client has an undeclared prereq on netrc
+
+  # Optionally load plugins from source
+  eval((IO.read(File.expand_path('~/.openshift/broker_plugins.rb')) rescue ''))
+else
+  gem 'openshift-origin-controller'
+end
+
+# Load plugin gems.
+Dir["/etc/openshift/plugins.d/*.conf"].delete_if{ |x| x.end_with? "-dev.conf" }.map{|x| File.basename(x, ".conf")}.each {|plugin| gem plugin}
+
+# Bundle edge Rails instead:
+# gem 'rails', :git => 'git://github.com/rails/rails.git'
+
+# Use unicorn as the web server
+# gem 'unicorn'
+
+# Deploy with Capistrano
+# gem 'capistrano'
+
+# To use debugger (ruby-debug for Ruby 1.8.7+, ruby-debug19 for Ruby 1.9.2+)
+# gem 'ruby-debug'
+# gem 'ruby-debug19', :require => 'ruby-debug'
+
+# Bundle the extra gems:
+# gem 'bj'
+# gem 'nokogiri'
+# gem 'sqlite3-ruby', :require => 'sqlite3'
+# gem 'aws-s3', :require => 'aws/s3'

--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -38,7 +38,6 @@ Requires:      %{?scl:%scl_prefix}mod_passenger
 Requires:      %{?scl:%scl_prefix}rubygem(bson_ext)
 Requires:      %{?scl:%scl_prefix}rubygem(json)
 Requires:      %{?scl:%scl_prefix}rubygem(json_pure)
-Requires:      %{?scl:%scl_prefix}rubygem(minitest)
 # This gem is required by oo-admin-chk, oo-admin-fix-sshkeys, and
 # oo-stats, for OpenShift::DataStore API support
 Requires:      %{?scl:%scl_prefix}rubygem(mongo)
@@ -54,7 +53,6 @@ Requires:      %{?scl:%scl_prefix}rubygem-passenger-native-libs
 Requires:      %{?scl:%scl_prefix}rubygem(rails)
 Requires:      %{?scl:%scl_prefix}rubygem(regin)
 Requires:      %{?scl:%scl_prefix}rubygem(rest-client)
-Requires:      %{?scl:%scl_prefix}rubygem(simplecov)
 Requires:      %{?scl:%scl_prefix}rubygem(systemu)
 Requires:      %{?scl:%scl_prefix}rubygem(xml-simple)
 %if %{with_systemd}
@@ -126,6 +124,12 @@ mv %{buildroot}%{brokerdir}/httpd/httpd.conf.apache-2.4 %{buildroot}%{brokerdir}
 mv %{buildroot}%{brokerdir}/httpd/httpd.conf.apache-2.3 %{buildroot}%{brokerdir}/httpd/httpd.conf
 %endif
 rm %{buildroot}%{brokerdir}/httpd/httpd.conf.apache-*
+
+%if 0%{?fedora} >= 18
+mv %{buildroot}%{brokerdir}/Gemfile.fedora %{buildroot}%{brokerdir}/Gemfile
+%else
+mv %{buildroot}%{brokerdir}/Gemfile.rhel %{buildroot}%{brokerdir}/Gemfile
+%endif
 
 %if 0%{?scl:1}
 rm %{buildroot}%{brokerdir}/httpd/broker.conf

--- a/console/Gemfile.fedora
+++ b/console/Gemfile.fedora
@@ -1,0 +1,19 @@
+source 'http://rubygems.org'
+
+gemspec
+
+gem 'pry', :require => 'pry' if ENV['PRY']
+gem 'perftools.rb', :require => 'perftools' if ENV['PERFTOOLS']
+
+group :assets do
+  gem 'compass-rails', '~> 1.0.3'
+  gem 'sass-rails',    '~> 3.2.5'
+  gem 'coffee-rails',  '~> 3.2.2'
+  gem 'jquery-rails',  '~> 2.0.2'
+  gem 'uglifier',      '>= 1.2.6'
+  gem 'therubyracer',  '>= 0.10'
+  gem 'minitest',      '~> 3.5.0', :require => false
+end
+
+
+

--- a/console/Gemfile.rhel
+++ b/console/Gemfile.rhel
@@ -1,0 +1,19 @@
+source 'http://rubygems.org'
+
+gemspec
+
+gem 'pry', :require => 'pry' if ENV['PRY']
+gem 'perftools.rb', :require => 'perftools' if ENV['PERFTOOLS']
+
+group :assets do
+  gem 'compass-rails', '~> 1.0.3'
+  gem 'sass-rails',    '~> 3.2.5'
+  gem 'coffee-rails',  '~> 3.2.2'
+  gem 'jquery-rails',  '~> 2.0.2'
+  gem 'uglifier',      '>= 1.2.6'
+  gem 'therubyracer',  '>= 0.10'
+  gem 'minitest',      '~> 3.5.0', :require => false
+end
+
+
+

--- a/console/lib/tasks/assets.rake
+++ b/console/lib/tasks/assets.rake
@@ -1,3 +1,5 @@
+require 'rake/tasklib'
+
 class GenerateConsoleViewTask < Rake::TaskLib
   attr_accessor :layout, :views
 

--- a/console/rubygem-openshift-origin-console.spec
+++ b/console/rubygem-openshift-origin-console.spec
@@ -38,6 +38,10 @@ BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 BuildRequires: %{?scl:%scl_prefix}rubygem(rails)
 BuildRequires: %{?scl:%scl_prefix}rubygem(compass-rails)
+BuildRequires: %{?scl:%scl_prefix}rubygem(coffee-rails)
+BuildRequires: %{?scl:%scl_prefix}rubygem(sass-rails)
+BuildRequires: %{?scl:%scl_prefix}rubygem(uglifier-rails)
+BuildRequires: %{?scl:%scl_prefix}rubygem(jquery-rails)
 BuildRequires: %{?scl:%scl_prefix}rubygem(sprockets)
 BuildRequires: %{?scl:%scl_prefix}rubygem(rdiscount)
 BuildRequires: %{?scl:%scl_prefix}rubygem(formtastic)

--- a/console/rubygem-openshift-origin-console.spec
+++ b/console/rubygem-openshift-origin-console.spec
@@ -47,7 +47,7 @@ BuildRequires: %{?scl:%scl_prefix}rubygem(rdiscount)
 BuildRequires: %{?scl:%scl_prefix}rubygem(sass-rails)
 BuildRequires: %{?scl:%scl_prefix}rubygem(sprockets)
 BuildRequires: %{?scl:%scl_prefix}rubygem(therubyracer)
-BuildRequires: %{?scl:%scl_prefix}rubygem(uglifier-rails)
+BuildRequires: %{?scl:%scl_prefix}rubygem(uglifier)
 BuildRequires: scl-utils-build
 
 %endif

--- a/console/rubygem-openshift-origin-console.spec
+++ b/console/rubygem-openshift-origin-console.spec
@@ -28,40 +28,24 @@ Requires:      %{?scl:%scl_prefix}rubygem(rdiscount)
 Requires:      %{?scl:%scl_prefix}rubygem(formtastic)
 Requires:      %{?scl:%scl_prefix}rubygem(net-http-persistent)
 Requires:      %{?scl:%scl_prefix}rubygem(haml)
-Requires:      %{?scl:%scl_prefix}rubygem(ci_reporter)
 Requires:      %{?scl:%scl_prefix}rubygem(coffee-rails)
 Requires:      %{?scl:%scl_prefix}rubygem(compass-rails)
 Requires:      %{?scl:%scl_prefix}rubygem(jquery-rails)
-Requires:      %{?scl:%scl_prefix}rubygem(mocha)
 Requires:      %{?scl:%scl_prefix}rubygem(sass-rails)
-Requires:      %{?scl:%scl_prefix}rubygem(simplecov)
-Requires:      %{?scl:%scl_prefix}rubygem(test-unit)
 Requires:      %{?scl:%scl_prefix}rubygem(uglifier)
-Requires:      %{?scl:%scl_prefix}rubygem(webmock)
-Requires:      %{?scl:%scl_prefix}rubygem(poltergeist)
-Requires:      %{?scl:%scl_prefix}rubygem(konacha)
-Requires:      %{?scl:%scl_prefix}rubygem(minitest)
-Requires:      %{?scl:%scl_prefix}rubygem(rspec-core)
 
 BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 BuildRequires: %{?scl:%scl_prefix}rubygem(rails)
 BuildRequires: %{?scl:%scl_prefix}rubygem(compass-rails)
-BuildRequires: %{?scl:%scl_prefix}rubygem(mocha)
-BuildRequires: %{?scl:%scl_prefix}rubygem(simplecov)
-BuildRequires: %{?scl:%scl_prefix}rubygem(test-unit)
-BuildRequires: %{?scl:%scl_prefix}rubygem(ci_reporter)
-BuildRequires: %{?scl:%scl_prefix}rubygem(webmock)
 BuildRequires: %{?scl:%scl_prefix}rubygem(sprockets)
 BuildRequires: %{?scl:%scl_prefix}rubygem(rdiscount)
 BuildRequires: %{?scl:%scl_prefix}rubygem(formtastic)
 BuildRequires: %{?scl:%scl_prefix}rubygem(net-http-persistent)
 BuildRequires: %{?scl:%scl_prefix}rubygem(haml)
 BuildRequires: %{?scl:%scl_prefix}rubygem(therubyracer)
-BuildRequires: %{?scl:%scl_prefix}rubygem(poltergeist)
-BuildRequires: %{?scl:%scl_prefix}rubygem(konacha)
+# Required by activesupport during the asset precompilation process
 BuildRequires: %{?scl:%scl_prefix}rubygem(minitest)
-BuildRequires: %{?scl:%scl_prefix}rubygem(rspec-core)
 
 %endif
 BuildRequires: %{?scl:%scl_prefix}rubygems-devel
@@ -91,6 +75,15 @@ OpenShift Origin Management Console ri documentation
 
 set -e
 mkdir -p .%{gem_dir}
+
+%if 0%{?fedora} >= 18
+mv Gemfile.fedora Gemfile
+%else
+mv Gemfile.rhel Gemfile
+%endif
+
+# requires ci_reporter
+rm lib/tasks/test_suites.rake
 
 %if 0%{?fedora}%{?rhel} <= 6
 rm -f Gemfile.lock

--- a/console/rubygem-openshift-origin-console.spec
+++ b/console/rubygem-openshift-origin-console.spec
@@ -22,34 +22,33 @@ Requires:      %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
 %endif
 Requires:      %{?scl:%scl_prefix}rubygems
 %if 0%{?fedora}%{?rhel} <= 6
-Requires:      %{?scl:%scl_prefix}rubygem(rails)
-Requires:      %{?scl:%scl_prefix}rubygem(compass-rails)
-Requires:      %{?scl:%scl_prefix}rubygem(rdiscount)
-Requires:      %{?scl:%scl_prefix}rubygem(formtastic)
-Requires:      %{?scl:%scl_prefix}rubygem(net-http-persistent)
-Requires:      %{?scl:%scl_prefix}rubygem(haml)
 Requires:      %{?scl:%scl_prefix}rubygem(coffee-rails)
 Requires:      %{?scl:%scl_prefix}rubygem(compass-rails)
+Requires:      %{?scl:%scl_prefix}rubygem(formtastic)
+Requires:      %{?scl:%scl_prefix}rubygem(haml)
 Requires:      %{?scl:%scl_prefix}rubygem(jquery-rails)
+Requires:      %{?scl:%scl_prefix}rubygem(net-http-persistent)
+Requires:      %{?scl:%scl_prefix}rubygem(rails)
+Requires:      %{?scl:%scl_prefix}rubygem(rdiscount)
 Requires:      %{?scl:%scl_prefix}rubygem(sass-rails)
 Requires:      %{?scl:%scl_prefix}rubygem(uglifier)
 
 BuildRequires: %{?scl:%scl_prefix}build
-BuildRequires: scl-utils-build
-BuildRequires: %{?scl:%scl_prefix}rubygem(rails)
-BuildRequires: %{?scl:%scl_prefix}rubygem(compass-rails)
 BuildRequires: %{?scl:%scl_prefix}rubygem(coffee-rails)
-BuildRequires: %{?scl:%scl_prefix}rubygem(sass-rails)
-BuildRequires: %{?scl:%scl_prefix}rubygem(uglifier-rails)
-BuildRequires: %{?scl:%scl_prefix}rubygem(jquery-rails)
-BuildRequires: %{?scl:%scl_prefix}rubygem(sprockets)
-BuildRequires: %{?scl:%scl_prefix}rubygem(rdiscount)
+BuildRequires: %{?scl:%scl_prefix}rubygem(compass-rails)
 BuildRequires: %{?scl:%scl_prefix}rubygem(formtastic)
-BuildRequires: %{?scl:%scl_prefix}rubygem(net-http-persistent)
 BuildRequires: %{?scl:%scl_prefix}rubygem(haml)
-BuildRequires: %{?scl:%scl_prefix}rubygem(therubyracer)
+BuildRequires: %{?scl:%scl_prefix}rubygem(jquery-rails)
 # Required by activesupport during the asset precompilation process
 BuildRequires: %{?scl:%scl_prefix}rubygem(minitest)
+BuildRequires: %{?scl:%scl_prefix}rubygem(net-http-persistent)
+BuildRequires: %{?scl:%scl_prefix}rubygem(rails)
+BuildRequires: %{?scl:%scl_prefix}rubygem(rdiscount)
+BuildRequires: %{?scl:%scl_prefix}rubygem(sass-rails)
+BuildRequires: %{?scl:%scl_prefix}rubygem(sprockets)
+BuildRequires: %{?scl:%scl_prefix}rubygem(therubyracer)
+BuildRequires: %{?scl:%scl_prefix}rubygem(uglifier-rails)
+BuildRequires: scl-utils-build
 
 %endif
 BuildRequires: %{?scl:%scl_prefix}rubygems-devel

--- a/console/test/rails_app/config/application.rb
+++ b/console/test/rails_app/config/application.rb
@@ -3,7 +3,6 @@ require File.expand_path('../boot', __FILE__)
 require "action_controller/railtie"
 require "action_mailer/railtie"
 require "active_resource/railtie"
-require "rails/test_unit/railtie"
 
 Bundler.require(*Rails.groups(:default, :assets => %w(development test))) if defined?(Bundler)
 require "console/engine"

--- a/devel/openshift-devel.spec
+++ b/devel/openshift-devel.spec
@@ -1,0 +1,45 @@
+%if 0%{?fedora}%{?rhel} <= 6
+    %global scl ruby193
+    %global scl_prefix ruby193-
+%endif
+%{!?scl:%global pkg_name %{name}}
+
+Summary:       OpenShift Origin development dependencies
+Name:          openshift-origin-devel
+Version:       0.0.1
+Release:       1%{?dist}
+Group:         Network/Daemons
+License:       ASL 2.0
+URL:           http://www.openshift.com
+Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
+Requires:      %{?scl:%scl_prefix}rubygem(ci_reporter)
+Requires:      %{?scl:%scl_prefix}rubygem(konacha)
+Requires:      %{?scl:%scl_prefix}rubygem(minitest)
+Requires:      %{?scl:%scl_prefix}rubygem(mocha)
+Requires:      %{?scl:%scl_prefix}rubygem(poltergeist)
+Requires:      %{?scl:%scl_prefix}rubygem(rspec-core)
+Requires:      %{?scl:%scl_prefix}rubygem(simplecov)
+Requires:      %{?scl:%scl_prefix}rubygem(test-unit)
+Requires:      %{?scl:%scl_prefix}rubygem(webmock)
+
+# unknown
+Requires:      %{?scl:%scl_prefix}rubygem(uglifier)
+
+BuildArch:     noarch
+
+%description
+This is a meta-package that pull in requirements from running the OpenShift
+Origin test suites.
+
+%prep
+%setup -q
+
+%build
+
+%install
+
+%files
+
+%changelog
+* Wed May 1 2013 Brenton Leanhardt <bleanhar@redhat.com> 0.0.1-1
+- Initial package

--- a/node/Gemfile.fedora
+++ b/node/Gemfile.fedora
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+# Specify your gem's dependencies in openshift-origin-node.gemspec
+gemspec

--- a/node/Gemfile.rhel
+++ b/node/Gemfile.rhel
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+# Specify your gem's dependencies in openshift-origin-node.gemspec
+gemspec

--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -29,9 +29,7 @@ Requires:      %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
 %endif
 Requires:      %{?scl:%scl_prefix}rubygem(commander)
 Requires:      %{?scl:%scl_prefix}rubygem(json)
-Requires:      %{?scl:%scl_prefix}rubygem(mocha)
 Requires:      %{?scl:%scl_prefix}rubygem(parseconfig)
-Requires:      %{?scl:%scl_prefix}rubygem(rspec)
 Requires:      %{?scl:%scl_prefix}rubygems
 Requires:      %{?scl:%scl_prefix}ruby(selinux)
 Requires:      cronie
@@ -196,6 +194,12 @@ ln -s /usr/lib/openshift/node/jobs/openshift-origin-cron-hourly %{buildroot}/etc
 ln -s /usr/lib/openshift/node/jobs/openshift-origin-cron-daily %{buildroot}/etc/cron.daily/
 ln -s /usr/lib/openshift/node/jobs/openshift-origin-cron-weekly %{buildroot}/etc/cron.weekly/
 ln -s /usr/lib/openshift/node/jobs/openshift-origin-cron-monthly %{buildroot}/etc/cron.monthly/
+
+%if 0%{?fedora} >= 18
+mv Gemfile.fedora %{buildroot}%{gem_instdir}/Gemfile
+%else
+mv Gemfile.rhel %{buildroot}%{gem_instdir}/Gemfile
+%endif
 
 %post
 /bin/rm -f /etc/openshift/env/*.rpmnew

--- a/openshift-console/Gemfile.fedora
+++ b/openshift-console/Gemfile.fedora
@@ -1,0 +1,17 @@
+source 'http://rubygems.org'
+
+gem 'openshift-origin-console', :require => 'console', :path => ENV['CONSOLE_PATH']
+
+gem 'rake', '~> 0.9.2'
+gem 'pry', :require => 'pry' if ENV['PRY']
+gem 'perftools.rb', :require => 'perftools' if ENV['PERFTOOLS']
+
+group :assets do
+  gem 'compass-rails', '~> 1.0.3'
+  gem 'sass-rails',    '~> 3.2.5'
+  gem 'coffee-rails',  '~> 3.2.2'
+  gem 'jquery-rails',  '~> 2.0.2'
+  gem 'uglifier',      '>= 1.2.6'
+  gem 'therubyracer',  '>= 0.10'
+end
+

--- a/openshift-console/Gemfile.rhel
+++ b/openshift-console/Gemfile.rhel
@@ -1,0 +1,17 @@
+source 'http://rubygems.org'
+
+gem 'openshift-origin-console', :require => 'console', :path => ENV['CONSOLE_PATH']
+
+gem 'rake', '~> 0.9.2'
+gem 'pry', :require => 'pry' if ENV['PRY']
+gem 'perftools.rb', :require => 'perftools' if ENV['PERFTOOLS']
+
+group :assets do
+  gem 'compass-rails', '~> 1.0.3'
+  gem 'sass-rails',    '~> 3.2.5'
+  gem 'coffee-rails',  '~> 3.2.2'
+  gem 'jquery-rails',  '~> 2.0.2'
+  gem 'uglifier',      '>= 1.2.6'
+  gem 'therubyracer',  '>= 0.10'
+end
+

--- a/openshift-console/openshift-origin-console.spec
+++ b/openshift-console/openshift-origin-console.spec
@@ -28,7 +28,6 @@ Requires:      %{?scl:%scl_prefix}rubygem-passenger-native-libs
 Requires:      %{?scl:%scl_prefix}mod_passenger
 
 %if 0%{?rhel}
-Requires:      %{?scl:%scl_prefix}rubygem-minitest
 Requires:      %{?scl:%scl_prefix}rubygem-therubyracer
 Requires:      openshift-origin-util-scl
 %endif
@@ -43,14 +42,13 @@ BuildRequires:  ruby193-build
 BuildRequires:  scl-utils-build
 BuildRequires: %{?scl:%scl_prefix}rubygem(rails)
 BuildRequires: %{?scl:%scl_prefix}rubygem(compass-rails)
-BuildRequires: %{?scl:%scl_prefix}rubygem(test-unit)
-BuildRequires: %{?scl:%scl_prefix}rubygem(ci_reporter)
 BuildRequires: %{?scl:%scl_prefix}rubygem(sprockets)
 BuildRequires: %{?scl:%scl_prefix}rubygem(rdiscount)
 BuildRequires: %{?scl:%scl_prefix}rubygem(formtastic)
 BuildRequires: %{?scl:%scl_prefix}rubygem(net-http-persistent)
 BuildRequires: %{?scl:%scl_prefix}rubygem(haml)
 BuildRequires: %{?scl:%scl_prefix}rubygem(therubyracer)
+# Required by activesupport during the asset precompilation process
 BuildRequires: %{?scl:%scl_prefix}rubygem(minitest)
 %endif
 BuildRequires: %{?scl:%scl_prefix}rubygems-devel
@@ -75,6 +73,12 @@ This includes the configuration necessary to run the console with mod_passenger.
 
 %build
 %{?scl:scl enable %scl - << \EOF}
+
+%if 0%{?fedora} >= 18
+mv Gemfile.fedora Gemfile
+%else
+mv Gemfile.rhel Gemfile
+%endif
 
 set -e
 %if 0%{?fedora}%{?rhel} <= 6


### PR DESCRIPTION
Test depedencies that make their way into the spec files result in wasted time
for distro maintainers. Our tests are not run at RPM build time nor can they
run in brew or koji.

By default the Gemfile in git will be configured for development. At RPM build
time a platform specific runtime Gemfile will be installed. Right now these platform Gemfiles do not contain any customization. We expect over time that Gemfile.fedora and Gemfile.rhel will diverge.

Along with this solution is the addition of openshift-origin-devel. That
package includes all the test dependencies. This will be installed by
origin-dev-tools' devenv script however there is no expectation that distro
maintainers ship this new package.
