### PR TITLE
<broker> make parallel passenger baseuri change in SCL conf file

### DIFF
--- a/broker/httpd/broker-scl-ruby193.conf
+++ b/broker/httpd/broker-scl-ruby193.conf
@@ -1,5 +1,5 @@
 ServerRoot "/var/www/openshift/broker/httpd"
-DocumentRoot "/var/www/openshift/broker/httpd/root"
+DocumentRoot "/var/www/openshift/broker/public"
 Listen 127.0.0.1:8080
 User apache
 Group apache
@@ -10,9 +10,8 @@ PassengerMaxPoolSize 80
 PassengerMinInstances 2
 PassengerPreStart http://127.0.0.1:8080/broker/rest/api.json
 PassengerUseGlobalQueue off
-RackBaseURI /broker
 PassengerRuby /var/www/openshift/broker/script/broker_ruby
 
-<Directory /var/www/openshift/broker/httpd/root/broker>
+<Directory /var/www/openshift/broker/public>
     Options -MultiViews
 </Directory>


### PR DESCRIPTION
I changed broker.conf but under the SCL, broker-scl-ruby193.conf is substituted. Updated that too.
