### PR TITLE
Delete old TODOs related to v2 switchover

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -57,7 +57,6 @@ module OpenShift
       @state            = OpenShift::Utils::ApplicationState.new(container_uuid)
       @build_model      = self.class.get_build_model(@user, @config)
 
-      # When v2 is the default cartridge format flip the test...
       if @build_model == :v1
         @cartridge_model = V1CartridgeModel.new(@config, @user)
       else
@@ -67,7 +66,6 @@ module OpenShift
     end
 
     def self.get_build_model(user, config)
-      # TODO: When v2 is the default cartridge format change this default...
       build_model = :v1
 
       if user.homedir && File.exist?(user.homedir)

--- a/node/lib/openshift-origin-node/utils/sdk.rb
+++ b/node/lib/openshift-origin-node/utils/sdk.rb
@@ -18,7 +18,6 @@ module OpenShift
         if v1_marker_exist and v2_marker_exist
           raise 'Node cannot create both v1 and v2 formatted cartridges. Delete one of the cartridge format marker files'
         end
-        # TODO: When v2 is the default cartridge format change this test...
         if v1_marker_exist
           return :v1
         else


### PR DESCRIPTION
Delete some old TODO comments that are obsolete now that the default
cartridge model has been changed to v2.
