### PR TITLE
Bug 985656 - minor improvement for consistency in broker and console spe...

### DIFF
--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -28,7 +28,7 @@ Requires:      httpd
 Requires:      mod_ssl
 Requires:      %{?scl:%scl_prefix}mod_passenger
 %if 0%{?scl:1}
-Requires:      ruby193-ruby-wrapper
+Requires:      %{?scl:%scl_prefix}ruby-wrapper
 Requires:      openshift-origin-util-scl
 %else
 Requires:      openshift-origin-util

--- a/openshift-console/openshift-origin-console.spec
+++ b/openshift-console/openshift-origin-console.spec
@@ -27,8 +27,8 @@ Requires:      %{?scl:%scl_prefix}rubygem-passenger-native
 Requires:      %{?scl:%scl_prefix}rubygem-passenger-native-libs
 Requires:      %{?scl:%scl_prefix}mod_passenger
 
-%if 0%{?rhel}
-Requires:      %{scl}-ruby-wrapper
+%if 0%{?scl:1}
+Requires:      %{?scl:%scl_prefix}ruby-wrapper
 Requires:      %{?scl:%scl_prefix}rubygem-minitest
 Requires:      %{?scl:%scl_prefix}rubygem-therubyracer
 Requires:      openshift-origin-util-scl


### PR DESCRIPTION
...c files

For some reason rhpkg really did not like the console spec's usage of
%{scl}-ruby-wrapper

Uploading: d79e6980b2997ea0f9b64fd2665f6d76  openshift-origin-console-1.5.22.tar.gz
error: line 32: Dependency tokens must begin with alpha-numeric, '_' or '/': Requires:      %{scl}-ruby-wrapper
error: query of specfile /home/bleanhar/git/rhpkg/openshift-origin-console/openshift-origin-console.spec failed, can't parse
