### PR TITLE
Bug 974632

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/install
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/install
@@ -17,9 +17,6 @@ done
 
 mkdir $OPENSHIFT_RUBY_DIR/tmp
 
-# .gem is now created by the platform. See https://bugzilla.redhat.com/show_bug.cgi?id=974632
-# mkdir $OPENSHIFT_HOMEDIR/.gem
-
 mkdir $OPENSHIFT_HOMEDIR/.passenger
 
 echo "$version" > $OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_VERSION

--- a/cartridges/openshift-origin-cartridge-ruby/bin/install
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/install
@@ -17,7 +17,8 @@ done
 
 mkdir $OPENSHIFT_RUBY_DIR/tmp
 
-mkdir $OPENSHIFT_HOMEDIR/.gem
+# .gem is now created by the platform. See https://bugzilla.redhat.com/show_bug.cgi?id=974632
+# mkdir $OPENSHIFT_HOMEDIR/.gem
 
 mkdir $OPENSHIFT_HOMEDIR/.passenger
 

--- a/controller/test/cucumber/runtime-cartridge-php.feature
+++ b/controller/test/cucumber/runtime-cartridge-php.feature
@@ -8,6 +8,7 @@ Feature: V2 SDK PHP Cartridge
     And the platform-created default environment variables will exist
     And the <cart_name> cartridge private endpoints will be exposed
     And the <cart_name> PHP_VERSION env entry will exist
+    And the php file permissions are correct
     When I destroy the application
     Then the application git repo will not exist
 

--- a/controller/test/cucumber/step_definitions/cartridge-php_steps.rb
+++ b/controller/test/cucumber/step_definitions/cartridge-php_steps.rb
@@ -40,29 +40,31 @@ Then /^the php file permissions are correct/ do
   se_context2 = "unconfined_u:object_r:openshift_rw_file_t:#{mcs}"
   # Configure files (relative to app_home)
   configure_files = {
-    "php-5.3" => ['root', 'root', '40755', se_context],
-    "php-5.3/" => ['root', 'root', '40755', se_context],
-    "php-5.3/conf/" => ['root', 'root', '40755', se_context],
-    "php-5.3/conf/php.ini" => ['root', 'root', '100644', se_context],
-    "php-5.3/conf/magic" => ['root', 'root', '100644', se_context],
-    "php-5.3/conf.d/" => ['root', 'root', '40755', se_context],
-    "php-5.3/conf.d/openshift.conf" => ['root', 'root', '100644', se_context],
-    "php-5.3/logs/" => [gear_uuid, gear_uuid, '40755', se_context],
-    "php-5.3/phplib/pear/" => [gear_uuid, gear_uuid, '40755', se_context],
-    "php-5.3/run/" => [gear_uuid, gear_uuid, '40755', se_context],
-    "php-5.3/run/httpd.pid" => [gear_uuid, gear_uuid, '100644', se_context],
-    "app-root/repo/php/index.php" => [gear_uuid, gear_uuid, '100664', se_context],
-    "php-5.3/sessions/" => [gear_uuid, gear_uuid, '40755', se_context],
-    "php-5.3/tmp/" => [gear_uuid, gear_uuid, '40755', se_context],
+    "php" => [gear_uuid, gear_uuid, '40755', se_context],
+    "php/" => [gear_uuid, gear_uuid, '40755', se_context],
+    "php/conf/" => ['root', gear_uuid, '40755', se_context],
+    "php/configuration/etc/php.ini" => [gear_uuid, gear_uuid, '100644', se_context],
+    "php/conf/magic" => ['root', 'root', '100644', se_context], # symlink to /etc/httpd/conf/magic
+    "php/configuration/etc/" => ['root', gear_uuid, '40755', se_context],
+    "php/configuration/etc/conf.d/openshift.conf" => [gear_uuid, gear_uuid, '100644', se_context],
+    "php/logs/" => [gear_uuid, gear_uuid, '40755', se_context],
+    "php/phplib/pear/" => [gear_uuid, gear_uuid, '40755', se_context],
+    "php/run/" => [gear_uuid, gear_uuid, '40755', se_context],
+    "php/run/httpd.pid" => [gear_uuid, gear_uuid, '100644', se_context],
+    "app-root/repo/php/index.php" => [gear_uuid, gear_uuid, '100644', se_context],
+    "php/sessions/" => [gear_uuid, gear_uuid, '40755', se_context],
+    "php/tmp/" => [gear_uuid, gear_uuid, '40755', se_context],
     "app-root/data/" => [gear_uuid, gear_uuid, '40750', se_context2],
     "app-root/repo/" => [gear_uuid, gear_uuid, '40750', se_context],
-    ".pearrc" => ['root', 'root', '100644', se_context],
+    ".gem" => [gear_uuid, gear_uuid, '40750', "unconfined_u:object_r:openshift_var_lib_t:s0"], # see https://bugzilla.redhat.com/show_bug.cgi?id=974632
+    ".pearrc" => ['root', gear_uuid, '100644', se_context],
   }
   configure_files.each do | file, permissions |
