### PR TITLE
Locale problem (bundle + gem + git) fixed

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -7,6 +7,11 @@ source "${OPENSHIFT_RUBY_DIR}/lib/ruby_context"
 HTTPD_CFG_FILE=$OPENSHIFT_RUBY_DIR/etc/conf/httpd_nolog.conf
 HTTPD_PID_FILE=$OPENSHIFT_RUBY_DIR/run/httpd.pid
 
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+export LANGUAGE=en_US.UTF-8
+
+
 function start() {
     echo "Starting Ruby cart"
     update_httpd_passenv $HTTPD_CFG_FILE


### PR DESCRIPTION
Using bundler to install some gems via git lead to an error "invalid byte sequence in US-ASCII" which fixed by set correct locale.

for example:

Gemfile: 

gem 'responders',          github: 'plataformatec/responders'
gem 'inherited_resources', github: 'josevalim/inherited_resources'
gem 'ransack',             github: 'ernie/ransack', branch: 'rails-4'
gem 'activeadmin',         github: 'gregbell/active_admin', branch: 'rails4'

lead us to : 

remote: Using responders (1.0.0.rc) from git://github.com/plataformatec/responders.git (at master) 
remote: ArgumentError: invalid byte sequence in US-ASCII
remote: An error occured while installing responders (1.0.0.rc), and Bundler cannot continue.
remote: Make sure that `gem install responders -v '1.0.0.rc'` succeeds before bundling.
remote: An error occurred executing 'gear postreceive' (exit code: 5)
remote: Error message: Failed to execute: 'control build' for /var/lib/openshift/51f193bc500446065d0000f5/ruby
remote: 
remote: For more details about the problem, try running the command again with the '--trace' option.

after push to openshift account.
