### PR TITLE
Bug 983374 - NodeJS status not being reported properly

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/bin/control
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/control
@@ -57,7 +57,7 @@ function is_node_module_installed() {
 }
 
 function status() {
-    if [ is_node_service_running ]; then
+    if is_node_service_running; then
         client_result "Application is running"
     else
         client_result "Application is not running"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=983374

Syntax error in `bin/control status` was causing the wrong status to be shown
