### PR TITLE
Bug 985218 - Display more user-friendly error message when erasing non-exiisting cartridge

### DIFF
--- a/node-util/bin/oo-admin-cartridge
+++ b/node-util/bin/oo-admin-cartridge
@@ -50,7 +50,11 @@ module OpenShift
           when :list
             return repository.to_s
           when :erase
-            repository.erase(options.name, options.version, options.cartridge_version)
+            begin
+              repository.erase(options.name, options.version, options.cartridge_version)
+            rescue KeyError => e
+              abort "requested cartridge does not exists (#{e.message})"
+            end
         end
         'succeeded'
       end


### PR DESCRIPTION
Before:

```
[root@xxx ~]# oo-admin-cartridge -a erase -n zend -v 5.7 -c 0.0.1
/opt/rh/ruby193/root/usr/share/gems/gems/openshift-origin-node-1.13.2/lib/openshift-origin-node/model/cartridge_repository.rb:199:in `erase': key not found: (zend, 5.7, 0.0.1) (KeyError)
    from /usr/sbin/oo-admin-cartridge:53:in `apply'
    from /usr/sbin/oo-admin-cartridge:137:in `<main>'
```

After this patch:

```
[root@xxx~]# oo-admin-cartridge -a erase -n zend -v 5.7 -c 0.0.1
requested cartridge does not exists (key not found: (zend, 5.7, 0.0.1))

```
