### PR TITLE
Bug 959476: Ensure psql uses the correct .psql_history location

### DIFF
--- a/node/misc/bin/rhcsh
+++ b/node/misc/bin/rhcsh
@@ -208,12 +208,20 @@ function psql() {
   pgpassword=${PGPASSWORD:-$OPENSHIFT_POSTGRESQL_DB_PASSWORD}
   pgdatabase=${PGDATABASE:-$OPENSHIFT_APP_NAME}
 
+  extra_args=""
+  # Ensure our psqlrc sets the histfile
+  grep HISTFILE $HOME/.psqlrc &> /dev/null
+  if [ $? -ne 0 ]
+  then
+    extra_args="${extra_args} --set HISTFILE=$OPENSHIFT_DATA_DIR/.psql_history-$pgdatabase"
+  fi
+
   PGHOST=$pghost \
     PGPORT=$pgport \
     PGUSER=$pguser \
     PGPASSWORD=$pgpassword \
     PGDATABASE=$pgdatabase \
-    /usr/bin/psql "$@"
+    /usr/bin/psql $extra_args "$@"
 }
 
 function mongo() {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=959476

Modified the `psql` helper in `rhcsh` to set the histfile location if it's not being set in `.psqlrc`
