### PR TITLE
Bug 975794: Move oo-admin-cartridge operations to %posttrans

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/openshift-origin-cartridge-jbossas.spec
+++ b/cartridges/openshift-origin-cartridge-jbossas/openshift-origin-cartridge-jbossas.spec
@@ -76,6 +76,7 @@ mkdir -p /etc/alternatives/jbossas-7/modules/org/postgresql/jdbc/main
 ln -fs /usr/share/java/postgresql-jdbc3.jar /etc/alternatives/jbossas-7/modules/org/postgresql/jdbc/main
 cp -p %{cartridgedir}/versions/7/modules/postgresql_module.xml /etc/alternatives/jbossas-7/modules/org/postgresql/jdbc/main/module.xml
 
+%posttrans
 %{_sbindir}/oo-admin-cartridge --action install --source %{cartridgedir}
 
 

--- a/cartridges/openshift-origin-cartridge-jbosseap/openshift-origin-cartridge-jbosseap.spec
+++ b/cartridges/openshift-origin-cartridge-jbosseap/openshift-origin-cartridge-jbosseap.spec
@@ -74,6 +74,7 @@ mkdir -p /etc/alternatives/jbosseap-6.0/modules/org/postgresql/jdbc/main
 ln -fs /usr/share/java/postgresql-jdbc3.jar /etc/alternatives/jbosseap-6.0/modules/org/postgresql/jdbc/main
 cp -p %{cartridgedir}/versions/6.0/modules/postgresql_module.xml /etc/alternatives/jbosseap-6.0/modules/org/postgresql/jdbc/main/module.xml
 
+%posttrans
 %{_sbindir}/oo-admin-cartridge --action install --source %{cartridgedir}
 
 %files

--- a/cartridges/openshift-origin-cartridge-jbossews/openshift-origin-cartridge-jbossews.spec
+++ b/cartridges/openshift-origin-cartridge-jbossews/openshift-origin-cartridge-jbossews.spec
@@ -65,6 +65,7 @@ alternatives --remove jbossews-2.0 /usr/share/tomcat7
 alternatives --install /etc/alternatives/jbossews-2.0 jbossews-2.0 /usr/share/tomcat7 102
 alternatives --set jbossews-2.0 /usr/share/tomcat7
 
+%posttrans
 %{_sbindir}/oo-admin-cartridge --action install --source %{cartridgedir}
 
 

--- a/cartridges/openshift-origin-cartridge-ruby/openshift-origin-cartridge-ruby.spec
+++ b/cartridges/openshift-origin-cartridge-ruby/openshift-origin-cartridge-ruby.spec
@@ -171,7 +171,7 @@ Ruby cartridge for OpenShift. (Cartridge Format V2)
 %__rm -f %{buildroot}%{cartridgedir}/lib/ruby_context.*
 %__rm -f %{buildroot}%{cartridgedir}/metadata/manifest.yml.*
 
-%post
+%posttrans
 %{_sbindir}/oo-admin-cartridge --action install --source %{cartridgedir}
 
 


### PR DESCRIPTION
The oo-admin-cartridge command isn't safe to use in %post the way we currently
install the package; during %post, the previous RPM version files haven't been
cleaned up, meaning we install from a source tree containing a mixture of old
and new cartridge version files.

Move the operation to %posttrans, which guarantees the install picks up the final
installed package state, and thus only files from the new RPM installation.
