### PR TITLE
[Do not merge] Reload cartridge repository cache when mcollective recieves a HUP signal

### DIFF
--- a/controller/test/cucumber/step_definitions/upgrade_steps.rb
+++ b/controller/test/cucumber/step_definitions/upgrade_steps.rb
@@ -119,7 +119,7 @@ def assert_successful_install(tmp_cart_src, next_version, current_manifest)
 
   assert_equal next_version, observed_latest_version
 
-  %x(pkill -USR1 -f /usr/sbin/mcollectived)
+  %x(pkill -HUP -f /usr/sbin/mcollectived)
 end
 
 Then /^the ([^ ]+) cartridge version should be updated$/ do |cart_name|

--- a/controller/test/cucumber/support/cart_repo_helper.rb
+++ b/controller/test/cucumber/support/cart_repo_helper.rb
@@ -15,7 +15,7 @@ def clean_cart_repo
     $logger.info('Erasing test-generated version mock-0.1')
     cart_repo.erase('mock', '0.1', '0.0.2')
 
-    %x(pkill -USR1 -f /usr/sbin/mcollectived)
+    %x(pkill -HUP -f /usr/sbin/mcollectived)
   end
 
   cart_repo.clear

--- a/node-util/bin/oo-admin-cartridge
+++ b/node-util/bin/oo-admin-cartridge
@@ -137,7 +137,7 @@ begin
     puts OpenShift::Runtime::AdminCartridgeCartridgeRepository.new.apply(options)
 
     if [:install, :erase].include?(options.action)
-      OpenShift::Runtime::Utils::oo_spawn('pkill -USR1 -f /usr/sbin/mcollectived')
+      OpenShift::Runtime::Utils::oo_spawn('pkill -HUP -f /usr/sbin/mcollectived')
     end
   end
 rescue OpenShift::Runtime::Utils::ShellExecutionException => e

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -11,6 +11,11 @@ require 'shellwords'
 require 'facter'
 require 'openshift-origin-common/utils/file_needs_sync'
 
+Signal.trap("SIGHUP") {
+  cartridge_repository = ::OpenShift::Runtime::CartridgeRepository.instance
+  cartridge_repository.lazy_reload_index
+}
+
 module MCollective
   module Agent
     class Openshift<RPC::Agent


### PR DESCRIPTION
Note: Sending USR1 to mcollective in F19 causes 100% cpu usage.

Our code doesnt need full daemon reload, only reload of cache so instead of using USR1, I am using HUP to cause cache to reload.

Since we should not execute any significant code in signal handler, marking cartridge repository as needing an update and doing it in a lazy manner.
