### PR TITLE
Fix ApplicationStateFunctionalTest for F19 [test]

### DIFF
--- a/node/test/functional/application_state_func_test.rb
+++ b/node/test/functional/application_state_func_test.rb
@@ -21,7 +21,7 @@ module OpenShift
   class ApplicationStateFunctionalTest < NodeTestCase
     def setup
       @uid     = 5907
-      @homedir = "/tmp/tests/#@uid"
+      @homedir = "/var/tmp-tests/#@uid"
       @runtime_dir = File.join(@homedir, %w{app-root runtime})
 
       # polyinstantiation makes creating the homedir a pain...


### PR DESCRIPTION
so that it creates test user in /var/tmp-tests instead of /tmp.
This avoids any poly-instantiated /tmp errors.
