### PR TITLE
[TO_STAGE] Fixing has_app method in mcollective

### DIFF
--- a/msg-common/agent/openshift.ddl
+++ b/msg-common/agent/openshift.ddl
@@ -133,6 +133,31 @@ action "set_district", :description => "run a cartridge action" do
            :display_as => "Exit Code"
 end
 
+action "has_gear", :description => "Does this server contain a specified gear?" do
+    display :always
+
+    input :uuid,
+        :prompt         => "Gear uuid",
+        :description    => "Gear uuid",
+        :type           => :string,
+        :validation     => '^[a-zA-Z0-9]+$',
+        :optional       => false,
+        :maxlength      => 32
+
+    output  :time,
+            :description => "The time as a message",
+            :display_as => "Time"
+
+    output  :output,
+            :description => "true or false",
+            :display_as => "Output"
+
+    output :exitcode,
+           :description => "Exit code",
+           :display_as => "Exit Code"
+end
+
+
 action "has_app", :description => "Does this server contain a specified app?" do
     display :always
 

--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -2509,7 +2509,7 @@ module OpenShift
       # * OpenShift::UserException
       #
       # NOTES:
-      # * uses find_app
+      # * uses find_gear
       # * uses sanitize_result
       #
       def parse_result(mcoll_reply, gear=nil, command=nil)
@@ -2522,7 +2522,7 @@ module OpenShift
           output = mcoll_result.results[:data][:output]
           result.exitcode = mcoll_result.results[:data][:exitcode]
         else
-          server_identity = app ? MCollectiveApplicationContainerProxy.find_app(app.uuid, app.name) : nil
+          server_identity = app ? MCollectiveApplicationContainerProxy.find_gear(gear.uuid) : nil
           if server_identity && @id != server_identity
             raise OpenShift::InvalidNodeException.new("Node execution failure (invalid  node).", 143, nil, server_identity)
           else
@@ -2547,24 +2547,22 @@ module OpenShift
       end
 
       #
-      # Returns the server identity of the specified app
+      # Returns the server identity of the specified gear
       #
       # INPUTS:
-      # * app_uuid: String
-      # * app_name: String
+      # * gear_uuid: String
       #
       # RETURNS:
-      # * server identity (string?)
+      # * server identity (string)
       #
       # NOTES:
       # * uses rpc_exec
       # * loops over all nodes
       #
-      def self.find_app(app_uuid, app_name)
+      def self.find_gear(gear_uuid)
         server_identity = nil
         rpc_exec('openshift') do |client|
-          client.has_app(:uuid => app_uuid,
-                         :application => app_name) do |response|
+          client.has_gear(:uuid => gear_uuid) do |response|
             output = response[:body][:data][:output]
             if output == true
               server_identity = response[:senderid]
@@ -2589,10 +2587,9 @@ module OpenShift
       # * loops over all nodes
       # * No longer being used
       #
-      def has_app?(app_uuid, app_name)
+      def has_gear?(gear_uuid)
         MCollectiveApplicationContainerProxy.rpc_exec('openshift', @id) do |client|
-          client.has_app(:uuid => app_uuid,
-                         :application => app_name) do |response|
+          client.has_gear(:uuid => gear_uuid) do |response|
             output = response[:body][:data][:output]
             return output == true
           end

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -879,11 +879,16 @@ module MCollective
       # Returns whether an app is on a server
       #
       def has_app_action
+        has_gear_action
+      end
+
+      #
+      # Returns whether a gear is on a server
+      #
+      def has_gear_action
         validate :uuid, /^[a-zA-Z0-9]+$/
-        validate :application, /^[a-zA-Z0-9]+$/
-        uuid = request[:uuid].to_s if request[:uuid]
-        app_name = request[:application]
-        if File.exist?("/var/lib/openshift/#{uuid}/#{app_name}")
+        uuid = request[:uuid].to_s
+        if File.exist?("/var/lib/openshift/#{uuid}")
           reply[:output] = true
         else
           reply[:output] = false


### PR DESCRIPTION
Maintaining N-1 compatibility since the parse_result method in the mcollective proxy uses find_app (that uses has_app)
