### PR TITLE
Bug 989782: Node platform should not log user sensitive login name and password credentials

### DIFF
--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -291,7 +291,7 @@ module OpenShift
         connect_frontend(cartridge)
         end
 
-        logger.info "configure output: #{output}"
+        logger.info "configure output: #{Runtime::Utils.sanitize_credentials(output)}"
         return output
       rescue ::OpenShift::Runtime::Utils::ShellExecutionException => e
         rc_override = e.rc < 100 ? 157 : e.rc
@@ -641,7 +641,7 @@ module OpenShift
             chdir:               cartridge_home,
             timeout:             @hourglass.remaining,
             expected_exitstatus: 0)
-        logger.info("Ran #{action} for #{@container.uuid}/#{cartridge.directory}\n#{out}")
+        logger.info("Ran #{action} for #{@container.uuid}/#{cartridge.directory}\n#{Runtime::Utils.sanitize_credentials(out)}")
         out
       end
 

--- a/node/lib/openshift-origin-node/utils/sanitize.rb
+++ b/node/lib/openshift-origin-node/utils/sanitize.rb
@@ -2,9 +2,14 @@ module OpenShift
   module Runtime
     module Utils
       def self.sanitize_credentials(arg)
-        arg.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
-           .gsub(/(passwo?r?d\s*[:=]+\s*)\S+/i, '\\1[HIDDEN]')
-           .gsub(/(usern?a?m?e?\s*[:=]+\s*)\S+/i,'\\1[HIDDEN]')
+        begin
+          arg.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+            .gsub(/(passwo?r?d\s*[:=]+\s*)\S+/i, '\\1[HIDDEN]')
+            .gsub(/(usern?a?m?e?\s*[:=]+\s*)\S+/i,'\\1[HIDDEN]')
+        rescue
+          # If we were unable to encode the string, then just return it verbatim
+          arg
+        end
       end
       def self.sanitize_argument(arg)
         arg.to_s.gsub(/'/, '')

--- a/node/lib/openshift-origin-node/utils/shell_exec.rb
+++ b/node/lib/openshift-origin-node/utils/shell_exec.rb
@@ -19,6 +19,7 @@ require 'timeout'
 require 'open4'
 
 require_relative '../utils/node_logger'
+require_relative 'sanitize'
 
 module OpenShift
   module Runtime
@@ -124,7 +125,7 @@ module OpenShift
               write_stderr.close
 
               out, err, status = read_results(pid, read_stdout, read_stderr, options)
-              NodeLogger.logger.debug { "Shell command '#{command}' ran. rc=#{status.exitstatus} out=#{options[:quiet] ? "[SILENCED]" : out}" }
+              NodeLogger.logger.debug { "Shell command '#{command}' ran. rc=#{status.exitstatus} out=#{options[:quiet] ? "[SILENCED]" : Runtime::Utils.sanitize_credentials(out)}" }
 
               if (!options[:expected_exitstatus].nil?) && (status.exitstatus != options[:expected_exitstatus])
                 raise ::OpenShift::Runtime::Utils::ShellExecutionException.new(
@@ -173,7 +174,7 @@ module OpenShift
                     partial = fd.readpartial(options[:buffer_size])
                     buffer << partial
 
-                    NodeLogger.logger.trace { "oo_spawn buffer(#{fd.fileno}/#{fd.pid}) #{partial}" }
+                    NodeLogger.logger.trace { "oo_spawn buffer(#{fd.fileno}/#{fd.pid}) #{Runtime::Utils.sanitize_credentials(partial)}" }
                   rescue Errno::EAGAIN, Errno::EINTR
                   rescue EOFError
                     readers.delete(fd)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=989782

NodeLogger was logging all results from client commands. This patch
applies a regex to all messages and can sanitize the data accordingly.
