### PR TITLE
Add slashes to mongodb's managed_files.yml

### DIFF
--- a/cartridges/openshift-origin-cartridge-mongodb/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-mongodb/metadata/managed_files.yml
@@ -2,11 +2,11 @@
 snapshot_exclusions:
 - mongodb/*
 locked_files:
-- bin
+- bin/
 - bin/*
-- env
+- env/
 - env/*
-- metadata
+- metadata/
 - metadata/*
 - hooks/
 - hooks/*


### PR DESCRIPTION
Add trailing slashes to directories in managed_files.yml of the mongodb
cartridge.

Although the absence of the slashes was not causing any apparent
problems, correctness and consistency with other cartridges demands that
directories be denoted with trailing slashes.
