### PR TITLE
Bug 990417 - Fix the restart operation when the PID file is corrupted

### DIFF
--- a/cartridges/openshift-origin-cartridge-perl/bin/control
+++ b/cartridges/openshift-origin-cartridge-perl/bin/control
@@ -29,6 +29,7 @@ function stop() {
 function restart() {
   echo "Restarting Perl cartridge"
   update_httpd_passenv $HTTPD_CFG_FILE
+  ensure_httpd_restart_succeed "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
   /usr/sbin/httpd -C "Include $OPENSHIFT_PERL_DIR/etc/conf.d/*.conf" -f $HTTPD_CFG_FILE -k restart
 }
 

--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -13,6 +13,13 @@ function apache() {
     return $?
 }
 
+function restart() {
+    update_httpd_passenv $HTTPD_CFG_FILE
+    ensure_httpd_restart_action "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
+    /usr/sbin/httpd -C "Include $HTTPD_CFG_DIR/*.conf" -f $HTTPD_CFG_FILE -k restart
+    return $?
+}
+
 function stop() {
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     if [ -f "$HTTPD_PID_FILE" ]; then
@@ -83,7 +90,7 @@ function build() {
 case "$1" in
   start)           echo "Starting PHP cartridge";   apache start ;;
   stop)            echo "Stopping PHP cartridge";   stop ;;
-  restart)         echo "Restarting PHP cartridge"; apache restart ;;
+  restart)         echo "Restarting PHP cartridge"; restart ;;
   reload|graceful) echo "Reloading PHP cartridge";  apache graceful ;;
   status)          status ;;
   configtest)      configtest ;;

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
@@ -76,6 +76,7 @@ function restart() {
     else
         stop_app
         update_httpd_passenv $HTTPD_CFG_FILE
+        ensure_httpd_restart_succeed "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
         /usr/sbin/httpd -C "Include $OPENSHIFT_PYTHON_DIR/etc/conf.d/*.conf" -f $HTTPD_CFG_FILE -k restart
     fi
 }

--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -28,6 +28,7 @@ function restart() {
     echo "${1}ing Ruby cart"
     update_httpd_passenv $HTTPD_CFG_FILE
     touch $OPENSHIFT_REPO_DIR/tmp/restart.txt
+    ensure_httpd_restart_succeed "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     ruby_context "/usr/sbin/httpd -C 'Include $OPENSHIFT_RUBY_DIR/etc/conf.d/*.conf' -f $HTTPD_CFG_FILE -k restart"
 }
 

--- a/node/misc/usr/lib/cartridge_sdk/bash/sdk
+++ b/node/misc/usr/lib/cartridge_sdk/bash/sdk
@@ -327,6 +327,19 @@ function hot_deploy_marker_is_present() {
     marker_present hot_deploy
 }
 
+# return 'start' instead of restart if the HTTPD pid file is corrupted and the
+# HTTPD is not running
+function ensure_httpd_restart_succeed() {
+    local pid_file="$1"
+    local cfg_file="$2"
+
+    if process_running 'httpd' $pid_file; then
+      ensure_valid_httpd_pid_file "$pid_file" "$cfg_file"
+    else
+      rm -f $pid_file 2>/dev/null
+    fi
+}
+
 # report the primary cartridge name for this gear
 function primary_cartridge_name() {
   awk -F: '{printf "%s-%s", $2, $3}' $OPENSHIFT_PRIMARY_CARTRIDGE_DIR/env/OPENSHIFT_*_IDENT


### PR DESCRIPTION
In case when the PID file is corrupted, Apache fails to restart with:

```
(20014)Internal error: Error retrieving pid file run/httpd.pid
```

This patch will check if there is valid PID file when restarting and if not, then execute the 'start' operation. In case when Apache is already running, it fails with meaningful message and automatically fix the PID file. In case when Apache is down, it starts it.... as user would expect when doing 'restart' ;-)