-    raise "Invalid permissions for #{file}" unless mode?("#{app_home}/#{file}", permissions[2])
-    raise "Invalid context for #{file}" unless context?("#{app_home}/#{file}", permissions[3])
-    target_uid = Etc.getpwnam(permissions[0]).uid.to_i
-    target_gid = Etc.getgrnam(permissions[1]).gid.to_i
+    user, group, mode, context = permissions
+    raise "Invalid permissions for #{file}" unless mode?("#{app_home}/#{file}", mode)
+    raise "Invalid context for #{file}" unless context?("#{app_home}/#{file}", context)
+    target_uid = Etc.getpwnam(user).uid.to_i
+    target_gid = Etc.getgrnam(group).gid.to_i
     raise "Invalid ownership for #{file}" unless owner?("#{app_home}/#{file}", target_uid, target_gid)
   end
 end

--- a/node/lib/openshift-origin-node/model/unix_user.rb
+++ b/node/lib/openshift-origin-node/model/unix_user.rb
@@ -852,6 +852,7 @@ Dir(after)    #{@uuid}/#{@uid} => #{list_home_dir(@homedir)}
     def setup_gem_home
       gem_home = File.join(homedir, ".gem")
       add_env_var "GEM_HOME", gem_home
+      add_env_var "OPENSHIFT_RUBYGEMS_PATH_ELEMENT", File.join(gem_home, "bin")
       mkdir_and_chown gem_home, :user => @uuid
     end
 

--- a/node/lib/openshift-origin-node/model/unix_user.rb
+++ b/node/lib/openshift-origin-node/model/unix_user.rb
@@ -478,15 +478,10 @@ Dir(after)    #{@uuid}/#{@uid} => #{list_home_dir(@homedir)}
         PathUtils.oo_chown(@uuid, nil, sandbox_uuid_dir)
       end
 
-      env_dir = File.join(homedir, ".env")
-      FileUtils.mkdir_p(env_dir)
-      FileUtils.chmod(0o0750, env_dir)
-      PathUtils.oo_chown(nil, @uuid, env_dir)
+      mkdir_and_chown File.join(homedir, ".env")
+      mkdir_and_chown File.join(homedir, ".ssh")
 
-      ssh_dir = File.join(homedir, ".ssh")
-      FileUtils.mkdir_p(ssh_dir)
-      FileUtils.chmod(0o0750, ssh_dir)
-      PathUtils.oo_chown(nil, @uuid, ssh_dir)
+      setup_gem_home
 
       geardir = File.join(homedir, @container_name, "/")
       gearappdir = File.join(homedir, "app-root", "/")
@@ -842,6 +837,22 @@ Dir(after)    #{@uuid}/#{@uid} => #{list_home_dir(@homedir)}
           end
         end
       end
+    end
+
+    private
+    def mkdir_and_chown(dir, opts = {})
+      user  = opts[:user]
+      group = opts[:group] || @uuid
+      mode  = opts[:mode] || 0o0750
+      FileUtils.mkdir_p(dir)
+      FileUtils.chmod(mode, dir)
+      PathUtils.oo_chown(user, group, dir)
+    end
+
+    def setup_gem_home
+      gem_home = File.join(homedir, ".gem")
+      add_env_var "GEM_HOME", gem_home
+      mkdir_and_chown gem_home, :user => @uuid
     end
 
   end


### PR DESCRIPTION
Create `~/.gem`, owned by the gear user, for all cartridges.
To have user gems be installed in this directory, we now set `$GEM_HOME`
explicitly on all cartridges.

Subsequently, the Ruby 1.9 cartridge need not create`~/.gem`.
