### PR TITLE
openshift_facts.rb: sort cart_list

### DIFF
--- a/plugins/msg-node/mcollective/facts/openshift_facts.rb
+++ b/plugins/msg-node/mcollective/facts/openshift_facts.rb
@@ -134,5 +134,6 @@ Facter.add(:cart_list) do
     carts = `oo-cartridge-list`.split
     # The first element is the text "Cartridges:"
     carts.shift
+    carts.sort!
     setcode { carts.join('|') }
 end


### PR DESCRIPTION
So instead of the following:

```
[root@broker ~]# mco facts cart_list
Report for fact: cart_list

        cron-1.4|ruby-1.9|ruby-1.8|python-2.6|mysql-5.1|diy-0.1|postgresql-8.4|haproxy-1.4|perl-5.10|php-5.3found 1  times
        haproxy-1.4|perl-5.10|cron-1.4|ruby-1.9|php-5.3|mysql-5.1|diy-0.1|python-2.6|ruby-1.8|postgresql-8.4found 1 times

Finished processing 2 / 2 hosts in 52.84 ms
```

I will get the following:

```
[root@broker ~]# mco facts cart_list
Report for fact: cart_list

        cron-1.4|diy-0.1|haproxy-1.4|mysql-5.1|perl-5.10|php-5.3|postgresql-8.4|python-2.6|ruby-1.8|ruby-1.9found 2 times

Finished processing 2 / 2 hosts in 59.38 ms
```
