### PR TITLE
Make action log tagging default to correct code

### DIFF
--- a/controller/app/controllers/alias_controller.rb
+++ b/controller/app/controllers/alias_controller.rb
@@ -1,6 +1,8 @@
 class AliasController < BaseController
   include RestModelHelper
   before_filter :get_domain, :get_application
+  action_log_tag_resource :alias
+
   def index
     begin
       rest_aliases = []
@@ -91,9 +93,5 @@ class AliasController < BaseController
     end
     status = requested_api_version <= 1.4 ? :no_content : :ok
     render_success(status, nil, nil, "Removed #{server_alias} from application #{@application.name}", result)
-  end
-  
-  def set_log_tag
-    @log_tag = get_log_tag_prepend + "ALIAS"
   end
 end

--- a/controller/app/controllers/api_controller.rb
+++ b/controller/app/controllers/api_controller.rb
@@ -2,7 +2,7 @@
 # Entry point for the Broker REST API
 # @api REST
 class ApiController < BaseController
-  skip_before_filter :check_outage, :authenticate_user!, :check_controller_scopes!, :set_log_tag, :only => :show
+  skip_before_filter :check_outage, :authenticate_user!, :check_controller_scopes!, :only => :show
 
   ##
   # Returns an array of {http://en.wikipedia.org/wiki/HATEOAS HATEOAS} links describing the REST API. All REST replies

--- a/controller/app/controllers/app_events_controller.rb
+++ b/controller/app/controllers/app_events_controller.rb
@@ -4,6 +4,8 @@
 class AppEventsController < BaseController
   include RestModelHelper
   before_filter :get_domain, :get_application
+  action_log_tag_resource :application
+
   ##
   # API to perform manage an application
   # 
@@ -101,12 +103,12 @@ class AppEventsController < BaseController
     render_success(:ok, "application", app, msg, r)
   end
   
-  def set_log_tag
-    event = params[:event]
-    if event
-      @log_tag = "#{event.sub('-', '_').upcase}_APPLICATION"
-    else
-      @log_tag = "UNKNOWN_EVENT_APPLICATION"
+  protected
+    def action_log_tag_action
+      if event = params[:event].presence
+        event.underscore.upcase
+      else
+        "UNKNOWN_EVENT"
+      end
     end
-  end
 end

--- a/controller/app/controllers/applications_controller.rb
+++ b/controller/app/controllers/applications_controller.rb
@@ -142,8 +142,4 @@ class ApplicationsController < BaseController
     status = requested_api_version <= 1.4 ? :no_content : :ok
     return render_success(status, nil, nil, "Application #{id} is deleted.", result)
   end
-
-  def set_log_tag
-    @log_tag = get_log_tag_prepend + "APPLICATION"
-  end
 end

--- a/controller/app/controllers/authorizations_controller.rb
+++ b/controller/app/controllers/authorizations_controller.rb
@@ -85,8 +85,4 @@ class AuthorizationsController < BaseController
       return render_exception(e) 
     end
   end
-  
-  def set_log_tag
-    @log_tag = get_log_tag_prepend + "AUTHORIZATION"
-  end
 end

--- a/controller/app/controllers/base_controller.rb
+++ b/controller/app/controllers/base_controller.rb
@@ -9,6 +9,5 @@ class BaseController < ActionController::Base
                 :check_nolinks,
                 :check_version,
                 :check_outage,
-                :authenticate_user!,
-                :set_log_tag
+                :authenticate_user!
 end

--- a/controller/app/controllers/cartridges_controller.rb
+++ b/controller/app/controllers/cartridges_controller.rb
@@ -48,8 +48,4 @@ class CartridgesController < BaseController
     rest_cartridges = cartridges.map { |c| get_rest_cartridge(c) }
     render_success(:ok, "cartridges", rest_cartridges, "List #{search.nil? ? 'all' : search} cartridges")
   end
-  
-  def set_log_tag
-    @log_tag = get_log_tag_prepend + "CARTRIDGE"
-  end
 end

--- a/controller/app/controllers/descriptors_controller.rb
+++ b/controller/app/controllers/descriptors_controller.rb
@@ -28,8 +28,4 @@ class DescriptorsController < BaseController
   def show
     render_success(:ok, "descriptor", @application.to_descriptor.to_yaml, "Show descriptor for application '#{@application.name}' for domain '#{@domain.namespace}'")
   end
-  
-  def set_log_tag
-    @log_tag = get_log_tag_prepend + "DESCRIPTOR"
-  end
 end

--- a/controller/app/controllers/dns_resolvable_controller.rb
+++ b/controller/app/controllers/dns_resolvable_controller.rb
@@ -28,8 +28,9 @@ class DnsResolvableController < BaseController
       render_error(:not_found, "Could not resolve DNS #{name}: #{e.message}", 170)
     end
   end
