### PR TITLE
Bug fixes: #982172, #980841

### DIFF
--- a/controller/app/models/gear.rb
+++ b/controller/app/models/gear.rb
@@ -67,7 +67,7 @@ class Gear
   end
   
   def unreserve_uid
-    get_proxy.unreserve_uid(self.uid)
+    get_proxy.unreserve_uid(self.uid) if get_proxy
     self.set :server_identity, nil
     self.set :uid, nil
   end

--- a/node/lib/openshift-origin-node/model/upgrade.rb
+++ b/node/lib/openshift-origin-node/model/upgrade.rb
@@ -174,8 +174,8 @@ module OpenShift
         progress.log "Migrating gear at #{gear_home}"
 
         config               = OpenShift::Config.new
-        state                = OpenShift::Runtime::Utils::ApplicationState.new(uuid)
         container            = OpenShift::Runtime::ApplicationContainer.from_uuid(uuid)
+        state                = OpenShift::Runtime::Utils::ApplicationState.new(container)
         cartridge_model      = OpenShift::Runtime::V2UpgradeCartridgeModel.new(config, container, state, OpenShift::Runtime::Utils::Hourglass.new(235))
         cartridge_repository = OpenShift::Runtime::CartridgeRepository.instance
         restart_required     = false


### PR DESCRIPTION
Bug 982172 - Do not try to unreserve_uid if we don't get valid container for the gear.
Bug 980841 - Need to pass 'container' instead of 'uuid' for ApplicationState constructor
