### PR TITLE
BZ963827 - Logs generated by oo-admin-ctl-gears should include timestamps

### DIFF
--- a/node-util/bin/oo-admin-ctl-gears
+++ b/node-util/bin/oo-admin-ctl-gears
@@ -408,7 +408,6 @@ end
 
 
 $lockfile = "/var/lock/subsys/openshift-gears"
-$gearsfile = "/var/log/openshift-gears-async-start.log"
 
 def lock_if_good
   if block_given?
@@ -441,7 +440,6 @@ begin
     cpid = fork do
       Dir.chdir('/')
       $stdin.reopen('/dev/null', 'r')
-      $stdout.reopen($gearsfile, 'w')
       $stderr.reopen($stdout)            
       ObjectSpace.each_object(IO) do |i|
         next if i.closed?
@@ -458,7 +456,7 @@ begin
     OpenShift::NodeLogger.logger.info("Background start initiated - process id = #{cpid}")
     OpenShift::NodeLogger.logger.info("Check #{$gearsfile} for more details.")
     $stdout.puts "Background start initiated - process id = #{cpid}"
-    $stdout.puts "Check #{$gearsfile} for more details."
+    $stdout.puts "Check /var/log/openshift/node/platform.log for more details."
     $stdout.puts
     $stdout.puts "Note: In the future, if you wish to start the OpenShift services in the"
     $stdout.puts "      foreground (waited), use:  service openshift-gears waited-start"

--- a/node-util/man8/oo-admin-ctl-gears.8
+++ b/node-util/man8/oo-admin-ctl-gears.8
@@ -57,7 +57,7 @@ The lock file used in support of the
 .B condrestartall
 command
 .TP
-.FN /var/log/openshift-gears-async-start.log
+.FN /var/log/openshift/node/platform.log
 The gear and component cartridge output during a back-grounded start is recorded in this file.
 .SH NOTES
 .nr step 1 1

--- a/node/lib/openshift-origin-node/utils/node_logger.rb
+++ b/node/lib/openshift-origin-node/utils/node_logger.rb
@@ -69,6 +69,9 @@ module OpenShift
         
         logger       = Logger.new(file, 5, 10 * 1024 * 1024)
         logger.level = log_level
+        logger.formatter = proc do |severity, datetime, progname, msg|
+          "#{datetime.strftime("%B %d %H:%M:%S")} #{severity} #{msg}\n"
+        end
         logger
       rescue Exception => e
         # If all else fails, use a STDOUT logger


### PR DESCRIPTION
...also reformatting logging header.
[merge]
