### PR TITLE
haproxy_ctld_daemon.rb: Fix backtrace option

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/haproxy_ctld_daemon.rb
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/haproxy_ctld_daemon.rb
@@ -4,7 +4,7 @@ require 'rubygems'
 require 'daemons'
 
 options = {
-    :backgrace => true,
+    :backtrace => true,
     :ontop => false,
     :log_output => true,
     :log_dir => "#{ENV['OPENSHIFT_HAPROXY_LOG_DIR']}",


### PR DESCRIPTION
The haproxy_ctld_daemon.rb script in the haproxy cartridge had a typo:
':backgrace' instead of ':backtrace'.

This typo appears to have been present since haproxy_ctld_daemon.rb was
introduced in commit ee8cebbe1adb351a3b80ca3fda4f047aee8fac1b.
