### PR TITLE
Fix Ruby's URL in the v2 cartridge

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml.f19
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml.f19
@@ -13,7 +13,7 @@ Categories:
   - service
   - ruby
   - web_framework
-Website: http://www.ruby.org
+Website: http://www.ruby-lang.org
 Help-Topics:
   "Developer Center": https://www.openshift.com/developers
 Cart-Data:

--- a/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml.rhel
@@ -13,7 +13,7 @@ Categories:
   - service
   - ruby
   - web_framework
-Website: http://www.ruby.org
+Website: http://www.ruby-lang.org
 Help-Topics:
   "Developer Center": https://www.openshift.com/developers
 Cart-Data:


### PR DESCRIPTION
Before:

![screen shot 2013-06-13 at 9 59 11 am](https://f.cloud.github.com/assets/25666/650443/6e47f792-d45c-11e2-9e98-f888fe741516.png)

After:
![screen shot 2013-06-13 at 3 07 13 pm](https://f.cloud.github.com/assets/25666/650450/a0a38d1e-d45c-11e2-8cbb-1b259976a690.png)
