### PR TITLE
Improve Postgres runtime_extended tests

### DIFF
--- a/controller/test/cucumber/step_definitions/before_hooks.rb
+++ b/controller/test/cucumber/step_definitions/before_hooks.rb
@@ -1,0 +1,53 @@
+# Reuse or create postgres applications
+Before('@postgres','~@smoke_test','~@scaled') do
+  if $postgres_app
+    @app = $postgres_app
+  else
+    step "a new client created mock-0.1 application"
+    step "the embedded postgresql-8.4 cartridge is added"
+    $postgres_app = @app
+  end
+end
+
+# Reuse or create scaled postgres applications
+Before('@postgres','~@smoke_test','@scaled') do
+  if $scaled_postgres_app
+    @app = $scaled_postgres_app
+  else
+    step 'a new client created scalable mock-0.1 application'
+    step 'the minimum scaling parameter is set to 2'
+    step 'the embedded postgresql-8.4 cartridge is added'
+    $scaled_postgres_app = @app
+  end
+end
+
+# Make sure scaled applications use the host to connect
+Before('@postgres','@snapshot','@scaled','~@smoke_test') do
+  step 'I use host to connect to the postgresql database as env with password'
+end
+
+# Prepare the test data once for snapshot tests
+Before('@postgres','@snapshot','~@smoke_test') do
+  step 'I drop existing test data'
+  step 'I create a test database in postgres'
+  step 'I create a test table in postgres'
+  step 'I insert test data into postgres'
+  step 'the test data will be present in postgres'
+  step 'I snapshot the application'
+  step 'I insert additional test data into postgres'
+  step 'the additional test data will be present in postgres'
+end
+
+# Clear the stashed application if a scenario fails
+After('@postgres','~@scaled') do |s|
+  if s.failed?
+    $postgres_app = nil
+  end
+end
+
+# Clear the stashed application if a scenario fails
+After('@postgres','@scaled') do |s|
+  if s.failed?
+    $scaled_postgres_app = nil
+  end
+end

--- a/controller/test/cucumber/step_definitions/cartridge-postgresql-extended_steps.rb
+++ b/controller/test/cucumber/step_definitions/cartridge-postgresql-extended_steps.rb
@@ -1,6 +1,6 @@
 include SQLHelper
 
-Given /^I use the helper to connect to the postgresql database$/ do
+Given /^I use the helper to connect to the postgresql database\s*$/ do
   @psql_env = {}
   @psql_opts = {}
 end
@@ -119,4 +119,11 @@ When "all databases will have the correct ownership" do
   dbs = run_psql("SELECT datname FROM pg_database JOIN pg_authid ON pg_database.datdba = pg_authid.oid WHERE NOT(rolname = '#{username}' OR rolname = 'postgres')").lines.to_a.compact.map(&:strip).delete_if(&:empty?)
   # TODO: This can be done better if we can run the ssh command without the MOTD
   dbs.select{|x| @apps.include?(x) }.should eq []
+end
+
+When "I drop existing test data" do
+  run_psql(<<-eof)
+  DROP DATABASE IF EXISTS new_test_database;
+  DROP TABLE IF EXISTS cuke_test;
+  eof
 end


### PR DESCRIPTION
- Allow application reuse when tests pass
- Run connection tests as scenario outlines so that they may be tried individually
