### PR TITLE
KrbLocalUserMapping enables conversion to local users.

### DIFF
--- a/openshift-console/httpd/conf.d/openshift-origin-auth-remote-user-kerberos.conf.sample
+++ b/openshift-console/httpd/conf.d/openshift-origin-auth-remote-user-kerberos.conf.sample
@@ -13,6 +13,10 @@ RequestHeader set X-Remote-User "%{RU}e" env=RU
     AuthType Kerberos
     KrbMethodNegotiate On
     KrbMethodK5Passwd On
+    # The KrbLocalUserMapping enables conversion to local users, using
+    # auth_to_local rules in /etc/krb5.conf. By default it strips the
+    # @REALM part. See krb5.conf(5) for details how to set up specific rules.
+    KrbLocalUserMapping On
     KrbServiceName HTTP/www.example.com
     KrbAuthRealms EXAMPLE.COM
     Krb5KeyTab /var/www/openshift/broker/httpd/conf.d/http.keytab

--- a/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-kerberos.conf.sample
+++ b/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-kerberos.conf.sample
@@ -7,6 +7,10 @@ LoadModule auth_kerb_module modules/mod_auth_kerb.so
     AuthType Kerberos
     KrbMethodNegotiate On
     KrbMethodK5Passwd On
+    # The KrbLocalUserMapping enables conversion to local users, using
+    # auth_to_local rules in /etc/krb5.conf. By default it strips the
+    # @REALM part. See krb5.conf(5) for details how to set up specific rules.
+    KrbLocalUserMapping On
     KrbServiceName HTTP/www.example.com
     KrbAuthRealms EXAMPLE.COM
     Krb5KeyTab /var/www/openshift/broker/httpd/conf.d/http.keytab


### PR DESCRIPTION
It uses auth_to_local rules in /etc/krb5.conf. By default it strips the
@REALM part. See krb5.conf(5) for details how to set up specific rules.

Without this directive set to On, after enabling mod_auth_kerb, users
will be logged in with username containing the @REALM which is different
account so they won't be able to see their data and applications.
