### PR TITLE
Use oo_spawn for all root scoped shell commands

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/environment.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/environment.rb
@@ -172,7 +172,7 @@ module OpenShift
 
           ssh_dir = PathUtils.join(@container_dir, ".ssh")
           cmd = "restorecon -R #{ssh_dir}"
-          run_in_root_context(cmd)
+          ::OpenShift::Runtime::Utils::oo_spawn(cmd)
         end
 
         # Generate the command entry for the ssh key to be written into the authorized keys file
@@ -238,7 +238,7 @@ module OpenShift
                   end
               end
                 set_ro_permission(authorized_keys_file)
-                run_in_root_context("restorecon #{authorized_keys_file}")
+                ::OpenShift::Runtime::Utils::oo_spawn("restorecon #{authorized_keys_file}")
               ensure
                 lock.flock(File::LOCK_UN)
               end

--- a/node/lib/openshift-origin-node/model/application_repository.rb
+++ b/node/lib/openshift-origin-node/model/application_repository.rb
@@ -119,7 +119,7 @@ module OpenShift
         @commit           = commit
 
         begin
-          @container.run_in_root_context(ERB.new(GIT_URL_CLONE).result(binding),
+          ::OpenShift::Runtime::Utils::oo_spawn(ERB.new(GIT_URL_CLONE).result(binding),
               chdir:               git_path,
               expected_exitstatus: 0)
         rescue ::OpenShift::Runtime::Utils::ShellExecutionException => e
@@ -222,15 +222,15 @@ module OpenShift
         FileUtils.rm_r(template) if File.exist? template
 
         git_path = PathUtils.join(@container.container_dir, 'git')
-        @container.run_in_root_context("/bin/cp -ad #{path} #{git_path}",
+        ::OpenShift::Runtime::Utils::oo_spawn("/bin/cp -ad #{path} #{git_path}",
                        expected_exitstatus: 0)
 
-        @container.run_in_root_context(ERB.new(GIT_INIT).result(binding),
+        ::OpenShift::Runtime::Utils::oo_spawn(ERB.new(GIT_INIT).result(binding),
             chdir:               template,
             expected_exitstatus: 0)
         begin
           # trying to clone as the user proved to be painful as git managed to "lose" the selinux context
-          @container.run_in_root_context(ERB.new(GIT_LOCAL_CLONE).result(binding),
+          ::OpenShift::Runtime::Utils::oo_spawn(ERB.new(GIT_LOCAL_CLONE).result(binding),
               chdir:               git_path,
               expected_exitstatus: 0)
         rescue ShellExecutionException => e

--- a/node/lib/openshift-origin-node/model/frontend_proxy.rb
+++ b/node/lib/openshift-origin-node/model/frontend_proxy.rb
@@ -45,7 +45,6 @@ module OpenShift
     #
     # Note: This is the HAProxy implementation; other implementations may vary.
     class FrontendProxyServer
-      include ::OpenShift::Runtime::Utils::ShellExec
       include NodeLogger
 
       def initialize

--- a/plugins/container/selinux/lib/openshift/runtime/containerization/selinux_container.rb
+++ b/plugins/container/selinux/lib/openshift/runtime/containerization/selinux_container.rb
@@ -4,7 +4,6 @@ module OpenShift
   module Runtime
     module Containerization
       class SELinuxContainer
-        include OpenShift::Runtime::Utils::ShellExec
         include OpenShift::Runtime::NodeLogger
 
         attr_reader :gear_shell, :mcs_label
@@ -52,7 +51,7 @@ module OpenShift
             if @container.supplementary_groups != ""
               cmd << %{ -G "#{@container.supplementary_groups}"}
             end
-            out,err,rc = @container.run_in_root_context(cmd)
+            out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn(cmd)
             raise ::OpenShift::Runtime::UserCreationException.new(
                       "ERROR: unable to create user account(#{rc}): #{cmd.squeeze(" ")} stdout: #{out} stderr: #{err}"
                   ) unless rc == 0
@@ -98,7 +97,7 @@ module OpenShift
           freeze_cgroups
           disable_traffic_control
           last_access_dir = @config.get("LAST_ACCESS_DIR")
-          @container.run_in_root_context("rm -f #{last_access_dir}/#{@container.name} > /dev/null")
+          ::OpenShift::Runtime::Utils::oo_spawn("rm -f #{last_access_dir}/#{@container.name} > /dev/null")
           @container.kill_procs
 
           purge_sysvipc
@@ -109,7 +108,7 @@ module OpenShift
           dirs = list_home_dir(@container.container_dir)
           begin
             cmd = "userdel --remove -f \"#{@container.uuid}\""
-            out,err,rc = @container.run_in_root_context(cmd)
+            out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn(cmd)
             raise ::OpenShift::Runtime::UserDeletionException.new(
                       "ERROR: unable to destroy user account(#{rc}): #{cmd} stdout: #{out} stderr: #{err}"
                   ) unless rc == 0
@@ -229,17 +228,17 @@ Dir(after)    #{@container.uuid}/#{@container.uid} => #{list_home_dir(@container
         end
 
         def enable_traffic_control
-          out,err,rc = @container.run_in_root_context("service openshift-tc status > /dev/null 2>&1")
+          out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn("service openshift-tc status > /dev/null 2>&1")
           if rc == 0
-            out,err,rc = @container.run_in_root_context("/usr/sbin/oo-admin-ctl-tc startuser #{@container.uuid} > /dev/null")
+            out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn("/usr/sbin/oo-admin-ctl-tc startuser #{@container.uuid} > /dev/null")
             raise ::OpenShift::Runtime::UserCreationException.new("Unable to setup tc for #{@container.uuid}") unless rc == 0
           end
         end
 
         def disable_traffic_control
-          out,err,rc = @container.run_in_root_context("service openshift-tc status > /dev/null 2>&1")
+          out,err,rc = ::OpenShift::Runtime::Utils::oo_spawn("service openshift-tc status > /dev/null 2>&1")
           if rc == 0
-            @container.run_in_root_context("/usr/sbin/oo-admin-ctl-tc deluser #{@container.uuid} > /dev/null")
+            ::OpenShift::Runtime::Utils::oo_spawn("/usr/sbin/oo-admin-ctl-tc deluser #{@container.uuid} > /dev/null")
           end
         end
 
@@ -364,13 +363,13 @@ Dir(after)    #{@container.uuid}/#{@container.uid} => #{list_home_dir(@container
         #
         def purge_sysvipc
           ['-m', '-q', '-s' ].each do |ipctype|
-            out,err,rc=@container.run_in_root_context(%{/usr/bin/ipcs -c #{ipctype} 2> /dev/null})
+            out,err,rc=::OpenShift::Runtime::Utils::oo_spawn(%{/usr/bin/ipcs -c #{ipctype} 2> /dev/null})
             out.lines do |ipcl|
               next unless ipcl=~/^\d/
               ipcent = ipcl.split
               if ipcent[2] == @container.uuid
                 # The ID may already be gone
-                @container.run_in_root_context(%{/usr/bin/ipcrm #{ipctype} #{ipcent[0]}})
+                ::OpenShift::Runtime::Utils::oo_spawn(%{/usr/bin/ipcrm #{ipctype} #{ipcent[0]}})
               end
             end
           end


### PR DESCRIPTION
Revert previous changes which replaced oo_spawn calls with ApplicationContainer.run_in_root_context.

The oo_spawn method was intentionally designed to be the single execution path for all shell executions,
for security and clarity. Adding a second execution path to oo_spawn not only results in multiple ways
to do the same thing, but having such a method in ApplicationContainer specifically promotes creating
unwarranted/undesirable dependencies on ApplicationContainer where no dependency was previously
necessary.
