### PR TITLE
<oo-admin-ctl-groups> Bug 964205 - fix stopuser(), add "repair" command

### DIFF
--- a/node/misc/sbin/oo-admin-ctl-cgroups
+++ b/node/misc/sbin/oo-admin-ctl-cgroups
@@ -104,7 +104,7 @@ function set_memory() {
 }
 
 # ==========================================================================
-#  Functions for tuning the user's memory limits in cgroups
+#  Functions for tuning the weighting of user's disk IO
 # ==========================================================================
 BLKIOVARS="weight weight_device"
 function set_blkio() {

--- a/node/misc/sbin/oo-admin-ctl-cgroups
+++ b/node/misc/sbin/oo-admin-ctl-cgroups
@@ -300,7 +300,7 @@ startall() {
     [ $GROUP_RETVAL -eq 0 ] && touch ${lockfile}
     [ $GROUP_RETVAL -eq 0 ] && (echo -n "[ OK ]") || (echo -n "[ FAILED ]")
 
-    echo -n $"Openshift cgroups initialized"
+    echo -n "Openshift cgroups initialized"
     echo
     return $GROUP_RETVAL
     echo
@@ -379,7 +379,7 @@ stopall() {
     fi
 
     [ $GROUP_RETVAL -eq 0 ] && touch ${lockfile}
-    echo -n $"Openshift cgroups uninitialized"
+    echo -n "Openshift cgroups uninitialized"
     echo
     return $GROUP_RETVAL
 }
@@ -493,7 +493,7 @@ case "$1" in
         ;;
 
     *)
-        echo $"Usage: $0 {startall|stopall|restartall|condrestartall|status|startuser <username>|stopuser <username>|freezeuser <username>|thawuser <username>}"
+        echo "Usage: $0 {startall|stopall|restartall|condrestartall|status|startuser <username>|stopuser <username>|freezeuser <username>|thawuser <username>}"
         exit 1
 esac
 

--- a/node/misc/sbin/oo-admin-ctl-cgroups
+++ b/node/misc/sbin/oo-admin-ctl-cgroups
@@ -70,14 +70,14 @@ function set_cpu() {
 
     for VARNAME in $CPUVARS
     do
-	# cgroups names can have periods(.)  shell varnames can't
-	SAFENAME=`echo $VARNAME | tr . _`
-	VALUE=`eval echo \\$cpu_$SAFENAME`
-	if [ -n "${VALUE}" ]
-	then
-	    # TODO: get per-app increments
-	    cgset -r "cpu.$VARNAME=$VALUE" $CGPATH
-	fi
+        # cgroups names can have periods(.)  shell varnames can't
+        SAFENAME=`echo $VARNAME | tr . _`
+        VALUE=`eval echo \\$cpu_$SAFENAME`
+        if [ -n "${VALUE}" ]
+        then
+            # TODO: get per-app increments
+            cgset -r "cpu.$VARNAME=$VALUE" $CGPATH
+        fi
     done
 }
 
@@ -92,14 +92,14 @@ function set_memory() {
     # for each var get and set the value
     for VARNAME in $MEMVARS
     do
-	# cgroups names can have periods(.)  shell varnames can't
-	SAFENAME=`echo $VARNAME | tr . _`
-	VALUE=`eval echo \\$memory_$SAFENAME`
-	if [ -n "${VALUE}" ]
-	then
-	    # TODO: get per-app increments
-	    cgset -r "memory.$VARNAME=$VALUE" $CGPATH
-	fi
+    # cgroups names can have periods(.)  shell varnames can't
+    SAFENAME=`echo $VARNAME | tr . _`
+    VALUE=`eval echo \\$memory_$SAFENAME`
+    if [ -n "${VALUE}" ]
+    then
+        # TODO: get per-app increments
+        cgset -r "memory.$VARNAME=$VALUE" $CGPATH
+    fi
     done
 }
 
@@ -114,17 +114,17 @@ function set_blkio() {
     # for each var get and set the value
     for VARNAME in $BLKIOVARS
     do
-	# cgroups names can have periods(.)  shell varnames can't
-	SAFENAME=`echo $VARNAME | tr . _`
-	VALUE=`eval echo \\$blkio_$SAFENAME`
-	if [ -n "${VALUE}" ]
-	then
-	    # TODO: get per-app increments
-	    # TODO: weight_device should really use the user's home device
-	    #       and set the rest (if any) to 0
-	    # cgset -r "blkio.$VARNAME=$VALUE" $CGPATH
-	    echo nothing >>/dev/null
-	fi
+        # cgroups names can have periods(.)  shell varnames can't
+        SAFENAME=`echo $VARNAME | tr . _`
+        VALUE=`eval echo \\$blkio_$SAFENAME`
+        if [ -n "${VALUE}" ]
+        then
+            # TODO: get per-app increments
+            # TODO: weight_device should really use the user's home device
+            #       and set the rest (if any) to 0
+            # cgset -r "blkio.$VARNAME=$VALUE" $CGPATH
+            echo nothing >>/dev/null
+        fi
     done
 }
 
@@ -192,7 +192,7 @@ cgroup_rule_exists() {
 add_cgroup_rule() {
     # USERNAME=$1
     cat <<EOF >>${CGROUP_RULES_FILE}
-$1	$OPENSHIFT_CGROUP_SUBSYSTEMS	$OPENSHIFT_CGROUP_ROOT/$1
+$1  $OPENSHIFT_CGROUP_SUBSYSTEMS    $OPENSHIFT_CGROUP_ROOT/$1
 EOF
 }
 
@@ -213,7 +213,7 @@ collect_tasks() {
 
     # add existing processes to the group
     for PID in $(ps -opid= -u $(id -u $1)) ; do
-	cgclassify -g ${OPENSHIFT_CGROUP_SUBSYSTEMS}:${CGPATH} $PID
+    cgclassify -g ${OPENSHIFT_CGROUP_SUBSYSTEMS}:${CGPATH} $PID
     done
 }
 
@@ -238,6 +238,7 @@ startuser() {
     then
         delete_cgroup_rule $NEWUSER
     fi
+
     add_cgroup_rule $NEWUSER
     if [ $? != 0 ]
     then
@@ -263,23 +264,22 @@ startall() {
     if ! is_systemd
     then
 
-  	if !(service cgconfig status >/dev/null)
-  	then
-              RETVAL=1
-              GROUP_RETVAL=3
-              echo "cgconfig service not running. attempting to start it"
-              service cgconfig start
-              return $GROUP_RETVAL
-  	fi
-  
-  	if !(service cgconfig status >/dev/null)
-  	then
-              RETVAL=1
-              GROUP_RETVAL=3
-              echo "cgconfig service not running."
-  	    
-              return $GROUP_RETVAL
-  	fi
+        if !(service cgconfig status >/dev/null)
+        then
+            RETVAL=1
+            GROUP_RETVAL=3
+            echo "cgconfig service not running. attempting to start it"
+            service cgconfig start
+            return $GROUP_RETVAL
+        fi
+
+        if !(service cgconfig status >/dev/null)
+        then
+            RETVAL=1
+            GROUP_RETVAL=3
+            echo "cgconfig service not running."
+            return $GROUP_RETVAL
+        fi
 
     fi
 
@@ -322,14 +322,14 @@ stopuser() {
     delete_cgroup $DELUSER
     if [ $? != 0 ]
     then
-	RETVAL=$?
+        RETVAL=$?
     fi
 
     # remove the user's cgroup binding rule
     delete_cgroup_rule $DELUSER
     if [ $? != 0 ]
     then
-	RETVAL=$?
+        RETVAL=$?
     fi
 
     if [ $RETVAL -eq 0 ]
@@ -347,20 +347,20 @@ stopall() {
 
     if ! is_systemd
     then
-	if !(service cgconfig status >/dev/null)
-	then
-	    RETVAL=1
-	    GROUP_RETVAL=3
-	    echo "cgconfig service not running"
+        if !(service cgconfig status >/dev/null)
+        then
+            RETVAL=1
+            GROUP_RETVAL=3
+            echo "cgconfig service not running"
 
-	    return $GROUP_RETVAL
-	fi
+            return $GROUP_RETVAL
+        fi
     fi
 
     # This won't scale forever, but works fine in the '100 or so' range
     for USERNAME in `openshift_users`
     do
-	stopuser $USERNAME
+        stopuser $USERNAME
     done
 
     # notify the cgroup rule daemon
@@ -395,16 +395,16 @@ status() {
     lscgroup | grep -e  ":${OPENSHIFT_CGROUP_ROOT}\$" >/dev/null 2>&1
     if [ $? -ne 0 ]
     then
-	echo "Openshift cgroups uninitialized"
-	echo
-	return 1
+        echo "Openshift cgroups uninitialized"
+        echo
+        return 1
     else
-	echo "Openshift cgroups initialized"
+        echo "Openshift cgroups initialized"
     fi
 
     if [ -z "$1" ]
     then
-	USERLIST=`openshift_users`
+        USERLIST=`openshift_users`
     else
         USERLIST=$1
     fi
@@ -415,19 +415,19 @@ status() {
     #  would be easy to convert to a 'in `find...`'     jj
     for USERNAME in $USERLIST
     do
-	# check that /openshift/<username> exists
-	SUBSYSTEMS=`cgroup_user_subsystems`
-	if ( cgroup_rule_exists $USERNAME )
+        # check that /openshift/<username> exists
+        SUBSYSTEMS=`cgroup_user_subsystems`
+        if ( cgroup_rule_exists $USERNAME )
         then
-	    RETVAL=0
+            RETVAL=0
             BOUND="BOUND"
         else
-	    RETVAL=1
+            RETVAL=1
             BOUND="UNBOUND"
         fi
 
-	echo -n "${USERNAME}: $BOUND	" `echo $SUBSYSTEMS | tr ' ' ,`
-	# check that cgrule exists
+        echo -n "${USERNAME}: $BOUND    " `echo $SUBSYSTEMS | tr ' ' ,`
+        # check that cgrule exists
 
         if [ $RETVAL -eq 0 ]
         then
@@ -436,65 +436,65 @@ status() {
             GROUP_RETVAL=$(($GROUP_RETVAL+1))
             echo -n "[ FAILED ]"
         fi
-	echo
+        echo
     done
     return $GROUP_RETVAL
 }
 
 case "$1" in
-  startall)
-    startall
-    ;;
+    startall)
+        startall
+        ;;
 
-  stopall)
-    stopall
-    ;;
+    stopall)
+        stopall
+        ;;
 
-  restartall)
-    restartall
-    ;;
+    restartall)
+        restartall
+        ;;
 
-  condrestartall)
-    [ -f "$lockfile" ] && restartall
-    ;;
+    condrestartall)
+        [ -f "$lockfile" ] && restartall
+        ;;
 
