### PR TITLE
Console: Make sure excluded_tags is set

### DIFF
--- a/console/app/views/application_types/index.html.haml
+++ b/console/app/views/application_types/index.html.haml
@@ -101,6 +101,7 @@
         .span6
           %p Want to build your own cartridge? Get started with the DIY cart.
           .tile-dark
+            - excluded_tags = common_tags_for(@custom_types)
             - @custom_types.sort!.each do |type|
               = render :partial => 'tile', :locals => {:type => type, :excluded_tags => excluded_tags}
 


### PR DESCRIPTION
When listing the custom cartridge type (i.e., the diy cartridge), make
sure that excluded_tags in case it was not set earlier.  This commit
fixes bug 982882.
