### PR TITLE
Adding Fedora vs RHEL cases for idler.

### DIFF
--- a/controller/test/cucumber/platform-idler.feature
+++ b/controller/test/cucumber/platform-idler.feature
@@ -1,38 +1,69 @@
 @singleton
 Feature: Explicit idle/restore checks
-  Scenario: Idle one application
+  Scenario Outline: Idle one application
     Given a new mock-0.1 type application
-    Then a ruby process for mock_server will be running
+    Then a <ruby_proc> process for mock_server will be running
     And I record the active capacity
 
     When I oo-idle the application
-    Then a ruby process for mock_server will not be running
+    Then a <ruby_proc> process for mock_server will not be running
     And the active capacity has been reduced
 
-  Scenario: Restore one application
+    @fedora-19-only
+    Scenarios: Fedora 19
+      | ruby_proc |
+      | ruby-mri  |
+
+    @rhel-only
+    Scenarios: RHEL
+      | ruby_proc |
+      | ruby      |
+
+  Scenario Outline: Restore one application
     Given a new mock-0.1 type application
-    Then a ruby process for mock_server will be running
+    Then a <ruby_proc> process for mock_server will be running
     And I record the active capacity
 
     When I oo-idle the application
-    Then a ruby process for mock_server will not be running
+    Then a <ruby_proc> process for mock_server will not be running
     And the active capacity has been reduced
     And I record the active capacity after idling
 
     When I oo-restore the application
-    Then a ruby process for mock_server will be running
+    Then a <ruby_proc> process for mock_server will be running
     And the active capacity has been increased
 
-  Scenario: Auto-restore one application
+    @fedora-19-only
+    Scenarios: Fedora 19
+      | ruby_proc |
+      | ruby-mri  |
+
+    @rhel-only
+    Scenarios: RHEL
+      | ruby_proc |
+      | ruby      |
+
+  Scenario Outline: Auto-restore one application
     Given a new mock-0.1 type application
-    Then a ruby process for mock_server will be running
+    Then a <ruby_proc> process for mock_server will be running
     And I record the active capacity
 
     When I oo-idle the application
-    Then a ruby process for mock_server will not be running
+    Then a <ruby_proc> process for mock_server will not be running
     And the active capacity has been reduced
     And I record the active capacity after idling
 
     When I run the health-check for the <type> cartridge
-    Then a ruby process for mock_server will be running
+    Then a <ruby_proc> process for mock_server will be running
     And the active capacity has been increased
+
+    @fedora-19-only
+    Scenarios: Fedora 19
+      | ruby_proc |
+      | ruby-mri  |
+
+    @rhel-only
+    Scenarios: RHEL
+      | ruby_proc |
+      | ruby      |
+


### PR DESCRIPTION
Ruby 2.0 in F19 runs as ruby-mri vs ruby in RHEL
