### PR TITLE
Bug 990382 - Return error message and code when wrong gear id is given to oo-pam-enable/disable

### DIFF
--- a/node/misc/bin/oo-pam-disable
+++ b/node/misc/bin/oo-pam-disable
@@ -80,7 +80,11 @@ begin
   if all_containers
     OpenShift::Runtime::Node::remove_pam_limits_all
   else
-    OpenShift::Runtime::Node::remove_pam_limits(container_uuid.to_s)
+    if OpenShift::Runtime::ApplicationContainer.exists?(container_uuid.to_s)
+      OpenShift::Runtime::Node::remove_pam_limits(container_uuid.to_s)
+    else
+      raise "ERROR: Unable to find specified container (#{container_uuid})"
+    end
   end
 rescue Exception => e
   $stderr.puts(e.message)

--- a/node/misc/bin/oo-pam-enable
+++ b/node/misc/bin/oo-pam-enable
@@ -80,10 +80,14 @@ begin
   if all_containers
     OpenShift::Runtime::Node::init_pam_limits_all
   else
-    OpenShift::Runtime::Node::init_pam_limits(container_uuid.to_s)
+    if OpenShift::Runtime::ApplicationContainer.exists?(container_uuid.to_s)
+      OpenShift::Runtime::Node::init_pam_limits(container_uuid.to_s)
+    else
+      raise "ERROR: Unable to find specified container (#{container_uuid})"
+    end
   end
 rescue Exception => e
   $stderr.puts(e.message)
-  exit -1
+  exit(-1)
 end
 exit 0


### PR DESCRIPTION
Testing:

Before:

```
[root@xxx ~]# oo-pam-enable -c 123456789
[root@xxx ~]# echo $?
0
```

After this patch:

```
[root@xxx ~]# oo-pam-enable -c 123456789
can't find user for 123456789
[root@xxx ~]# echo $?
255

```
