### PR TITLE
Use OPENSHIFT_*_DIR in standalone.conf

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/versions/7/bin/standalone.conf
+++ b/cartridges/openshift-origin-cartridge-jbossas/versions/7/bin/standalone.conf
@@ -10,8 +10,7 @@ function print_sed_exp_replace_env_var {
   printf "%s\n" "$sed_exp"
 }
 
-cartridge_type="jbossas"
-CART_DIR=${OPENSHIFT_HOMEDIR}${cartridge_type}
+CART_DIR=${OPENSHIFT_JBOSSAS_DIR}
 
 # This uses the sun jdk install since the current open-jdk version has a bug
 # Once this has been upgrade to something based on 1.6.0_20 or higher,

--- a/cartridges/openshift-origin-cartridge-jbosseap/versions/6.0/bin/standalone.conf
+++ b/cartridges/openshift-origin-cartridge-jbosseap/versions/6.0/bin/standalone.conf
@@ -10,8 +10,7 @@ function print_sed_exp_replace_env_var {
   printf "%s\n" "$sed_exp"
 }
 
-cartridge_type="jbosseap"
-CART_DIR=${OPENSHIFT_HOMEDIR}${cartridge_type}
+CART_DIR=${OPENSHIFT_JBOSSEAP_DIR}
 
 # This uses the sun jdk install since the current open-jdk version has a bug
 # Once this has been upgrade to something based on 1.6.0_20 or higher,


### PR DESCRIPTION
In the JBoss cartridges' standalone.conf file, use OPENSHIFT_JBOSSAS_DIR
or OPENSHIFT_JBOSSEAP_DIR as appropriate to set the value of CART_DIR.
