### PR TITLE
Bug 976112

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-nodejs/metadata/managed_files.yml
@@ -9,3 +9,5 @@ locked_files:
 - etc/
 processed_templates:
 - '**/*.erb'
+setup_rewritten:
+- 'versions/**/*'


### PR DESCRIPTION
Some node.js application migration may fail if the existing application
has a real directory `$OPENSHIFT_NODEJS_DIR/versions/0.6`.
Since we are copying the files over from the new version of the
cartridge, simply remove the files during migration so that `cp -ad`
does not fail.
