### PR TITLE
Card origin_runtime_163 - Validate attempted Gear env var overrides

### DIFF
--- a/node/README.writing_cartridges.md
+++ b/node/README.writing_cartridges.md
@@ -873,6 +873,10 @@ system-provided environment variables but before your code is called.
 OpenShift-provided environment variables will be loaded and available
 to be used for all cartridge entry points.
 
+You cannot override system provided variables by creating new copies in your cartridge `env` directory.
+If you attempt to do so, when an application developer attempts to instantiate your cartridge the system
+will raise an exception and refuse to do so.
+
 ### System Provided Variables (Read Only) ###
 
 | Name                | Value                                                                                                                    |


### PR DESCRIPTION
- Cart env vars should not be able to override platform env vars defined at a gear level
- Cart should not be able to create directories in gear home directory
