### PR TITLE
Bug 972757

### DIFF
--- a/msg-common/agent/openshift.ddl
+++ b/msg-common/agent/openshift.ddl
@@ -14,7 +14,7 @@ action "cartridge_do", :description => "run a cartridge action" do
         :prompt         => "Cartridge",
         :description    => "Full name and version of the cartridge to run an action on",
         :type           => :string,
-        :validation     => '^[a-zA-Z0-9\.\-\/]+$',
+        :validation     => '\A[a-zA-Z0-9\.\-\/_]+\z',
         :optional       => false,
         :maxlength      => 64
 

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -51,9 +51,67 @@ module MCollective
       def cartridge_do_action
         Log.instance.info("cartridge_do_action call / action: #{request.action}, agent=#{request.agent}, data=#{request.data.pretty_inspect}")
         Log.instance.info("cartridge_do_action validation = #{request[:cartridge]} #{request[:action]} #{request[:args]}")
-        validate :cartridge, /\A[a-zA-Z0-9\.\-\/]+\z/
+        validate :cartridge, /\A[a-zA-Z0-9\.\-\/_]+\z/
         validate :cartridge, :shellsafe
-        validate :action, /\A(app-create|app-destroy|env-var-add|env-var-remove|broker-auth-key-add|broker-auth-key-remove|authorized-ssh-key-add|authorized-ssh-key-remove|ssl-cert-add|ssl-cert-remove|configure|post-configure|deconfigure|unsubscribe|tidy|deploy-httpd-proxy|remove-httpd-proxy|restart-httpd-proxy|info|post-install|post-remove|pre-install|reload|restart|start|status|stop|force-stop|add-alias|remove-alias|threaddump|cartridge-list|expose-port|frontend-backup|frontend-restore|frontend-create|frontend-destroy|frontend-update-name|frontend-connect|frontend-disconnect|frontend-connections|frontend-idle|frontend-unidle|frontend-check-idle|frontend-sts|frontend-no-sts|frontend-get-sts|aliases|ssl-cert-add|ssl-cert-remove|ssl-certs|frontend-to-hash|system-messages|connector-execute|get-quota|set-quota)\Z/
+        valid_actions = %w(
+          app-create
+          app-destroy
+          env-var-add
+          env-var-remove
+          broker-auth-key-add
+          broker-auth-key-remove
+          authorized-ssh-key-add
+          authorized-ssh-key-remove
+          ssl-cert-add
+          ssl-cert-remove
+          configure
+          post-configure
+          deconfigure
+          unsubscribe
+          tidy
+          deploy-httpd-proxy
+          remove-httpd-proxy
+          restart-httpd-proxy
+          info
+          post-install
+          post-remove
+          pre-install
+          reload
+          restart
+          start
+          status
+          stop
+          force-stop
+          add-alias
+          remove-alias
+          threaddump
+          cartridge-list
+          expose-port
+          frontend-backup
+          frontend-restore
+          frontend-create
+          frontend-destroy
+          frontend-update-name
+          frontend-connect
+          frontend-disconnect
+          frontend-connections
+          frontend-idle
+          frontend-unidle
+          frontend-check-idle
+          frontend-sts
+          frontend-no-sts
+          frontend-get-sts
+          aliases
+          ssl-cert-add
+          ssl-cert-remove
+          ssl-certs
+          frontend-to-hash
+          system-messages
+          connector-execute
+          get-quota
+          set-quota
+        )
+        validate :action, /\A#{valid_actions.join("|")}\Z/
         validate :action, :shellsafe
         cartridge                  = request[:cartridge]
         action                     = request[:action]


### PR DESCRIPTION
Tweak validation Regexp for the broker. Underscore is now allowed.
The broker _could_ potentially reuse `Manifest`'s constant, but
additional thoughts should be given before that is done. For now, we
leave the patterns as liberal as reasonable.
