### PR TITLE
[TO STAGE] Bug 992464 - Authorization token needs to raise when checking eventual consistency

### DIFF
--- a/broker/test/unit/authentication_test.rb
+++ b/broker/test/unit/authentication_test.rb
@@ -190,9 +190,11 @@ class AuthenticationTest < ActiveSupport::TestCase
 
   test 'should read secondary then primary for authorization tokens on authenticate' do
     qualifier = mock
+    fully = mock
     s = sequence('load')
     Authorization.expects(:with).with(consistency: :eventual).in_sequence(s).returns(qualifier)
-    qualifier.expects(:where).with(:token => 'foo').in_sequence(s).raises(Mongoid::Errors::DocumentNotFound.new(Authorization, nil, ['foo']))
+    qualifier.expects(:where).with(:token => 'foo').in_sequence(s).returns(fully)
+    fully.expects(:find_by).in_sequence(s).raises(Mongoid::Errors::DocumentNotFound.new(Authorization, nil, ['foo']))
     Authorization.expects(:where).with(:token => 'foo').in_sequence(s).returns([true])
 
     assert Authorization.authenticate('foo')

--- a/controller/app/models/authorization.rb
+++ b/controller/app/models/authorization.rb
@@ -44,7 +44,7 @@ class Authorization
   scope :not_expired, lambda{ where(:expires_at.gt => DateTime.now, :revoked_at => nil) }
 
   def self.authenticate(token)
-    with(consistency: :eventual).where(token: token).first
+    with(consistency: :eventual).where(token: token).find_by
   rescue Mongoid::Errors::DocumentNotFound
     where(token: token).first
   end


### PR DESCRIPTION
Was using .first which returns nil
