### PR TITLE
Bug 969876 - Don't run execute_connections if there are no add/remove component ops

### DIFF
--- a/broker-util/oo-admin-upgrade
+++ b/broker-util/oo-admin-upgrade
@@ -652,6 +652,7 @@ Usage: #{$0}
   --app-name app_name                  App name of the gear to upgrade
   --upgrade-node server_identity       Server identity of the node to upgrade
   --upgrade-file file                  File containing the gears to upgrade
+  --version                            Target version number
   --num-upgraders num                  The total number of upgraders to be run.  Each upgrade-position will be a 
                                        upgrade-position of num-upgraders.  All positions must to taken to upgrade
                                        all gears.  Ex: If you are going to run 2 upgraders you would need to run:
@@ -661,7 +662,7 @@ Usage: #{$0}
   --max-threads num                    Indicates the number of processing queues
   --ignore-cartridge-version           Force cartridge upgrade even if cartridge versions match
   --continue                           Flag indicating to continue a previous upgrade
-
+  --help                               Show usage info
 USAGE
   exit 255
 end

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1868,10 +1868,12 @@ class Application
       component_ops[config_order[idx]][:post_configures].each { |op| op.prereq += prereq_ids }
     end
 
-    execute_connection_op = nil
-    all_ops_ids = pending_ops.map{ |op| op._id.to_s }
-    execute_connection_op = PendingAppOp.new(op_type: :execute_connections, prereq: all_ops_ids)
-    pending_ops.push execute_connection_op
+    unless pending_ops.empty? or ((pending_ops.length == 1) and (pending_ops[0].op_type == :set_group_overrides))
+      execute_connection_op = nil
+      all_ops_ids = pending_ops.map{ |op| op._id.to_s }
+      execute_connection_op = PendingAppOp.new(op_type: :execute_connections, prereq: all_ops_ids)
+      pending_ops.push execute_connection_op
+    end
 
     # check to see if there are any deployable carts being configured
     # if so, then make sure that the post-configure op for it is executed at the end


### PR DESCRIPTION
 Bug 982994 - Minor: add version/help options to usage info