-  status)
-    status $2
-    ;;
+    status)
+        status $2
+        ;;
 
-  startuser)
-    if is_systemd || service cgconfig status >/dev/null 2>&1
-    then 
-        startuser $2
-        pkill -USR2 cgrulesengd
-    else
-        RETVAL=1
-        echo "cgconfig service is not running"
-    fi
-    ;;
+    startuser)
+        if is_systemd || service cgconfig status >/dev/null 2>&1
+        then
+            startuser $2
+            pkill -USR2 cgrulesengd
+        else
+            RETVAL=1
+            echo "cgconfig service is not running"
+        fi
+        ;;
 
-  stopuser)
-    if is_systemd || service cgconfig status >/dev/null 2>&1
-    then
-        stopuser $2
-        pkill -USR2 cgrulesengd
-    else
-        RETVAL=1
-        echo "cgconfig service is not running"
-    fi
-    ;;
+    stopuser)
+        if is_systemd || service cgconfig status >/dev/null 2>&1
+        then
+            stopuser $2
+            pkill -USR2 cgrulesengd
+        else
+            RETVAL=1
+            echo "cgconfig service is not running"
+        fi
+        ;;
 
-  freezeuser)
-    freeze_user $2
-    ;;
+    freezeuser)
+        freeze_user $2
+        ;;
 
