### PR TITLE
Bug 989706: Move cgroups logging to cgroups class

### DIFF
--- a/node/lib/openshift-origin-node/utils/cgroups/libcgroup.rb
+++ b/node/lib/openshift-origin-node/utils/cgroups/libcgroup.rb
@@ -452,7 +452,6 @@ module OpenShift
             r
           end
 
-
           # Private: Open and safely swap the file if it changed
           def overwrite_with_safe_swap(filename)
             r=nil
@@ -478,6 +477,22 @@ module OpenShift
             SELinux::chcon(filename)
 
             r
+          end
+
+          def logger
+            @logger ||= Libcgroup.logger
+          end
+
+          def self.logger
+            @@logger ||= build_logger
+          end
+
+          def self.build_logger
+            config = OpenShift::Config.new(nil,{
+              'PLATFORM_LOG_FILE' => File.join(File::SEPARATOR, %w{var log openshift node cgroups.log}),
+              'PLATFORM_TRACE_LOG_FILE' => File.join(File::SEPARATOR, %w{var log openshift node cgroups-trace.log}),
+            })
+            OpenShift::Runtime::NodeLogger::SplitTraceLogger.new(config, OpenShift::Runtime::NodeLogger.context)
           end
         end
       end


### PR DESCRIPTION
This is a follow on to a previous PR that allows this log to be used elsewhere in the cgroups classes

watchman updated to use new code in [this PR](https://github.com/openshift/li/pull/1783)
