### PR TITLE
Changes required to support ruby193-mcollective

### DIFF
--- a/admin-console/rubygem-openshift-origin-admin-console.spec
+++ b/admin-console/rubygem-openshift-origin-admin-console.spec
@@ -36,7 +36,7 @@ Requires:      %{?scl:%scl_prefix}rubygem-uglifier
 Requires:      %{?scl:%scl_prefix}rubygem-therubyracer
 Requires:      rubygem-openshift-origin-common
 Requires:      rubygem-openshift-origin-controller
-Requires:      mcollective-client
+Requires:      %{?scl:%scl_prefix}mcollective-client
 Requires:      openshift-origin-broker
 %if 0%{?fedora}%{?rhel} <= 6
 BuildRequires: %{?scl:%scl_prefix}build

--- a/broker-util/oo-accept-systems
+++ b/broker-util/oo-accept-systems
@@ -214,7 +214,7 @@ if __FILE__ == $0
   load_rails_env
   check_nodes_public_hostname
   if !$NODES_EXIST
-    do_fail "No node hosts responded. Run 'mco ping' and troubleshoot if this is unexpected."
+    do_fail "No node hosts responded. Run 'oo-mco ping' and troubleshoot if this is unexpected."
   else
     check_nodes_public_ip
     check_nodes_cartridges

--- a/broker-util/openshift-origin-broker-util.spec
+++ b/broker-util/openshift-origin-broker-util.spec
@@ -23,7 +23,7 @@ Requires:      mongodb
 # For oo-register-dns
 Requires:      bind-utils
 # For oo-admin-broker-auth
-Requires:      mcollective-client
+Requires:      %{?scl:%scl_prefix}mcollective-client
 BuildArch:     noarch
 
 %description

--- a/broker/test/unit/district_test.rb
+++ b/broker/test/unit/district_test.rb
@@ -169,7 +169,7 @@ class DistrictTest < ActiveSupport::TestCase
     orig_d = get_district_obj
     orig_d.save!
     begin
-      hostname = `mco ping | xargs | cut -d' ' -f1`
+      hostname = `oo-mco ping | xargs | cut -d' ' -f1`
       hostname.chomp!
       orig_d.add_node(hostname)
       new_d = District.find_by(uuid: orig_d.uuid)

--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -189,6 +189,7 @@ class OODiag
     @project_is = {}
     # It's OpenShift Enterprise if there are any el6op RPMs on the system.
     @project_is[:enterprise] = @rpms.values.select {|rpm| rpm[:release].include? 'el6op'}.length > 0
+    @scl_prefix = @project_is[:enterprise] ? "ruby193-" : ""
     # It's OpenShift Online if certain RPMs are present
     @project_is[:online] = @rpms['rhc-common'] && true
     # It's OpenShift Origin otherwise...
@@ -722,7 +723,7 @@ class OODiag
       broker error_log: this problem indicates mcollective client logging is failing:
         #{out}
       Please fix this issue with the following commands:
-        # chown apache:root /var/log/mcollective-client.log
+        # chown apache:root /var/log/#{@scl_prefix}-mcollective-client.log
         # service openshift-broker restart
     FIXLOG
     #
@@ -847,9 +848,9 @@ class OODiag
     #
     # create a tmp file with all of the unique log statements after most recent mcollective start
     tmpfile = Tempfile.new("oodiag-mco-#{$$}").path
-    system %Q! sed -n 'H; /INFO.*The Marionette Collective.*started logging/h; ${g;p;}' /var/log/mcollective.log | sed 's|^\w, \[[^]]*\]||' | sort -u > #{tmpfile} !
+    system %Q! sed -n 'H; /INFO.*The Marionette Collective.*started logging/h; ${g;p;}' /var/log/#{@scl_prefix}mcollective.log | sed 's|^\w, \[[^]]*\]||' | sort -u > #{tmpfile} !
     # if no restart seen, just use the whole thing
-    system %Q! sort -u /var/log/mcollective.log > #{tmpfile} ! unless File.exists? tmpfile
+    system %Q! sort -u /var/log/#{@scl_prefix}mcollective.log > #{tmpfile} ! unless File.exists? tmpfile
     return unless File.exists? tmpfile
     #
     # Look for the mco timeout warning
