### PR TITLE
Bug 970147 - fixes collapse in IE (Bootstrap bug)

### DIFF
--- a/console/vendor/assets/javascripts/bootstrap-collapse.js
+++ b/console/vendor/assets/javascripts/bootstrap-collapse.js
@@ -1,5 +1,5 @@
 /* =============================================================
- * bootstrap-collapse.js v2.0.3
+ * bootstrap-collapse.js v2.1.1
  * http://twitter.github.com/bootstrap/javascript.html#collapse
  * =============================================================
  * Copyright 2012 Twitter, Inc.
@@ -67,7 +67,7 @@
 
       this.$element[dimension](0)
       this.transition('addClass', $.Event('show'), 'shown')
-      this.$element[dimension](this.$element[0][scroll])
+      $.support.transition && this.$element[dimension](this.$element[0][scroll])
     }
 
   , hide: function () {
@@ -144,12 +144,13 @@
   * ==================== */
 
   $(function () {
-    $('body').on('click.collapse.data-api', '[data-toggle=collapse]', function ( e ) {
+    $('body').on('click.collapse.data-api', '[data-toggle=collapse]', function (e) {
       var $this = $(this), href
         , target = $this.attr('data-target')
           || e.preventDefault()
           || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
         , option = $(target).data('collapse') ? 'toggle' : $this.data()
+      $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
       $(target).collapse(option)
     })
   })

--- a/console/vendor/assets/javascripts/bootstrap-transition.js
+++ b/console/vendor/assets/javascripts/bootstrap-transition.js
@@ -1,5 +1,5 @@
 /* ===================================================
- * bootstrap-transition.js v2.0.3
+ * bootstrap-transition.js v2.1.1
  * http://twitter.github.com/bootstrap/javascript.html#transitions
  * ===================================================
  * Copyright 2012 Twitter, Inc.
@@ -36,8 +36,7 @@
           , transEndEventNames = {
                'WebkitTransition' : 'webkitTransitionEnd'
             ,  'MozTransition'    : 'transitionend'
-            ,  'OTransition'      : 'oTransitionEnd'
-            ,  'msTransition'     : 'MSTransitionEnd'
+            ,  'OTransition'      : 'oTransitionEnd otransitionend'
             ,  'transition'       : 'transitionend'
             }
           , name

--- a/console/vendor/assets/stylesheets/bootstrap/_component-animations.scss
+++ b/console/vendor/assets/stylesheets/bootstrap/_component-animations.scss
@@ -2,17 +2,17 @@
 // --------------------
 
 .fade {
-  @include transition(opacity .15s linear);
   opacity: 0;
+  @include transition(opacity .15s linear);
   &.in {
     opacity: 1;
   }
 }
 
 .collapse {
-  @include transition(height .35s ease);
   position:relative;
+  height:0;
   overflow:hidden;
-  height: 0;
+  @include transition(height .35s ease);
   &.in { height: auto; }
 }

--- a/console/vendor/assets/stylesheets/bootstrap/_mixins.scss
+++ b/console/vendor/assets/stylesheets/bootstrap/_mixins.scss
@@ -351,7 +351,6 @@
 @mixin transition($transition) {
   -webkit-transition: $transition;
      -moz-transition: $transition;
-      -ms-transition: $transition;
        -o-transition: $transition;
           transition: $transition;
 }


### PR DESCRIPTION
@smarterclayton, @liggitt: this is the bug 970147 related to collapsible menus only toggling once and then breaking on IE.

It's a Bootstrap issue fixed in 2.1.1 so it requires patching bootstrap in origin-server/console/vendor. The patch is decently isolated in collapse-related files (which are only used in the collapsible menus afaik), but we might want to consider if this fix is worth changing vendor stuff like I did in this pull request, and/or upgrading the whole Bootstrap.
