### PR TITLE
Bug 967532: Fix initial ROOT.war deployment for jboss cartridges

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/haproxy_ctld.rb
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/haproxy_ctld.rb
@@ -192,7 +192,7 @@ class Haproxy
     def add_gear(verbose=false)
         @last_scale_up_time = Time.now
         @log.info("GEAR_UP - capacity: #{self.session_capacity_pct}% gear_count: #{self.gear_count} sessions: #{self.sessions} up_thresh: #{@gear_up_pct}%")
-        res=`#{ENV['OPENSHIFT_HAPROXY_DIR']}/usr/bin/add-gear -n #{self.gear_namespace}  -a #{ENV['OPENSHIFT_APP_NAME']} -u #{ENV['OPENSHIFT_APP_UUID']}`
+        res=`#{ENV['OPENSHIFT_HAPROXY_DIR']}/usr/bin/add-gear -n #{self.gear_namespace}  -a #{ENV['OPENSHIFT_APP_NAME']} -u #{ENV['OPENSHIFT_APP_UUID']} 2>&1`
         @log.debug("GEAR_UP - add-gear: exit: #{$?}  stdout: #{res}")
         $stderr.puts(res) if verbose and res != ""
         self.print_gear_stats
@@ -200,7 +200,7 @@ class Haproxy
 
     def remove_gear(verbose=false)
         @log.info("GEAR_DOWN - capacity: #{self.session_capacity_pct}% gear_count: #{self.gear_count} sessions: #{self.sessions} remove_thresh: #{@gear_remove_pct}%")
-        res=`#{ENV['OPENSHIFT_HAPROXY_DIR']}/usr/bin/remove-gear -n #{self.gear_namespace} -a #{ENV['OPENSHIFT_APP_NAME']} -u #{ENV['OPENSHIFT_APP_UUID']}`
+        res=`#{ENV['OPENSHIFT_HAPROXY_DIR']}/usr/bin/remove-gear -n #{self.gear_namespace} -a #{ENV['OPENSHIFT_APP_NAME']} -u #{ENV['OPENSHIFT_APP_UUID']} 2>&1`
         @log.debug("GEAR_DOWN - remove-gear: exit: #{$?}  stdout: #{res}")
         $stderr.puts(res) if verbose and res != ""
         self.print_gear_stats

--- a/cartridges/openshift-origin-cartridge-jbossas/bin/install
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/install
@@ -23,6 +23,8 @@ pushd $OPENSHIFT_JBOSSAS_DIR/versions/${version}/template/src/main/webapp 1> /de
   jar cvf $OPENSHIFT_JBOSSAS_DIR/standalone/deployments/ROOT.war ./*
 popd 1> /dev/null
 
+cp $OPENSHIFT_JBOSSAS_DIR/standalone/deployments/ROOT.war ${OPENSHIFT_JBOSSAS_DIR}/template/deployments
+
 JBOSS_HOME=/etc/alternatives/jbossas-$version
 pushd $OPENSHIFT_JBOSSAS_DIR 1> /dev/null
   ln -s ${JBOSS_HOME}/jboss-modules.jar

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/install
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/install
@@ -23,6 +23,8 @@ pushd $OPENSHIFT_JBOSSEAP_DIR/versions/${version}/template/src/main/webapp 1>/de
   jar cvf $OPENSHIFT_JBOSSEAP_DIR/standalone/deployments/ROOT.war ./*
 popd 1> /dev/null
 
+cp $OPENSHIFT_JBOSSEAP_DIR/standalone/deployments/ROOT.war ${OPENSHIFT_JBOSSEAP_DIR}/template/deployments
+
 JBOSS_HOME=/etc/alternatives/jbosseap-$version
 pushd $OPENSHIFT_JBOSSEAP_DIR 1> /dev/null
   ln -s ${JBOSS_HOME}/jboss-modules.jar


### PR DESCRIPTION
Install the initial ROOT.war into both the live deployments directory and the
template app repo to ensure unmodified applications correctly scale up.