@@ -912,7 +913,7 @@ class OODiag
       fail_without += %w{httpd network sshd openshift-port-proxy openshift-gears
                         cgconfig cgred crond openshift-node-web-proxy}
       scl_prefix = @project_is[:enterprise] ? "ruby193-" : ""
-      fail_without << scl_prefix + "mcollective"
+      fail_without << @scl_prefix + "mcollective"
 
       warn_without += %w{ntpd oddjobd messagebus}
     end

--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -247,8 +247,8 @@ class OODiag
     geos-debuginfo geos-devel geos-python geos-ruby haproxy haproxy-debuginfo
     jboss-eap6-index jboss-eap6-modules jenkins jenkins-plugin-openshift js
     js-debuginfo js-devel libev libev-debuginfo libev-devel libev-source
-    libmcrypt libmcrypt-debuginfo libmcrypt-devel libmongodb mcollective
-    mcollective-client mcollective-common mod_bw mod_bw-debuginfo mod_passenger
+    libmcrypt libmcrypt-debuginfo libmcrypt-devel libmongodb ruby193-mcollective
+    ruby193-mcollective-client ruby193-mcollective-common mod_bw mod_bw-debuginfo mod_passenger
     mongodb mongodb-debuginfo mongodb-devel mongodb-server openshift-console
     openshift-origin-console openshift-origin-broker openshift-origin-broker-util
     openshift-origin-cartridge-cron
@@ -546,7 +546,7 @@ class OODiag
       if a_profile_for.empty?
         do_fail <<-NONE
           No node hosts found. Please install some,
-          or ensure the existing ones respond to 'mco ping'.
+          or ensure the existing ones respond to 'oo-mco ping'.
           OpenShift cannot host gears without at least one node host responding.
         NONE
         skip_test
@@ -909,8 +909,10 @@ class OODiag
       warn_without += %w{ntpd}
     end
     if @is_node
