### PR TITLE
undefined local variable or method `paswd_lines'

### DIFF
--- a/node-util/bin/oo-accept-node
+++ b/node-util/bin/oo-accept-node
@@ -414,7 +414,7 @@ def check_cgroup_procs
         if (min_uid..max_uid).include?(uid)
             passwd_lines = $USERS.select { |u| u.uid == uid }
 
-          if paswd_lines.empty?
+          if passwd_lines.empty?
                 user_fail(uid, "Process #{pid} is owned by a gear that's no longer on the system, uid: #{uid}")
                 next
             end


### PR DESCRIPTION
The following typo fix should prevent the oo-accept-node command from failing.

``` ruby
/usr/sbin/oo-accept-node:417:in `block in check_cgroup_procs': undefined local variable or method `paswd_lines' for main:Object (NameError)
    from /usr/sbin/oo-accept-node:411:in `each'
    from /usr/sbin/oo-accept-node:411:in `check_cgroup_procs'
    from /usr/sbin/oo-accept-node:829:in `<main>'
```
