### PR TITLE
oo-accept-broker: check httpd_execmem

### DIFF
--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -455,7 +455,7 @@ function check_selinux_booleans() {
     return
   fi
 
-  SELINUX_BOOLEANS='httpd_unified httpd_can_network_connect httpd_can_network_relay httpd_run_stickshift'
+  SELINUX_BOOLEANS='httpd_execmem httpd_unified httpd_can_network_connect httpd_can_network_relay httpd_run_stickshift'
   for bool in $SELINUX_BOOLEANS
   do
     if getsebool "$bool" | grep -e '--> on' >/dev/null


### PR DESCRIPTION
Add httpd_execmem to the list of Booleans that check_selinux_booleans
checks.
