### PR TITLE
Require attr because oo-namespace-init uses getfacl

### DIFF
--- a/pam_openshift/pam_openshift.spec
+++ b/pam_openshift/pam_openshift.spec
@@ -7,6 +7,7 @@ License:       GPLv2
 URL:           http://www.openshift.com/
 Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 Requires:      policycoreutils
+Requires:      attr
 BuildRequires: gcc
 BuildRequires: pam-devel
 BuildRequires: libselinux-devel


### PR DESCRIPTION
Fixes bz973377

In the (exceedingly unlikely) case that the "attr" RPM isn't installed,
oo-namespace-init will bomb trying to set appropriate attributes. "attr" is in
the minimal install but at least one customer managed to run into this, so
might as well make it explicit.