-  
-  def set_log_tag
-    @log_tag = "DNS_RESOLVABLE"
-  end
+
+  protected
+    def action_log_tag
+      "DNS_RESOLVABLE"
+    end
 end

--- a/controller/app/controllers/domains_controller.rb
+++ b/controller/app/controllers/domains_controller.rb
@@ -164,10 +164,4 @@ class DomainsController < BaseController
       return render_exception(e) 
     end
   end
-
-  private
-  
-  def set_log_tag
-    @log_tag = get_log_tag_prepend + "DOMAIN"
-  end
 end

--- a/controller/app/controllers/emb_cart_controller.rb
+++ b/controller/app/controllers/emb_cart_controller.rb
@@ -1,6 +1,7 @@
 class EmbCartController < BaseController
   include RestModelHelper
   before_filter :get_domain, :get_application
+  action_log_tag_resource :app_cartridge
 
   # This is the regex for cartridge names
   # We need to ensure backward compatibility for fetches
@@ -269,9 +270,5 @@ class EmbCartController < BaseController
     rescue Exception => e
       return render_exception(e)
     end
-  end
-  
-  def set_log_tag
-    @log_tag = get_log_tag_prepend + "APP_CARTRIDGE"
   end
 end

--- a/controller/app/controllers/emb_cart_events_controller.rb
+++ b/controller/app/controllers/emb_cart_events_controller.rb
@@ -1,6 +1,8 @@
 class EmbCartEventsController < BaseController
   include RestModelHelper
   before_filter :get_domain, :get_application
+  action_log_tag_resource :cartridge
+
   # POST /domain/[domain_id]/applications/[application_id]/cartridges/[cartridge_id]/events
   def create
     cartid = params[:cartridge_id].downcase if params[:cartridge_id].presence
@@ -32,13 +34,12 @@ class EmbCartEventsController < BaseController
     render_success(:ok, "application", app, "Added #{event} on #{cartridge} for application #{@application.name}", result) 
   end
   
-  def set_log_tag
-    event = params[:event].presence
-    if event
-      @log_tag = "#{event.sub('-', '_').upcase}_CARTRIDGE"
-    else
-      @log_tag = "UNKNOWN_EVENT_CARTRIDGE"
+  protected
+    def action_log_tag_action
+      if event = params[:event].presence
+        event.underscore.upcase
+      else
+        "UNKNOWN_EVENT"
+      end
     end
-      
-  end
 end

--- a/controller/app/controllers/environment_controller.rb
+++ b/controller/app/controllers/environment_controller.rb
@@ -9,8 +9,4 @@ class EnvironmentController < BaseController
     environment['download_cartridges_enabled'] = Rails.application.config.openshift[:download_cartridges_enabled]
     render_success(:ok, "environment", environment, "Showing broker environment")
   end
-  
-  def set_log_tag
-    @log_tag = get_log_tag_prepend + "ENVIRONMENT"
-  end
 end

--- a/controller/app/controllers/gear_groups_controller.rb
+++ b/controller/app/controllers/gear_groups_controller.rb
@@ -34,8 +34,4 @@ class GearGroupsController < BaseController
       return render_error(:internal_server_error, "Failed to get gear group #{gear_group_id}  for application #{@application.name} due to: #{e.message}", 1)
     end
   end
-  
-  def set_log_tag
-    @log_tag = get_log_tag_prepend + "GEAR_GROUP"
-  end
 end

--- a/controller/app/controllers/gears_controller.rb
+++ b/controller/app/controllers/gears_controller.rb
@@ -11,8 +11,4 @@ class GearsController < BaseController
     new_url = url[0..url.rindex("/")] << "gear_groups"
     render_error(:moved_permanently, "Please use this URL instead #{new_url}", 112)
   end
-  
-  def set_log_tag
-    @log_tag = get_log_tag_prepend + "GEAR"
-  end
 end

--- a/controller/app/controllers/keys_controller.rb
+++ b/controller/app/controllers/keys_controller.rb
@@ -118,8 +118,4 @@ class KeysController < BaseController
       return render_exception(e)
     end
   end
-  
-  def set_log_tag
-    @log_tag = get_log_tag_prepend + "KEY"
-  end
 end

--- a/controller/app/controllers/quickstarts_controller.rb
+++ b/controller/app/controllers/quickstarts_controller.rb
@@ -28,8 +28,4 @@ class QuickstartsController < BaseController
     def file
       File.join(OpenShift::Config::CONF_DIR, 'quickstarts.json')
     end
-    
-    def set_log_tag
-      @log_tag = get_log_tag_prepend + "QUICKSTART"
-    end
 end

--- a/controller/app/controllers/user_controller.rb
+++ b/controller/app/controllers/user_controller.rb
@@ -28,10 +28,4 @@ class UserController < BaseController
       return render_exception(e)
     end
   end
