### PR TITLE
Bug 966963: Remove unnecessary versioned conf files from php cart

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/bin/setup
+++ b/cartridges/openshift-origin-cartridge-php/bin/setup
@@ -9,7 +9,7 @@ esac
 shopt -s dotglob
 
 mkdir -p $OPENSHIFT_PHP_DIR/configuration/etc/
-cp -Hr $OPENSHIFT_PHP_DIR/versions/$version/configuration/etc/* $OPENSHIFT_PHP_DIR/configuration/etc/
+cp -Hr $OPENSHIFT_PHP_DIR/versions/shared/configuration/etc/* $OPENSHIFT_PHP_DIR/configuration/etc/
 
 # Create additional directories required by PHP
 mkdir -p $OPENSHIFT_PHP_DIR/phplib/pear/{docs,ext,php,cache,cfg,data,download,temp,tests,www}

--- a/cartridges/openshift-origin-cartridge-php/openshift-origin-cartridge-php.spec
+++ b/cartridges/openshift-origin-cartridge-php/openshift-origin-cartridge-php.spec
@@ -57,13 +57,11 @@ PHP cartridge for openshift. (Cartridge Format V2)
 
 %if 0%{?fedora}%{?rhel} <= 6
 %__mv %{buildroot}%{cartridgedir}/versions/shared/configuration/etc/conf-httpd-2.2/* %{buildroot}%{cartridgedir}/versions/shared/configuration/etc/conf/
-%__rm -rf %{buildroot}%{cartridgedir}/versions/5.4
 %__mv %{buildroot}%{cartridgedir}/metadata/manifest.yml.rhel %{buildroot}%{cartridgedir}/metadata/manifest.yml
 %__rm %{buildroot}%{cartridgedir}/metadata/manifest.yml.fedora
 %endif
 %if 0%{?fedora} >= 18
 %__mv %{buildroot}%{cartridgedir}/versions/shared/configuration/etc/conf-httpd-2.4/* %{buildroot}%{cartridgedir}/versions/shared/configuration/etc/conf/
-%__rm -rf %{buildroot}%{cartridgedir}/versions/5.3
 %__mv %{buildroot}%{cartridgedir}/metadata/manifest.yml.fedora %{buildroot}%{cartridgedir}/metadata/manifest.yml
 %__rm %{buildroot}%{cartridgedir}/metadata/manifest.yml.rhel
 sed -i 's/#DefaultRuntimeDir/DefaultRuntimeDir/g' %{buildroot}%{cartridgedir}/versions/shared/configuration/etc/conf.d/openshift.conf.erb

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/conf
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/conf
@@ -1,1 +1,0 @@
-../../../shared/configuration/etc/conf

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/conf.d
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/conf.d
@@ -1,1 +1,0 @@
-../../../shared/configuration/etc/conf.d

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.ini.erb
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.ini.erb
@@ -1,1 +1,0 @@
-../../../shared/configuration/etc/php.ini.erb

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/metadata
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/metadata
@@ -1,1 +1,0 @@
-../shared/metadata/

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/conf
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/conf
@@ -1,1 +1,0 @@
-../../../shared/configuration/etc/conf

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/conf.d
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/conf.d
@@ -1,1 +1,0 @@
-../../../shared/configuration/etc/conf.d

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.ini.erb
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.ini.erb
@@ -1,1 +1,0 @@
-../../../shared/configuration/etc/php.ini.erb

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/metadata
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/metadata
@@ -1,1 +1,0 @@
-../shared/metadata/

--- a/controller/test/cucumber/step_definitions/application_steps.rb
+++ b/controller/test/cucumber/step_definitions/application_steps.rb
@@ -62,7 +62,7 @@ end
 When /^the submodule is added$/ do
   Dir.chdir(@app.repo) do
     # Add a submodule created in devenv and link the index file
-    run("git submodule add /root/submodule_test_repo")
+    run("git submodule add #{$submodule_repo_dir}")
     run("REPLACE=`cat submodule_test_repo/index`; sed -i \"s/OpenShift/${REPLACE}/\" #{@app.get_index_file}")
     run("git commit -a -m 'Test submodule change'")
     run("git push >> " + @app.get_log("git_push") + " 2>&1")

--- a/controller/test/cucumber/support/00_setup_helper.rb
+++ b/controller/test/cucumber/support/00_setup_helper.rb
@@ -34,7 +34,7 @@ end
 $alias_domain = "foobar.com"
 
 # Submodule repo directory for testing submodule addition test case
-$submodule_repo_dir = "#{Etc.getpwuid.dir}/submodule_test_repo"
+$submodule_repo_dir = "/opt/openshift-cucumber/submodule_test_repo"
 
 # RHC Client
 $rhc_script = '/usr/bin/rhc'
@@ -84,8 +84,9 @@ module SetupHelper
         `git add index`
         `git commit -m 'test'`
       end
+      `chmod -R 666 $submodule_repo_dir`
     end
-    
+
     # set the bind keyvalue from the installed plugin config
     if File.exists?("/etc/openshift/plugins.d/openshift-origin-dns-bind.conf")
       $bind_keyvalue = `cat /var/named/example.com.key | grep -i secret | gawk -F ' ' '{ print $2 }'`


### PR DESCRIPTION
The php 5.3/5.4 configuration files all symlink back to shared. Remove the specific version
directories/files and use only the shared directory for setup. This also fixes a bug where
the symlinks to shared become broken during setup (as ERBs are removed during processing)
and cause the remaining symlinks to be re-processed as ERBs (which fails).
