### PR TITLE
Card origin_runtime_213: realtime node_utilization checks

### DIFF
--- a/node/conf/resource_limits.conf
+++ b/node/conf/resource_limits.conf
@@ -29,6 +29,11 @@ quota_blocks=1048576
 # For no over-commit, should be (Total System Memory - 1G) / memory_limit_in_bytes
 max_active_gears=100
 
+# no_overcommit_active enforces max_active_gears in a more stringent manner than normal,
+# however it also adds overhead to gear creation, so should only be set to true
+# when needed, like in the case of enforcing single tenancy on a node.
+no_overcommit_active=false
+
 # PAM - resource limits
 # limits_core
 #<item> can be one of the following:

--- a/node/lib/openshift-origin-node/model/node.rb
+++ b/node/lib/openshift-origin-node/model/node.rb
@@ -40,7 +40,7 @@ module OpenShift
       DEFAULT_PAM_LIMITS       = { 'nproc' => 100 }
 
       DEFAULT_NODE_PROFILE         = 'small'
-      DEFUALT_QUOTA_BLOCKS         = '1048576'
+      DEFAULT_QUOTA_BLOCKS         = '1048576'
       DEFAULT_QUOTA_FILES          = '40000'
       DEFAULT_NO_OVERCOMMIT_ACTIVE = false
       DEFAULT_MAX_ACTIVE_GEARS     = 0
@@ -345,7 +345,7 @@ module OpenShift
 
         resource = resource_limits
         res['node_profile'] = resource.get('node_profile', DEFAULT_NODE_PROFILE)
-        res['quota_blocks'] = resource.get('quota_blocks', DEFUALT_QUOTA_BLOCKS)
+        res['quota_blocks'] = resource.get('quota_blocks', DEFAULT_QUOTA_BLOCKS)
         res['quota_files'] = resource.get('quota_files', DEFAULT_QUOTA_FILES)
         res['no_overcommit_active'] = resource.get_bool('no_overcommit_active', DEFAULT_NO_OVERCOMMIT_ACTIVE)
 

--- a/node/misc/bin/oo-app-create
+++ b/node/misc/bin/oo-app-create
@@ -118,6 +118,10 @@ rescue ::OpenShift::Runtime::UserCreationException => e
   $stderr.puts(e.message)
   $stderr.puts(e.backtrace)
   exit 129
+rescue ::OpenShift::Runtime::GearCreationException => e
+  $stderr.puts(e.message)
+  $stderr.puts(e.backtrace)
+  exit 146
 rescue Exception => e
   $stderr.puts(e.message)
   $stderr.puts(e.backtrace)

--- a/node/test/test_helper.rb
+++ b/node/test/test_helper.rb
@@ -48,6 +48,7 @@ module OpenShift
       @config = mock('OpenShift::Config')
       @config.stubs(:get).returns(nil)
       @config.stubs(:get).with("CONTAINERIZATION_PLUGIN").returns('openshift-origin-container-selinux')
+      @config.stubs(:get_bool).with("no_overcommit_active", false).returns(false)
       OpenShift::Config.stubs(:new).returns(@config)
 
       @cgroups_mock = mock('OpenShift::Runtime::Utils::Cgroups')

--- a/node/test/unit/application_container_test.rb
+++ b/node/test/unit/application_container_test.rb
@@ -336,4 +336,45 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
     assert_equal 127, rc
     assert_equal "CLIENT_ERROR: 'TOO_BIG' value exceeds maximum size of 512b", msg
   end
+
+  # Tests that no_overcommit logic works as intended
+  def test_no_overcommit
+        scenarios = [
+        [5507, true, 0.0],
+        [5508, true, 100.0],
+        [5509, false, 0.0],
+        [5510, false, 100.0],
+    ]
+
+    scenarios.each do |s|
+      if s[1]
+        @config.stubs(:get_bool).with('no_overcommit_active', false).returns(true)
+      else
+        @config.stubs(:get_bool).with('no_overcommit_active', false).returns(false)
+      end
+      OpenShift::Runtime::Node.stubs(:node_utilization).returns({'gears_active_usage_pct' => s[2]})
+      containerization_plugin_mock = mock('OpenShift::Runtime::Containerization::Plugin')
+      containerization_plugin_mock.stubs(:create).returns(nil)
+      OpenShift::Runtime::Containerization::Plugin.stubs(:new).returns(containerization_plugin_mock)
+      Etc.stubs(:getpwnam).returns(
+        OpenStruct.new(
+          uid: s[0],
+          gid: s[0],
+          gecos: "OpenShift guest",
+          container_dir: "/var/lib/openshift/#{s[0].to_s}"
+        )
+      )
+
+      container = OpenShift::Runtime::ApplicationContainer.new(s[0].to_s, s[0].to_s, s[0],
+                                                               @app_name, s[0].to_s, @namespace, nil, nil, nil)
+      container.stubs(:generate_ssh_key).returns('generate_ssh_key stub')
+      if s[1] and (s[2] == 100.0)
+        assert_raise OpenShift::Runtime::GearCreationException do
+          container.create
+        end
+      else
+        container.create
+      end
+    end
+  end
 end

