### PR TITLE
Bug 975708: Fix jboss java7 marker regression

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/bin/install
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/install
@@ -29,4 +29,4 @@ pushd $OPENSHIFT_JBOSSAS_DIR 1> /dev/null
   ln -s ${JBOSS_HOME}/modules
 popd 1> /dev/null
 
-update-configuration
+update-configuration java7

--- a/cartridges/openshift-origin-cartridge-jbossas/bin/util
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/util
@@ -3,7 +3,7 @@
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 function update-configuration() {
-  if marker_present java7
+  if marker_present java7 || [ ${1:-undefined} == java7 ]
   then
     export JAVA_HOME=$OPENSHIFT_JBOSSAS_JDK7
   else

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/install
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/install
@@ -29,4 +29,4 @@ pushd $OPENSHIFT_JBOSSEAP_DIR 1> /dev/null
   ln -s ${JBOSS_HOME}/modules
 popd 1> /dev/null
 
-update-configuration
+update-configuration java7

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/util
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/util
@@ -3,7 +3,7 @@
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 function update-configuration() {
-  if marker_present java7
+  if marker_present java7 || [ ${1:-undefined} == java7 ]
   then
     export JAVA_HOME=$OPENSHIFT_JBOSSEAP_JDK7
   else


### PR DESCRIPTION
Due to a regression introduced by c3e63de3c7f84cd62df99634dc58371cfd19fd6c, the initial java7
configuration was not being updated properly during setup. Newly created apps using the buggy
cart will default to java6 until the next Git push, at which point java7 will be correctly
enabled.

Fix setup logic to correctly configure java7 for new applications.
