### PR TITLE
Upgrade enhancements

### DIFF
--- a/broker-util/oo-admin-upgrade
+++ b/broker-util/oo-admin-upgrade
@@ -5,6 +5,7 @@ require 'thread'
 require 'getoptlong'
 require 'stringio'
 require 'set'
+require 'json'
 
 $max_threads = 8
 WORK_DIR = '/tmp/oo-upgrade'
@@ -41,100 +42,99 @@ def upgrade_gear(login, app_name, gear_uuid, version, ignore_cartridge_version=f
       user = CloudUser.with(consistency: :eventual).find_by(login: login)
     rescue Mongoid::Errors::DocumentNotFound
     end
-    if user
-      app, gear = Application.find_by_gear_uuid(gear_uuid)
-      if app
-        if gear
-          server_identity = gear.server_identity
-          # gear.node_profile = app.node_profile if gear.node_profile.nil?
-          begin
-            Timeout::timeout(420) do
-              output = ''
-              exit_code = 1
-              upgrade = MIGRATION_CART_TYPES.nil? 
-              cartridges = gear.group_instance.all_component_instances.map { |ci| ci.cartridge_name }.uniq
-              MIGRATION_CART_TYPES.each do |cart_name|
-                if cartridges.include?(cart_name)
-                  upgrade = true
-                  break
-                end
-              end unless upgrade
 
-              if upgrade
-                upgrade_on_node_start_time = (Time.now.to_f * 1000).to_i
-                out << "Upgrading on node...\n"
-                OpenShift::MCollectiveApplicationContainerProxy.rpc_exec('openshift', server_identity) do |client|
-                  client.upgrade(:uuid => gear_uuid,
-                                 :namespace => app.domain.namespace,
-                                 :version => version,
-                                 :ignore_cartridge_version => ignore_cartridge_version.to_s) do |response|
-                    exit_code = response[:body][:data][:exitcode]
-                    output = response[:body][:data][:output]
-                  end
-                end
-                upgrade_on_node_time = (Time.now.to_f * 1000).to_i - upgrade_on_node_start_time
-                out << "***time_upgrade_on_node_measured_from_broker=#{upgrade_on_node_time}***\n"
-              end
-              if (output.length > 0)
-                out << "Upgrade on node output:\n #{output}\n"
-              end
-              if upgrade && exit_code != 0
-                out << "Upgrade on node exit code: #{exit_code}\n"
-                raise "Failed upgrading gear. Rerun with: #{upgrade_cmd}"
-              else
-                redeploy_httpd_proxy = REDEPLOY_HTTPD_PROXY_CART_TYPES.nil?
+    raise "User not found: #{login}" unless user
 
-                if REDEPLOY_HTTPD_PROXY_CART_TYPES
-                  gear_cartridges = cartridges
-                  REDEPLOY_HTTPD_PROXY_CART_TYPES.each do |cart_name|
-                    redeploy_httpd_proxy = gear_cartridges.include?(cart_name)
-                    break if redeploy_httpd_proxy
-                  end unless redeploy_httpd_proxy
-                end
+    app, gear = Application.find_by_gear_uuid(gear_uuid)
 
-                # Should call oo-frontend-destroy and re-build the
-                # application, including idle state from scratch if
-                # need to purge possibly stale configuration.
-                # remove_httpd_proxy(gear, out) if recreate_httpd_proxy
+    out << "WARNING: App not found: #{app_name}\n" unless app
+    out << "WARNING: Gear not found with uuid #{gear_uuid} for app '#{app_name}' and user '#{login}'\n" unless gear
+    
+    if app && gear
+      server_identity = gear.server_identity
 
-                redeploy_httpd_proxy_start_time = (Time.now.to_f * 1000).to_i
-                redeploy_httpd_proxy(gear, out) if redeploy_httpd_proxy
-                redeploy_httpd_proxy_time = (Time.now.to_f * 1000).to_i - redeploy_httpd_proxy_start_time
-                out << "***time_redeploy_httpd_proxy=#{redeploy_httpd_proxy_time}***\n"
-                redeploy_aliases(gear, out) if redeploy_httpd_proxy
-
-                restart_start_time = (Time.now.to_f * 1000).to_i
-                cartridges.each do |gear_cart|
-                  restart = RESTART_CART_TYPES.nil?
-                  RESTART_CART_TYPES.each do |cart_name|
-                    if gear_cart == cart_name
-                      restart = true
-                      break
-                    end
-                  end unless restart
-                  if restart
-                    component = gear.group_instance.all_component_instances.to_a.find { |ci| ci.cartridge_name==gear_cart }
-                    restart_component(gear, component, out)
-                  end
-                end
-                restart_time = (Time.now.to_f * 1000).to_i - restart_start_time
-                out << "***time_restart=#{restart_time}***\n"
-              end
-            end
-          rescue Timeout::Error
-            raise "Command '#{upgrade_cmd}' timed out"
+      Timeout::timeout(420) do
+        output = ''
+        exit_code = 1
+        upgrade = MIGRATION_CART_TYPES.nil? 
+        cartridges = gear.group_instance.all_component_instances.map { |ci| ci.cartridge_name }.uniq
+        MIGRATION_CART_TYPES.each do |cart_name|
+          if cartridges.include?(cart_name)
+            upgrade = true
+            break
           end
-          #gear.quarantined = false
-          #gear.save
-        else
-          out << "WARNING: Gear not found with uuid #{gear_uuid} for app '#{app_name}' and user '#{login}'\n"
+        end unless upgrade
+
+        json_data = nil
+
+        if upgrade
+          upgrade_on_node_start_time = (Time.now.to_f * 1000).to_i
+          out << "Upgrading on node...\n"
+          OpenShift::MCollectiveApplicationContainerProxy.rpc_exec('openshift', server_identity) do |client|
+            client.upgrade(:uuid => gear_uuid,
+                           :namespace => app.domain.namespace,
+                           :version => version,
+                           :ignore_cartridge_version => ignore_cartridge_version.to_s) do |response|
+              exit_code = response[:body][:data][:exitcode]
+              output = response[:body][:data][:output]
+              json_data = response[:body][:data][:json_data]
+            end
+          end
+          upgrade_on_node_time = (Time.now.to_f * 1000).to_i - upgrade_on_node_start_time
+          out << "***time_upgrade_on_node_measured_from_broker=#{upgrade_on_node_time}***\n"
         end
-      else
-        out << "WARNING: App not found: #{app_name}\n"
+
+        if (output.length > 0)
+          out << "Upgrade on node output:\n #{output}\n"
+        end
+
+        if upgrade && exit_code != 0
+          out << "Upgrade on node exit code: #{exit_code}\n"
+          raise "Failed upgrading gear. Rerun with: #{upgrade_cmd}"
+        end
+
+        redeploy_httpd_proxy = REDEPLOY_HTTPD_PROXY_CART_TYPES.nil?
+
+        if REDEPLOY_HTTPD_PROXY_CART_TYPES
+          gear_cartridges = cartridges
+          REDEPLOY_HTTPD_PROXY_CART_TYPES.each do |cart_name|
+            redeploy_httpd_proxy = gear_cartridges.include?(cart_name)
+            break if redeploy_httpd_proxy
+          end unless redeploy_httpd_proxy
+        end
+
+        # Should call oo-frontend-destroy and re-build the
+        # application, including idle state from scratch if
+        # need to purge possibly stale configuration.
+        # remove_httpd_proxy(gear, out) if recreate_httpd_proxy
+
+        redeploy_httpd_proxy_start_time = (Time.now.to_f * 1000).to_i
+        redeploy_httpd_proxy(gear, out) if redeploy_httpd_proxy
+        redeploy_httpd_proxy_time = (Time.now.to_f * 1000).to_i - redeploy_httpd_proxy_start_time
+        out << "***time_redeploy_httpd_proxy=#{redeploy_httpd_proxy_time}***\n"
+        redeploy_aliases(gear, out) if redeploy_httpd_proxy
+
+        restart_start_time = (Time.now.to_f * 1000).to_i
+        cartridges.each do |gear_cart|
+          restart = RESTART_CART_TYPES.nil?
+          RESTART_CART_TYPES.each do |cart_name|
+            if gear_cart == cart_name
+              restart = true
+              break
+            end
+          end unless restart
+          if restart
+            component = gear.group_instance.all_component_instances.to_a.find { |ci| ci.cartridge_name==gear_cart }
+            restart_component(gear, component, out)
+          end
+        end
+
+        restart_time = (Time.now.to_f * 1000).to_i - restart_start_time
+        out << "***time_restart=#{restart_time}***\n"
       end
-    else
-      raise "User not found: #{login}"
     end
+  rescue Timeout::Error
+    raise "Command '#{upgrade_cmd}' timed out\n#{e.backtrace}\nOutput:\n#{out.string}"
   rescue Exception => e
     raise "#{e.message}\n#{e.backtrace}\nOutput:\n#{out.string}"
   end
@@ -245,7 +245,28 @@ def add_to(stuffs, more_stuffs)
   end
 end
 
-def upgrade(version, continue=false, ignore_cartridge_version=false, target_server_identity=nil, upgrade_position=1, num_upgraders=1)
+def upgrade(args={})
+  defaults = {
+    version: nil,
+    continue: false,
+    ignore_cartridge_version: false,
+    target_server_identity: nil,
+    upgrade_position: 1,
+    num_upgraders: 1,
+    rerun: false
+  }
+  opts = defaults.merge(args) {|k, default, arg| arg.nil? ? default : arg}
+
+  puts "Performing upgrade with options: #{opts.inspect}"
+
+  version = opts[:version]
+  continue = opts[:continue]
+  ignore_cartridge_version = opts[:ignore_cartridge_version]
+  target_server_identity = opts[:target_server_identity]
+  upgrade_position = opts[:upgrade_position]
+  num_upgraders = opts[:num_upgraders]
+  rerun = opts[:rerun]
+
   start_time = (Time.now.to_f * 1000).to_i
   logins_cnt = 0
   gear_cnt = 0
@@ -362,14 +383,21 @@ def upgrade(version, continue=false, ignore_cartridge_version=false, target_serv
         end
       end
 
+      # If continue is specified, re-use the existing upgrade file without writing
+      # a new one from the node gears. If rerun is specified, convert the rerun file
+      # into the upgrade file.
       unless active_gears.empty?
-        write_node_to_file(server_identity + ACTIVE_SUFFIX, active_gears, version, ignore_cartridge_version) unless continue
+        write_node_to_file(server_identity + ACTIVE_SUFFIX, active_gears, version, ignore_cartridge_version) unless (continue || rerun)
         active_node_queue << {:server_identity => server_identity + ACTIVE_SUFFIX, :gears_length => active_gears.length}
+
+        prepare_rerun(server_identity + ACTIVE_SUFFIX) if rerun
       end
 
       unless inactive_gears.empty?
-        write_node_to_file(server_identity, inactive_gears, version, ignore_cartridge_version) unless continue
+        write_node_to_file(server_identity, inactive_gears, version, ignore_cartridge_version) unless (continue || rerun)
         inactive_node_queue << {:server_identity => server_identity, :gears_length => inactive_gears.length}
+
+        prepare_rerun(server_identity) if rerun
       end
     end
   end
@@ -480,6 +508,16 @@ def upgrade(version, continue=false, ignore_cartridge_version=false, target_serv
   puts "#####################################################"
 end
 
+def prepare_rerun(server_identity)
+  rerun_file = rerun_file_path(server_identity)
+  upgrade_file = upgrade_file_path(server_identity)
+  if File.exists?(rerun_file)
+    puts "Preparing upgrade file #{upgrade_file} from rerun file #{rerun_file} for server #{server_identity}"
+    FileUtils.rm_f(upgrade_file) if File.exists?(upgrade_file)
+    FileUtils.mv(rerun_file, upgrade_file)
+  end
+end
+
 def write_node_to_file(server_identity, gears, version, ignore_cartridge_version)
   f = upgrade_file_path(server_identity)
   puts "Writing #{gears.length} gears for node #{server_identity} to file #{f}"
@@ -502,6 +540,10 @@ end
 
 def upgrade_file_path(server_identity)
   "#{WORK_DIR}/upgrade_#{server_identity}"
+end
+
+def rerun_file_path(server_identity)
+  "#{WORK_DIR}/upgrade_rerun_#{server_identity}"
 end
 
 def upgrade_node(server_identity, continue)
@@ -535,6 +577,14 @@ def upgrade_node(server_identity, continue)
       elsif line =~ /\*\*\*acceptable_error_(.*)=(.+)\*\*\*/
         acceptable_errors[$1] = [] unless acceptable_errors[$1]
         acceptable_errors[$1] << $2
+      elsif line =~/gear_upgrade_json=(.*)/
+        begin
+          gear_json = JSON.load($1)
+          gear_json['times'].each_pair do |k, v|
+            timings[k] = v.to_i
+          end
+        rescue
+        end
       end
       print line
     end
@@ -562,6 +612,7 @@ def upgrade_from_file(file)
         base_path += ACTIVE_SUFFIX
       end
       error_file = error_file_path(base_path)
+      rerun_file = rerun_file_path(base_path)
       log_file = log_file_path(base_path)
       append_to_file(log_file,  "Migrating app '#{app_name}' gear '#{gear_name}' with uuid '#{gear_uuid}' on node '#{server_identity}' for user: #{login}")
       num_tries = 2
@@ -574,6 +625,7 @@ def upgrade_from_file(file)
           if i == num_tries
             append_to_file(log_file, "Failed to upgrade with cmd: '#{upgrade_on_node_cmd}' after #{num_tries} tries with exception: #{e.message}")
             append_to_file(error_file, upgrade_on_node_cmd)
+            append_to_file(rerun_file, line)
             break
           else
             user = nil
@@ -680,6 +732,7 @@ begin
     ["--max-threads", GetoptLong::REQUIRED_ARGUMENT],
     ["--ignore-cartridge-version", GetoptLong::NO_ARGUMENT],
     ["--continue", GetoptLong::NO_ARGUMENT],
+    ["--rerun", GetoptLong::NO_ARGUMENT],
     ["--help", "-h", GetoptLong::NO_ARGUMENT]
   )
   opt = {}
@@ -695,6 +748,7 @@ if opt['help']
 end
 
 opt['ignore-cartridge-version'] = opt['ignore-cartridge-version'] ? true : false
+opt['rerun'] = opt['rerun'] ? true : false
 
 
 $:.unshift('/var/www/openshift/broker')
@@ -726,8 +780,8 @@ elsif opt['upgrade-node']
   if opt['version']
     upgrade_file = upgrade_file_path(opt['upgrade-node'])
     if opt['continue']
-      upgrade(opt['version'], true, opt['upgrade-node'])
-    elsif File.exists?(upgrade_file)
+      upgrade(version: opt['version'], continue: true, ignore_cartridge_version: opt['ignore-cartridge-version'], target_server_identity: opt['upgrade-node'])
+    elsif !opt['rerun'] && File.exists?(upgrade_file)
         puts <<-WARNING
 !!!!!!!!!!!!!!!!!!!! EXISTING MIGRATION DATA FOUND !!!!!!!!!!!!!!!!!!!!
 Data from a previous upgrade exists at #{upgrade_file}.  You must 
@@ -736,7 +790,7 @@ where it left off with '#{__FILE__} --upgrade-node #{opt['upgrade-node']} --vers
 WARNING
         exit 1
     else
-      upgrade(opt['version'], false, opt['ignore-cartridge-version'], opt['upgrade-node'])
+      upgrade(version: opt['version'], continue: false, ignore_cartridge_version: opt['ignore-cartridge-version'], target_server_identity: opt['upgrade-node'], rerun: opt['rerun'])
     end
   else
     puts "--version is required with --upgrade-node"
@@ -770,8 +824,8 @@ else
       upgrade_position = 1
     end
     if opt['continue']
-      upgrade(opt['version'], true, opt['ignore-cartridge-version'], nil, upgrade_position, num_upgraders)
-    elsif File.exists?(WORK_DIR)
+      upgrade(version: opt['version'], continue: true, ignore_cartridge_version: opt['ignore-cartridge-version'], upgrade_position: upgrade_position, num_upgraders: num_upgraders)
+    elsif !opt['rerun'] && File.exists?(WORK_DIR)
       puts <<-WARNING
 !!!!!!!!!!!!!!!!!!!! EXISTING MIGRATION DATA FOUND !!!!!!!!!!!!!!!!!!!!
 Data from a previous migration exists at #{WORK_DIR}.  You must 
@@ -780,7 +834,7 @@ where it left off with '#{__FILE__} --continue'.
 WARNING
       exit 1
     else
-      upgrade(opt['version'], false, opt['ignore-cartridge-version'], nil, upgrade_position, num_upgraders)
+      upgrade(version: opt['version'], continue: false, ignore_cartridge_version: opt['ignore-cartridge-version'], upgrade_position: upgrade_position, num_upgraders: num_upgraders, rerun: opt['rerun'])
     end
   else
     puts "--version is required"

--- a/node/README.writing_cartridges.md
+++ b/node/README.writing_cartridges.md
@@ -1249,3 +1249,73 @@ authors should take care to be as conservative as possible.
 [erb_processing]: #erb-processing
 [erb]: http://ruby-doc.org/stdlib-1.9.3/libdoc/erb/rdoc/ERB.html
 [locking_ruby]: http://www.ruby-doc.org/docs/ProgrammingRuby/html/taint.html).
+
+## OpenShift Upgrades
+
+The OpenShift runtime contains an upgrade system used to upgrade the cartridges in a gear to the latest available version and to apply gear-scoped changes which are orthogonal to cartridges to a gear.  The `oo-admin-upgrade` command provides the CLI for the upgrade system and can be used to upgrade all gears in an OpenShift environment, all gears on a node, or a single gear.  This command queries the openshift broker to determine the locations of the indicated gears to migrate and makes mcollective calls to trigger the upgrade for a gear.
+
+During upgrades, OpenShift follows the following high-level process to upgrade a gear:
+
+1.  Load the gear upgrade extension, if configured.
+1.  Inspect the gear state.
+1.  Run the gear extension's pre-upgrade method, if it exists.
+1.  Compute the upgrade itinerary for the gear.
+1.  If the itinerary contains an incompatible upgrade, stop the gear.
+1.  Upgrade the cartridges in the gear according to the itinerary.
+1.  Run the gear extension's post-upgrade method, if it exists.
+1.  If the itinerary contains an incompatible upgrade, restart and validate the gear.
+1.  Clean up after the upgrade by deleting pre-upgrade state and upgrade metadata.
+
+### Upgrade Itinerary
+
+The upgrade process must be re-entrant; if it fails or times out, a subsequent upgrade operation must pick up where the last one left off without losing any data about which operations must be performed to fully upgrade a gear.  The upgrade itinerary stores information about which cartridges in a gear must be upgraded and which type of upgrade to perform.
+
+There are two types of cartridge upgrade process: compatible and incompatible.  Whether an upgrade from version X to version Y is compatible is driven by the presence of version X in version Y's `Compatible-Versions` manifest element.  Though compatible and incompatible upgrades differ in various ways, the chief difference is that when an incompatible upgrade is to be applied to any cartridge in a gear, that gear is stopped before the cartridge upgrades are performed and restarted after all cartridges have been upgraded.
+
+The upgrade itinerary is computed as follows for each cartridge in a gear:
+
+1.  Read in the current IDENT of the cartridge.
+1.  If the vendor is not 'redhat', skip the cartridge.
+1.  Select the name and software version of the cartridge from the cartridge repository; this will
+    yield the manifest for the latest version of the cartridge.  If the manifest does not exist in the cartridge repository or does not include the software version, skip the cartridge.
+1.  If the latest manifest is for the same cartridge version as that currently installed in the
+    gear, skip the cartridge unless the `ignore_cartridge_version` parameter is set.  If the `ignore_cartridge_version` parameter is set, record an incompatible upgrade for the cartridge in the itinerary.  (TODO: case where manifest declares itself as compatible version).
+1.  If the latest manifest includes the current cartridge version in the `Compatible-Versions`
+    element, record a compatible upgrade for the cartridge in the itinerary.  Otherwise, record an incompatible upgrade for the cartridge in the itinerary.
+
+### Compatible Upgrades
+
+The compatible upgrade process for a cartridge is as follows:
+
+1.  The new version of the cartridge is overlaid in the gear.
+1.  The files declared in the `Processed-Templates` section of the cartridge's `managed-files.yml`
+    are removed.
+1.  The cartridge directory is unlocked.
+1.  The cartridge directory is secured.
+1.  If the cartridge provides an `upgrade` script, that script is executed.
+1.  The cartridge directory is locked.
+
+### Incompatible Upgrades
+
+The incompatible upgrade process for a cartridge is as follows:
+
+1.  The files and directories declared in the `Setup-Rewritten` section of the cartridge's 
+    `managed_files.yml` are removed.
+1.  The new version of the cartridge is overlaid in the gear.
+1.  The cartridge directory is unlocked.
+1.  The cartridge directory is secured.
+1.  The cartridge `setup` script is run.
+1.  The erb templates for the cartridge are processed.
+1.  If the cartridge provides an `upgrade` script, that script is executed.
+1.  The cartridge directory is locked.
+1.  The frontend is connected.
+
+### Cartridge Upgrade Script
+
+A cartridge may provide an `upgrade` script in the `bin` directory which will be executed during the upgrade process.  The purpose of this script is to allow for arbitrary actions to occur during the upgrade process which are not accounted for by the compatible or incompatible processes.  If the `upgrade` script is provided, it will be passed the following arguments:
+
+1.  The software version of the cartridge.
+1.  The current cartridge version.
+1.  The cartridge version being upgraded to.
+
+A non-zero exit code from this script will result in the upgrade operation failing until the exit code is corrected.

--- a/node/lib/openshift-origin-node/utils/upgrade_itinerary.rb
+++ b/node/lib/openshift-origin-node/utils/upgrade_itinerary.rb
@@ -1,0 +1,55 @@
+module OpenShift
+  module Runtime
+    module UpgradeType
+      COMPATIBLE   = 'compatible'
+      INCOMPATIBLE = 'incompatible'
+    end
+
+  	class UpgradeItinerary
+      attr_reader :entries
+
+  	  def initialize(gear_home, entries = {}, has_incompatible = false)
+  	  	@gear_home = gear_home
+        @entries = entries || {}
+        @has_incompatible = has_incompatible
+  	  end
+
+      def create_entry(cartridge_name, upgrade_type)
+      	@entries[cartridge_name] = upgrade_type
+
+      	if upgrade_type == UpgradeType::INCOMPATIBLE
+      	  @has_incompatible = true
+      	end
+      end
+
+      def has_incompatible_upgrade?
+      	@has_incompatible
+      end
+
+      def each_cartridge
+        @entries.each_pair do |name, upgrade_type|
+          yield name, upgrade_type if block_given?
+        end
+      end
+
+      def persist
+      	jsonish_self = { entries: @entries, has_incompatible: @has_incompatible}
+        IO.write(self.class.itinerary_file(@gear_home), JSON.dump(jsonish_self))
+      end
+
+      def self.itinerary_file(gear_home)
+        PathUtils.join(gear_home, %w(app-root runtime .upgrade_itinerary))
+      end
+
+      def self.for_gear(gear_home)
+        serialized_self = IO.read(itinerary_file(gear_home))
+        jsonish_self = JSON.load(serialized_self)
+        UpgradeItinerary.new(gear_home, jsonish_self['entries'], jsonish_self['has_incompatible'])
+      end
+
+      def self.remove_from(gear_home)
+        FileUtils.rm_f(itinerary_file(gear_home))
+      end
+  	end
+  end
+end

--- a/node/lib/openshift-origin-node/utils/upgrade_progress.rb
+++ b/node/lib/openshift-origin-node/utils/upgrade_progress.rb
@@ -6,22 +6,43 @@ module OpenShift
   module Runtime
     module Utils
       class UpgradeProgress
-        attr_reader :gear_home
+        attr_reader :gear_home, :gear_base_dir, :uuid, :steps
 
-        def initialize(gear_home)
+        def initialize(gear_base_dir, gear_home, uuid)
+          @gear_base_dir = gear_base_dir
           @gear_home = gear_home
+          @uuid = uuid
           @buffer = []
+          @steps = {}
         end
 
-        def init_store
-          runtime_dir = File.join(gear_home, %w(app-root runtime))
-          if !File.exists?(runtime_dir)
-            log "Creating data directory #{runtime_dir} for #{@gear_home} because it does not exist"
-            FileUtils.mkpath(runtime_dir)
-            FileUtils.chmod_R(0o750, runtime_dir)
-            PathUtils.oo_chown_R(@uuid, @uuid, runtime_dir)
-            mcs_label = OpenShift::Runtime::Utils::SELinux::get_mcs_label(uuid)
-            OpenShift::Runtime::Utils::SELinux.set_mcs_label_R(mcs_label, runtime_dir)
+        def step(name)
+          unless @steps.has_key?(name)
+            @steps[name] = {
+              :status => complete?(name) ? :complete : :incomplete,
+              :errors => [],
+              :context => {}
+            }
+          end
+
+          step = @steps[name]
+
+          if incomplete?(name)
+            begin
+              yield(step[:context], step[:errors])
+            rescue OpenShift::Runtime::Utils::ShellExecutionException => e
+              step[:errors] << "Unhandled shell exception performing step: #{e.message}\nreturn code: #{e.rc}\nstdout: #{e.stdout}\nstderr: #{e.stderr}"
+              raise e
+            rescue => e
+              step[:errors] << "Unhandled exception performing step: #{e.message}\n#{e.backtrace.join("\n")}"
+              raise e
+            end
+
+            if not step[:errors].empty?
+              raise "Errors encountered executing step #{name}"
+            end
+
+            mark_complete(name)
           end
         end
 
@@ -36,19 +57,11 @@ module OpenShift
         def mark_complete(marker)
           IO.write(marker_path(marker), '')
           log "Marking step #{marker} complete"
-        end
-
-        def has_instruction?(instruction)
-          File.exists?(instruction_path(instruction))
-        end
-
-        def set_instruction(instruction)
-          FileUtils.touch(instruction_path(instruction))
-          log "Creating migration instruction #{instruction}"
+          @steps[marker][:status] = :complete
         end
 
         def done
-          globs = %w(.upgrade_complete* .upgrade_instruction*)
+          globs = %w(.upgrade_complete*)
 
           globs.each do |glob|
             Dir.glob(File.join(gear_home, 'app-root', 'runtime', glob)).each do |entry|
@@ -61,11 +74,11 @@ module OpenShift
           File.join(gear_home, 'app-root', 'runtime', ".upgrade_complete_#{marker}")
         end
 
-        def instruction_path(instruction)
-          File.join(gear_home, 'app-root', 'runtime', ".upgrade_instruction_#{instruction}")
-        end
+        def log(string, event_args = {})
+          if event_args.has_key?(:rc) || event_args.has_key?(:stdout) || event_args.has_key?(:stderr)
+            string = "#{string}\nrc: #{event_args[:rc]}\nstdout: #{event_args[:stdout]}\nstderr: #{event_args[:stderr]}"
+          end
 
-        def log(string)
           @buffer << string
           string
         end

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -228,7 +228,7 @@ module MCollective
           require 'openshift-origin-node/model/upgrade'
 
           upgrader = OpenShift::Runtime::Upgrader.new(uuid, namespace, version, hostname, ignore_cartridge_version)
-          output, exitcode = upgrader.execute
+          output, exitcode, json_data = upgrader.execute
         rescue LoadError => e
           exitcode = 127
           output += "upgrade not supported. #{e.message}\n"
@@ -244,6 +244,7 @@ module MCollective
 
         reply[:output] = output
         reply[:exitcode] = exitcode
+        reply[:json_data] = json_data
         reply.fail! "upgrade_action failed #{exitcode}.  Output #{output}" unless exitcode == 0
       end
 


### PR DESCRIPTION
Refactor the upgrade code to use well-defined step and itinerary structures. Return a JSON payload of
all relevant upgrade data to facilitate enhancements in higher level upgrade orchestration tools.

Add a new '--rerun' feature to oo-admin-upgrade which allows the re-upgrade of the last run's errors,
facilitating an "upgrade until it succeeds" workflow.
