### PR TITLE
Bug 979302 - Depend on formtastic which is available in Fedora 19.

### DIFF
--- a/console/openshift-origin-console.gemspec
+++ b/console/openshift-origin-console.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   # match gems available in Fedora.  This may be relaxed at a future 
   # date.
   s.add_dependency 'rails',               '~> 3.2.8'
-  s.add_dependency 'formtastic',          '~> 1.2.4'
+  s.add_dependency 'formtastic',          '~> 1.2.3'
   s.add_dependency 'net-http-persistent', '>= 2.7'
   s.add_dependency 'haml',                '~> 3.1.7'
   s.add_dependency 'rdiscount',           '~> 1.6.3'


### PR DESCRIPTION
Commit 59db435ba40222fe1d961eb630c4ccfeac6df9de bumped up the dependency
on formtastic to 1.2.4 but Fedora 19 only contains
rubygem-formtastic-1.2.3-9.fc19.noarch.