--- a/node/test/unit/node_test.rb
+++ b/node/test/unit/node_test.rb
@@ -88,13 +88,15 @@ class NodeTest < OpenShift::NodeTestCase
     ]
 
     scenarios.each do |scenario|
-      @config.stubs(:get).with("GEAR_BASE_DIR", anything()).returns('/var/lib/openshift')
-      @config.stubs(:get).with("node_profile", anything()).returns(scenario[:node_profile])
-      @config.stubs(:get).with("quota_blocks", anything()).returns(scenario[:quota_blocks])
-      @config.stubs(:get).with("quota_files", anything()).returns(scenario[:quota_files])
-      @config.stubs(:get).with("max_active_gears", anything()).returns(scenario[:max_active_gears])
-      @config.stubs(:get).with("max_active_apps", anything()).returns(scenario[:max_active_apps])
-      @config.stubs(:get_bool).with("no_overcommit_active", anything()).returns(scenario[:no_overcommit_active])
+      @config.stubs(:get).with("GEAR_BASE_DIR", anything).returns('/var/lib/openshift')
+      @config.stubs(:get).with("node_profile", anything).returns(scenario[:node_profile])
+      @config.stubs(:get).with("quota_blocks", anything).returns(scenario[:quota_blocks])
+      @config.stubs(:get).with("quota_files", anything).returns(scenario[:quota_files])
+      @config.stubs(:get).with("max_active_gears", anything).returns(scenario[:max_active_gears])
+      @config.stubs(:get).with("max_active_apps", anything).returns(scenario[:max_active_apps])
+      @config.stubs(:get_bool).with("no_overcommit_active", anything).returns(scenario[:no_overcommit_active])
+      OpenShift::Runtime::Node.stubs(:resource_limits).returns(@config)
+
       OpenShift::Runtime::Utils::SELinux.stubs(:set_mcs_label).returns nil
 
       appuids = (501...(501+ (scenario[:max_active_gears].nil? ? scenario[:max_active_apps].to_i : scenario[:max_active_gears].to_i)))
@@ -258,7 +260,6 @@ class NodeTest < OpenShift::NodeTestCase
       end
 
       node_utilization = OpenShift::Runtime::Node.node_utilization
-      print node_utilization.pretty_inspect # DEBUG
       assert_equal apps.count, node_utilization['gears_total_count']
       assert_equal 0, node_utilization['gears_started_count'] # 1/2 idled, 1/2 stopped
       assert_equal apps.count/2, node_utilization['git_repos_count']

--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -2527,6 +2527,8 @@ module OpenShift
           result.debugIO << "Command return code: " + result.exitcode.to_s
           if result.hasUserActionableError
             raise OpenShift::UserException.new(result.errorIO.string, result.exitcode, nil, result)
+          elsif result.exitcode == 146
+            raise OpenShift::NodeException.new("Gear creation failed (chosen node capacity exceeded).", 146, result)
           else
             raise OpenShift::NodeException.new("Node execution failure (invalid exit code from node).", 143, result)
           end

--- a/plugins/msg-node/mcollective/facts/openshift_facts.rb
+++ b/plugins/msg-node/mcollective/facts/openshift_facts.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'parseconfig'
+require 'openshift-origin-node/model/node'
 
 def get_node_config_value(key, default)
   config_file = ParseConfig.new('/etc/openshift/node.conf')
@@ -34,89 +35,31 @@ Facter.add(:public_ip) { setcode { public_ip } }
 Facter.add(:public_hostname) { setcode { public_hostname } }
 
 #
-# Find node_profile, max_apps, max_active_apps
+# Pull node_utilization data from node model
 #
-node_profile = 'small'
-max_apps = nil
-max_active_apps = nil
-max_active_gears = nil
-if File.exists?('/etc/openshift/resource_limits.conf')
-  config_file = ParseConfig.new('/etc/openshift/resource_limits.conf')
-  node_profile = config_file['node_profile'] || 'small'
-  quota_blocks = config_file['quota_blocks'] || '1048576'
-  quota_files = config_file['quota_files'] || '40000'
-  # use max_{active_,}gears if set in resource limits, or fall back to old "apps" names
-  max_active_gears = config_file['max_active_gears'] ||
-    config_file['max_active_apps'] || '0'
-end
+results = OpenShift::Runtime::Node.node_utilization
 
