### PR TITLE
Bug 983038 - Remove ecdsa ssh key type from supported list.

### DIFF
--- a/broker-util/man/oo-admin-ctl-domain.8
+++ b/broker-util/man/oo-admin-ctl-domain.8
@@ -40,12 +40,8 @@ The user's SSH key.
 .PP
 \fB-t\fP|\fB--key_type\fP \fIsshkey_type\fP
 User's SSH key type. Available types are ssh-rsa, ssh-dss, 
-ecdsa-sha2-nistp256-cert-v01@openssh.com, 
-ecdsa-sha2-nistp384-cert-v01@openssh.com,
-ecdsa-sha2-nistp521-cert-v01@openssh.com,
 ssh-rsa-cert-v01@openssh.com, ssh-dss-cert-v01@openssh.com, 
 ssh-rsa-cert-v00@openssh.com, ssh-dss-cert-v00@openssh.com, 
-ecdsa-sha2-nistp256, ecdsa-sha2-nistp384, ecdsa-sha2-nistp521
 .PP
 \fB-k\fP|\fB--key_name\fP \fIsshkey_name\fP
 User's SSH key name.

--- a/broker-util/man/oo-admin-ctl-domain.txt2man
+++ b/broker-util/man/oo-admin-ctl-domain.txt2man
@@ -28,12 +28,8 @@ OPTIONS
 
   -t|--key_type sshkey_type
     User's SSH key type. Available types are ssh-rsa, ssh-dss, 
-    ecdsa-sha2-nistp256-cert-v01@openssh.com, 
-    ecdsa-sha2-nistp384-cert-v01@openssh.com,
-    ecdsa-sha2-nistp521-cert-v01@openssh.com,
     ssh-rsa-cert-v01@openssh.com, ssh-dss-cert-v01@openssh.com, 
     ssh-rsa-cert-v00@openssh.com, ssh-dss-cert-v00@openssh.com, 
-    ecdsa-sha2-nistp256, ecdsa-sha2-nistp384, ecdsa-sha2-nistp521
 
   -k|--key_name sshkey_name
     User's SSH key name.

--- a/broker-util/oo-admin-ctl-domain
+++ b/broker-util/oo-admin-ctl-domain
@@ -22,7 +22,7 @@ Options:
 -s|--ssh_key <ssh key>
     User's SSH key
 -t|--key_type <ssh key type>
-    User's SSH key type (ssh-rsa|ssh-dss|ecdsa-sha2-nistp256-cert-v01@openssh.com|ecdsa-sha2-nistp384-cert-v01@openssh.com|ecdsa-sha2-nistp521-cert-v01@openssh.com|ssh-rsa-cert-v01@openssh.com|ssh-dss-cert-v01@openssh.com|ssh-rsa-cert-v00@openssh.com|ssh-dss-cert-v00@openssh.com|ecdsa-sha2-nistp256|ecdsa-sha2-nistp384|ecdsa-sha2-nistp521)
+    User's SSH key type (ssh-rsa|ssh-dss|ssh-rsa-cert-v01@openssh.com|ssh-dss-cert-v01@openssh.com|ssh-rsa-cert-v00@openssh.com|ssh-dss-cert-v00@openssh.com)
 -k|--key_name <ssh key name>
     User's SSH key name
 -e|--env_name <env var name>

--- a/broker/test/helpers/rest/api_models_v1.rb
+++ b/broker/test/helpers/rest/api_models_v1.rb
@@ -151,9 +151,8 @@ end
 
 class RestUser_V1 < BaseObj_V1
   attr_accessor :login, :consumed_gears, :max_gears, :capabilities, :plan_id, :usage_account_id, :links
