### PR TITLE
Bug 974786: Scaled gear hot deploy logic fix

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/bin/deploy
+++ b/cartridges/openshift-origin-cartridge-haproxy/bin/deploy
@@ -34,7 +34,9 @@ function set_default_post_actions {
     else
       # Only respect hot deployment for initialized gears
       if hot_deploy_marker_is_present; then
-        remote_deploy_cmd="${remote_deploy_cmd} --hot-deploy"
+        remote_deploy_cmd="${remote_deploy_cmd} --hot-deploy=true"
+      else
+        remote_deploy_cmd="${remote_deploy_cmd} --hot-deploy=false"
       fi
     fi
 

--- a/cartridges/openshift-origin-cartridge-haproxy/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-haproxy/metadata/manifest.yml
@@ -6,7 +6,8 @@ Version: '1.4'
 License: GPLv2+
 License-Url: http://www.gnu.org/licenses/gpl-2.0.html
 Vendor: http://haproxy.1wt.eu/
-Cartridge-Version: '0.0.1'
+Cartridge-Version: '0.0.2'
+Compatible-Versions: ['0.0.1']
 Cartridge-Vendor: redhat
 Categories:
   - web_proxy

--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -144,10 +144,17 @@ command :remotedeploy do |c|
 
   c.description = "Run the remotedeploy steps"
   c.option "--init", "Run post_install for new gears"
-  c.option "--hot-deploy", "Perform hot deployment regardless of the presence of the hot_deploy marker in the application Git repo"
+  c.option "--hot-deploy BOOLEAN", "Perform hot deployment according to the specified "\
+           "argument rather than checking for the presence of the hot_deploy marker in the application Git repo"
+
   c.action do |args, options|
     do_command(c, options) do
-      hot_deploy_enabled = options.hot_deploy || file_committed?(HOT_DEPLOY_MARKER)
+      if options.hot_deploy.nil?
+        hot_deploy_enabled = file_committed?(HOT_DEPLOY_MARKER)
+      else
+        hot_deploy_enabled = (options.hot_deploy == true)
+      end
+
       if options.init
         @container.remote_deploy(out: $stdout, err: $stderr, hot_deploy: hot_deploy_enabled, init: true)
       else


### PR DESCRIPTION
Make the `gear` script `--hot-deploy` option require an explicit boolean argument
so that the option overrides a repo check for the hot_deploy marker.
