### PR TITLE
Better handle applications that use deleted carts

### DIFF
--- a/controller/app/helpers/cartridge_cache.rb
+++ b/controller/app/helpers/cartridge_cache.rb
@@ -75,6 +75,14 @@ class CartridgeCache
 
   end
 
+  # Returns the first cartridge that provides the specified feature,
+  # same as find_cartridge, but raise an OOException if no cartridge is
+  # found.
+
+  def self.find_cartridge_or_raise_exception(feature, app)
+    find_cartridge(feature, app) or raise OpenShift::OOException.new("The application '#{app.name}' requires '#{feature}' but a matching cartridge could not be found")
+  end
+
   def self.find_all_cartridges(requested_feature)
 
     carts = self.cartridges

--- a/controller/app/rest_models/rest_application.rb
+++ b/controller/app/rest_models/rest_application.rb
@@ -78,11 +78,7 @@ class RestApplication < OpenShift::Model
   def initialize(app, url, nolinks=false, applications=nil)
     self.embedded = {}
     app.requires(true).each do |feature|
-      cart = CartridgeCache.find_cartridge(feature, app)
-
-      # raise an exception in case the application cartridge is not found
-      raise OpenShift::OOException.new("The application '#{app.name}' requires '#{feature}' but a matching cartridge could not be found") if cart.nil?
-
+      cart = CartridgeCache.find_cartridge_or_raise_exception(feature, app)
       if cart.is_web_framework?
         self.framework = cart.name
       else
@@ -116,7 +112,7 @@ class RestApplication < OpenShift::Model
     self.members = app.members.map{ |m| RestMember.new(m, app.owner_id == m._id, url, nolinks) }
 
     app.component_instances.each do |component_instance|
-      cart = CartridgeCache::find_cartridge(component_instance.cartridge_name, app)
+      cart = CartridgeCache::find_cartridge_or_raise_exception(component_instance.cartridge_name, app)
 
       # add the builder properties if this is a builder component
       if cart.categories.include?("ci_builder")
@@ -145,7 +141,7 @@ class RestApplication < OpenShift::Model
         apps = applications || app.domain.applications
         apps.each do |domain_app|
           domain_app.component_instances.each do |component_instance|
-            cart = CartridgeCache::find_cartridge(component_instance.cartridge_name, domain_app)
+            cart = CartridgeCache::find_cartridge_or_raise_exception(component_instance.cartridge_name, domain_app)
             if cart.categories.include?("ci")
               self.building_app = domain_app.name
               break

--- a/controller/app/rest_models/rest_application10.rb
+++ b/controller/app/rest_models/rest_application10.rb
@@ -80,11 +80,7 @@ class RestApplication10 < OpenShift::Model
   def initialize(app, url, nolinks=false, applications=nil)
     self.embedded = {}
     app.requires(true).each do |feature|
-      cart = CartridgeCache.find_cartridge(feature, app)
-
-      # raise an exception in case the application cartridge is not found
-      raise OpenShift::OOException.new("The application '#{app.name}' requires '#{feature}' but a matching cartridge could not be found") if cart.nil?
-
+      cart = CartridgeCache.find_cartridge_or_raise_exception(feature, app)
       if cart.categories.include? "web_framework"
         self.framework = cart.name
       else
@@ -121,7 +117,7 @@ class RestApplication10 < OpenShift::Model
     self.build_job_url = nil
 
     app.component_instances.each do |component_instance|
-      cart = CartridgeCache::find_cartridge(component_instance.cartridge_name, app)
+      cart = CartridgeCache::find_cartridge_or_raise_exception(component_instance.cartridge_name, app)
       # add the builder properties if this is a builder component
       if cart.categories.include?("ci_builder")
         self.building_with = cart.name
@@ -148,7 +144,7 @@ class RestApplication10 < OpenShift::Model
         apps = applications || app.domain.applications
         apps.each do |domain_app|
           domain_app.component_instances.each do |component_instance|
-            cart = CartridgeCache::find_cartridge(component_instance.cartridge_name, domain_app)
+            cart = CartridgeCache::find_cartridge_or_raise_exception(component_instance.cartridge_name, domain_app)
             if cart.categories.include?("ci")
               self.building_app = domain_app.name
               break

--- a/controller/app/rest_models/rest_application13.rb
+++ b/controller/app/rest_models/rest_application13.rb
@@ -5,11 +5,7 @@ class RestApplication13 < OpenShift::Model
   def initialize(app, url, nolinks=false, applications=nil)
     self.embedded = {}
     app.requires(true).each do |feature|
-      cart = CartridgeCache.find_cartridge(feature, app)
-
-      # raise an exception in case the application cartridge is not found
-      raise OpenShift::OOException.new("The application '#{app.name}' requires '#{feature}' but a matching cartridge could not be found") if cart.nil?
-
+      cart = CartridgeCache.find_cartridge_or_raise_exception(feature, app)
       if cart.categories.include? "web_framework"
         self.framework = cart.name
       else