-  thawuser)
-    thaw_user $2
-    ;;
+    thawuser)
+        thaw_user $2
+        ;;
 
-  *)
-    echo $"Usage: $0 {startall|stopall|restartall|condrestartall|status|startuser <username>|stopuser <username>|freezeuser <username>|thawuser <username>}"
-    exit 1
+    *)
+        echo $"Usage: $0 {startall|stopall|restartall|condrestartall|status|startuser <username>|stopuser <username>|freezeuser <username>|thawuser <username>}"
+        exit 1
 esac
 
 exit $RETVAL

--- a/node/misc/sbin/oo-admin-ctl-cgroups
+++ b/node/misc/sbin/oo-admin-ctl-cgroups
@@ -192,7 +192,7 @@ cgroup_rule_exists() {
 add_cgroup_rule() {
     # USERNAME=$1
     cat <<EOF >>${CGROUP_RULES_FILE}
-$1  $OPENSHIFT_CGROUP_SUBSYSTEMS    $OPENSHIFT_CGROUP_ROOT/$1
+$1	$OPENSHIFT_CGROUP_SUBSYSTEMS	$OPENSHIFT_CGROUP_ROOT/$1
 EOF
 }
 
@@ -218,47 +218,49 @@ collect_tasks() {
 }
 
 startuser() {
-    NEWUSER=$1
+    local _newuser=$1
 
-    echo -n "starting cgroups for $NEWUSER..."
+    local _retval=0
+    local _group_retval=0
 
-    add_cgroup $NEWUSER
-    if [ $? != 0 ]
-    then
-        RETVAL=$?
-    fi
+    echo -n "starting cgroups for ${_newuser}..."
 
-    set_cpu $NEWUSER
-    set_memory $NEWUSER
-    #set_blkio $NEWUSER
-    set_net_cls $NEWUSER
+    add_cgroup $_newuser
+    (( _retval |= $? )) # capture return value
+
+    set_cpu $_newuser
+    set_memory $_newuser
+    #set_blkio $_newuser
+    set_net_cls $_newuser
 
     # CHECK: don't trust old rules
-    if ( cgroup_rule_exists $NEWUSER )
+    if ( cgroup_rule_exists $_newuser )
     then
-        delete_cgroup_rule $NEWUSER
+        delete_cgroup_rule $_newuser
     fi
 
-    add_cgroup_rule $NEWUSER
-    if [ $? != 0 ]
-    then
-        RETVAL=$?
-    fi
+    add_cgroup_rule $_newuser
+    (( _retval |= $? )) # capture return value
 
-    collect_tasks $NEWUSER
+    collect_tasks $_newuser
 
-    if [ $RETVAL -eq 0 ]
+    if [ $_retval -eq 0 ]
     then
         echo -n " [OK] "
     else
-        GROUP_RETVAL=$(($GROUP_RETVAL+1))
+        (( _group_retval += 1 ))
         echo -n " [FAILED] "
     fi
     echo
+    return $_group_retval
 }
+
 
 startall() {
     echo "Initializing Openshift guest control groups: "
+
+    local _retval=0
+    local _group_retval=0
 
     # Hosts running an OS based on systemd already have cgroups running
     if ! is_systemd
@@ -266,94 +268,98 @@ startall() {
 
         if !(service cgconfig status >/dev/null)
         then
-            RETVAL=1
-            GROUP_RETVAL=3
+            _retval=1
+            _group_retval=3
             echo "cgconfig service not running. attempting to start it"
             service cgconfig start
-            return $GROUP_RETVAL
+            return $_group_retval
         fi
 
         if !(service cgconfig status >/dev/null)
         then
-            RETVAL=1
-            GROUP_RETVAL=3
+            _retval=1
+            _group_retval=3
             echo "cgconfig service not running."
-            return $GROUP_RETVAL
+            return $_group_retval
         fi
 
     fi
 
     # create the root of the openshift user control group
     add_cgroup # defaults to creating the root group
-    RETVAL=$?
+    _retval=$?
+    [ $_retval -eq 0 ] || return $_retval
 
     # This won't scale forever, but works fine in the '100 or so' range
     for USERNAME in `openshift_users`
     do
         startuser $USERNAME
+        (( _group_retval += $? ))
     done
 
     # kick the Cgroups rules daemon
     #service cgred reload
     pkill -USR2 cgrulesengd
 
-    [ $GROUP_RETVAL -eq 0 ] && touch ${lockfile}
-    [ $GROUP_RETVAL -eq 0 ] && (echo -n "[ OK ]") || (echo -n "[ FAILED ]")
+    [ $_group_retval -eq 0 ] && touch ${lockfile}
+    [ $_group_retval -eq 0 ] && (echo -n "[ OK ]") || (echo -n "[ FAILED ]")
 
     echo -n "Openshift cgroups initialized"
     echo
-    return $GROUP_RETVAL
     echo
     echo "WARNING !!! WARNING !!! WARNING !!!"
     echo "Cgroups may have just restarted.  It's important to confirm all the openshift apps are actively running."
     echo "It's suggested you run service openshift restart now"
     echo "WARNING !!! WARNING !!! WARNING !!!"
     echo
+    return $_group_retval
 }
 
 stopuser() {
-    DELUSER=$1
-    echo -n "stopping cgroups for $DELUSER..."
+    local _deluser=$1
+
+    local _retval=0
+    local _group_retval=0
+
+    echo -n "stopping cgroups for ${_deluser}..."
 
     # kill any processes owned by these users
-    #pkill -u $(id -u $DELUSER)
+    #pkill -u $(id -u $_deluser)
 
     # remove the user's cgroup
-    delete_cgroup $DELUSER
-    if [ $? != 0 ]
-    then
-        RETVAL=$?
-    fi
+    delete_cgroup $_deluser
+    (( _retval |= $? )) # capture return value
 
     # remove the user's cgroup binding rule
-    delete_cgroup_rule $DELUSER
-    if [ $? != 0 ]
-    then
-        RETVAL=$?
-    fi
+    delete_cgroup_rule $_deluser
+    (( _retval |= $? )) # capture return value
 
-    if [ $RETVAL -eq 0 ]
+    if [ $_retval -eq 0 ]
     then
         echo -n " [OK] "
     else
-        GROUP_RETVAL=$(($GROUP_RETVAL+1))
+        (( _group_retval += 1 ))
         echo -n " [FAILED] "
     fi
     echo
+    return $_group_retval
 }
 
 stopall() {
     echo "Removing Openshift guest control groups: "
 
+    local _retval=0
+    local _group_retval=0
+
     if ! is_systemd
     then
         if !(service cgconfig status >/dev/null)
         then
-            RETVAL=1
-            GROUP_RETVAL=3
+            _retval=1
+            _group_retval=3
             echo "cgconfig service not running"
 
-            return $GROUP_RETVAL
+            return $_group_retval
         fi
     fi
 
@@ -361,6 +367,7 @@ stopall() {
     for USERNAME in `openshift_users`
     do
         stopuser $USERNAME
+        (( _group_retval += $? ))
     done
 
     # notify the cgroup rule daemon
@@ -370,36 +377,44 @@ stopall() {
     # remove the openshift root cgroup
     delete_cgroup
 
-    if [ $RETVAL -eq 0 ]
+    if [ $_retval -eq 0 ]
     then
         echo -n "[ OK ]"
     else
-        GROUP_RETVAL=$(($GROUP_RETVAL+1))
+        (( _group_retval += 1 ))
         echo -n "[ FAILED ]"
     fi
 
-    [ $GROUP_RETVAL -eq 0 ] && touch ${lockfile}
+    [ $_group_retval -eq 0 ] && touch ${lockfile}
     echo -n "Openshift cgroups uninitialized"
     echo
-    return $GROUP_RETVAL
+    return $_group_retval
 }
 
 restartall() {
+
+    local _group_retval=0
+
     stopall
+    (( _group_retval += $? ))
     startall
+    (( _group_retval += $? ))
+    return $_group_retval
 }
 
 status() {
     echo "Checking Openshift Services: "
 
-    lscgroup | grep -e  ":${OPENSHIFT_CGROUP_ROOT}\$" >/dev/null 2>&1
-    if [ $? -ne 0 ]
+    local _retval=0
+    local _group_retval=0
+
+    if lscgroup | grep -e  ":${OPENSHIFT_CGROUP_ROOT}\$" >/dev/null 2>&1
     then
+        echo "Openshift cgroups initialized"
+    else
         echo "Openshift cgroups uninitialized"
         echo
         return 1
-    else
-        echo "Openshift cgroups initialized"
     fi
 
     if [ -z "$1" ]
@@ -419,53 +434,59 @@ status() {
         SUBSYSTEMS=`cgroup_user_subsystems`
         if ( cgroup_rule_exists $USERNAME )
         then
-            RETVAL=0
+            _retval=0
             BOUND="BOUND"
         else
-            RETVAL=1
+            _retval=1
             BOUND="UNBOUND"
         fi
 
         echo -n "${USERNAME}: $BOUND    " `echo $SUBSYSTEMS | tr ' ' ,`
         # check that cgrule exists
 
-        if [ $RETVAL -eq 0 ]
+        if [ $_retval -eq 0 ]
         then
             echo -n "[ OK ]"
         else
-            GROUP_RETVAL=$(($GROUP_RETVAL+1))
+            (( _group_retval += 1 ))
             echo -n "[ FAILED ]"
         fi
         echo
     done
-    return $GROUP_RETVAL
+    return $_group_retval
 }
 
 case "$1" in
     startall)
         startall
+        RETVAL=$?
         ;;
 
     stopall)
         stopall
+        RETVAL=$?
         ;;
 
     restartall)
         restartall
+        RETVAL=$?
         ;;
 
     condrestartall)
         [ -f "$lockfile" ] && restartall
+        RETVAL=$?
         ;;
 
     status)
         status $2
