### PR TITLE
Compare config files in /var/www/openshift, not with /etc.

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -1122,13 +1122,13 @@ class OODiag
       do_match_check = false
     end
 
-    broker = `ls /etc/openshift/plugins.d/*auth*.conf | grep -v -- '-dev.conf$'`.split
+    broker = `ls /var/www/openshift/broker/httpd/conf.d/*auth*.conf | grep -v -- '-dev.conf$'`.split
     #Make sure there is only 1 conf file for the broker
     if(broker.size > 1)
       do_match_check = false
       do_warn <<-BROKER
         There is more than one authentication configuration file for the
-        broker in /etc/openshift/plugins.d
+        broker in /var/www/openshift/console/httpd/conf.d
         Authentication configuration files:
         #{broker.join "\n\t"}
       BROKER


### PR DESCRIPTION
The file /etc/openshift/plugins.d/openshift-origin-auth-remote-user.conf
contains

<code>TRUSTED_HEADER="REMOTE_USER"
</code>

which can be valid for multiple authentication mechanisms. It does not
however ensure that broker and console will use the same mechanisms.

Addressing

<pre>
WARN: test_auth_conf_files
        The two authentication configuration file names set up for the console and broker do not match;
        please ensure that they are using the same authentication mechanism.
        Authentication configration files:
        Broker: /etc/openshift/plugins.d/openshift-origin-auth-remote-user.conf

        Console: /var/www/openshift/console/httpd/conf.d/openshift-origin-auth-remote-user-kerberos.conf
</pre>
