### PR TITLE
List of mirrors to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ information on the community process and how you can get involved.
 Also see our [Contributor Guidelines](CONTRIBUTING.md).
 
 
+Mirrors
+----------------------
+
+The OpenShift Origin content is mirrored on
+[mirror.openshift.com](http://mirror.openshift.com/). This content is also
+available through other mirrors worldwide.
+
+* http://mirror.digmia.com/openshift/ (SK, Europe)
+
 Copyright
 ----------------------
 


### PR DESCRIPTION
We started to offer rsync capability for our mirror at mirror.openshift.com. Some people are starting mirroring it already. We were looking at a good place to list the mirrors and provide more information about it and decided the github README would be a better place then the wiki as it mirrors primarily the Origin content. This list will expand over time, as we release a blog post about this feature too.
