### PR TITLE
Bug 972757: Allow vendor names to start with a numeral

### DIFF
--- a/common/lib/openshift-origin-common/models/manifest.rb
+++ b/common/lib/openshift-origin-common/models/manifest.rb
@@ -156,7 +156,7 @@ module OpenShift
       # vendor name by matching against VALID_VENDOR_NAME_PATTERN,
       # and the cartridge name agasint VALID_CARTRIDGE_NAME_PATTERN.
       # If it does not match the respective pattern, the cartridge will be rejected.
-      VALID_VENDOR_NAME_PATTERN    = /\A[a-z][a-z0-9_]*\z/
+      VALID_VENDOR_NAME_PATTERN    = /\A[a-z0-9](?:[a-z0-9_]*[a-z0-9]|)\z/
       VALID_CARTRIDGE_NAME_PATTERN = /\A[a-z0-9](?:[-\.a-z0-9_]*[a-z0-9]|)\z/
 
       # Furthermore, we validate the vendor name by matching against

--- a/node/test/functional/cartridge_repository_func_test.rb
+++ b/node/test/functional/cartridge_repository_func_test.rb
@@ -247,7 +247,7 @@ module OpenShift
 
     def test_invalid_vendor_name
       manifest = IO.read(File.join(@cartridge.manifest_path))
-      manifest << "Cartridge-Vendor: 0a" << "\n"
+      manifest << "Cartridge-Vendor: 0a_" << "\n"
       manifest << 'Source-Url: https://www.example.com/mock-plugin.tar.gz' << "\n"
       manifest << "Source-Md5: #{@tgz_hash}"
 


### PR DESCRIPTION
This allows vendor names such as '10gen'.

Also disallow vendor name to end with an underscore.
