### PR TITLE
Admin stats tests

### DIFF
--- a/broker/test/coverage_helper.rb
+++ b/broker/test/coverage_helper.rb
@@ -30,7 +30,6 @@ SimpleCov.add_filter StringFilter.new("openshift-origin-billing")
 SimpleCov.add_filter StringFilter.new("openshift-origin-dns")
 SimpleCov.add_filter StringFilter.new("openshift-origin-auth")
 SimpleCov.add_filter StringFilter.new("openshift-origin-admin-console")
-SimpleCov.add_filter StringFilter.new("/models/admin/")
 
 SimpleCov.start 'rails' do
   coverage_dir 'test/coverage/'

--- a/broker/test/functional/admin_stats_db_test.rb
+++ b/broker/test/functional/admin_stats_db_test.rb
@@ -1,0 +1,58 @@
+ENV["TEST_NAME"] = "admin_stats_db_test"
+# Although there's no controller that uses Admin::Stats, we need some
+# applications in the DB to test that its parsing of mongo documents
+# is working. So, we'll use functional test techniques to create those
+# and then test that Stats doesn't choke on anything.
+require 'test_helper'
+class AdminStatsDbTest < ActionController::TestCase
+
+  # yanked almost verbatim from application_test.rb
+  def setup
+    @controller = ApplicationsController.new
+
+    @random = rand(1000000000)
+    @login = "user#{@random}"
+    @password = "password"
+    @user = CloudUser.new(login: @login)
+    @user.save
+    Lock.create_lock(@user)
+    register_user(@login, @password)
+
+    @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['HTTP_ACCEPT'] = "application/json"
+    stubber
+    @namespace = "ns#{@random}"
+    @domain = Domain.new(namespace: @namespace, owner:@user)
+    @domain.save
+  end
+
+  def teardown
+    begin
+      @user.force_delete
+    rescue
+    end
+  end
+
+  test "create some apps and check that stats work out" do
+    # create a PHP app
+    php_app = "app#{@random}php"
+    post :create, {"name" => php_app, "cartridge" => PHP_VERSION, "domain_id" => @domain.namespace}
+    assert_response :created
+    # Add other apps with problematic data to test
+
+    # run some stats assuming the created app(s)
+    stats = Admin::Stats.new
+    c = {}
+    assert_nothing_raised { c[:all], c[:profile], c[:user] = stats.get_db_stats }
+    assert c[:all][:apps] >= 1, "number of apps should be at least what we created"
+    assert c[:all][:users_with_num_apps][1] >= 1,
+      "number of users with our user's number of apps should be at least 1"
+    assert c[:all][:cartridges_short]['php'] >= 1,
+      "number of php carts should be at least what we created"
+    assert c[:user].has_key?(@login), "our user should be in the results"
+
+    # delete any apps created
+    delete :destroy , {"id" => php_app, "domain_id" => @domain.namespace}
+    assert_response :ok
+  end
+end

