### PR TITLE
[TO_STAGE] Bug 977563

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/managed_files.yml
@@ -9,4 +9,5 @@ locked_files:
 - env/OPENSHIFT_RUBY_LOG_DIR
 - etc/
 processed_templates:
-- '**/*.erb'
+- 'etc/conf.d/openshift.conf.erb'
+- 'metadata/jenkins_shell_command.erb'


### PR DESCRIPTION
Instead of using glob, explicitly list templates belonging to the Ruby
cartridge.

PR corresponding to #2939.
