### PR TITLE
Bug 971586

### DIFF
--- a/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
+++ b/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
@@ -23,9 +23,19 @@ done
 ## with v2, PATH is no longer modified by the cartridge
 ## use OPENSHIFT_*_PATH_ELEMENT from the primary cartridge instead
 ## here, we assume that OPENSHIFT_*_PATH_ELEMENT has only one line
+path=$(env |grep 'OPENSHIFT_.*_PATH_ELEMENT'| sed 's/^.*=\(.*\)$/\1/'|tr '\n' ':')
+
 for f in $OPENSHIFT_PRIMARY_CARTRIDGE_DIR/env/OPENSHIFT_*_PATH_ELEMENT; do
-  PATH=$(cat $f | tr -d '\n'):$PATH
+  path=$(cat $f | tr -d '\n'):$path
 done
+
+if [ -f /etc/openshift/env/PATH ]
+then
+  load_env /etc/openshift/PATH
+  path=$path:$PATH
+fi
+
+export PATH=$path
 
 CART_CONF_DIR=$OPENSHIFT_CRON_DIR/versions/$OPENSHIFT_CRON_VERSION/configuration
 

--- a/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
+++ b/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
@@ -20,6 +20,13 @@ do
     load_env $f
 done
 
+## with v2, PATH is no longer modified by the cartridge
+## use OPENSHIFT_*_PATH_ELEMENT from the primary cartridge instead
+## here, we assume that OPENSHIFT_*_PATH_ELEMENT has only one line
+for f in $OPENSHIFT_PRIMARY_CARTRIDGE_DIR/env/OPENSHIFT_*_PATH_ELEMENT; do
+  PATH=$(cat $f | tr -d '\n'):$PATH
+done
+
 CART_CONF_DIR=$OPENSHIFT_CRON_DIR/versions/$OPENSHIFT_CRON_VERSION/configuration
 
 function log_message() {


### PR DESCRIPTION
Set up `cron`'s `PATH` to use primary cartridge's `*_PATH_ELEMENT` so that
`cron` can use the cartridge's executables.
