### PR TITLE
Bug 966876 - Fix AVC denial in jbossas7 and jbosseap6 carts on startup

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/versions/7/bin/standalone.conf
+++ b/cartridges/openshift-origin-cartridge-jbossas/versions/7/bin/standalone.conf
@@ -52,8 +52,9 @@ if [ -n "$OPENSHIFT_POSTGRESQL_DB_URL" ]
 then
     POSTGRESQL_ENABLED="true"
 fi
-       
-max_memory_bytes=$(oo-cgroup-read memory.limit_in_bytes)
+
+# Redirect stderr for oo-cgroup-read since it tries to open a file handle to /tmp/jbosseap.log
+max_memory_bytes=$(oo-cgroup-read memory.limit_in_bytes 2> /dev/null)
 max_threads=$(ulimit -u)
 
 if ! [[ "$max_memory_bytes" =~ ^[0-9]+$ ]] ; then

--- a/cartridges/openshift-origin-cartridge-jbosseap/versions/6.0/bin/standalone.conf
+++ b/cartridges/openshift-origin-cartridge-jbosseap/versions/6.0/bin/standalone.conf
@@ -53,7 +53,8 @@ then
     POSTGRESQL_ENABLED="true"
 fi
        
-max_memory_bytes=$(oo-cgroup-read memory.limit_in_bytes)
+# Redirect stderr for oo-cgroup-read since it tries to open a file handle to /tmp/jbosseap.log
+max_memory_bytes=$(oo-cgroup-read memory.limit_in_bytes 2> /dev/null)
 max_threads=$(ulimit -u)
 
 if ! [[ "$max_memory_bytes" =~ ^[0-9]+$ ]] ; then


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=966876

Redirect stderr to /dev/null when running oo-cgroup-read from bin/standalone.conf in jbosseap and jbossas v2 carts.  These are run with stderr redirected to a logfile in the gears tmp directory and oo-cgroup-read is trying to open a file handle to this logfile causing an AVC denial
