### PR TITLE
Fix runtime extended tests

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/control
@@ -31,6 +31,7 @@ function getscanconfig() {
 function waitondeployments() {
     if ! ismgmtup; then
       client_message "Timed out waiting for management listening port"
+      client_message "Could not connect to JBoss management interface, skipping deployment verification"
     else 
       getscanconfig
 

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/control
@@ -30,7 +30,8 @@ function getscanconfig() {
 # Verify that the deployment scanner has finished running
 function waitondeployments() {
     if ! ismgmtup; then
-        client_message "Timed out waiting for management listening port"
+      client_message "Timed out waiting for management listening port"
+      client_message "Could not connect to JBoss management interface, skipping deployment verification"
     else
       getscanconfig
 


### PR DESCRIPTION
Changes made to openshift-origin-cartrige-jboss{as,eap} casued the
output to change when the management interface is disabled, this fixes
the output and restores sanity to the runtime-extended tests.

@jhonce