-  KEY_TYPES = ['ssh-rsa', 'ssh-dss', 'ecdsa-sha2-nistp256-cert-v01@openssh.com', 'ecdsa-sha2-nistp384-cert-v01@openssh.com',
-               'ecdsa-sha2-nistp521-cert-v01@openssh.com', 'ssh-rsa-cert-v01@openssh.com', 'ssh-dss-cert-v01@openssh.com',
-               'ssh-rsa-cert-v00@openssh.com', 'ssh-dss-cert-v00@openssh.com', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521']
+  KEY_TYPES = ['ssh-rsa', 'ssh-dss', 'ssh-rsa-cert-v01@openssh.com', 'ssh-dss-cert-v01@openssh.com',
+               'ssh-rsa-cert-v00@openssh.com', 'ssh-dss-cert-v00@openssh.com']
                                                                                                        
   def initialize
     self.login = nil
@@ -252,9 +251,8 @@ end
 
 class RestKey_V1 < BaseObj_V1
   attr_accessor :name, :content, :type, :links
-  KEY_TYPES = ['ssh-rsa', 'ssh-dss', 'ecdsa-sha2-nistp256-cert-v01@openssh.com', 'ecdsa-sha2-nistp384-cert-v01@openssh.com',
-               'ecdsa-sha2-nistp521-cert-v01@openssh.com', 'ssh-rsa-cert-v01@openssh.com', 'ssh-dss-cert-v01@openssh.com',
-               'ssh-rsa-cert-v00@openssh.com', 'ssh-dss-cert-v00@openssh.com', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521']
+  KEY_TYPES = ['ssh-rsa', 'ssh-dss', 'ssh-rsa-cert-v01@openssh.com', 'ssh-dss-cert-v01@openssh.com',
+               'ssh-rsa-cert-v00@openssh.com', 'ssh-dss-cert-v00@openssh.com']
 
   def initialize(name=nil, content=nil, type=nil)
     self.name = name

--- a/console/test/integration/rest_api/key_test.rb
+++ b/console/test/integration/rest_api/key_test.rb
@@ -37,13 +37,6 @@ class RestApiKeyTest < ActiveSupport::TestCase
     end
   end
 
-  def test_key_create_custom_type
-    assert_difference('Key.find(:all, :as => @user).length', 1) do
-      key = Key.new :type => 'ecdsa-sha2-nistp521', :name => unique_name, :content => unique_name, :as => @user
-      assert key.save
-    end
-  end
-
   def test_invalid_key_create
     assert_difference('Key.find(:all, :as => @user).length', 0) do
       key = Key.new :type => 'ssh-rsa', :name => "invalid%name#{uuid}", :content => uuid, :as => @user

--- a/console/test/unit/rest_api_test.rb
+++ b/console/test/unit/rest_api_test.rb
@@ -674,10 +674,6 @@ class RestApiTest < ActiveSupport::TestCase
     assert_equal 'ssh-rsa', key.type
     assert_equal 'key', key.content
 
-    key = Key.new :raw_content => 'ecdsa-sha2-nistp52 key test'
-    assert_equal 'ecdsa-sha2-nistp52', key.type
-    assert_equal 'key', key.content
-
     key = Key.new :raw_content => 'ssh-dss key test'
     assert_equal 'ssh-dss', key.type
     assert_equal 'key', key.content

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -418,16 +418,16 @@ class Application
     features.each do |feature_name|
       cart = CartridgeCache.find_cartridge(feature_name, self)
       
+      # Make sure this is a valid cartridge
+      if cart.nil?
+        raise OpenShift::UserException.new("Invalid cartridge '#{feature_name}' specified.", 109)
+      end
+
       # ensure that the user isn't trying to add multiple versions of the same cartridge
       if cart_name_map.has_key?(cart.original_name)
         raise OpenShift::UserException.new("#{cart.name} cannot co-exist with #{cart_name_map[cart.original_name]} in the same application", 109)
       else
         cart_name_map[cart.original_name] = cart.name
-      end
-
-      # Make sure this is a valid cartridge
-      if cart.nil?
-        raise OpenShift::UserException.new("Invalid cartridge '#{feature_name}' specified.", 109)
       end
 
       if cart.is_web_framework?

--- a/controller/app/models/ssh_key.rb
+++ b/controller/app/models/ssh_key.rb
@@ -19,9 +19,8 @@ class SshKey
   # Minimum length of valid SSH key name  
   KEY_NAME_MIN_LENGTH = 1 unless defined? KEY_NAME_MIN_LENGTH
   # List of valid SSH key types  
-  VALID_SSH_KEY_TYPES = ['ssh-rsa', 'ssh-dss', 'ecdsa-sha2-nistp256-cert-v01@openssh.com', 'ecdsa-sha2-nistp384-cert-v01@openssh.com',
-                         'ecdsa-sha2-nistp521-cert-v01@openssh.com', 'ssh-rsa-cert-v01@openssh.com', 'ssh-dss-cert-v01@openssh.com',
-                         'ssh-rsa-cert-v00@openssh.com', 'ssh-dss-cert-v00@openssh.com', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521']
+  VALID_SSH_KEY_TYPES = ['ssh-rsa', 'ssh-dss', 'ssh-rsa-cert-v01@openssh.com', 'ssh-dss-cert-v01@openssh.com',
+                         'ssh-rsa-cert-v00@openssh.com', 'ssh-dss-cert-v00@openssh.com']
   
   field :name, type: String
   field :type, type: String, default: "ssh-rsa"


### PR DESCRIPTION
Rationale: Due to patent concerns, ECC support is not bundled in fedora/rhel(needed for ecdsa key generation).
So even if someone has a valid ecdsa keys, sshd server on our node won't be able to authenticate the user.
