### PR TITLE
Bug 989706: Quiet extra output from Libcgroup.usage

### DIFF
--- a/node/lib/openshift-origin-node/utils/logger/split_trace_logger.rb
+++ b/node/lib/openshift-origin-node/utils/logger/split_trace_logger.rb
@@ -36,18 +36,18 @@ module OpenShift
       #
       class SplitTraceLogger
         PROFILES = {
-            :standard => {
-                file_config:   'PLATFORM_LOG_FILE',
+          :standard => {
+            file_config:   'PLATFORM_LOG_FILE',
             level_config:  'PLATFORM_LOG_LEVEL',
             default_file:  File.join(File::SEPARATOR, %w{var log openshift node platform.log}),
             default_level: Logger::DEBUG
-        },
-            :trace    => {
+          },
+          :trace    => {
             file_config:   'PLATFORM_TRACE_LOG_FILE',
             level_config:  'PLATFORM_TRACE_LOG_LEVEL',
             default_file:  File.join(File::SEPARATOR, %w{var log openshift node platform-trace.log}),
             default_level: Logger::INFO
-        }
+          }
         }
 
         def initialize(config, context)

--- a/node/lib/openshift-origin-node/utils/node_logger.rb
+++ b/node/lib/openshift-origin-node/utils/node_logger.rb
@@ -123,6 +123,10 @@ module OpenShift
       def self.context
         @context ||= {}
       end
+
+      def self.set_logger(logger)
+        @logger = logger
+      end
     end
   end
 end

--- a/node/lib/openshift-origin-node/utils/shell_exec.rb
+++ b/node/lib/openshift-origin-node/utils/shell_exec.rb
@@ -74,6 +74,7 @@ module OpenShift
       #                                provided +IO+ object.
       #   :err                       : If specified, STDERR from the child process will be redirected to the
       #                                provided +IO+ object.
+      #   :quiet                     : If specified, the output from the command will not be logged
       #
       # NOTE: If the +out+ or +err+ options are specified, the corresponding return value from +oo_spawn+
       # will be the incoming/provided +IO+ objects instead of the buffered +String+ output. It's the
@@ -123,7 +124,7 @@ module OpenShift
               write_stderr.close
 
               out, err, status = read_results(pid, read_stdout, read_stderr, options)
-              NodeLogger.logger.debug { "Shell command '#{command}' ran. rc=#{status.exitstatus} out=#{out}" }
+              NodeLogger.logger.debug { "Shell command '#{command}' ran. rc=#{status.exitstatus} out=#{options[:quiet] ? "[SILENCED]" : out}" }
 
               if (!options[:expected_exitstatus].nil?) && (status.exitstatus != options[:expected_exitstatus])
                 raise ::OpenShift::Runtime::Utils::ShellExecutionException.new(

--- a/node/test/unit/throttler_test.rb
+++ b/node/test/unit/throttler_test.rb
@@ -36,8 +36,6 @@ class ThrottlerTest < OpenShift::NodeTestCase
       }
     }
 
-    @mock_usage_str = fake_usage(@mock_usage)
-
     @mock_apps = {
       "A" => mock(@@mg.to_s),
       "B" => mock(@@mg.to_s),
@@ -60,11 +58,6 @@ class ThrottlerTest < OpenShift::NodeTestCase
 
     assert_equal period, throttler.interval
     assert_equal threshold, throttler.threshold
-  end
-
-  def test_parse_usage
-    usage = @throttler.parse_usage(@mock_usage_str)
-    assert_equal @mock_usage, usage
   end
 
   def test_update
@@ -306,23 +299,5 @@ class ThrottlerTest < OpenShift::NodeTestCase
     end
 
     yield mock_apps, mock_util
-  end
-
-  def fake_usage(gears)
-    gears.inject("") do |a,(uuid,vals)|
-      v = vals.clone
-      v[:uuid] = uuid
-      str = usage_template % v
-      a << str
-    end.lines.map(&:strip).join("\n")
-  end
-
-  def usage_template
-    <<-STR
-      %<uuid>s/cpuacct.usage:%<usage>d
-      %<uuid>s/cpu.stat:throttled_time %<throttled_time>d
-      %<uuid>s/cpu.stat:nr_periods %<nr_periods>d
-      %<uuid>s/cpu.cfs_quota_us:%<cfs_quota_us>d
-    STR
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=989706

Added option to `oo_spawn` that silences output when logged to
`NodeLogger`. Output will now appear like:

```
July 30 11:30:00 INFO Shell command 'grep -H "" */{cpu.stat,cpuacct.usage,cpu.cfs_quota_us} 2> /dev/null' ran. rc=0 out=<silenced>
```

Also added custom logger for cgroups information, which is used [here](https://github.com/openshift/li/pull/1782)
