### PR TITLE
Bug 980102

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/bin/control
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/control
@@ -93,8 +93,8 @@ function start() {
     #  Ensure we have script file.
     node_app=${node_app:-"server.js"}
 
-    if [ ! -h "$OPENSHIFT_REPO_DIR/../node_modules" ]; then
-       ln -s ../../nodejs-0.6/node_modules $OPENSHIFT_REPO_DIR/../node_modules
+    if [ ! -h "$OPENSHIFT_NODEJS_DIR/node_modules" ]; then
+       ln -s $OPENSHIFT_HOMEDIR/.node_modules $OPENSHIFT_NODEJS_DIR/node_modules
     fi
 
     pushd "$OPENSHIFT_REPO_DIR" > /dev/null

--- a/cartridges/openshift-origin-cartridge-nodejs/bin/setup
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/setup
@@ -19,6 +19,13 @@ for dir in configuration etc; do
     cp -Lr $OPENSHIFT_NODEJS_DIR/versions/$version/$dir/* $OPENSHIFT_NODEJS_DIR/$dir 
 done
 
+# Bug 980102
+# The symlink $OPENSHIFT_REPO_DIR/../node_modules is wrong
+if [ -h "$OPENSHIFT_REPO_DIR/../node_modules" ]; then
+   rm $OPENSHIFT_REPO_DIR/../node_modules
+fi
+
+
 ###
 pushd $OPENSHIFT_NODEJS_DIR > /dev/null
 for dir in conf logs sessions run tmp; do


### PR DESCRIPTION
The original link `$OPENSHIFT_REPO_DIR/../node_modules` is wrong.
The one we need is `$OPENSHIFT_NODEJS_DIR/node_modules`, which
will be used in `build()` if `deplist.txt` is present.

There is another occurrence of `npm install`, but that happens in
`$OPENSHIFT_REPO_DIR`, to which we have write access.

For existing Node.js applications, we simply remove the dangling symlink.

To test, create a Node.js app, then add a module (say `coffee-script`)
to `deplist.txt`, add and commit this change, and push.