--- a/broker/test/unit/admin_stats_test.rb
+++ b/broker/test/unit/admin_stats_test.rb
@@ -1,0 +1,167 @@
+require 'test_helper'
+
+class AdminStatsTest < ActiveSupport::TestCase
+  def setup
+    super
+    @stats = Admin::Stats.new
+    @dist_uuid = "1234"
+    @node_details = {
+      node_profile: "test",
+      district_uuid: @dist_uuid,
+      district_active: "true",
+      max_active_gears: 10,
+      gears_started_count: 7,
+      gears_idle_count: 10,
+      gears_stopped_count: 3,
+      gears_deploying_count: 2,
+      gears_unknown_count: 1,
+      gears_total_count: 23,
+      gears_active_count: 10,
+      gears_usage_pct: 230,
+      gears_active_usage_pct: 100,
+    }
+    @node_name = "test-node.example.com"
+    @short_name = "test-node"
+    OpenShift::ApplicationContainerProxy.stubs(:get_details_for_all).returns({
+      @node_name => @node_details,
+      "clone.example.com" => @node_details.merge(district_uuid: "NONE"),
+    })
+
+    @db = Class.new do # mock what :_with_each_record needs
+      def collection(name, &block); @name = name; @block = block; self; end
+      def find(*args, &block); block.call(self); end
+      def each(&block)
+        coll = {
+          :districts => [{
+                          'gear_size' => "test",
+                          'name' => "1234_district",
+                          'uuid' => '1234',
+                          'server_identities' => [ {'name' => "test-node.example.com",
+                                                    'active' => true },
+                                                   {'name' => "missing.example.com",
+                                                    'active' => true }
+                                                 ],
+                          'max_capacity' => 6000,
+                          'available_capacity' => 3,
+                          'available_uids' => [1,2,3,4,5],
+                       }],
+          # the other ones are too complex to stub...
+          :cloud_users => [],
+          :domains => [],
+          :applications => [],
+        }
+        coll[@name].each {|hash| block.call(hash) }
+      end
+    end
+    @db = @db.new
+    OpenShift::DataStore.stubs(:db).returns(@db)
+  end
+
+  def teardown
+    super
+    OpenShift::ApplicationContainerProxy.unstub(:get_details_for_all)
+    OpenShift::DataStore.unstub(:db)
+  end
+
+  test "fetch and return list of node details" do
+    node_hash = @stats.get_node_entries
+    assert node_hash.has_key?(@node_name),
+      "expecting to see #{@node_name} in node hash"
+    assert_equal @short_name, node_hash[@node_name][:name]
+    assert_equal 2, node_hash.size
+  end
+
+  test "fetch a list of districts from the db" do
+    dist_hash = @stats.get_district_entries
+    assert_equal 1, dist_hash.size, "should be 1 district in db: #{dist_hash}"
+    assert dist_hash.has_key?(@dist_uuid),
+      "expecting to see #{@dist_uuid} in district hash"
+    assert_equal 5, dist_hash[@dist_uuid][:dist_avail_uids]
+    assert dist_hash[@dist_uuid][:nodes].has_key?(@node_name),
+      "expecting to see #{@node_name} in the node list for district #{@dist_uuid}"
+  end
+
+  test "summarize district details" do
+    sum_hash = @stats.summarize_districts(@stats.get_district_entries, @stats.get_node_entries)
+    assert_equal 2, sum_hash.size, "number of districts to summarize (one is NONE)"
+    assert sum_hash.has_key?(@dist_uuid), "expecting district #{@dist_uuid}"
+    assert sum_hash.has_key?('NONE profile=test'), "expecting district NONE"
+    assert_equal 0, sum_hash[@dist_uuid][:effective_available_gears]
+    assert_equal 1, sum_hash[@dist_uuid][:missing_nodes].size,
+      "missing.example.com should be missing"
+  end
+
+  test "getting db stats" do
+    count_all, count_for_profile, count_for_user = @stats.get_db_stats
+    # there won't be a lot but we can spot check the counts are there...
+    assert count_all.has_key?(:apps), "count_all should have :apps"
+    assert count_all.has_key?(:cartridges), "count_all should have :cartridges"
+    assert_equal 0, count_all[:cartridges]['ruby'], "expecting cart counts 0"
+
+    assert_empty count_for_profile, "count_for_profile not filled from db"
+    assert_empty count_for_user, "Expecting no users in fake db"
+  end
+
+  test "clearing on clones of the results allows marshaling" do
+    # first test on something ordinary
+    h = Hash.new {|h,k| h[k] = 0}
+    assert_raise(TypeError) {Marshal.dump(h)}
+    @stats.deep_clear_default!(h)
+    assert_nothing_raised {Marshal.dump(h)}
+
+    # now test on stats we gathered
+    @stats.gather_statistics
+    results = @stats.results
+    assert_raise(TypeError) {Marshal.dump(results)}
+    @stats.deep_clear_default!(results)
+    assert_nothing_raised { Marshal.dump(results) }
+  end
+
+  test "summarize profile details without db stats" do
+    sum_hash = @stats.summarize_districts(@stats.get_district_entries, @stats.get_node_entries)
+    pro_hash = @stats.summarize_profiles(sum_hash, nil)
+    assert pro_hash.has_key?('test'), "should see profile 'test'"
+    test_p = pro_hash['test']
+    assert_includes test_p[:districts], sum_hash[@dist_uuid]
+    assert_equal 2, test_p[:district_count], "district count"
+    assert_equal 2, test_p[:nodes_count], "node count"
+    assert_equal 2, test_p[:nodes_active], "active nodes (2 responding)"
+    assert_equal 0, test_p[:nodes_inactive], "inactive nodes (according to selves)"
+    assert_equal 1, test_p[:missing_nodes].size, "missing.example.com should be missing"
+  end
+
+  test "summarize profile details with db stats" do
+    count_all, count_for_profile, count_for_user = @stats.get_db_stats
+    dist_hash = @stats.summarize_districts(@stats.get_district_entries, @stats.get_node_entries)
+    pro_hash = @stats.summarize_profiles(dist_hash, count_for_profile)
+    test_d = dist_hash[@dist_uuid]
+    assert pro_hash.has_key?('test'), "should see profile 'test'"
+    test_p = pro_hash['test']
+    # summed district stats
+    assert_equal 6000, test_p[:district_capacity], "1 district's capacity"
+    assert_equal 3, test_p[:dist_avail_capacity], "1 district's available capacity"
+    assert test_p[:highest_dist_usage_pct] > 5996.0 / 6000,
+      "our test district should supply the highest usage pct"
+    assert_equal 0.0, test_p[:lowest_dist_usage_pct],
+      "fake district should report 0 usage pct"
+    # summed db stats
+    assert_equal 0, test_p[:total_gears_in_db_records], "no gears in db"
+    assert_equal 0, test_p[:total_apps], "no apps in db"
+    assert_equal 0, test_p[:cartridges].size, "no cartridges in db"
+    assert_equal 0, test_p[:cartridges_short].size, "no short cartridges in db"
+    assert_equal -2 * @node_details[:gears_total_count],
+                 test_p[:gear_count_db_minus_node],
+                  "node gears are not in db"
+  end
+
+  test "db option appropriately influences stats gathering" do
+    @stats.gather_statistics
+    assert_nil @stats.results[:count_all][:apps],
+      "expecting no db app counting to have occurred"
+    @stats.set_option :db_stats => true
+    @stats.gather_statistics
+    assert_not_nil @stats.results[:count_all][:apps],
+      "expecting db counting has occurred"
+  end
+
+end

