### PR TITLE
Bug 983631: Allow resource_limits values to be specified in human-readable strings

### DIFF
--- a/node-util/bin/oo-accept-node
+++ b/node-util/bin/oo-accept-node
@@ -183,8 +183,20 @@ def source_file(file)
       val.gsub!(/[ \t]*#[^\n]*/,"") if not val.nil?
       val = val[1..-2] if not val.nil? and val.start_with? "\""
       val = val[1..-2] if not val.nil? and val.start_with? "\'"
-      ENV[key] = val
+      ENV[key] = "#{parse_value(val)}"
     end
+end
+
+# This method was taken from openshift-origin-node/utils/cgroups/config.rb
+# It will parse any human-readable values into numeric values
+def parse_value(val)
+  # Convert prefixed byte values to bytes
+  factors = { k: 1, m: 2, g: 3, t: 4 }
+  val.match(/^(\d+)(#{factors.keys.join('|')})b?/i) do |mg|
+    (num,unit) = mg[1,2]
+    val = num.to_i * ((2**10)**factors[unit.downcase.to_sym])
+  end
+  val
 end
 
 ###############################
@@ -881,3 +893,5 @@ if __FILE__ == $0
 
     exit($STATUS)
 end
+
+# vim: ft=ruby

--- a/node/conf/resource_limits.conf
+++ b/node/conf/resource_limits.conf
@@ -77,8 +77,8 @@ cpu_shares=128
 cpu_cfs_quota_us=100000
 #
 # memory
-memory_limit_in_bytes=536870912       # 512MB
-memory_memsw_limit_in_bytes=641728512 # 512M + 100M (100M swap)
+memory_limit_in_bytes=512M       # 512MB
+memory_memsw_limit_in_bytes=612M # 512M + 100M (100M swap)
 # memory_soft_limit_in_bytes=-1
 # memory_swappiness=60
 

--- a/node/lib/openshift-origin-node/model/node.rb
+++ b/node/lib/openshift-origin-node/model/node.rb
@@ -18,6 +18,7 @@ require 'openshift-origin-node/utils/sdk'
 require 'openshift-origin-node/utils/node_logger'
 require 'openshift-origin-common/models/manifest'
 require 'openshift-origin-node/model/cartridge_repository'
+require 'openshift-origin-node/utils/cgroups/config'
 require 'openshift-origin-common'
 require 'systemu'
 require 'safe_yaml'
@@ -195,7 +196,7 @@ module OpenShift
       end
 
       def self.init_quota(uuid, blocksmax=nil, inodemax=nil)
-        resource = OpenShift::Config.new('/etc/openshift/resource_limits.conf')
+        resource = ::OpenShift::Runtime::Utils::Cgroups::Config.new
         blocksmax = (blocksmax or resource.get('quota_blocks') or DEFAULT_QUOTA['quota_blocks'])
         inodemax  = (inodemax  or resource.get('quota_files')  or DEFAULT_QUOTA['quota_files'])
         self.set_quota(uuid, blocksmax.to_i, inodemax.to_i)
@@ -229,7 +230,7 @@ module OpenShift
       end
 
       def self.init_pam_limits(uuid, limits={})
-        resource =OpenShift::Config.new('/etc/openshift/resource_limits.conf')
+        resource = ::OpenShift::Runtime::Utils::Cgroups::Config.new
         limits_order = (resource.get('limits_order') or DEFAULT_PAM_LIMITS_ORDER)
         limits_file = PathUtils.join(DEFAULT_PAM_LIMITS_DIR, "#{limits_order}-#{uuid}.conf")
 
@@ -263,7 +264,7 @@ module OpenShift
       end
 
       def self.get_pam_limits(uuid)
-        resource = OpenShift::Config.new('/etc/openshift/resource_limits.conf')
+        resource = ::OpenShift::Runtime::Utils::Cgroups::Config.new
         limits_order = (resource.get('limits_order') or DEFAULT_PAM_LIMITS_ORDER)
         limits_file = PathUtils.join(DEFAULT_PAM_LIMITS_DIR, "#{limits_order}-#{uuid}.conf")
 
@@ -308,7 +309,7 @@ module OpenShift
       end
 
       def self.remove_pam_limits(uuid)
-        resource = OpenShift::Config.new('/etc/openshift/resource_limits.conf')
+        resource = ::OpenShift::Runtime::Utils::Cgroups::Config.new
         limits_order = (resource.get('limits_order') or DEFAULT_PAM_LIMITS_ORDER)
         limits_file = PathUtils.join(DEFAULT_PAM_LIMITS_DIR, "#{limits_order}-#{uuid}.conf")
         begin

--- a/node/lib/openshift-origin-node/utils/cgroups.rb
+++ b/node/lib/openshift-origin-node/utils/cgroups.rb
@@ -13,23 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #++
-require 'openshift-origin-common/config'
 
+require_relative 'cgroups/config'
 require_relative 'cgroups/libcgroup'
 
 module OpenShift
   module Runtime
     module Utils
       class Cgroups
-
-        # Subclass OpenShift::Config so we can split the values easily
-        class Config < ::OpenShift::Config
-          def get(key)
-            super(key.gsub('.','_'))
-          end
-        end
-
-
         @@TEMPLATE_SET = {
           :default => [ :default, :default? ],
           :boosted => [ :boost, :boosted? ],
@@ -69,7 +60,7 @@ module OpenShift
 
         def templates
           if not @@templates_cache
-            res = Config.new('/etc/openshift/resource_limits.conf')
+            res = Cgroups::Config.new
             @@templates_cache={ :default => {} }
 
             @@TEMPLATE_SET.each do |templ, calls|

--- a/node/lib/openshift-origin-node/utils/cgroups/config.rb
+++ b/node/lib/openshift-origin-node/utils/cgroups/config.rb
@@ -1,0 +1,21 @@
+require 'openshift-origin-common/config'
+
+module OpenShift
+  module Runtime
+    module Utils
+      class Cgroups
+        # Subclass OpenShift::Config so we can split the values easily
+        class Config < ::OpenShift::Config
+          RESOURCE_LIMITS_FILE = PathUtils.join(CONF_DIR, 'resource_limits.conf')
+          def initialize(conf_path = RESOURCE_LIMITS_FILE, defaults = {})
+            super
+          end
+
+          def get(key)
+            super(key.gsub('.','_'))
+          end
+        end
+      end
+    end
+  end
+end

--- a/node/lib/openshift-origin-node/utils/cgroups/config.rb
+++ b/node/lib/openshift-origin-node/utils/cgroups/config.rb
@@ -12,7 +12,24 @@ module OpenShift
           end
 
           def get(key)
-            super(key.gsub('.','_'))
+            val = super(key.gsub('.','_'))
+            parse_value(val)
+          end
+
+          # Parse values into usable formats
+          # This is useful for storing values, such as byte values, in a human readable format
+          #
+          # NOTE: This function is also copied into the following files and must be updated if this is changed
+          #         - plugins/msg-node/mcollective/facts/openshift_facts.rb
+          #         - node-util/bin/oo-accept-node b/node-util/bin/oo-accept-node
+          def parse_value(val)
+            # Convert prefixed byte values to bytes
+            factors = { k: 1, m: 2, g: 3, t: 4 }
+            val.match(/^(\d+)(#{factors.keys.join('|')})b?/i) do |mg|
+              (num,unit) = mg[1,2]
+              val = num.to_i * ((2**10)**factors[unit.downcase.to_sym])
+            end
+            val
           end
         end
       end

--- a/node/lib/openshift-origin-node/utils/cgroups/throttler.rb
+++ b/node/lib/openshift-origin-node/utils/cgroups/throttler.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/numeric/time'
 require 'openshift-origin-node/utils/cgroups'
 require 'syslog'
 require_relative 'monitored_gear'
+require_relative 'config'
 
 module OpenShift
   module Runtime
@@ -13,8 +14,6 @@ module OpenShift
 
           attr_reader :wanted_keys, :uuids, :running_apps, :threshold, :interval
 
-          @@conf_file = '/etc/openshift/resource_limits.conf'
-
           def initialize
             # Make sure we create a MonitoredGear for the root OpenShift cgroup
             # Keys for information we want from cgroups
@@ -23,7 +22,9 @@ module OpenShift
             @mutex = Mutex.new
             @uuids = []
 
-            throttler_config = ::OpenShift::Runtime::Utils::Cgroups::Config.new(@@conf_file).get_group('cg_template_throttled')
+            @config = Cgroups::Config.new
+
+            throttler_config = @config.get_group('cg_template_throttled')
 
             # Set the interval to save
             @interval = throttler_config.get('apply_period').to_i rescue nil

--- a/node/lib/openshift-origin-node/utils/tc.rb
+++ b/node/lib/openshift-origin-node/utils/tc.rb
@@ -20,6 +20,8 @@ require 'tempfile'
 require 'fileutils'
 require 'etc'
 
+require_relative 'cgroups/config'
+
 $OPENSHIFT_RUNTIME_UTILS_TC_MUTEX = Mutex.new
 
 module OpenShift
@@ -44,7 +46,7 @@ module OpenShift
           @output = []
 
           @config    = ::OpenShift::Config.new('/etc/openshift/node.conf')
-          @resources = ::OpenShift::Config.new('/etc/openshift/resource_limits.conf')
+          @resources = ::OpenShift::Runtime::Utils::Cgroups::Config.new
 
           # ============================================================================
           #  Functions for setting the net class


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=983631

Some values are easier to use and less error prone if
specified in human-readable format, such as "1GB" instead of
"1073741824".
