### PR TITLE
Bug 970150

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -49,7 +49,6 @@ function tidy() {
 }
 
 function pre-repo-archive() {
-  # set -x
   rm -rf ${OPENSHIFT_RUBY_DIR}/tmp/.bundle ${OPENSHIFT_RUBY_DIR}/tmp/vendor
 
   # If the previous and current commits didn't upload .bundle and you have .bundle and vendor/bundle already deployed then store away for redeploy
@@ -69,8 +68,7 @@ function pre-repo-archive() {
 }
 
 function pre-build() {
-  # empty
-  true
+  rails_app_name_check
 }
 
 function build() {
@@ -185,6 +183,22 @@ function _threaddump() {
       echo "Failed to signal application. Please retry after restarting application and access it by its URL (http://${OPENSHIFT_GEAR_DNS})"
     fi
   fi
+}
+
+function rails_app_name_check() {
+  # Rails does not work if the application name starts with a number
+  pushd ${OPENSHIFT_REPO_DIR} >/dev/null
+  if [ -f Gemfile.lock ]; then
+    grep 'rails' Gemfile.lock 2>&1 >/dev/null
+    if [ $? -eq 0 ]; then
+      echo "$OPENSHIFT_APP_NAME" | grep '^[0-9]' >/dev/null
+      if [ $? -eq 0 ]; then
+        client_error "Invalid Rails application name. Please delete this applicatin and re-create it with a name which does not start with numbers"
+        exit 1
+      fi
+    fi
+  fi
+  popd > /dev/null
 }
 
 case "$1" in


### PR DESCRIPTION
Fail early during the build cycle if a Rails app name starts with a
numeral.

We should fail before we run `bundle install`, since it is completely
unnecessary if Rails can't run.

If the application is created with `--from-code`, the initial build will
fail, with error message like this:

```
Creating application '12345' ...
The initial build for the application failed: Shell command
'/sbin/runuser -s /bin/sh 80e4c0ea037a11e3962922000ab2046b -c "exec
/usr/bin/runcon 'unconfined_u:system_r:openshift_t:s0:c0,c502' /bin/sh
-c \"gear
postreceive >> /tmp/initial-build.log 2>&1\""' returned an error. rc=255

.Last 10 kB of build output:
Stopping Ruby cart
httpd (no pid file) not running
Invalid Rails application name. Please delete this applicatin and
re-create it with a name which does not start with numbers
An error occurred executing 'gear postreceive' (exit code: 1)
Error message: Failed to execute: 'control pre-build' for
/var/lib/openshift/80e4c0ea037a11e3962922000ab2046b/ruby

For more details about the problem, try running the command again with
the '--trace' option.
```

If the application is created from a template Rack app, and updated via
`git pull -s recursive -X theirs`, the build will fail on the first
push:

```
remote: Stopping Ruby cart
remote: Waiting for stop to finish
remote: CLIENT_ERROR: Invalid Rails application name. Please delete this applicatin and re-create it with a name which does not start with
numbers
remote: An error occurred executing 'gear postreceive' (exit code: 1)
remote: Error message: Failed to execute: 'control pre-build' for /var/lib/openshift/520924b77b2a19115a000001/ruby
remote:
remote: For more details about the problem, try running the command again with the '--trace' option.
To ssh://520924b77b2a19115a000001@12345-fooooooooooo.dev.rhcloud.com/~/git/12345.git/
   9b5a31d..398f08a  master -> master
```
