### PR TITLE
Workaround for F19 mcollective issue where it goes into inf. loop and 100% cpu usage.

### DIFF
--- a/node-util/bin/oo-admin-cartridge
+++ b/node-util/bin/oo-admin-cartridge
@@ -137,7 +137,12 @@ begin
     puts OpenShift::Runtime::AdminCartridgeCartridgeRepository.new.apply(options)
 
     if [:install, :erase].include?(options.action)
-      OpenShift::Runtime::Utils::oo_spawn('pkill -USR1 -f /usr/sbin/mcollectived')
+      if File.exist?("/etc/fedora-release")
+        OpenShift::Runtime::Utils::oo_spawn('service mcollective restart')
+        sleep(5) #wait for mcollective to be stable again
+      else
+        OpenShift::Runtime::Utils::oo_spawn('pkill -USR1 -f /usr/sbin/mcollectived')
+      end
     end
   end
 rescue OpenShift::Runtime::Utils::ShellExecutionException => e


### PR DESCRIPTION
Using mcollctive restart instead of mcollective reload.
