### PR TITLE
Add gmp-devel as a dependency for the ruby cartridge

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/openshift-origin-cartridge-ruby.spec
+++ b/cartridges/openshift-origin-cartridge-ruby/openshift-origin-cartridge-ruby.spec
@@ -138,6 +138,7 @@ Requires:      ruby-nokogiri
 %if 0%{?fedora}
 Requires:      rubygem-nokogiri
 %endif
+Requires:      gmp-devel
 
 Obsoletes: openshift-origin-cartridge-ruby-1.8
 Obsoletes: openshift-origin-cartridge-ruby-1.9-scl


### PR DESCRIPTION
This pull request adds a dependency of gmp-devel to the ruby cartridge, because it is required to build the gmp gem, a popular library for arbitrary-precision arithmetic. Note that gmp-devel is part of the RHEL packages and does not need backporting.