--- a/controller/app/models/admin/stats.rb
+++ b/controller/app/models/admin/stats.rb
@@ -498,7 +498,8 @@ class Admin::Stats
         app['component_instances'].each do |comp|
           carts_for_group[gid = comp['group_instance_id']] << (cart = comp['cartridge_name'])
           # from "foo-bar-1.1" we want "foo-bar" for the short name
-          short_carts_for_group[gid] << cart.match(/^  ([-\w]+)  -  [\d.]+  $/x)[1]
+          cart.match(/^  ([-\w]+)  -  [\d.]+  $/x)
+          short_carts_for_group[gid] << ($1 || cart)
         end
         # now walk the gears and count up everything.
         # group_instances contain arrays of like-minded gears.

--- a/controller/app/models/admin/stats.rb
+++ b/controller/app/models/admin/stats.rb
@@ -21,7 +21,6 @@ class Admin::Stats
   def initialize(options = nil)
     @options = options || {}
     @time = {}
-    # Get a read-only DB connection (to a secondary if possible)
   end
 
   # Currently only option is :db_stats which table scans the DB and is kind of expensive
@@ -29,6 +28,7 @@ class Admin::Stats
   def set_option(options)
     @options.merge! options
   end
+
 
   # use to time an operation in milliseconds
   def time_msecs
@@ -39,7 +39,6 @@ class Admin::Stats
 
   # gather all statistics and analyze
   def gather_statistics
-    @db = OpenShift::DataStore.db
     # read method comments about the structures they return
     @time[:get_node_entries] = time_msecs { @entry_for_node = get_node_entries }
     @time[:get_district_entries] = time_msecs { @entry_for_district = get_district_entries }
@@ -58,7 +57,6 @@ class Admin::Stats
     @count_all[:nodes] = @entry_for_node.size
     @count_all[:districts] = @entry_for_district.size
     @count_all[:profiles] = @summary_for_profile.size
-    @db = nil
     return @time
   end
 
@@ -122,7 +120,7 @@ class Admin::Stats
     #   "node2.example.com" => ...
     # }
     detail_names = %w[
-      node_profile district_uuid
+      node_profile district_uuid district_active
       max_active_gears gears_started_count
       gears_idle_count gears_stopped_count gears_deploying_count
       gears_unknown_count gears_total_count gears_active_count
@@ -333,7 +331,7 @@ class Admin::Stats
     #      :available_active_gears => 173, # how many more active gears the nodes will support
     #
     #      # the following are usage numbers according to the DB, if collected
-    #      :total_db_gears        => 27,  # gears recorded with this profile in the DB
+    #      :total_gears_in_db_records => 27,  # gears recorded with this profile in the DB
     #      :total_apps            => 20,  # apps recorded with this profile in the DB
     #      :cartridges            => { cartridge counts as in get_db_stats }
     #      :cartridges_short      => { cartridge short name counts as in get_db_stats }
@@ -536,13 +534,14 @@ class Admin::Stats
     return count_all, count_for_profile, count_for_user
   end
 
-  def _with_each_record(collection_name, query, selection)
-    coll = @db.collection(collection_name)
-    coll.find(query, selection) do |mcursor|
-      mcursor.each do |hash|
-        yield hash
+  def _with_each_record(collection_name, query, selection, &block)
+    OpenShift::DataStore.db.
+      collection(collection_name).
+      find(query, selection) do |mcursor|
+        mcursor.each do |hash|
+          block.call(hash)
+        end
       end
-    end
   end
 
 end #class OpenShift::Admin::Stats


### PR DESCRIPTION
rake test:mine

**\* Mocha deprecation warning: Change `require 'mocha'` to `require 'mocha/setup'`.

/root/openshift-test/broker/test/test_helper.rb:13: warning: already initialized constant RUBY_VERSION
Run options: 

Running tests:

.........

Finished tests in 4.035828s, 2.2300 tests/s, 12.3890 assertions/s.

9 tests, 50 assertions, 0 failures, 0 errors, 0 skips