+        RETVAL=$?
         ;;
 
     startuser)
         if is_systemd || service cgconfig status >/dev/null 2>&1
         then
             startuser $2
+            RETVAL=$?
             pkill -USR2 cgrulesengd
         else
             RETVAL=1
@@ -477,6 +498,7 @@ case "$1" in
         if is_systemd || service cgconfig status >/dev/null 2>&1
         then
             stopuser $2
+            RETVAL=$?
             pkill -USR2 cgrulesengd
         else
             RETVAL=1
@@ -486,14 +508,16 @@ case "$1" in
 
     freezeuser)
         freeze_user $2
+        RETVAL=$?
         ;;
 
     thawuser)
         thaw_user $2
+        RETVAL=$?
         ;;
 
     *)
-        echo "Usage: $0 {startall|stopall|restartall|condrestartall|status|startuser <username>|stopuser <username>|freezeuser <username>|thawuser <username>}"
+        echo "Usage: $0 {startall|stopall|restartall|condrestartall|status [<username>]|startuser <username>|stopuser <username>|freezeuser <username>|thawuser <username>}"
         exit 1
 esac
 

--- a/node/misc/sbin/oo-admin-ctl-cgroups
+++ b/node/misc/sbin/oo-admin-ctl-cgroups
@@ -152,9 +152,10 @@ valid_user() {
 }
 
 #
