### PR TITLE
<broker> improve Gemfile loading + bug 993250

### DIFF
--- a/broker/Gemfile
+++ b/broker/Gemfile
@@ -33,13 +33,25 @@ if ENV['BROKER_SOURCE']
   gem 'openshift-origin-controller', :path => '../controller'
   gem 'netrc' # rest-client has an undeclared prereq on netrc
 
-  # Optionally load plugins from source
-  eval((IO.read(File.expand_path('~/.openshift/broker_plugins.rb')) rescue ''))
+  # Load broker plugins according to local file
+  load File.expand_path(ENV['BROKER_PLUGINS_FILE'] || '~/.openshift/broker_plugins.rb')
 else
   gem 'openshift-origin-controller'
-  
-  # Load plugin gems.
-  Dir["/etc/openshift/plugins.d/*.conf"].delete_if{ |x| x.end_with? "-dev.conf" }.map{|x| File.basename(x, ".conf")}.each {|plugin| gem plugin}
+
+  # Load broker plugin gems specified by .conf files in plugins.d/
+  # Load if either .conf or -dev.conf is present;
+  # Plugins use -dev.conf only in development mode.
+  plugins = Dir[(ENV['OPENSHIFT_CONF_DIR'] || "/etc/openshift") + '/plugins.d/*.conf'].
+              map {|file| File.basename(file, ".conf") }
+  # in development, load if there is a -dev.conf file, even if no prod.conf
+  group :development do
+    plugins.map! {|name| name.sub(/-dev$/, '')}
+  end
+  # otherwise, ignore presence of -dev.conf files
+  group :test, :production do
+    plugins.reject! {|name| name.match /-dev$/}
+  end
+  plugins.sort.uniq.each {|name| gem name}
 end
 
 # Bundle edge Rails instead:

--- a/broker/config/boot.rb
+++ b/broker/config/boot.rb
@@ -1,14 +1,42 @@
 require 'rubygems'
+require 'stringio'
 
+conf_dir = ENV['OPENSHIFT_CONF_DIR'] || '/etc/openshift'
 unless ENV["RAILS_ENV"] == "test"
-  if File.exist?('/etc/openshift/development')
-    ENV["RAILS_ENV"] = "development"
-  else
-    ENV["RAILS_ENV"] = "production"
-  end
+  ENV["RAILS_ENV"] = File.exist?(conf_dir+'/development') ? "development" : "production"
 end
 
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+gem_file = ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+# we have to jump through some hoops to intercept Bundler errors
+captured = StringIO.new
+save_err, save_out, $stderr, $stdout = $stderr, $stdout, captured, captured
+begin
+  require 'bundler/setup' if File.exist?(gem_file)
+rescue Exception # Bundler calls system.exit
+  $stderr, $stdout = save_err, save_out
+  puts "Error while loading gems for the broker:"
+  # show whatever error occurred, without any "bundle install" recommendation
+  puts captured.string.split(/\n/).reject {|line| line.match(/bundle install/)}
+  captured.string.match(/Could not find gem '(\S+)/) do
+    # typically means a plugin or RPM is outright missing
+    name = $1
+    prefix = name.start_with?('openshift-origin') ? "rubygem-"
+           : ENV['PATH'].match(/ruby193/)         ? "ruby193-rubygem-" : "rubygem-"
+    puts "You may need to install the #{prefix + name} RPM."
+    if name.start_with?('openshift-origin')
+      puts "Or, you may need to remove/rename the #{name} conf file(s) in #{conf_dir}/plugins.d"
+    end
+  end
+  captured.string.match(/Could not find (\S+) in any of the sources/) do
+    # means a version mismatch with Gemfile.lock
+    puts "This usually means gem RPMs have been updated and Gemfile.lock is stale."
+    puts "Please restart the openshift-broker service to update it, and try again."
+    # They could just delete Gemfile.lock, but if root regenerates it instead of
+    # httpd, then the next time an update is needed, httpd won't be able to.
+  end
+  raise # we really do not want to proceed, just reword the error
+ensure
+  $stderr, $stdout = save_err, save_out
+end

--- a/common/lib/openshift-origin-common/config.rb
+++ b/common/lib/openshift-origin-common/config.rb
@@ -20,7 +20,7 @@ require 'openshift-origin-common/utils/path_utils'
 
 module OpenShift
   class Config
-    CONF_DIR = '/etc/openshift/'
+    CONF_DIR = ENV['OPENSHIFT_CONF_DIR'] || '/etc/openshift/'
     PLUGINS_DIR = PathUtils.join(CONF_DIR, 'plugins.d/')
     NODE_CONF_FILE = PathUtils.join(CONF_DIR, 'node.conf')
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=993250
Bundler load failures are wrapped and re-interpreted for OpenShift
  instead of telling the user to "bundle install"
OPENSHIFT_CONF_DIR overrides /etc/openshift base for broker config files
Gemfile loads plugins even if just the -dev.conf file is present
Plugins are loaded in sorted order, in case it matters