-
-  private
-
-  def set_log_tag
-    @log_tag = get_log_tag_prepend + "USER"
-  end
 end

--- a/controller/lib/openshift/controller/action_log.rb
+++ b/controller/lib/openshift/controller/action_log.rb
@@ -5,6 +5,20 @@ module OpenShift::Controller::ActionLog
     around_filter :set_logged_request
   end
 
+  module ClassMethods
+    #
+    # Override the default controller log resource by calling:
+    #
+    #   action_log_tag_resource :name_with_underscore
+    #
+    def action_log_tag_resource(resource)
+      s = resource.to_s.upcase
+      define_method :action_log_tag_resource do
+        s
+      end
+    end    
+  end
+
   protected
     #
     # Log an action for a user who has not been authenticated yet.
@@ -27,6 +41,38 @@ module OpenShift::Controller::ActionLog
     def log_actions_as(user)
       OpenShift::UserActionLog.with_user(user.id, user.login)
     end
+
+    #
+    # The tag for an action made from this controller method
+    #
+    def action_log_tag_action
+      case request.method
+      when "GET"    then params[:id] ? "SHOW" : "LIST"
+      when "POST"   then "ADD" 
+      when "PUT"    then "UPDATE"
+      when "DELETE" then "DELETE"
+      else               "UNKNOWN"
+      end
+    end
+
+    #
+    # The resource that is being logged
+    #
+    def action_log_tag_resource
+      controller_name.singularize.upcase
+    end
+
+    #
+    # The user action log tag for requests made from this controller.
+    #
+    def action_log_tag
+      @action_log_tag ||= "#{action_log_tag_action}_#{action_log_tag_resource}"
+    end
+    #
+    # Override the action log tag for a particular action.  Should be set
+    # as early as possible in the request chain.
+    #
+    attr_writer :action_log_tag
 
   private
     def set_logged_request

--- a/controller/lib/openshift/controller/api_behavior.rb
+++ b/controller/lib/openshift/controller/api_behavior.rb
@@ -10,7 +10,6 @@ module OpenShift
         attr :requested_api_version
 
         def check_version
-
           version = catch(:version) do
             (request.accept || "").split(',').each do |mime_type|
               values = mime_type.split(';').map(&:strip)

--- a/controller/lib/openshift/controller/api_responses.rb
+++ b/controller/lib/openshift/controller/api_responses.rb
@@ -30,11 +30,11 @@ module OpenShift
           reply = new_rest_reply(status)
           if messages.present?
             reply.messages.concat(messages)
-            log_action(@log_tag, !internal_error, msg, get_log_args, messages.map(&:text).join(', '))
+            log_action(action_log_tag, !internal_error, msg, get_log_args, messages.map(&:text).join(', '))
           else
             msg_type = :error unless msg_type
             reply.messages.push(Message.new(msg_type, msg, err_code, field)) if msg
-            log_action(@log_tag, !internal_error, msg, get_log_args)
+            log_action(action_log_tag, !internal_error, msg, get_log_args)
           end
           respond_with reply
         end
@@ -109,9 +109,9 @@ module OpenShift
           
           if extra_messages.present?
             reply.messages.concat(messages)
-            log_action(@log_tag, true, message, log_args, messages.map(&:text).join(', '))
+            log_action(action_log_tag, true, message, log_args, messages.map(&:text).join(', '))
           else
-            log_action(@log_tag, true, message, log_args)
+            log_action(action_log_tag, true, message, log_args)
           end
           respond_with reply
         end

--- a/plugins/auth/kerberos/app/controllers/account_controller.rb
+++ b/plugins/auth/kerberos/app/controllers/account_controller.rb
@@ -5,9 +5,4 @@ class AccountController < BaseController
     Rails.logger.debug "username = #{username}"
     return render_error(:unprocessable_entity, "Cannot create account, managed by kerberos", 1001, "username")
   end
-  
-  def set_log_tag
-    @log_tag = get_log_tag_prepend + "ACCOUNT"
-  end
-  
 end

--- a/plugins/auth/mongo/app/controllers/account_controller.rb
+++ b/plugins/auth/mongo/app/controllers/account_controller.rb
@@ -14,10 +14,5 @@ class AccountController < BaseController
 
     auth_service.register_user(username, password)
     render_success(:created, "account", RestAccount.new(username, Time.new), "User '#{username}' successfully registered")
-  end
-  
-  def set_log_tag
-    @log_tag = get_log_tag_prepend + "ACCOUNT"
-  end
-  
+  end 
 end


### PR DESCRIPTION
Make set_log_tag lazy, so that all controllers have a default behavior Allow
controllers to override log tag on their class, not on the instance Make
allowances for legacy behavior