-# Check to see if a cgroup exists for the specified user
+# Check that a cgroup exists for a user
 #
 cgroup_exists() {
+    # USERNAME=$1
     [ "$(lscgroup ${OPENSHIFT_CGROUP_SUBSYSTEMS}:${OPENSHIFT_CGROUP_ROOT}/$1 | wc -l)" != "0" ]
 }
 

--- a/node/misc/sbin/oo-admin-ctl-cgroups
+++ b/node/misc/sbin/oo-admin-ctl-cgroups
@@ -334,12 +334,17 @@ stopuser() {
     #pkill -u $(id -u $_deluser)
 
     # remove the user's cgroup
-    delete_cgroup $_deluser
-    (( _retval |= $? )) # capture return value
+    if cgroup_exists $_deluser
+    then
+        delete_cgroup $_deluser
+        (( _retval |= $? )) # capture return value
 
-    # remove the user's cgroup binding rule
-    delete_cgroup_rule $_deluser
-    (( _retval |= $? )) # capture return value
+        # remove the user's cgroup binding rule
+        delete_cgroup_rule $_deluser
+        (( _retval |= $? )) # capture return value
+    else
+        echo -n " cgroup already stopped"
+    fi
 
     if [ $_retval -eq 0 ]
     then

--- a/node/misc/sbin/oo-admin-ctl-cgroups
+++ b/node/misc/sbin/oo-admin-ctl-cgroups
@@ -152,6 +152,13 @@ valid_user() {
 }
 
 #
+# Check to see if a cgroup exists for the specified user
+#
+cgroup_exists() {
+    [ "$(lscgroup ${OPENSHIFT_CGROUP_SUBSYSTEMS}:${OPENSHIFT_CGROUP_ROOT}/$1 | wc -l)" != "0" ]
+}
+
+#
 # Create a new openshift user cgroup
 #
 add_cgroup() {
@@ -456,6 +463,33 @@ status() {
     return $_group_retval
 }
 
+#
+# Find all users (or the specified user) which don't have cgroup
+# containers and create containers for them
+#
+repair() {
+    local _group_retval=0
+
+    # Iterate over the user-supplied list, or default to the list of
+    # all users
+    if [ -z "$1" ]
+    then
+        USERLIST=$(openshift_users)
+    else
+        USERLIST=$1
+    fi
+
+    for USERNAME in $USERLIST
+    do
+        if ! cgroup_exists $USERNAME
+        then
+            startuser $USERNAME
+            (( _group_retval += $? ))
+        fi
+    done
+    return $_group_retval
+}
+
 case "$1" in
     startall)
         startall
@@ -469,6 +503,11 @@ case "$1" in
 
     restartall)
         restartall
+        RETVAL=$?
+        ;;
+
+    repair)
+        repair $2
         RETVAL=$?
         ;;
 
@@ -517,7 +556,7 @@ case "$1" in
         ;;
 
     *)
-        echo "Usage: $0 {startall|stopall|restartall|condrestartall|status [<username>]|startuser <username>|stopuser <username>|freezeuser <username>|thawuser <username>}"
+        echo "Usage: $0 {startall|stopall|restartall|repair [<username>]|condrestartall|status [<username>]|startuser <username>|stopuser <username>|freezeuser <username>|thawuser <username>}"
         exit 1
 esac
 


### PR DESCRIPTION
Modified stopuser() to check if the cgroup for the specified user has
already been stopped, and echo a useful message if that is the case
instead running cgdelete and generating "file not found" noise

Added a new command to oo-admin-ctl-cgroups called
"repair". This command identifies users which lack a cgroup and
creates a cgroup for them. It can be called with an optional username
argument (or a quoted space-separated list of usernames) to restrict
the action to a specific subset.

@markllama @kwoodson
