### PR TITLE
Bug 975108 - Error on git push too generic: An error occurred executing 'gear postreceive'

### DIFF
--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -65,12 +65,12 @@ def do_command(command, options)
     puts
     exit 1
   rescue OpenShift::Utils::ShellExecutionException => e
-    $stderr.puts "An error occurred executing 'gear #{command.name}'"
+    $stderr.puts "An error occurred executing 'gear #{command.name}' (exit code: #{e.rc})"
+    $stderr.puts "Error message: #{e.message}" if e.message.is_a? String
     $stderr.puts "stdout: #{e.stdout}" if e.stdout.is_a? String 
     $stderr.puts "stderr: #{e.stderr}" if e.stderr.is_a? String
     $stderr.puts ""
     if options.trace
-      $stderr.puts "#{e.message}: rc(#{e.rc})"
       $stderr.puts e.backtrace.join("\n")
     else
       $stderr.puts "For more details about the problem, try running the command again with the '--trace' option."


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=975108

The useful `e.message` was only being printed if `--trace` was passed. We now always print the message, which displays something like.

```
remote: An error occurred executing 'gear postreceive' (exit code: 1)
remote: Error message: Failed to execute action hook 'deploy' for 640595622662830496415744 application foobar
remote: 
remote: For more details about the problem, try running the command again with the '--trace' option.
```
