### PR TITLE
Bug 979740 - Fix Postgres cartridge using $HOME

### DIFF
--- a/cartridges/openshift-origin-cartridge-postgresql/bin/install
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/install
@@ -39,9 +39,9 @@ chmod 0700 $OPENSHIFT_POSTGRESQL_DB_SOCKET
 conf_dir="${OPENSHIFT_POSTGRESQL_DIR}/versions/$version/conf"
 cp $conf_dir/*.conf $OPENSHIFT_POSTGRESQL_DIR/data/
 
-cp $conf_dir/psqlrc $HOME/.psqlrc
-echo "*:*:*:${username}:${password}" > $HOME/.pgpass
-chmod 0600 $HOME/.pgpass
+cp $conf_dir/psqlrc $OPENSHIFT_HOMEDIR/.psqlrc
+echo "*:*:*:${username}:${password}" > $OPENSHIFT_HOMEDIR/.pgpass
+chmod 0600 $OPENSHIFT_HOMEDIR/.pgpass
 
 update-configuration $version
 

--- a/cartridges/openshift-origin-cartridge-postgresql/bin/teardown
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/teardown
@@ -1,5 +1,5 @@
 #!/bin/bash -ue
 
-rm -f $HOME/.psqlrc
-rm -f $HOME/.pgpass
+rm -f $OPENSHIFT_HOMEDIR/.psqlrc
+rm -f $OPENSHIFT_HOMEDIR/.pgpass
 find $OPENSHIFT_DATA_DIR -type f -name ".psql_history*" -exec rm {} \;


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=979740

The Postgres cartridge was using $HOME in some places, but it should be using $OPENSHIFT_HOMEDIR.
This is causing an unbound variable error.
