### PR TITLE
Fix PHP PEAR Jenkins build

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -72,6 +72,8 @@ function build() {
             else
                 echo "Extension already installed in the system: $f"
             fi
+            # Remove gear-specific absolute paths from the generated PEAR files
+            find ${OPENSHIFT_PHP_DIR}phplib/pear/pear/ -type f ! -name '.*' -exec sed -i "s|${OPENSHIFT_HOMEDIR}|~/|g" {} \;
         done
     fi
     return 0


### PR DESCRIPTION
Substitutes Jenkins builder absolute paths hardcoded by the PEAR installer into to relative paths.
https://trello.com/c/HOKvYxdJ/224-3-allow-php-pear-to-work-with-jenkins

https://github.com/openshift/drupal-quickstart/pull/6

[test]
