### PR TITLE
Updates to allow basic tests to pass on F19 [test]

### DIFF
--- a/console/openshift-origin-console.gemspec
+++ b/console/openshift-origin-console.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   # match gems available in Fedora.  This may be relaxed at a future 
   # date.
   s.add_dependency 'rails',               '~> 3.2.8'
-  s.add_dependency 'formtastic',          '~> 1.2.4'
+  s.add_dependency 'formtastic',          '>= 1.2.3'
   s.add_dependency 'net-http-persistent', '>= 2.7'
   s.add_dependency 'haml',                '~> 3.1.7'
-  s.add_dependency 'rdiscount',           '~> 1.6.3'
+  s.add_dependency 'rdiscount',           '> 1.6.3'
 end

--- a/controller/test/cucumber/step_definitions/application_steps.rb
+++ b/controller/test/cucumber/step_definitions/application_steps.rb
@@ -251,12 +251,6 @@ Then /^the applications should( not)? be accessible?$/ do |negate|
   end
 end
 
-When /^the applications are destroyed$/ do
-  @apps.each do |app|
-    rhc_ctl_destroy(app)
-  end
-end
-
 Then /^the applications should be accessible via node\-web\-proxy$/ do
   @apps.each do |app|
     app.is_accessible?(false, 120, nil, 8000).should be_true

--- a/node/test/functional/application_state_func_test.rb
+++ b/node/test/functional/application_state_func_test.rb
@@ -27,6 +27,7 @@ module OpenShift
       # polyinstantiation makes creating the homedir a pain...
       FileUtils.rm_r @homedir if File.exist?(@homedir)
       FileUtils.mkpath(@runtime_dir)
+      FileUtils.mkdir_p @homedir
       %x{useradd -u #@uid -d #@homedir #@uid 1>/dev/null 2>&1}
       %x{chown -R #@uid:#@uid #@homedir}
       FileUtils.mkpath(File.join(@homedir, '.tmp', @uid.to_s))


### PR DESCRIPTION
- Update console requirements to match those available on F19 as RPMs
- Remove duplicate application deletion step in tests
- Explicitly creating test home dir since selinux prevents it from being created normally
