### PR TITLE
<node-proxy,port-proxy> Bug 964212 - Fix init script dependencies

### DIFF
--- a/node-proxy/scripts/init.d/openshift-node-web-proxy
+++ b/node-proxy/scripts/init.d/openshift-node-web-proxy
@@ -1,12 +1,20 @@
 #!/bin/bash
 #
-# openshift-port-proxy
+# openshift-node-web-proxy
 #
 # chkconfig:   345 85 15
 # description: OpenShift proxy
 # processname: node-supervisor
-# config:      /etc/openshift/port-proxy.cfg
+# config:      /etc/openshift/web-proxy-config.json
 # pidfile:     /var/run/node-web-proxy.pid
+#
+### BEGIN INIT INFO
+# Provides: openshift-node-web-proxy
+# Required-Start: $local_fs $remote_fs $network $named
+# Required-Stop: $local_fs $remote_fs $network
+# Short-Description: start and stop OpenShift Node Web Proxy
+# Description: Routing proxy for OpenShift Origin Node
+### END INIT INFO
 
 # Source function library.
 . /etc/rc.d/init.d/functions

--- a/port-proxy/init-scripts/openshift-port-proxy
+++ b/port-proxy/init-scripts/openshift-port-proxy
@@ -7,6 +7,14 @@
 # processname: haproxy
 # config:      /etc/openshift/port-proxy.cfg
 # pidfile:     /var/run/openshift-port-proxy.pid
+#
+### BEGIN INIT INFO
+# Provides: openshift-port-proxy
+# Required-Start: $local_fs $remote_fs $network $named
+# Required-Stop: $local_fs $remote_fs $network
+# Short-Description: start and stop OpenShift Node Port Proxy
+# Description: Script to configure HAProxy to do port forwarding for OpenShift
+### END INIT INFO
 
 # Source function library.
 . /etc/rc.d/init.d/functions


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=964212

Add INIT INFO to node-proxy and port-proxy to make sure required
services are started before init scripts are called during startup

Fix references to port-proxy in node-proxy init script
