### PR TITLE
Cannot comment settings in resource_limits.conf - Bug 995460

### DIFF
--- a/controller/app/models/gear.rb
+++ b/controller/app/models/gear.rb
@@ -40,7 +40,7 @@ class Gear
   def self.base_filesystem_gb(gear_size)
     CacheHelper.get_cached(gear_size + "_quota_blocks", :expires_in => 1.day) {
       proxy = OpenShift::ApplicationContainerProxy.find_one(gear_size)
-      quota_blocks = Integer(proxy.get_quota_blocks)
+      quota_blocks = proxy.get_quota_blocks.to_i
       # calculate the minimum storage in GB - blocks are 1KB each
       quota_blocks / 1024 / 1024
     }


### PR DESCRIPTION
Bug 995460 Can not comment settings (directly following directives) in /etc/openshift/resource_limits.conf
https://bugzilla.redhat.com/show_bug.cgi?id=995460
Using .to_i will strip everything after the actual integer, allowing comments directly after. 
