### PR TITLE
Bug 974983

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/lib/util
+++ b/cartridges/openshift-origin-cartridge-ruby/lib/util
@@ -19,7 +19,8 @@ function wait_for_stop {
 function update-configuration {
     case "$1" in
       1.9)
-        dirname $(scl enable ruby193 "which ruby") >$OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_PATH_ELEMENT
+        echo -n "${GEM_HOME}/bin:" >$OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_PATH_ELEMENT
+        dirname $(scl enable ruby193 "which ruby") >>$OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_PATH_ELEMENT
 
         local ld_path=$(LD_LIBRARY_PATH="" scl enable ruby193 "printenv LD_LIBRARY_PATH")
         path_append $LD_LIBRARY_PATH $ld_path >$OPENSHIFT_RUBY_DIR/env/LD_LIBRARY_PATH
@@ -32,6 +33,7 @@ function update-configuration {
         rm -f $OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_PATH_ELEMENT \
             $OPENSHIFT_RUBY_DIR/env/LD_LIBRARY_PATH \
             $OPENSHIFT_RUBY_DIR/env/MANPATH
+        echo -n "${GEM_HOME}/bin" > $OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_PATH_ELEMENT
         ;;
     esac
 }

--- a/node/lib/openshift-origin-node/model/application_container_ext/setup.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/setup.rb
@@ -49,7 +49,6 @@ module OpenShift
 
           gem_home = PathUtils.join(homedir, ".gem")
           add_env_var "GEM_HOME", gem_home
-          add_env_var "OPENSHIFT_RUBYGEMS_PATH_ELEMENT", PathUtils.join(gem_home, "bin")
           FileUtils.mkdir_p(gem_home)
           FileUtils.chmod(0o0750, gem_home)
           set_rw_permission(gem_home)


### PR DESCRIPTION
Set up $PATH so that ~/.gem/bin precedes /opt/rh/ruby193/root/usr/bin or
/usr/bin (as appropriate).

This effectively reverts fcc9026, which added RubyGems' path during the
user setup. That commit was incomplete, since that led to inconsistency
with the 1.9 apps (see
https://bugzilla.redhat.com/show_bug.cgi?id=974983#c8).

Instead, we use $OPENSHIFT_RUBY_PATH_ELEMENT to ensure that $PATH is
correct. (It is possible to use $OPENSHIFT_RUBYGEMS_PATH_ELEMENT still,
but that relies on $*_PATH_ELEMENT processing order, which we need to
avoid here.)
