### PR TITLE
Optimize gear script for ~50% Git push overhead reduction

### DIFF
--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -17,10 +17,11 @@
 
 require 'pp'
 require 'rubygems'
-require 'commander/import'
 require 'openshift-origin-node/model/application_container'
 require 'openshift-origin-node/model/application_repository'
 require 'openshift-origin-node/utils/node_logger'
+
+require 'commander/import'
 
 name="#{__FILE__}"
 


### PR DESCRIPTION
The require order for the Commander library is significant: by moving it to the end
of the requires list, a massive overhead reduction is observed (24s to 13s cumulative
Git push time when pushing a change a Mock cartridge based application).
