### PR TITLE
<JBoss Cartridges> - Move deployment verification to client_result

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/control
@@ -82,19 +82,19 @@ function waitondeployments() {
         popd
 
         if [ ${#artifactsskipped[@]} -gt 0 ]; then
-          client_message "Artifacts skipped because of deployment-scanner configuration: ${artifactsskipped[*]}"
+          client_result "Artifacts skipped because of deployment-scanner configuration: ${artifactsskipped[*]}"
         fi
   
         if [ ${#artifactsfailed[@]} -gt 0 ]; then
-          client_message "Failed deployments: ${artifactsfailed[*]}"
+          client_result "Failed deployments: ${artifactsfailed[*]}"
         fi
   
         if [ ${#artifactsdeployed[@]} -gt 0 ]; then
-          client_message "Artifacts deployed: ${artifactsdeployed[*]}"
+          client_result "Artifacts deployed: ${artifactsdeployed[*]}"
         fi
   
         if [ ${#artifactsunknown[@]} -gt 0 ]; then
-          client_message "Artifacts in an unknown state: ${artifactsunknown[*]}"
+          client_result "Artifacts in an unknown state: ${artifactsunknown[*]}"
         fi
       else
           client_message "Deployment scanner disabled, skipping deployment verification"

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/control
@@ -82,19 +82,19 @@ function waitondeployments() {
         popd
 
         if [ ${#artifactsskipped[@]} -gt 0 ]; then
-          client_message "Artifacts skipped because of deployment-scanner configuration: ${artifactsskipped[*]}"
+          client_result "Artifacts skipped because of deployment-scanner configuration: ${artifactsskipped[*]}"
         fi
 
         if [ ${#artifactsfailed[@]} -gt 0 ]; then
-          client_message "Failed deployments: ${artifactsfailed[*]}"
+          client_result "Failed deployments: ${artifactsfailed[*]}"
         fi
 
         if [ ${#artifactsdeployed[@]} -gt 0 ]; then
-          client_message "Artifacts deployed: ${artifactsdeployed[*]}"
+          client_result "Artifacts deployed: ${artifactsdeployed[*]}"
         fi
 
         if [ ${#artifactsunknown[@]} -gt 0 ]; then
-          client_message "Artifacts in an unknown state: ${artifactsunknown[*]}"
+          client_result "Artifacts in an unknown state: ${artifactsunknown[*]}"
         fi
       else
           client_message "Deployment scanner disabled, skipping deployment verification"


### PR DESCRIPTION
Previously all deployment verification messages were sent to
client_message, move the deployed/non-deployed messages to client_result

[test]
