### PR TITLE
Account for case when BIND_KRB_* is used in openshift-origin-dns-nsupdate.conf.

### DIFF
--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -748,32 +748,45 @@ function check_authentication() {
 # ============================================================================
 
 function dns_bind_update_record() {
-    # $1 = server
-    # $2 = key name
-    # $3 = key value
-    # $4 = function (add|delete)
-    # $5 = type (A, TXT, CNAME)
-    # $6 = name 
-    # $7 = value
+    # $1 = key or Kerberos
+    # $2 = server
+    # $3 = key name
+    # $4 = key value
+    # $5 = Kerberos keytab
+    # $6 = Kerberos principal
+    # $7 = function (add|delete)
+    # $8 = type (A, TXT, CNAME)
+    # $9 = name
+    # $10 = value
 
-    # check $1: should be an IP address
-    # check $3: should be a key string
-    # check $4: should be add|delete
-    # check $5 should be A, TXT, CNAME
+    # check $2: should be an IP address
+    # check $4: should be a key string
+    # check $7: should be add|delete
+    # check $8 should be A, TXT, CNAME
 
-    verbose "${4}ing $5 record named $6 to server $1: $7"
+    verbose "${7}ing $8 record named $9 to server $2: $10"
 
-    nsupdate <<EOF
-server $1
-key $2 $3
-update $4 $6 1 $5 $7
+    if [ "$1" = "key" ]
+    then
+        nsupdate <<EOF
+server $2
+key $3 $4
+update $7 $9 1 $8 $10
 send
 EOF
+    else
+        kinit -kt "$5" -p "$6"
+        nsupdate -g <<EOF
+server $2
+update $7 $9 1 $8 $10
+send
+EOF
+    fi
 
     if [ $? != 0 ]
     then
-	fail "error ${4}ing $5 record name $6 to server $1: $7
-	-- is the nameserver running, reachable, and key auth working?"
+	fail "error ${7}ing $8 record name $9 to server $2: $10
+	-- is the nameserver running, reachable, and $1 auth working?"
     fi
 
 }
@@ -818,7 +831,7 @@ function check_dns_bind() {
     # check that zone suffix ends exactly with dns_zone (zone contains suffix)
 
     # try to add a dummy TXT record to the zone
-    dns_bind_update_record ${APP_VALUES[DNS_SERVER]} ${APP_VALUES[DNS_KEYNAME]} ${APP_VALUES[DNS_KEYVAL]} add txt testrecord.${APP_VALUES[DNS_SUFFIX]} this_is_a_test
+    dns_bind_update_record ${APP_VALUES[DNS_KEY_OR_KRB]} ${APP_VALUES[DNS_SERVER]} "${APP_VALUES[DNS_KEYNAME]}" "${APP_VALUES[DNS_KEYVAL]}" "${APP_VALUES[DNS_KRB_KEYTAB]}" "${APP_VALUES[DNS_KRB_PRINCIPAL]}" add txt testrecord.${APP_VALUES[DNS_SUFFIX]} this_is_a_test
 
     # verify that the record is there
     if host -t txt testrecord.${APP_VALUES[DNS_SUFFIX]} ${APP_VALUES[DNS_SERVER]} >/dev/null
@@ -829,7 +842,7 @@ function check_dns_bind() {
     fi
 
     # remove it.
-    dns_bind_update_record ${APP_VALUES[DNS_SERVER]} ${APP_VALUES[DNS_KEYNAME]} ${APP_VALUES[DNS_KEYVAL]} delete txt testrecord.${APP_VALUES[DNS_SUFFIX]}
+    dns_bind_update_record ${APP_VALUES[DNS_KEY_OR_KRB]} ${APP_VALUES[DNS_SERVER]} "${APP_VALUES[DNS_KEYNAME]}" "${APP_VALUES[DNS_KEYVAL]}" "${APP_VALUES[DNS_KRB_KEYTAB]}" "${APP_VALUES[DNS_KRB_PRINCIPAL]}" delete txt testrecord.${APP_VALUES[DNS_SUFFIX]}
 
     # verify that the record is removed
     if host -t txt testrecord.${APP_VALUES[DNS_SUFFIX]} ${APP_VALUES[DNS_SERVER]} >/dev/null

--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -784,19 +784,36 @@ function check_dns_bind() {
 	APP_VALUE_MAP=(
 		["DNS_SERVER"]="Rails.application.config.dns[:server]"
 		["DNS_PORT"]="Rails.application.config.dns[:port].to_s"
-		["DNS_KEYNAME"]="Rails.application.config.dns[:keyname]"
-		["DNS_KEYVAL"]="Rails.application.config.dns[:keyvalue]"
 		["DNS_ZONE"]="Rails.application.config.dns[:zone]"
 		["DNS_SUFFIX"]="Rails.application.config.openshift[:domain_suffix]"
+		["DNS_KEY_OR_KRB"]='(Rails.application.config.dns[:keyvalue].blank?)?"krb":"key"'
 		)
 	load_application_values
 
     verbose "DNS Server: ${APP_VALUES[DNS_SERVER]}"
     verbose "DNS Port: ${APP_VALUES[DNS_PORT]}"
-    verbose "DNS Key Name: ${APP_VALUES[DNS_KEYNAME]}"
-    verbose "DNS Key Value: *****"
     verbose "DNS Zone: ${APP_VALUES[DNS_ZONE]}"
     verbose "DNS Domain Suffix: ${APP_VALUES[DNS_SUFFIX]}"
+    verbose "DNS Update Auth: ${APP_VALUES[DNS_KEY_OR_KRB]}"
+
+    if [ "${APP_VALUES[DNS_KEY_OR_KRB]}" = "key" ]
+    then
+	APP_VALUE_MAP=(
+		["DNS_KEYNAME"]="Rails.application.config.dns[:keyname]"
+		["DNS_KEYVAL"]="Rails.application.config.dns[:keyvalue]"
+		)
+	load_application_values
+        verbose "DNS Key Name: ${APP_VALUES[DNS_KEYNAME]}"
+        verbose "DNS Key Value: *****"
+    else
+	APP_VALUE_MAP=(
+		["DNS_KRB_KEYTAB"]="Rails.application.config.dns[:krb_keytab]"
+		["DNS_KRB_PRINCIPAL"]="Rails.application.config.dns[:krb_principal]"
+		)
+	load_application_values
+        verbose "DNS Kerberos Keytab: ${APP_VALUES[DNS_KRB_KEYTAB]}"
+        verbose "DNS Kerberos Principal: ${APP_VALUES[DNS_KRB_PRINCIPAL]}"
+    fi
 
     # check that zone suffix ends exactly with dns_zone (zone contains suffix)
 


### PR DESCRIPTION
When the GSS-TSIG is configured for nsupdate, BIND_KRB_KEYTAB and
BIND_KRB_PRINCIPAL are used in /etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf instead of BIND_KEYNAME and BIND_KEYVALUE.

We need to allow the check to pass when one pair of values is used and not the other one, and we probably want to use nsupdate -g in case GSS-TSIG is configured (we assume the kinit was already done).

This patch amends https://github.com/openshift/openshift-extras/pull/26 which was already merged, so that configuring the GSS-TSIG with openshift.sh does not lead to broker oo-accept-broker.

Thank you,

Jan
