### PR TITLE
Fixes Bug 967504 and Bug 969536 - increased timeout to properly handle some quickstarts

### DIFF
--- a/console/app/models/rest_api/base.rb
+++ b/console/app/models/rest_api/base.rb
@@ -800,7 +800,7 @@ module RestApi
   class Base
     self.idle_timeout = 4
     self.open_timeout = 3
-    self.read_timeout = 180
+    self.read_timeout = 240
 
     #
     # Update the configuration of the Rest API.  Use instead of


### PR DESCRIPTION
@smarterclayton, @danmcp: a timeout of 210s worked fine for the Spring quickstart and EAP with scaling, but not for Perl Dancer. 240s worked fine for all of them.