-Facter.add(:node_profile) { setcode { node_profile } }
-Facter.add(:max_active_gears) { setcode { max_active_gears || '0' } }
-Facter.add(:quota_blocks) { setcode { quota_blocks } }
-Facter.add(:quota_files) { setcode { quota_files } }
-
-#
-# Count number of git repos and stopped apps
-#
-git_repos_count = 0
-stopped_app_count = 0
-gears_active_count = 0 # includes everything but idle and stopped
-gears_total_count = 0
-gears_idled_count = 0
-gears_stopped_count = 0
-gears_started_count = 0
-gears_deploying_count = 0
-gears_unknown_count = 0
-Dir.glob("/var/lib/openshift/*").each do |app_dir|
-  if File.directory?(app_dir) && !File.symlink?(app_dir)
-    git_repos_count += Dir.glob(File.join(app_dir, "git/*.git")).count
-
-    # note: only considered a gear if .state file is present. There are
-    # other directories that aren't gears, e.g. ".httpd.d"
-    Dir.glob(File.join(app_dir, %w{app-root runtime .state})).each do |file|
-      gears_total_count += 1
-      case File.read(file).chomp
-        # expected values: building, deploying, started, idle, new, stopped, or unknown
-      when 'idle'
-          stopped_app_count += 1 # legacy
-          gears_idled_count += 1
-      when 'stopped'
-          stopped_app_count += 1 # legacy
-          gears_stopped_count += 1
-      when 'started'
-          gears_started_count += 1
-      when *%w[new building deploying]
-          gears_deploying_count += 1
-      else # literally 'unknown' or something else
-          gears_unknown_count += 1
-      end
-    end
-  end
-  # consider a gear active unless explicitly not
-  gears_active_count = gears_total_count - gears_idled_count - gears_stopped_count
-end
-
-#
-# Record gear-based counts and capacity
-#
-Facter.add(:gears_active_count) { setcode { gears_active_count } }
-Facter.add(:gears_total_count) { setcode { gears_total_count } }
-Facter.add(:gears_idle_count) { setcode { gears_idled_count } }
-Facter.add(:gears_stopped_count) { setcode { gears_stopped_count } }
-Facter.add(:gears_started_count) { setcode { gears_started_count } }
-Facter.add(:gears_deploying_count) { setcode { gears_deploying_count } }
-Facter.add(:gears_unknown_count) { setcode { gears_unknown_count } }
-gears_usage_pct = begin gears_total_count * 100.0 / max_active_gears.to_f; rescue; 0.0; end
-gears_active_usage_pct = begin gears_active_count * 100.0 / max_active_gears.to_f; rescue; 0.0; end
-Facter.add(:gears_usage_pct) { setcode { gears_usage_pct } }
-Facter.add(:gears_active_usage_pct) { setcode { gears_active_usage_pct } }
+Facter.add(:node_profile) { setcode { results['node_profile'] } }
+Facter.add(:max_active_gears) { setcode { results['max_active_gears'] || '0' } }
+Facter.add(:no_overcommit_active) { setcode { results['no_overcommit_active'] || false } }
+Facter.add(:quota_blocks) { setcode { results['quota_blocks'] } }
+Facter.add(:quota_files) { setcode { results['quota_files'] } }
+Facter.add(:gears_active_count) { setcode { results['gears_active_count'] } }
+Facter.add(:gears_total_count) { setcode { results['gears_total_count'] } }
+Facter.add(:gears_idle_count) { setcode { results['gears_idled_count'] } }
+Facter.add(:gears_stopped_count) { setcode { results['gears_stopped_count'] } }
+Facter.add(:gears_started_count) { setcode { results['gears_started_count'] } }
+Facter.add(:gears_deploying_count) { setcode { results['gears_deploying_count'] } }
+Facter.add(:gears_unknown_count) { setcode { results['gears_unknown_count'] } }
+Facter.add(:gears_usage_pct) { setcode { results['gears_usage_pct'] } }
+Facter.add(:gears_active_usage_pct) { setcode { results['gears_active_usage_pct'] } }
 
 # Old "app" count, excludes some gears
-Facter.add(:git_repos) { setcode { git_repos_count } }
-#
+Facter.add(:git_repos) { setcode { results['git_repos_count'] } }
+
 # capacity and active capacity - deprecated but kept for backward compat
-Facter.add(:capacity) { setcode { gears_usage_pct.to_s } }
-Facter.add(:active_capacity) { setcode { gears_active_usage_pct.to_s } }
+Facter.add(:capacity) { setcode { results['capacity'] } }
+Facter.add(:active_capacity) { setcode { results['active_capacity'] } }
 
 #
 # Get sshfp record

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -288,6 +288,10 @@ module MCollective
           Log.instance.info e.message
           Log.instance.info e.backtrace
           return 129, e.message
+        rescue OpenShift::Runtime::GearCreationException => e
+          Log.instance.info e.message
+          Log.instance.info e.backtrace
+          return 146, e.message
         rescue Exception => e
           Log.instance.info e.message
           Log.instance.info e.backtrace


### PR DESCRIPTION
Add helper script oo-node-utilization
Update facter to use oo-node-utilization
Update mcollective_application_container_proxy to call a new mcollective action on the node to use oo-node-utilization to get the active_capacity instead of using the fact (which is only updated minutely)
