### PR TITLE
Bug 989706: Throttler dies if no cgroups are present

### DIFF
--- a/node/lib/openshift-origin-node/utils/cgroups/libcgroup.rb
+++ b/node/lib/openshift-origin-node/utils/cgroups/libcgroup.rb
@@ -141,7 +141,7 @@ module OpenShift
 
           def self.usage
             cmd = 'grep -H "" */{cpu.stat,cpuacct.usage,cpu.cfs_quota_us} 2> /dev/null'
-            (out, err, rc) = ::OpenShift::Runtime::Utils::oo_spawn(cmd, :chdir => cgroup_paths['cpu'], :expected_exitstatus => 0, :quiet => true)
+            (out, err, rc) = ::OpenShift::Runtime::Utils::oo_spawn(cmd, :chdir => cgroup_paths['cpu'], :quiet => true)
             parse_usage(out)
           end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=989706

If there were no cgroups present, the `grep` command would fail. By not
expecting a 0 exit status, we can silently ignore this problem.
