### PR TITLE
Remove rubygem-builder dep from php cartridges

### DIFF
--- a/cartridges/openshift-origin-cartridge-php-5.3/openshift-origin-cartridge-php-5.3.spec
+++ b/cartridges/openshift-origin-cartridge-php-5.3/openshift-origin-cartridge-php-5.3.spec
@@ -21,7 +21,6 @@ Requires:      php < 5.4
 Requires:      httpd < 2.4
 Requires:      php
 Requires:      mod_bw
-Requires:      %{?scl:%scl_prefix}rubygem-builder
 Requires:      php-devel
 Requires:      php-pdo
 Requires:      php-gd

--- a/cartridges/openshift-origin-cartridge-php/openshift-origin-cartridge-php.spec
+++ b/cartridges/openshift-origin-cartridge-php/openshift-origin-cartridge-php.spec
@@ -21,7 +21,6 @@ Requires:      php < 5.5
 Requires:      httpd < 2.5
 %endif
 Requires:      php
-Requires:      rubygem-builder
 Requires:      php-devel
 Requires:      php-pdo
 Requires:      php-gd


### PR DESCRIPTION
Both v1 and v2 php cartridges had a RPM dependency for rubygem-builder
that is not needed.

These dependencies do not appear to be used anywhere for these carts.  I've done some basic testing to verify that cart deployment/update still work properly following the removal.
