### PR TITLE
Bug 990849 - Bumped manifest Version element in error

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/metadata/manifest.yml
@@ -2,10 +2,10 @@ Name: 10gen-mms-agent
 Cartridge-Short-Name: 10GENMMSAGENT
 Display-Name: 10gen Mongo Monitoring Service Agent
 Description: "MongoDB Monitoring Service (MMS) instruments MongoDB and provides information about current and historical operational metrics of your system."
-Version: '0.2'
-Compatible-Versions: ['0.1']
+Version: '0.1'
 License-Url: https://mms.10gen.com/links/terms-of-service
-Cartridge-Version: 0.0.1
+Cartridge-Version: '0.0.2'
+Compatible-Versions: ['0.0.1']
 Cartridge-Vendor: redhat
 Vendor: 10gen.com
 Categories:


### PR DESCRIPTION
- Bumped 10gen-mms-agent manifest Version number in place of Cartridge-Version
