### PR TITLE
<node tests> - Update shell_exec_func_test to create homedir in /var/tmp

### DIFF
--- a/node/test/functional/shell_exec_func_test.rb
+++ b/node/test/functional/shell_exec_func_test.rb
@@ -20,14 +20,12 @@ module OpenShift
 
     def setup
       @uid     = 5999
-      @homedir = "/tmp/tests/#@uid"
 
-      # polyinstantiation makes creating the homedir a pain...
+      # Using /var/tmp since using /tmp causes problems with polyinstantiation
+      @homedir = "/var/tmp/homedir-#{@uid}"
+
       FileUtils.rm_r @homedir if File.exist?(@homedir)
       %x{useradd -m -u #@uid -d #@homedir #@uid 1>/dev/null 2>&1}
-      full_poly_dir = File.join(@homedir, '.tmp')
-      FileUtils.mkpath(File.join(full_poly_dir, @uid.to_s))
-      FileUtils.chmod(0o0000, full_poly_dir)
     end
 
     def teardown


### PR DESCRIPTION
Creating the user homedir in /tmp has caused issues, moving the homedir
creation to /var/tmp to prevent these issues.
