### PR TITLE
Use oo_spawn for all root scoped shell commands

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -247,8 +247,8 @@ module OpenShift
         #    directories by pam_namespace.
         out = err = rc = nil
         10.times do |i|
-          run_in_root_context(%{/usr/bin/pkill -9 -u #{uid}})
-          out,err,rc = run_in_root_context(%{/usr/bin/pgrep -u #{uid}})
+          ::OpenShift::Runtime::Utils::oo_spawn(%{/usr/bin/pkill -9 -u #{uid}})
+          out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn(%{/usr/bin/pgrep -u #{uid}})
           break unless 0 == rc
 
           logger.error "ERROR: attempt #{i}/10 there are running \"killed\" processes for #{uid}(#{rc}): stdout: #{out} stderr: #{err}"
@@ -257,7 +257,7 @@ module OpenShift
 
         # looks backwards but 0 implies processes still existed
         if 0 == rc
-          out,err,rc = run_in_root_context("ps -u #{uid} -o state,pid,ppid,cmd")
+          out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn("ps -u #{uid} -o state,pid,ppid,cmd")
           logger.error "ERROR: failed to kill all processes for #{uid}(#{rc}): stdout: #{out} stderr: #{err}"
         end
       end
@@ -557,37 +557,6 @@ module OpenShift
             end
           end
         end
-      end
-
-      # run_in_root_context(command, [, options]) -> [stdout, stderr, exit status]
-      #
-      # Executes specified command and return its stdout, stderr and exit status.
-      # Or, raise exceptions if certain conditions are not met.
-      #
-      # command: command line string which is passed to the standard shell
-      #
-      # options: hash
-      #   :env: hash
-      #     name => val : set the environment variable
-      #     name => nil : unset the environment variable
-      #   :unsetenv_others => true   : clear environment variables except specified by :env
-      #   :chdir => path             : set current directory when running command
-      #   :expected_exitstatus       : An Integer value for the expected return code of command
-      #                              : If not set spawn() returns exitstatus from command otherwise
-      #                              : raise an error if exitstatus is not expected_exitstatus
-      #   :timeout                   : Maximum number of seconds to wait for command to finish. default: 3600
-      #   :out                       : If specified, STDOUT from the child process will be redirected to the
-      #                                provided +IO+ object.
-      #   :err                       : If specified, STDERR from the child process will be redirected to the
-      #                                provided +IO+ object.
-      #
-      # NOTE: If the +out+ or +err+ options are specified, the corresponding return value from +oo_spawn+
-      # will be the incoming/provided +IO+ objects instead of the buffered +String+ output. It's the
-      # responsibility of the caller to correctly handle the resulting data type.
-      def run_in_root_context(command, options = {})
-        options.delete(:uid)
-        options.delete(:selinux_context)
-        ::OpenShift::Runtime::Utils::oo_spawn(command, options)
       end
 
       # run_in_container_context(command, [, options]) -> [stdout, stderr, exit status]

--- a/node/lib/openshift-origin-node/model/application_container_ext/environment.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/environment.rb
@@ -172,7 +172,7 @@ module OpenShift
 
           ssh_dir = PathUtils.join(@container_dir, ".ssh")
           cmd = "restorecon -R #{ssh_dir}"
-          run_in_root_context(cmd)
+          ::OpenShift::Runtime::Utils::oo_spawn(cmd)
         end
 
         # Generate the command entry for the ssh key to be written into the authorized keys file
@@ -238,7 +238,7 @@ module OpenShift
                   end
               end
                 set_ro_permission(authorized_keys_file)
-                run_in_root_context("restorecon #{authorized_keys_file}")
+                ::OpenShift::Runtime::Utils::oo_spawn("restorecon #{authorized_keys_file}")
               ensure
                 lock.flock(File::LOCK_UN)
               end

--- a/node/lib/openshift-origin-node/model/application_repository.rb
+++ b/node/lib/openshift-origin-node/model/application_repository.rb
@@ -119,7 +119,7 @@ module OpenShift
         @commit           = commit
 
         begin
-          @container.run_in_root_context(ERB.new(GIT_URL_CLONE).result(binding),
+          ::OpenShift::Runtime::Utils::oo_spawn(ERB.new(GIT_URL_CLONE).result(binding),
               chdir:               git_path,
               expected_exitstatus: 0)
         rescue ::OpenShift::Runtime::Utils::ShellExecutionException => e
@@ -222,15 +222,15 @@ module OpenShift
         FileUtils.rm_r(template) if File.exist? template
 
         git_path = PathUtils.join(@container.container_dir, 'git')
-        @container.run_in_root_context("/bin/cp -ad #{path} #{git_path}",
+        ::OpenShift::Runtime::Utils::oo_spawn("/bin/cp -ad #{path} #{git_path}",
                        expected_exitstatus: 0)
 
-        @container.run_in_root_context(ERB.new(GIT_INIT).result(binding),
+        ::OpenShift::Runtime::Utils::oo_spawn(ERB.new(GIT_INIT).result(binding),
             chdir:               template,
             expected_exitstatus: 0)
         begin
           # trying to clone as the user proved to be painful as git managed to "lose" the selinux context
-          @container.run_in_root_context(ERB.new(GIT_LOCAL_CLONE).result(binding),
+          ::OpenShift::Runtime::Utils::oo_spawn(ERB.new(GIT_LOCAL_CLONE).result(binding),
               chdir:               git_path,
               expected_exitstatus: 0)
         rescue ShellExecutionException => e

--- a/plugins/container/libvirt/lib/openshift/runtime/containerization/libvirt_container.rb
+++ b/plugins/container/libvirt/lib/openshift/runtime/containerization/libvirt_container.rb
@@ -43,7 +43,7 @@ module OpenShift
         def create
           cmd = %{groupadd -g #{@container.gid} \
           #{@container.uuid}}
-          out,err,rc = @container.run_in_root_context(cmd)
+          out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn(cmd)
           raise ::OpenShift::Runtime::UserCreationException.new(
                     "ERROR: unable to create group for user account(#{rc}): #{cmd.squeeze(" ")} stdout: #{out} stderr: #{err}"
                 ) unless rc == 0
@@ -61,7 +61,7 @@ module OpenShift
           if @container.supplementary_groups != ""
             cmd << %{ -G "#{@container.supplementary_groups}"}
           end
-          out,err,rc = @container.run_in_root_context(cmd)
+          out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn(cmd)
           raise ::OpenShift::Runtime::UserCreationException.new(
                     "ERROR: unable to create user account(#{rc}): #{cmd.squeeze(" ")} stdout: #{out} stderr: #{err}"
                 ) unless rc == 0
@@ -94,7 +94,7 @@ module OpenShift
                  "host-bind:/proc/meminfo=/proc/meminfo " +
               " -- " +
               "#{@container.uuid} /usr/sbin/oo-gear-init"
-          out, err, rc = @container.run_in_root_context(cmd)
+          out, err, rc = ::OpenShift::Runtime::Utils::oo_spawn(cmd)
           raise ::UserCreationException.new( "Failed to create lxc container. rc=#{rc}, out=#{out}, err=#{err}" ) if rc != 0
 
           container_link = File.join(@container.container_dir, @container.uuid)
@@ -122,9 +122,9 @@ module OpenShift
           if File.exist?("/etc/libvirt-sandbox/services/#{@uuid}.sandbox")
             container_stop if container_running?
 
-            out, _, _ = @container.run_in_root_context("/usr/bin/virt-sandbox-service list")
+            out, _, _ = ::OpenShift::Runtime::Utils::oo_spawn("/usr/bin/virt-sandbox-service list")
             if out.split("\n").include?(@uuid)
-              out, err, rc = @container.run_in_root_context("/usr/bin/virt-sandbox-service delete #{@uuid}")
+              out, err, rc = ::OpenShift::Runtime::Utils::oo_spawn("/usr/bin/virt-sandbox-service delete #{@uuid}")
               raise Exception.new( "Failed to delete lxc container. rc=#{rc}, out=#{out}, err=#{err}" ) if rc != 0
             end
 
@@ -143,7 +143,7 @@ module OpenShift
           freeze_cgroups
 
           last_access_dir = @config.get("LAST_ACCESS_DIR")
-          @container.run_in_root_context("rm -f #{last_access_dir}/#{@container.name} > /dev/null")
+          ::OpenShift::Runtime::Utils::oo_spawn("rm -f #{last_access_dir}/#{@container.name} > /dev/null")
           @container.kill_procs
 
           purge_sysvipc
@@ -166,7 +166,7 @@ module OpenShift
             user = Etc.getpwnam(@container.uuid)
 
             cmd = "userdel --remove -f \"#{@container.uuid}\""
-            out,err,rc = @container.run_in_root_context(cmd)
+            out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn(cmd)
             raise ::OpenShift::Runtime::UserDeletionException.new(
                       "ERROR: unable to destroy user account(#{rc}): #{cmd} stdout: #{out} stderr: #{err}"
                   ) unless rc == 0
@@ -178,7 +178,7 @@ module OpenShift
             group = Etc.getgrnam(@container.uuid)
 
             cmd = "groupdel \"#{@container.uuid}\""
-            out,err,rc = @container.run_in_root_context(cmd)
+            out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn(cmd)
             raise ::OpenShift::Runtime::UserDeletionException.new(
                       "ERROR: unable to destroy group of user account(#{rc}): #{cmd} stdout: #{out} stderr: #{err}"
                   ) unless rc == 0
@@ -227,12 +227,12 @@ Dir(after)    #{@container.uuid}/#{@container.uid} => #{list_home_dir(@container
         #
         def stop
           @container.kill_procs
-          out, err, rc = @container.run_in_root_context("/usr/bin/virt-sandbox-service stop #{@uuid}")
+          out, err, rc = ::OpenShift::Runtime::Utils::oo_spawn("/usr/bin/virt-sandbox-service stop #{@uuid}")
           raise Exception.new( "Failed to stop lxc container. rc=#{rc}, out=#{out}, err=#{err}" ) if rc != 0
         end
 
         def start
-          out, err, rc = @container.run_in_root_context("/usr/bin/virt-sandbox-service start #{@container.uuid} < /dev/null > /dev/null 2> /dev/null &")
+          out, err, rc = ::OpenShift::Runtime::Utils::oo_spawn("/usr/bin/virt-sandbox-service start #{@container.uuid} < /dev/null > /dev/null 2> /dev/null &")
           raise Exception.new( "Failed to start lxc container. rc=#{rc}, out=#{out}, err=#{err}" ) if rc != 0
 
           #Wait for container to become available
@@ -323,28 +323,28 @@ Dir(after)    #{@container.uuid}/#{@container.uid} => #{list_home_dir(@container
 
         #TODO: notes why disabled
         def enable_cgroups
-          #out,err,rc = @container.run_in_root_context("service cgconfig status > /dev/null 2>&1")
+          #out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn("service cgconfig status > /dev/null 2>&1")
           #
           #if rc == 0
-          #  out,err,rc = @container.run_in_root_context("/usr/sbin/oo-admin-ctl-cgroups startuser #{@container.uuid} > /dev/null")
+          #  out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn("/usr/sbin/oo-admin-ctl-cgroups startuser #{@container.uuid} > /dev/null")
           #  raise ::OpenShift::Runtime::UserCreationException.new("Unable to setup cgroups for #{@container.uuid}: stdout -- #{out} stderr --#{err}}") unless rc == 0
           #end
         end
 
         def stop_cgroups
-          #out,err,rc = @container.run_in_root_context("service cgconfig status > /dev/null 2>&1")
-          #@container.run_in_root_context("/usr/sbin/oo-admin-ctl-cgroups stopuser #{@container.uuid} > /dev/null") if rc == 0
+          #out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn("service cgconfig status > /dev/null 2>&1")
+          #::OpenShift::Runtime::Utils::oo_spawn("/usr/sbin/oo-admin-ctl-cgroups stopuser #{@container.uuid} > /dev/null") if rc == 0
         end
 
         def enable_fs_limits
           cmd = "/bin/sh #{File.join('/usr/libexec/openshift/lib', "setup_pam_fs_limits.sh")} #{@container.uuid} #{@container.quota_blocks ? @container.quota_blocks : ''} #{@container.quota_files ? @container.quota_files : ''}"
-          out,err,rc = @container.run_in_root_context(cmd)
+          out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn(cmd)
           raise ::OpenShift::Runtime::UserCreationException.new("Unable to setup pam/fs limits for #{@container.name}: stdout -- #{out} stderr -- #{err}") unless rc == 0
         end
 
         def disable_fs_limits
           cmd = "/bin/sh #{File.join("/usr/libexec/openshift/lib", "teardown_pam_fs_limits.sh")} #{@container.uuid}"
-          out,err,rc = @container.run_in_root_context(cmd)
+          out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn(cmd)
           raise ::OpenShift::Runtime::UserCreationException.new("Unable to teardown pam/fs/nproc limits for #{@container.uuid}") unless rc == 0
         end
 
@@ -516,21 +516,21 @@ Dir(after)    #{@container.uuid}/#{@container.uid} => #{list_home_dir(@container
 
         def freeze_fs_limits
           cmd = "/bin/sh #{File.join('/usr/libexec/openshift/lib', "setup_pam_fs_limits.sh")} #{@container.uuid} 0 0 0"
-          out,err,rc = @container.run_in_root_context(cmd)
+          out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn(cmd)
           raise ::OpenShift::Runtime::UserCreationException.new("Unable to setup pam/fs/nproc limits for #{@container.uuid}") unless rc == 0
         end
 
         def freeze_cgroups
-          #out,err,rc = @container.run_in_root_context("service cgconfig status > /dev/null")
+          #out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn("service cgconfig status > /dev/null")
           #if rc == 0
-          #  @container.run_in_root_context("/usr/sbin/oo-admin-ctl-cgroups freezeuser #{@container.uuid} > /dev/null") if rc == 0
+          #  ::OpenShift::Runtime::Utils::oo_spawn("/usr/sbin/oo-admin-ctl-cgroups freezeuser #{@container.uuid} > /dev/null") if rc == 0
           #end
         end
 
         # release resources (cgroups thaw), this causes Zombies to get killed
         def unfreeze_cgroups
-          #out,err,rc = @container.run_in_root_context("service cgconfig status > /dev/null")
-          #@container.run_in_root_context("/usr/sbin/oo-admin-ctl-cgroups thawuser #{@container.uuid} > /dev/null") if rc == 0
+          #out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn("service cgconfig status > /dev/null")
+          #::OpenShift::Runtime::Utils::oo_spawn("/usr/sbin/oo-admin-ctl-cgroups thawuser #{@container.uuid} > /dev/null") if rc == 0
         end
 
         # Private: list directories (cartridges) in home directory
@@ -563,13 +563,13 @@ Dir(after)    #{@container.uuid}/#{@container.uid} => #{list_home_dir(@container
         #
         def purge_sysvipc
           ['-m', '-q', '-s' ].each do |ipctype|
-            out,err,rc=@container.run_in_root_context(%{/usr/bin/ipcs -c #{ipctype} 2> /dev/null})
+            out,err,rc=::OpenShift::Runtime::Utils::oo_spawn(%{/usr/bin/ipcs -c #{ipctype} 2> /dev/null})
             out.lines do |ipcl|
               next unless ipcl=~/^\d/
               ipcent = ipcl.split
               if ipcent[2] == @container.uuid
                 # The ID may already be gone
-                @container.run_in_root_context(%{/usr/bin/ipcrm #{ipctype} #{ipcent[0]}})
+                ::OpenShift::Runtime::Utils::oo_spawn(%{/usr/bin/ipcrm #{ipctype} #{ipcent[0]}})
               end
             end
           end
@@ -628,7 +628,7 @@ Dir(after)    #{@container.uuid}/#{@container.uid} => #{list_home_dir(@container
                 "-j DNAT --to-destination #{container_ip}:#{public_port};" +
                 "firewall-cmd --direct --passthrough ipv4 -t filter -I FORWARD " +
                 "-p tcp --dport #{public_port} -d #{container_ip} -j ACCEPT"
-            @container.run_in_root_context(cmd)
+            ::OpenShift::Runtime::Utils::oo_spawn(cmd)
           end
 
           if action == :delete
@@ -648,7 +648,7 @@ Dir(after)    #{@container.uuid}/#{@container.uid} => #{list_home_dir(@container
                 "-j DNAT --to-destination #{container_ip}:#{public_port};" +
                 "firewall-cmd --direct --passthrough ipv4 -t filter -D FORWARD " +
                 "-p tcp --dport #{public_port} -d #{container_ip} -j ACCEPT"
-            @container.run_in_root_context(cmd)
+            ::OpenShift::Runtime::Utils::oo_spawn(cmd)
           end
         end
       end

--- a/plugins/container/selinux/lib/openshift/runtime/containerization/selinux_container.rb
+++ b/plugins/container/selinux/lib/openshift/runtime/containerization/selinux_container.rb
@@ -52,7 +52,7 @@ module OpenShift
             if @container.supplementary_groups != ""
               cmd << %{ -G "#{@container.supplementary_groups}"}
             end
-            out,err,rc = @container.run_in_root_context(cmd)
+            out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn(cmd)
             raise ::OpenShift::Runtime::UserCreationException.new(
                       "ERROR: unable to create user account(#{rc}): #{cmd.squeeze(" ")} stdout: #{out} stderr: #{err}"
                   ) unless rc == 0
@@ -98,7 +98,7 @@ module OpenShift
           freeze_cgroups
           disable_traffic_control
           last_access_dir = @config.get("LAST_ACCESS_DIR")
-          @container.run_in_root_context("rm -f #{last_access_dir}/#{@container.name} > /dev/null")
+          ::OpenShift::Runtime::Utils::oo_spawn("rm -f #{last_access_dir}/#{@container.name} > /dev/null")
           @container.kill_procs
 
           purge_sysvipc
@@ -109,7 +109,7 @@ module OpenShift
           dirs = list_home_dir(@container.container_dir)
           begin
             cmd = "userdel --remove -f \"#{@container.uuid}\""
-            out,err,rc = @container.run_in_root_context(cmd)
+            out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn(cmd)
             raise ::OpenShift::Runtime::UserDeletionException.new(
                       "ERROR: unable to destroy user account(#{rc}): #{cmd} stdout: #{out} stderr: #{err}"
                   ) unless rc == 0
@@ -229,17 +229,17 @@ Dir(after)    #{@container.uuid}/#{@container.uid} => #{list_home_dir(@container
         end
 
         def enable_traffic_control
-          out,err,rc = @container.run_in_root_context("service openshift-tc status > /dev/null 2>&1")
+          out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn("service openshift-tc status > /dev/null 2>&1")
           if rc == 0
-            out,err,rc = @container.run_in_root_context("/usr/sbin/oo-admin-ctl-tc startuser #{@container.uuid} > /dev/null")
+            out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn("/usr/sbin/oo-admin-ctl-tc startuser #{@container.uuid} > /dev/null")
             raise ::OpenShift::Runtime::UserCreationException.new("Unable to setup tc for #{@container.uuid}") unless rc == 0
           end
         end
 
         def disable_traffic_control
-          out,err,rc = @container.run_in_root_context("service openshift-tc status > /dev/null 2>&1")
+          out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn("service openshift-tc status > /dev/null 2>&1")
           if rc == 0
-            @container.run_in_root_context("/usr/sbin/oo-admin-ctl-tc deluser #{@container.uuid} > /dev/null")
+            ::OpenShift::Runtime::Utils::oo_spawn("/usr/sbin/oo-admin-ctl-tc deluser #{@container.uuid} > /dev/null")
           end
         end
 
@@ -364,13 +364,13 @@ Dir(after)    #{@container.uuid}/#{@container.uid} => #{list_home_dir(@container
         #
         def purge_sysvipc
           ['-m', '-q', '-s' ].each do |ipctype|
-            out,err,rc=@container.run_in_root_context(%{/usr/bin/ipcs -c #{ipctype} 2> /dev/null})
+            out,err,rc=::OpenShift::Runtime::Utils::oo_spawn(%{/usr/bin/ipcs -c #{ipctype} 2> /dev/null})
             out.lines do |ipcl|
               next unless ipcl=~/^\d/
               ipcent = ipcl.split
               if ipcent[2] == @container.uuid
                 # The ID may already be gone
-                @container.run_in_root_context(%{/usr/bin/ipcrm #{ipctype} #{ipcent[0]}})
+                ::OpenShift::Runtime::Utils::oo_spawn(%{/usr/bin/ipcrm #{ipctype} #{ipcent[0]}})
               end
             end
           end


### PR DESCRIPTION
Revert previous changes which replaced oo_spawn calls with ApplicationContainer.run_in_root_context.

The oo_spawn method was intentionally designed to be the single execution path for all shell executions,
for security and clarity. Adding a second execution path to oo_spawn not only results in multiple ways
to do the same thing, but having such a method in ApplicationContainer specifically promotes creating
unwarranted/undesirable dependencies on ApplicationContainer where no dependency was previously
necessary.
