### PR TITLE
Making assert_repo_reset test more resilient to git versions [merge]

### DIFF
--- a/node/test/functional/application_repository_func_test.rb
+++ b/node/test/functional/application_repository_func_test.rb
@@ -107,7 +107,7 @@ class ApplicationRepositoryFuncTest < OpenShift::NodeTestCase
 
   def assert_repo_reset(repo)
     reflog = Dir.chdir(repo.path){ `git reflog | head -1` }
-    assert reflog.include?("reset: moving to HEAD~1"), "Repository was not reset or reflog was not enabled (#{reflog})"
+    assert reflog.include?("reset: moving to HEAD~1") || reflog.include?("HEAD~1: updating HEAD"), "Repository was not reset or reflog was not enabled (#{reflog})"
   end
 
   def test_new


### PR DESCRIPTION
Fedora 19:

[root@broker tmp]# git clone --bare --no-hardlinks git://github.com/openshift/downloadable-mock.git AppRepoFuncTest.git
[root@broker tmp]# cd AppRepoFuncTest.git
[root@broker AppRepoFuncTest.git]# git config core.logAllRefUpdates true
[root@broker AppRepoFuncTest.git]# git reset --soft 'HEAD~1'
[root@broker AppRepoFuncTest.git]# git reflog | head -1
e7bbb95 HEAD@{0}: reset: moving to HEAD~1

RHEL 6.4:

[root@broker tmp]# git clone --bare --no-hardlinks git://github.com/openshift/downloadable-mock.git AppRepoFuncTest.git
[root@broker tmp]# cd AppRepoFuncTest.git/
[root@broker AppRepoFuncTest.git]# git config core.logAllRefUpdates true
[root@broker AppRepoFuncTest.git]# git reset --soft 'HEAD~1'
[root@broker AppRepoFuncTest.git]# git reflog | head -1
e7bbb95 HEAD@{0}: HEAD~1: updating HEAD
