### PR TITLE
Card online_runtime_197

### DIFF
--- a/cartridges/openshift-origin-cartridge-postgresql/openshift-origin-cartridge-postgresql.spec
+++ b/cartridges/openshift-origin-cartridge-postgresql/openshift-origin-cartridge-postgresql.spec
@@ -32,10 +32,12 @@ Requires:      %{?scl:%scl_prefix}postgresql-contrib
 Requires:      %{?scl:%scl_prefix}postgresql-plperl
 Requires:      %{?scl:%scl_prefix}postgresql-plpython
 Requires:      %{?scl:%scl_prefix}postgresql-pltcl
+Requires:      postgresql92-postgis
 %endif
 %if 0%{?fedora} >= 19
 Requires:      postgresql >= 9.2
 Requires:      postgresql < 9.3
+Requires:      postgis >= 2
 %endif
 Requires:      postgresql-server
 Requires:      postgresql-libs


### PR DESCRIPTION
Install postgis package from devenv.
With this, a PostgreSQL 9.2 database can now use:

``` sql
CREATE EXTENSION postgis;
```