@@ -41,7 +37,7 @@ class RestApplication13 < OpenShift::Model
     self.initial_git_url = app.init_git_url
 
     app.component_instances.each do |component_instance|
-      cart = CartridgeCache::find_cartridge(component_instance.cartridge_name, app)
+      cart = CartridgeCache::find_cartridge_or_raise_exception(component_instance.cartridge_name, app)
       # add the builder properties if this is a builder component
       if cart.categories.include?("ci_builder")
         self.building_with = cart.name
@@ -68,7 +64,7 @@ class RestApplication13 < OpenShift::Model
         apps = applications || app.domain.applications
         apps.each do |domain_app|
           domain_app.component_instances.each do |component_instance|
-            cart = CartridgeCache::find_cartridge(component_instance.cartridge_name, domain_app)
+            cart = CartridgeCache::find_cartridge_or_raise_exception(component_instance.cartridge_name, domain_app)
             if cart.categories.include?("ci")
               self.building_app = domain_app.name
               break

--- a/controller/app/rest_models/rest_application15.rb
+++ b/controller/app/rest_models/rest_application15.rb
@@ -78,11 +78,7 @@ class RestApplication15 < OpenShift::Model
   def initialize(app, url, nolinks=false, applications=nil)
     self.embedded = {}
     app.requires(true).each do |feature|
-      cart = CartridgeCache.find_cartridge(feature, app)
-
-      # raise an exception in case the application cartridge is not found
-      raise OpenShift::OOException.new("The application '#{app.name}' requires '#{feature}' but a matching cartridge could not be found") if cart.nil?
-
+      cart = CartridgeCache.find_cartridge_or_raise_exception(feature, app)
       if cart.categories.include? "web_framework"
         self.framework = cart.name
       else
@@ -116,7 +112,7 @@ class RestApplication15 < OpenShift::Model
     self.members = app.members.map{ |m| RestMember.new(m, app.owner_id == m._id, url, nolinks) }
 
     app.component_instances.each do |component_instance|
-      cart = CartridgeCache::find_cartridge(component_instance.cartridge_name, app)
+      cart = CartridgeCache::find_cartridge_or_raise_exception(component_instance.cartridge_name, app)
 
       # add the builder properties if this is a builder component
       if cart.categories.include?("ci_builder")
@@ -145,7 +141,7 @@ class RestApplication15 < OpenShift::Model
         apps = applications || app.domain.applications
         apps.each do |domain_app|
           domain_app.component_instances.each do |component_instance|
-            cart = CartridgeCache::find_cartridge(component_instance.cartridge_name, domain_app)
+            cart = CartridgeCache::find_cartridge_or_raise_exception(component_instance.cartridge_name, domain_app)
             if cart.categories.include?("ci")
               self.building_app = domain_app.name
               break

--- a/controller/app/rest_models/rest_gear_group.rb
+++ b/controller/app/rest_models/rest_gear_group.rb
@@ -83,10 +83,7 @@ class RestGearGroup < OpenShift::Model
     }
 
     self.cartridges   = group_instance.all_component_instances.map { |component_instance| 
-      cart = CartridgeCache.find_cartridge(component_instance.cartridge_name, app)
-
-      # raise an exception in case the application cartridge is not found
-      raise OpenShift::OOException.new("The application '#{app.name}' requires '#{component_instance.cartridge_name}' but a matching cartridge could not be found") if cart.nil?
+      cart = CartridgeCache.find_cartridge_or_raise_exception(component_instance.cartridge_name, app)
 
       # Handling the case when component_properties is an empty array
       # This can happen if the mongo document is copied and pasted back and saved using a UI tool

--- a/controller/app/rest_models/rest_gear_group15.rb
+++ b/controller/app/rest_models/rest_gear_group15.rb
@@ -80,10 +80,7 @@ class RestGearGroup15 < OpenShift::Model
     }
 
     self.cartridges   = group_instance.all_component_instances.map { |component_instance| 
-      cart = CartridgeCache.find_cartridge(component_instance.cartridge_name, app)
-
-      # raise an exception in case the application cartridge is not found
-      raise OpenShift::OOException.new("The application '#{app.name}' requires '#{component_instance.cartridge_name}' but a matching cartridge could not be found") if cart.nil?
+      cart = CartridgeCache.find_cartridge_or_raise_exception(component_instance.cartridge_name, app)
 
       # Handling the case when component_properties is an empty array
       # This can happen if the mongo document is copied and pasted back and saved using a UI tool


### PR DESCRIPTION
In RestApplication#initialize, raise an UnfulfilledRequirementException
exception in the contingency that the application requires a feature that
is not provided by any cartridge, as can happen if a cartridge on which the
application depends is uninstalled.

In ApplicationsController#show, rescue UnfulfilledRequirementException
exceptions by reporting the problem to the client.

Previously, the user would get a generic "The server did not respond
correctly" message, and a backtrace would be logged.

This commit fixes bug 993440.
