### PR TITLE
Bug 965105: Cannot delete application

### DIFF
--- a/cartridges/openshift-origin-cartridge-postgresql/bin/teardown
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/teardown
@@ -2,4 +2,4 @@
 
 rm -f $HOME/.psqlrc
 rm -f $HOME/.pgpass
-rm -r $OPENSHIFT_DATA_DIR/.psql_history*
+find $OPENSHIFT_DATA_DIR -type f -name ".psql_history*" -exec rm {} \;


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=965105

This was caused by trying to delete the psql history file. If the user has never used psql directly from the command line this file would not exist. Changed the functionality to use find instead, which will only try to remove existing files.
