### PR TITLE
Bug 976758 & 969948 - Update the name of internal IP env var

### DIFF
--- a/cartridges/openshift-origin-cartridge-diy/usr/template/.openshift/action_hooks/start
+++ b/cartridges/openshift-origin-cartridge-diy/usr/template/.openshift/action_hooks/start
@@ -1,5 +1,5 @@
 #!/bin/bash
 # The logic to start up your application should be put in this
 # script. The application will work only if it binds to
-# $OPENSHIFT_INTERNAL_IP:8080
+# $OPENSHIFT_DIY_IP:8080
 nohup $OPENSHIFT_REPO_DIR/diy/testrubyserver.rb $OPENSHIFT_DIY_IP $OPENSHIFT_REPO_DIR/diy > $OPENSHIFT_DIY_DIR/logs/server.log 2>&1 &

--- a/cartridges/openshift-origin-cartridge-diy/usr/template/diy/index.html
+++ b/cartridges/openshift-origin-cartridge-diy/usr/template/diy/index.html
@@ -131,7 +131,7 @@
       to start and stop your application.
   </p>
   <p>
-      The only restriction is that your application should bind to $OPENSHIFT_INTERNAL_IP:8080
+      The only restriction is that your application should bind to $OPENSHIFT_DIY_IP:8080
   </p>
   <p>
       Don't forget to stop the existing server that is running before you push your stop file.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=976758
https://bugzilla.redhat.com/show_bug.cgi?id=969948
Changed the OPENSHIFT_INTERNAL_IP env var in index.html and start hook to OPENSHIFT_DIY_IP
