### PR TITLE
Bug 971460 - Refactor path_append/prepend to accept multiple elements

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/setup
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/setup
@@ -9,9 +9,6 @@ esac
 source "${OPENSHIFT_RUBY_DIR}/lib/util"
 parse_args $@
 
-# Don't set -u until after the above arg parsing is complete
-set -u
-
 # Copy the version specific files to ruby directory
 shopt -s dotglob
 for dir in etc; do
@@ -19,7 +16,12 @@ for dir in etc; do
     cp -Lr $OPENSHIFT_RUBY_DIR/versions/$version/$dir/* $OPENSHIFT_RUBY_DIR/$dir 
 done
 
-if [ $version == '1.9' ]; then
+ if [ $version == '1.9' ]; then
+    # Cleanup from version 0.0.1
+    [ -f $OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_PATH_ELEMENT ] && rm -f $OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_PATH_ELEMENT
+    [ -f $OPENSHIFT_RUBY_DIR/env/LD_LIBRARY_PATH ] && rm -f $OPENSHIFT_RUBY_DIR/env/LD_LIBRARY_PATH
+    [ -f $OPENSHIFT_RUBY_DIR/env/MANPATH ] && rm -f $OPENSHIFT_RUBY_DIR/env/MANPATH
+
     dirname $(scl enable ruby193 "which ruby")    > $OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_PATH_ELEMENT
     scl enable ruby193 "printenv LD_LIBRARY_PATH" > $OPENSHIFT_RUBY_DIR/env/LD_LIBRARY_PATH
     scl enable ruby193 "printenv MANPATH"         > $OPENSHIFT_RUBY_DIR/env/MANPATH

--- a/cartridges/openshift-origin-cartridge-ruby/lib/util
+++ b/cartridges/openshift-origin-cartridge-ruby/lib/util
@@ -20,8 +20,12 @@ function update-configuration {
     case "$1" in
       1.9)
         dirname $(scl enable ruby193 "which ruby") >$OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_PATH_ELEMENT
-        path_append $LD_LIBRARY_PATH $(scl enable ruby193 "printenv LD_LIBRARY_PATH") >$OPENSHIFT_RUBY_DIR/env/LD_LIBRARY_PATH
-        path_append $MANPATH $(scl enable ruby193 "printenv MANPATH") >$OPENSHIFT_RUBY_DIR/env/MANPATH
+
+        local ld_path=$(LD_LIBRARY_PATH="" scl enable ruby193 "printenv LD_LIBRARY_PATH")
+        path_append $LD_LIBRARY_PATH $ld_path >$OPENSHIFT_RUBY_DIR/env/LD_LIBRARY_PATH
+
+        local man_path=$(MANPATH="" scl enable ruby193 "printenv MANPATH")
+        path_append $MANPATH $man_path >$OPENSHIFT_RUBY_DIR/env/MANPATH
         ;;
 
       1.8)

--- a/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml.rhel
@@ -7,7 +7,7 @@ Versions: ['1.9', '1.8']
 License: "Ruby BSDL"
 License-Url: http://www.ruby-lang.org/en/about/license.txt
 Vendor: ruby.org
-Cartridge-Version: 0.0.1
+Cartridge-Version: 0.0.2
 Cartridge-Vendor: redhat
 Categories:
   - service

--- a/node/lib/openshift-origin-node/model/cartridge_repository.rb
+++ b/node/lib/openshift-origin-node/model/cartridge_repository.rb
@@ -151,7 +151,7 @@ module OpenShift
     #   CartridgeRepository.instance['php', '3.5']                #=> Cartridge
     #   CartridgeRepository.instance['php']                       #=> Cartridge
                     #
-    def select(cartridge_name, version = nil, cartridge_version = nil)
+    def select(cartridge_name, version = '_', cartridge_version = '_')
       unless exist?(cartridge_name, cartridge_version, version)
         raise KeyError.new("key not found: (#{cartridge_name}, #{version}, #{cartridge_version})")
       end
@@ -244,7 +244,7 @@ module OpenShift
 
       # wildcards: cartridges and cartridge versions
       glob = PathUtils.join(directory, '*', '*', 'metadata', 'manifest.yml')
-      Dir[glob].each { |e| yield e }
+      Dir[glob].sort.each { |e| yield e }
     end
 
     # :call-seq:
@@ -269,8 +269,8 @@ module OpenShift
     def insert(cartridge) # :nodoc:
       cartridge.versions.each do |version|
         @index[cartridge.name][version][cartridge.cartridge_version] = cartridge
-        @index[cartridge.name][version][nil]                         = cartridge
-        @index[cartridge.name][nil][nil]                             = cartridge
+        @index[cartridge.name][version]['_']                         = cartridge
+        @index[cartridge.name]['_']['_']                             = cartridge
       end
       cartridge
     end

--- a/node/misc/usr/lib/cartridge_sdk/bash/sdk
+++ b/node/misc/usr/lib/cartridge_sdk/bash/sdk
@@ -294,31 +294,37 @@ function marker_present() {
   [ -f "${OPENSHIFT_REPO_DIR}/.openshift/markers/$1" ]
 }
 
-# Add element to end of path
+# Add element(s) to end of path
 #
 # $1 path
-# $2 element to add
+# $2 element(s) to add
 # return modified path
-path_append ()  {
-    echo -n "$(path_remove $1 $2):$2"
+function path_append {
+    local canon="$(path_remove $1 $2)"
+    echo -n "${canon:+"$canon:"}$2"
 }
 
-# Add element to front of path
+# Add element(s) to front of path
 #
 # $1 path
-# $2 element to add
+# $2 element(s) to add
 # return modified path
-function path_prepend () {
-    echo -n "$2:$(path_remove $1 $2)"
+function path_prepend {
+    local canon="$(path_remove $1 $2)"
+    echo -n "$2${canon:+":$canon"}"
 }
 
-# Remove element from path
+# Remove element(s) from path
 #
 # $1 path
-# $2 element to remove
+# $2 element(s) to remove
 # return modified path
-function path_remove ()  {
-    echo -n $(echo -n $1 | awk -v RS=: -v ORS=: '$0 != "'$2'"' | sed 's/:$//')
+function path_remove {
+  local results="$1"
+  for e in $(echo -n "$2" | sed -e 's/:/ /g'); do
+    results=$(echo -n "$results" | awk -v RS=: -v ORS=: '$0 != "'$e'"' | sed 's/:$//')
+  done
+  echo -n "$results"
 }
 
 # Update the PassEnv directives in the httpd configuration file

--- a/node/test/functional/bash_sdk_test.rb
+++ b/node/test/functional/bash_sdk_test.rb
@@ -1,0 +1,72 @@
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+require_relative '../test_helper'
+
+module OpenShift
+  class BashSdkTest < OpenShift::NodeTestCase
+    def setup
+      @ld_library_path='/usr/local/lib'
+    end
+
+    def test_path_prepend
+      actual = %x(source /usr/lib/openshift/cartridge_sdk/bash/sdk
+        path_prepend "a:b" #{@ld_library_path} )
+      assert_equal "#{@ld_library_path}:a:b", actual
+    end
+
+    def test_path_append
+      actual = %x(source /usr/lib/openshift/cartridge_sdk/bash/sdk
+        path_append "a:b" #{@ld_library_path} )
+      assert_equal "a:b:#{@ld_library_path}", actual
+    end
+
+    def test_path_prepend_dedup
+      actual = %x(source /usr/lib/openshift/cartridge_sdk/bash/sdk
+        path_prepend "a:b:#{@ld_library_path}" #{@ld_library_path} )
+      assert_equal "#{@ld_library_path}:a:b", actual
+    end
+
+    def test_path_append_dedup
+      actual = %x(source /usr/lib/openshift/cartridge_sdk/bash/sdk
+        path_append "a:b:#{@ld_library_path}" #{@ld_library_path} )
+      assert_equal "a:b:#{@ld_library_path}", actual
+    end
+
+    def test_path_prepend_path
+      actual = %x(source /usr/lib/openshift/cartridge_sdk/bash/sdk
+        path_prepend "a:b" #{@ld_library_path}:#{@ld_library_path} )
+      assert_equal "#{@ld_library_path}:#{@ld_library_path}:a:b", actual
+    end
+
+    def test_path_append_path
+      actual = %x(source /usr/lib/openshift/cartridge_sdk/bash/sdk
+        path_append "a:b" #{@ld_library_path}:#{@ld_library_path} )
+      assert_equal "a:b:#{@ld_library_path}:#{@ld_library_path}", actual
+    end
+
+    def test_path_prepend_path_dedup
+      actual = %x(source /usr/lib/openshift/cartridge_sdk/bash/sdk
+        path_prepend "a:b:#{@ld_library_path}" #{@ld_library_path}:#{@ld_library_path} )
+      assert_equal "#{@ld_library_path}:#{@ld_library_path}:a:b", actual
+    end
+
+    def test_path_append_path_dedup
+      actual = %x(source /usr/lib/openshift/cartridge_sdk/bash/sdk
+        path_append "a:b:#{@ld_library_path}" #{@ld_library_path}:#{@ld_library_path} )
+      assert_equal "a:b:#{@ld_library_path}:#{@ld_library_path}", actual
+    end
+  end
+end

--- a/node/test/functional/cartridge_repository_func_test.rb
+++ b/node/test/functional/cartridge_repository_func_test.rb
@@ -26,9 +26,9 @@ module OpenShift
 
     def before_setup
 
-      @uuid = %x(uuidgen -r).gsub(/-/,'').chomp[0..15]
+      @uuid = %x(uuidgen -r).gsub(/-/, '').chomp[0..15]
 
-      @test_home      = "/tmp/tests/#{@uuid}"
+      @test_home      = "/data/tests/#{@uuid}"
       @tgz_file       = File.join(@test_home, 'mock_plugin.tar.gz')
       @zip_file       = File.join(@test_home, 'mock_plugin.zip')
       @tar_file       = File.join(@test_home, 'mock_plugin.tar')
@@ -252,21 +252,7 @@ module OpenShift
       manifest << "Source-Md5: #{@tgz_hash}"
 
       err = assert_raise(OpenShift::InvalidElementError) do
-        cartridge      = OpenShift::Runtime::Manifest.new(manifest)
-      end
-
-      assert_match 'Cartridge-Vendor', err.message
-    end
-
-    def test_reserved_cartridge_name
-      manifest = IO.read(File.join(@cartridge.manifest_path))
-      manifest << "Cartridge-Vendor: redhat" << "\n"
-      manifest << 'Source-Url: https://www.example.com/mock-plugin.tar.gz' << "\n"
-      manifest << "Source-Md5: #{@tgz_hash}"
-      manifest = change_cartridge_vendor_of manifest
-
-      err = assert_raise(OpenShift::InvalidElementError) do
-        cartridge      = OpenShift::Runtime::Manifest.new(manifest)
+        cartridge = OpenShift::Runtime::Manifest.new(manifest)
       end
 
       assert_match 'Cartridge-Vendor', err.message
@@ -279,7 +265,7 @@ module OpenShift
       manifest << "Source-Md5: #{@tgz_hash}"
 
       err = assert_raise(OpenShift::InvalidElementError) do
-        cartridge      = OpenShift::Runtime::Manifest.new(manifest)
+        cartridge = OpenShift::Runtime::Manifest.new(manifest)
       end
 
       assert_match 'Cartridge-Vendor', err.message
@@ -293,7 +279,7 @@ module OpenShift
       manifest = change_cartridge_vendor_of manifest
 
       err = assert_raise(OpenShift::InvalidElementError) do
-        cartridge      = OpenShift::Runtime::Manifest.new(manifest)
+        cartridge = OpenShift::Runtime::Manifest.new(manifest)
       end
 
       assert_match /\bName\b/, err.message
@@ -307,7 +293,7 @@ module OpenShift
       manifest = change_cartridge_vendor_of manifest
 
       err = assert_raise(OpenShift::InvalidElementError) do
-        cartridge      = OpenShift::Runtime::Manifest.new(manifest)
+        cartridge = OpenShift::Runtime::Manifest.new(manifest)
       end
 
       assert_match 'Name', err.message
@@ -321,11 +307,25 @@ module OpenShift
       manifest = change_cartridge_vendor_of manifest
 
       err = assert_raise(OpenShift::InvalidElementError) do
-        cartridge      = OpenShift::Runtime::Manifest.new(manifest)
+        cartridge = OpenShift::Runtime::Manifest.new(manifest)
       end
 
       assert_match /is reserved\.: 'Name'/, err.message
     end
+
+    #def test_reserved_cartridge_name
+    #  manifest = IO.read(File.join(@cartridge.manifest_path))
+    #  manifest << "Cartridge-Vendor: redhat" << "\n"
+    #  manifest << 'Source-Url: https://www.example.com/mock-plugin.tar.gz' << "\n"
+    #  manifest << "Source-Md5: #{@tgz_hash}"
+    #  manifest = change_cartridge_vendor_of manifest
+    #
+    #  err = assert_raise(OpenShift::InvalidElementError) do
+    #    cartridge = OpenShift::Runtime::Manifest.new(manifest)
+    #  end
+    #
+    #  assert_match 'Cartridge-Vendor', err.message
+    #end
 
     def test_instantiate_cartridge_tgz
       # Point manifest at "remote" URL
@@ -363,6 +363,26 @@ module OpenShift
       assert_path_exist(File.join(cartridge_home, 'bin', 'control'))
     end
 
+    def test_cartridge_update
+      build_multi_versions()
+
+      name = "crftest_#{@uuid}"
+      cr   = OpenShift::CartridgeRepository.instance
+      cr.clear
+
+      cr.install(@source_dir + '/1')
+      m = cr.select(name)
+      assert_equal '0.0.1', m.cartridge_version
+
+      cr.install(@source_dir + '/2')
+      m = cr.select(name, '0.3')
+      assert_equal '0.0.2', m.cartridge_version
+
+      cr.install(@source_dir + '/3')
+      m = cr.select(name, '0.3')
+      assert_equal '0.0.3', m.cartridge_version
+    end
+
     def with_detail_output
       begin
         yield
@@ -394,6 +414,22 @@ module OpenShift
       end
 
       return cuckoo_repo, cuckoo_source
+    end
+
+    def build_multi_versions
+      (1..3).each do |i|
+        target = File.join(@source_dir, i.to_s)
+        FileUtils.mkpath(target + '/metadata')
+        FileUtils.mkpath(target + '/bin')
+        IO.write(target + '/metadata/manifest.yml', %Q{#
+        Name: crftest_#{@uuid}
+        Cartridge-Short-Name: CRFTEST
+        Version: '0.3'
+        Cartridge-Version: '0.0.#{i}'
+        Cartridge-Vendor: redhat
+      }
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
- Original code only supported single argument substitutions
- Update function declarations to match rest of file
- Add functional tests
- Fixed issue in Ruby cartridge where scl use was duping path elements
- Bumped Ruby cartridge version number
- Fixed CartridgeRepository to rebuild index correctly
