### PR TITLE
Bug BZ983545 - force_clean_build fails on NodeJS

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/bin/control
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/control
@@ -187,11 +187,33 @@ function build() {
         rm -rf "${OPENSHIFT_NODEJS_DIR}/tmp/saved.node_modules"
     fi
 
-    if [ -f "${OPENSHIFT_REPO_DIR}/.openshift/markers/force_clean_build" ]; then
-        echo ".openshift/markers/force_clean_build found!  Recreating npm modules" 1>&2
-        rm -rf "${OPENSHIFT_NODEJS_DIR}"/node_modules/*
-        rm -rf "${OPENSHIFT_HOMEDIR}"/.npm/*
-        rm -rf "${OPENSHIFT_REPO_DIR}"node_modules/*
+    if marker_present "force_clean_build"; then
+      echo "force_clean_build marker found!  Recreating npm modules" 1>&2
+      # These are directories we want to remove modules from
+      clean_dirs=(
+        "${OPENSHIFT_NODEJS_DIR}/node_modules"
+        "${OPENSHIFT_HOMEDIR}/.npm"
+        "${OPENSHIFT_REPO_DIR}/node_modules"
+      )
+
+      for dir in "${clean_dirs[@]}"
+      do
+        if [ -d "${dir}" ]
+        then
+          pushd "${dir}" > /dev/null
+          # Only remove non-hidden directories that are not symlinks.
+          #   This lets us remove all installed modules except:
+          #     - Globally installed modules
+          #     - The regex prevents us from deleting hidden top level directories, including .bin
+          find . -maxdepth 1 -regex '^\.\/[^\.].*' -type d -exec rm -rf {} \;
+          # Clear out any missing symlinks from .bin (in case we removed the module)
+          if [ -d ".bin" ]
+          then
+            find .bin -type l -! -exec test -e {} \; -exec rm {} \;
+          fi
+          popd > /dev/null
+        fi
+      done
     fi
 
     #  Newer versions of Node set tmp to $HOME/tmp, which is not available


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=983545

We were removing the global modules on force_clean_build.
Since they are all symlinks, we only remove actual directories.