-      fail_without += %w{httpd network sshd openshift-port-proxy openshift-gears mcollective
+      fail_without += %w{httpd network sshd openshift-port-proxy openshift-gears
                         cgconfig cgred crond openshift-node-web-proxy}
+      scl_prefix = @project_is[:enterprise] ? "ruby193-" : ""
+      fail_without << scl_prefix + "mcollective"
 
       warn_without += %w{ntpd oddjobd messagebus}
     end
@@ -1062,7 +1064,8 @@ class OODiag
     # One bug would express when commands were run through oo-spawn/shellExec.
     # Under certain circumstances they would not have the dominating MCS label
     # (s0-s0:c0.c1023) and not be able to affect gears.
-    context = `ps -o label= $(pgrep -f ruby[[:space:]]/usr/sbin/mcollectived)`.chomp.split ":"
+    scl_root = @project_is[:enterprise] ? "/opt/rh/ruby193/root" : ""
+    context = `ps -o label= $(pgrep -f ruby[[:space:]]#{scl_root}/usr/sbin/mcollectived)`.chomp.split ":"
     context.shift
     context = context.join ":"
     expected = "system_r:openshift_initrc_t:s0-s0:c0.c1023"
@@ -1070,7 +1073,7 @@ class OODiag
       do_fail <<-CONTEXT
       Mcollectived is not running in the expected SELinux context, which
       may result in node execution failures. Please check that the correct
-      context is set on /usr/sbin/mcollectived and that the correct SELinux
+      context is set on #{scl_root}/usr/sbin/mcollectived and that the correct SELinux
       policies are loaded.
         Expected: #{expected}
         Found: #{context}
@@ -1082,7 +1085,7 @@ class OODiag
   def test_mcollective_bad_facts
     skip_test unless @is_broker
     #Grep for a NaN of max active gears from mcollective
-    max_active_gears = `mco facts max_active_gears | grep -i NaN`
+    max_active_gears = `oo-mco facts max_active_gears | grep -i NaN`
     #If not empty, then there is a problem
     if(!max_active_gears.empty?)
       do_fail <<-NAN

--- a/node-util/bin/oo-accept-node
+++ b/node-util/bin/oo-accept-node
@@ -86,8 +86,12 @@ $LIMITS_CONF_DIR="/etc/security/limits.d"
 DEFAULT_SEBOOL_LIST="httpd_can_network_connect:on allow_polyinstantiation:on"
 DEFAULT_PACKAGES="rubygem-openshift-origin-node openshift-origin-node-util \
     rubygem-openshift-origin-common selinux-policy selinux-policy-targeted"
-DEFAULT_SERVICES="mcollective cgconfig cgred httpd openshift-port-proxy oddjobd"
-DEFAULT_SERVICE_CONTEXTS="mcollective='unconfined_u:system_r:openshift_initrc_t:s0-s0:c0.c1023' oddjobd='system_u:system_r:oddjob_t:s0-s0:c0.c1023'"
+
+%x[/bin/rpm -q ruby193-mcollective &>/dev/null]
+scl_prefix = $?.exitstatus == 0 ? "ruby193-" : ""
+
+DEFAULT_SERVICES="#{scl_prefix}mcollective cgconfig cgred httpd openshift-port-proxy oddjobd"
+DEFAULT_SERVICE_CONTEXTS="#{scl_prefix}mcollective='unconfined_u:system_r:openshift_initrc_t:s0-s0:c0.c1023' oddjobd='system_u:system_r:oddjob_t:s0-s0:c0.c1023'"
 DEFAULT_MINSEM=512
 V1_DIRECTORIES=%w(ruby-1.8 ruby-1.9 nodejs-0.6
                   jbosseap-6.0 jbossews-1.0 jbossews-2.0 jbossas-7
@@ -356,7 +360,7 @@ end
 
 def check_service_contexts
     offset = 0
-    while m = /(\w+)\=[\'\"]?(\w+):(\w+):(\w+):([\w\-\:\.\,]+)[\'\"]?/.match($SERVICE_CONTEXTS[offset..-1])
+    while m = /([-\w]+)\=[\'\"]?(\w+):(\w+):(\w+):([\w\-\:\.\,]+)[\'\"]?/.match($SERVICE_CONTEXTS[offset..-1])
       offset += m.end(0)
       service = m[1]
       serole = m[3]

--- a/node-util/bin/oo-admin-cartridge
+++ b/node-util/bin/oo-admin-cartridge
@@ -72,11 +72,11 @@ module OpenShift
                    end
 
             dirs.each do |dir|
-              out, _, _ = ::OpenShift::Runtime::Utils.oo_spawn("mco rpc -q openshift cartridge_repository action=install path=#{dir}")
+              out, _, _ = ::OpenShift::Runtime::Utils.oo_spawn("oo-mco rpc -q openshift cartridge_repository action=install path=#{dir}")
               buffer << out
             end
           when :list
-            buffer, _, _ = ::OpenShift::Runtime::Utils.oo_spawn('mco rpc -q openshift cartridge_repository action=list',
+            buffer, _, _ = ::OpenShift::Runtime::Utils.oo_spawn('oo-mco rpc -q openshift cartridge_repository action=list',
                                                                  expected_exitstatus: 0)
           when :erase
             command      = %Q(mco rpc openshift cartridge_repository action=erase \

--- a/plugins/msg-broker/mcollective/config/initializers/openshift-origin-msg-broker-mcollective.rb
+++ b/plugins/msg-broker/mcollective/config/initializers/openshift-origin-msg-broker-mcollective.rb
@@ -13,6 +13,9 @@ Broker::Application.configure do
     end
     conf = OpenShift::Config.new(conf_file)
 
+    %x[/bin/rpm -q ruby193-mcollective &>/dev/null]
+    scl_root = $?.exitstatus == 0 ? "/opt/rh/ruby193/root" : ""
+
     config.msg_broker = {
       :rpc_options => {
         :disctimeout => conf.get("MCOLLECTIVE_DISCTIMEOUT", 5).to_i,
@@ -20,7 +23,7 @@ Broker::Application.configure do
         :verbose => conf.get_bool("MCOLLECTIVE_VERBOSE", "false"),
         :progress_bar => conf.get_bool("MCOLLECTIVE_PROGRESS_BAR", false),
         :filter => {"identity" => [], "fact" => [], "agent" => [], "cf_class" => [], "compound" => []},
-        :config => conf.get("MCOLLECTIVE_CONFIG", "/etc/mcollective/client.cfg"),
+        :config => conf.get("MCOLLECTIVE_CONFIG", "#{scl_root}/etc/mcollective/client.cfg"),
       },
       :fact_timeout => conf.get("MCOLLECTIVE_FACT_TIMEOUT", 10).to_i,
       :districts => {

--- a/plugins/msg-broker/mcollective/rubygem-openshift-origin-msg-broker-mcollective.spec
+++ b/plugins/msg-broker/mcollective/rubygem-openshift-origin-msg-broker-mcollective.spec
@@ -23,7 +23,7 @@ Requires:      %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
 Requires:      %{?scl:%scl_prefix}rubygems
 Requires:      %{?scl:%scl_prefix}rubygem(json)
 Requires:      rubygem(openshift-origin-common)
-Requires:      mcollective-client
+Requires:      %{?scl:%scl_prefix}mcollective-client
 Requires:      selinux-policy-targeted
 Requires:      policycoreutils-python
 Requires:      openshift-origin-msg-common

--- a/plugins/msg-broker/mcollective/rubygem-openshift-origin-msg-broker-mcollective.spec
+++ b/plugins/msg-broker/mcollective/rubygem-openshift-origin-msg-broker-mcollective.spec
@@ -66,6 +66,10 @@ cp -a ./%{gem_dir}/* %{buildroot}%{gem_dir}/
 mkdir -p %{buildroot}/etc/openshift/plugins.d
 cp %{buildroot}/%{gem_dir}/gems/%{gem_name}-%{version}/conf/openshift-origin-msg-broker-mcollective.conf.example %{buildroot}/etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf.example
 
+%if 0%{?scl_build} > 0
+sed -e -i "s|\(/etc/mcollective/client.cfg\)|/opt/rh/ruby193/root/\1|" /etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf.example
+%endif
+
 %files
 %dir %{gem_instdir}
 %dir %{gem_dir}

--- a/plugins/msg-node/mcollective/facts/openshift-facts
+++ b/plugins/msg-node/mcollective/facts/openshift-facts
@@ -1,2 +1,8 @@
 #!/bin/bash
-oo-exec-ruby /usr/libexec/mcollective/update_yaml.rb /etc/mcollective/facts.yaml &> /dev/null
+rpm -q ruby193-mcollective &> /dev/null
+if [ $? -eq 0 ]; then
+  YAML="/opt/rh/ruby193/root/etc/mcollective/facts.yaml"
+else
+  YAML="/etc/mcollective/facts.yaml"
+fi
+oo-exec-ruby /usr/libexec/mcollective/update_yaml.rb $YAML &> /dev/null

--- a/plugins/msg-node/mcollective/openshift-origin-msg-node-mcollective.spec
+++ b/plugins/msg-node/mcollective/openshift-origin-msg-node-mcollective.spec
@@ -20,7 +20,7 @@ Requires:      %{?scl:%scl_prefix}rubygems
 Requires:      %{?scl:%scl_prefix}rubygem-open4
 Requires:      %{?scl:%scl_prefix}rubygem-json
 Requires:      rubygem-openshift-origin-node
-Requires:      mcollective
+Requires:      %{?scl:%scl_prefix}mcollective
 Requires:      %{?scl:%scl_prefix}facter
 Requires:      openshift-origin-msg-common
 BuildArch:     noarch

--- a/util-scl/oo-mco
+++ b/util-scl/oo-mco
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec oo-exec-ruby /opt/rh/ruby193/root/usr/sbin/mco "$@"

--- a/util-scl/openshift-origin-util-scl.spec
+++ b/util-scl/openshift-origin-util-scl.spec
@@ -24,6 +24,7 @@ cp oo-* %{buildroot}%{_bindir}/
 %attr(0755,-,-) %{_bindir}/oo-ruby
 %attr(0755,-,-) %{_bindir}/oo-erb
 %attr(0755,-,-) %{_bindir}/oo-exec-ruby
+%attr(0755,-,-) %{_bindir}/oo-mco
 
 
 %changelog

--- a/util/oo-mco
+++ b/util/oo-mco
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# This script allows OpenShift Origin to keep command consistancy 
+#   across SCL'ized and non-SCL'ized machines
+
+exec mco "$@"

--- a/util/openshift-origin-util.spec
+++ b/util/openshift-origin-util.spec
@@ -34,6 +34,7 @@ chmod 0755 %{buildroot}%{_bindir}/*
 %{_bindir}/oo-ruby
 %{_bindir}/oo-erb
 %{_bindir}/oo-exec-ruby
+%{_bindir}/oo-mco
 
 
 %changelog


### PR DESCRIPTION
For Fedora this should be a no-op.  For Online devenvs the tests will fail until ruby193-mcollective is available.
