### PR TITLE
move_gear: drop outdated rollback code

### DIFF
--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -1855,21 +1855,6 @@ module OpenShift
           rescue Exception => e
             gear.server_identity = source_container.id
             gear.group_instance.gear_size = source_container.get_node_profile
-            # remove-httpd-proxy of destination
-            log_debug "DEBUG: Moving failed.  Rolling back gear '#{gear.name}' '#{app.name}' with remove-httpd-proxy on '#{destination_container.id}'"
-            gi.all_component_instances.each do |cinst|
-              next if cinst.is_sparse? and (not gear.sparse_carts.include? cinst._id) and (not gear.host_singletons)
-              cart = cinst.cartridge_name
-              if framework_carts(app).include? cart
-                begin
-                  args = build_base_gear_args(gear)
-                  args = build_base_component_args(cinst, args)
-                  reply.append destination_container.send(:run_cartridge_command, cart, gear, "remove-httpd-proxy", args, false)
-                rescue Exception => e
-                  log_debug "DEBUG: Remove httpd proxy with cart '#{cart}' failed on '#{destination_container.id}'  - gear: '#{gear.name}', app: '#{app.name}'"
-                end
-              end
-            end
             # destroy destination
             log_debug "DEBUG: Moving failed.  Rolling back gear '#{gear.name}' in '#{app.name}' with destroy on '#{destination_container.id}'"
             reply.append destination_container.destroy(gear, !district_changed, nil, true)


### PR DESCRIPTION
Don't call the remove-httpd-proxy hook when rolling back a failed
move_gear operation in MCollectiveApplicationContainerProxy.

The remove-httpd-proxy hook was removed from the v2 cartridge model, so
calling the hook results in calling an undefined method in the cartridge
model when v2 cartridges are used.  Furthermore, the platform now takes
care of configuring the port proxy, so it is no longer necessary for
move_gear to invoke remove-httpd-proxy.  Commit
7d458f76116a0b72b651155d1178ad3d70398104 already dropped the call in
move_gear to the "move" hook, which invoked the deploy-httpd-proxy hook,
which is also handled by the platform now.

This commit fixes Bug 987218.
