### PR TITLE
Bug 968994: Fix hot deploy during initial scaled gear deployment

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/bin/deploy
+++ b/cartridges/openshift-origin-cartridge-haproxy/bin/deploy
@@ -13,11 +13,14 @@ fi
 # Defines the default pre sync actions, taking into account
 # the hot_deploy marker.
 function set_default_pre_actions {
-  if hot_deploy_marker_is_present; then
-    echo "Application will not be stopped during gear sync to to presence of hot_deploy marker"
-    OPENSHIFT_SYNC_GEARS_PRE=()
-  else
-    OPENSHIFT_SYNC_GEARS_PRE=('gear stop')
+  OPENSHIFT_SYNC_GEARS_PRE=('gear stop')
+
+  # Only respect hot deployment for initialized gears
+  if [ "$new_gear" = "false" ]; then
+    if hot_deploy_marker_is_present; then
+      echo "Application will not be stopped during gear sync to to presence of hot_deploy marker"
+      OPENSHIFT_SYNC_GEARS_PRE=()
+    fi
   fi
 }
 
@@ -28,10 +31,11 @@ function set_default_post_actions {
 
     if [ "$new_gear" = "true" ]; then
       remote_deploy_cmd="${remote_deploy_cmd} --init"
-    fi
-
-    if hot_deploy_marker_is_present; then
-      remote_deploy_cmd="${remote_deploy_cmd} --hot-deploy"
+    else
+      # Only respect hot deployment for initialized gears
+      if hot_deploy_marker_is_present; then
+        remote_deploy_cmd="${remote_deploy_cmd} --hot-deploy"
+      fi
     fi
 
     OPENSHIFT_SYNC_GEARS_POST=("${remote_deploy_cmd}")


### PR DESCRIPTION
Don't respect the hot_deploy marker when peforming initial deployment of
a newly created scaled gear; these gears are not pre-initialized by the
platform.
