### PR TITLE
oo-accept-node changed the cgroups check to ignore defunct processes

### DIFF
--- a/node-util/bin/oo-accept-node
+++ b/node-util/bin/oo-accept-node
@@ -368,8 +368,10 @@ def check_cgroup_procs
             missing.each do |pid|
                 proc_data = %x[/bin/ps -p #{pid} -o uid,pid,ppid,etime,cmd].split("\n")
 
-                # ensure the process is still running before failing (fixes transient process problem)
-                if proc_data.size > 1
+                # ensure the process is still running and not defunct before failing
+                # this fixes both the transient process and the defunct process
+                # detection problems
+                if proc_data.size > 1 && ! proc_data[1].strip().end_with?('<defunct>')
                     do_fail("#{uuid} has a process missing from cgroups:  #{pid}")
                 end
             end


### PR DESCRIPTION
Changed the oo-accept-node cgroups check to ignore defunct processes as these
processes can't consume any resources, so it's normal for the kernel to remove
them from cgroups.
