### PR TITLE
Bug 994922

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/bin/control
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/control
@@ -118,7 +118,7 @@ function start() {
         executor_cmdline="node $node_opts $node_app $node_app_args"
     fi
 
-    if [ -f "$OPENSHIFT_REPO_DIR/.openshift/markers/hot_deploy" ]; then
+    if marker_present "hot_deploy"; then
         nohup supervisor -e 'node|js|coffee' -- $script_n_opts  >> $logf 2>&1 &
     else
         nohup $executor_cmdline >> $logf 2>&1 &
@@ -266,7 +266,7 @@ function is_supervisor_running() {
 }  #  End of function  is_supervisor_running.
 
 function post-deploy() {
-    if [ -f "$OPENSHIFT_REPO_DIR/.openshift/markers/hot_deploy" ]; then
+    if marker_present "hot_deploy"; then
         # Check if supervisor is already running. If not do a restart.
         if ! is_supervisor_running ; then
             restart

--- a/cartridges/openshift-origin-cartridge-nodejs/bin/control
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/control
@@ -3,6 +3,12 @@
 STOPTIMEOUT=10
 FMT="%a %b %d %Y %H:%M:%S GMT%z (%Z)"
 
+function check_hot_deploy_marker() {
+  if marker_present "hot_deploy"; then
+    echo "hot_deploy marker found. Switching to using supervisor. Subsequent pushes won't require restart until the marker is removed."
+  fi
+}
+
 function print_missing_package_json_warning() {
        cat <<DEPRECATED
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -266,6 +272,8 @@ function is_supervisor_running() {
 }  #  End of function  is_supervisor_running.
 
 function post-deploy() {
+    check_hot_deploy_marker
+
     if marker_present "hot_deploy"; then
         # Check if supervisor is already running. If not do a restart.
         if ! is_supervisor_running ; then
@@ -275,6 +283,8 @@ function post-deploy() {
 }
 
 function pre-repo-archive() {
+    check_hot_deploy_marker
+
     rm -rf ${OPENSHIFT_NODEJS_DIR}/tmp/{node_modules,saved.node_modules}
 
     # If the node_modules/ directory exists, then "stash" it away for redeploy.


### PR DESCRIPTION
Warn user of supervisor control when we detect `hot_deploy` marker.

When the `hot_deploy` marker is present, stop nor start is invoked, so
we need to check the presence of the marker in a different way.

Notice that the first time we push `hot_deploy` marker, the stop cycle
will not warn that it detected the marker (because it doesn't exist on
the gear).
