### PR TITLE
Fix runtime-extended tests for jboss cartridges

### DIFF
--- a/controller/test/cucumber/cartridge-lifecycle-jbossas.feature
+++ b/controller/test/cucumber/cartridge-lifecycle-jbossas.feature
@@ -11,17 +11,19 @@ Feature: Cartridge Lifecycle JBossAS Verification Tests
     Then the applications should display default content on first attempt
     Given an existing jbossas-7 application
     When the jboss application is changed to multiartifact
-    Then the application should display default content for all artifacts on first attempt
-    When the jboss application deployment-scanner is changed to archive only
-    Then only archive artifacts should be deployed
+    Then the application should display default content for deployed artifacts on first attempt
+    And default artifacts should be deployed
+    When the jboss application deployment-scanner is changed to all
+    Then the application should display default content for deployed artifacts on first attempt
+    And all artifacts should be deployed
     When the jboss application deployment-scanner is changed to exploded only
     Then only exploded artifacts should be deployed
     When the jboss application deployment-scanner is changed to none
     Then no artifacts should be deployed
     When the jboss application deployment-scanner is changed to disabled
     Then deployment verification should be skipped with scanner disabled message
-    When the jboss application deployment-scanner is changed to all
-    Then all artifacts should be deployed
+    When the jboss application deployment-scanner is changed to archive only
+    Then only archive artifacts should be deployed
     When the jboss management interface is disabled
     Then deployment verification should be skipped with management unavailable message
     When the application is changed

--- a/controller/test/cucumber/cartridge-lifecycle-jbosseap.feature
+++ b/controller/test/cucumber/cartridge-lifecycle-jbosseap.feature
@@ -14,19 +14,21 @@ Feature: Cartridge Lifecycle JBossEAP Verification Tests
   #Scenario: Multiartifact 
     Given an existing jbosseap-6.0 application
     When the jboss application is changed to multiartifact
-    Then the application should display default content for all artifacts on first attempt
+    Then the application should display default content for deployed artifacts on first attempt
+    And default artifacts should be deployed
 
   #Scenario: Deployment Scanner Modification
-    When the jboss application deployment-scanner is changed to archive only
-    Then only archive artifacts should be deployed
+    When the jboss application deployment-scanner is changed to all
+    Then the application should display default content for deployed artifacts on first attempt
+    And all artifacts should be deployed
     When the jboss application deployment-scanner is changed to exploded only
     Then only exploded artifacts should be deployed
     When the jboss application deployment-scanner is changed to none
     Then no artifacts should be deployed
     When the jboss application deployment-scanner is changed to disabled
     Then deployment verification should be skipped with scanner disabled message
-    When the jboss application deployment-scanner is changed to all
-    Then all artifacts should be deployed
+    When the jboss application deployment-scanner is changed to archive only
+    Then only archive artifacts should be deployed
 
   #Scenario: Management Interface Unavailable
     When the jboss management interface is disabled

--- a/controller/test/cucumber/step_definitions/application_steps.rb
+++ b/controller/test/cucumber/step_definitions/application_steps.rb
@@ -411,16 +411,7 @@ Then /^the application should display default content on first attempt$/ do
   body.should match(/Welcome to OpenShift/)
 end
 
-Then /^the application should display default content for all artifacts on first attempt$/ do
-  result = run("grep 'Failed deployments:' " + @app.get_log("git_push_multiartifact"))
-  result.should_not == 0
-
-  result = run("grep 'Artifacts in an unknown state:' " + @app.get_log("git_push_multiartifact"))
-  result.should_not == 0
-
-  result = run("grep 'Artifacts skipped because of deployment-scanner configuration:' " + @app.get_log("git_push_multiartifact"))
-  result.should_not == 0
-
+Then /^the application should display default content for deployed artifacts on first attempt$/ do
   output=[]
   result = run("grep 'Artifacts deployed:' " + @app.get_log("git_push_multiartifact"), output)
   result.should == 0
@@ -458,7 +449,7 @@ Then /^deployment verification should be skipped with (scanner disabled|manageme
   run("grep 'Artifacts deployed:' " + logfile).should_not == 0
 end
 
-Then /^(only exploded|only archive|no|all) artifacts should be deployed$/ do |scanner_config|
+Then /^(only exploded|only archive|no|all|default) artifacts should be deployed$/ do |scanner_config|
   case scanner_config
   when 'no'
     log_postfix = "none"
@@ -468,6 +459,8 @@ Then /^(only exploded|only archive|no|all) artifacts should be deployed$/ do |sc
     log_postfix = "exploded"
   when 'only archive'
     log_postfix = "archive"
+  when 'default'
+    log_postfix = "multiartifact"
   end
 
   logfile = @app.get_log("git_push_scanner_config_#{log_postfix}")


### PR DESCRIPTION
The jboss cartridge cartridge-lifecycle-jboss{as,eap}.feature scripts
were assuming all artifacts (exploded and archive) were being deployed
after multi-artifact deployment, when the deployment-scanner was
reverted back to deploying only archive artifacts it broke this
assumption.
