### PR TITLE
Bug 965317 - Add way to patch File class so all files have sync enabled.

### DIFF
--- a/common/lib/openshift-origin-common/utils/file_needs_sync.rb
+++ b/common/lib/openshift-origin-common/utils/file_needs_sync.rb
@@ -1,0 +1,54 @@
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+
+#
+# Bug 965317
+#
+# Under high load, there's achance that writes have their buffers
+# duplicated inside the C code for IO.  This problem goes away if you
+# set sync=true on the IO object but does not go away if you open with
+# File::SYNC or call sync after the write.
+#
+# Require this file in any program which is likely to be called under
+# a heavy load or have a number of threads doing file writes.
+#
+File.class_eval do
+  class << self
+    alias_method :open_needs_sync, :open
+    alias_method :new_needs_sync,  :new
+
+    def open(*args)
+      if block_given?
+        open_needs_sync(*args) do |f|
+          f.sync=true
+          yield(f)
+        end
+      else
+        f=open_needs_sync(*args)
+        f.sync=true
+        f
+      end
+    end
+
+    def new(*args)
+      f=new_needs_sync(*args)
+      f.sync=true
+      f
+    end
+
+  end
+end

--- a/node-util/bin/oo-admin-ctl-gears
+++ b/node-util/bin/oo-admin-ctl-gears
@@ -20,6 +20,7 @@ require 'openshift-origin-node/utils/node_logger'
 require 'openshift-origin-node/utils/application_state'
 require 'openshift-origin-node/model/application_container'
 require 'openshift-origin-node/model/frontend_httpd'
+require 'openshift-origin-common/utils/file_needs_sync'
 
 module OpenShift
   class AdminGearsControl

--- a/node/lib/openshift-origin-node/model/frontend_httpd.rb
+++ b/node/lib/openshift-origin-node/model/frontend_httpd.rb
@@ -458,7 +458,7 @@ module OpenShift
     # Returns nil on Success or raises on Failure
     def disconnect(*paths)
       ApacheDBNodes.open(ApacheDBNodes::WRCREAT) do |d|
-        paths.each do |p|
+        paths.flatten.each do |p|
           d.delete(@fqdn + p.to_s)
         end
       end
@@ -466,7 +466,7 @@ module OpenShift
     end
 
     def disconnect_websocket(*paths)
-      if paths.include?("")
+      if paths.flatten.include?("")
         NodeJSDBRoutes.open(NodeJSDBRoutes::WRCREAT) do |d|
           d.delete(@fqdn)
         end

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -8,6 +8,7 @@ require 'openshift-origin-node'
 require 'openshift-origin-node/model/cartridge_repository'
 require 'shellwords'
 require 'facter'
+require 'openshift-origin-common/utils/file_needs_sync'
 
 module MCollective
   module Agent


### PR DESCRIPTION
After some tests and examining the C code, it appears as though the following happens:

File.open(...) do |file|
  file.write(...)
end

Has a chance of the string passed to write being duplicated in io.c.  There's even some code and a comment in io.c pertaining to the issue.

Setting File::SYNC on open doesn't help.  Nor does calling sync, or fsync after the write.

Surprisingly, File::SYNC does not appear to toggle sync on the IO object though it does cause the underlying system open to use O_SYNC.

File.open("foo",  File::RDWR|File::CREAT|File::TRUNC|File::SYNC) do |f| 
  puts "#{f.sync.inspect}"
end

...returns "false".

Setting f.sync=true does appear to help.

This has been observed to affect the following file operations:
1. Creating gear variables.
2. Writing Apache databases in FrontendHttpServer
3. NodeLogger

It is suspected that the problem has also happened during ERB file processing.

I believe that this problem potentially affects any file write orchestrated by the node code that happens with high concurrency or under a load.

This includes:
1. Anything done through mcollective
2. oo-admin-ctl-gears

Because of the pervasive nature of the problem, it is proposed that a module be created to monkey patch File to set sync=true on the resulting IO object in open and new.
