### PR TITLE
Remove references to deprecated MONGO_REPLICA_SETS

### DIFF
--- a/broker/conf/broker.conf
+++ b/broker/conf/broker.conf
@@ -11,10 +11,6 @@ DEFAULT_GEAR_CAPABILITIES="small"
 # Default gear size for a new gear
 DEFAULT_GEAR_SIZE="small"
 
-# Broker datastore configuration
-#Set to true if MongoDB is set up in replica set mode
-MONGO_REPLICA_SETS=false
-
 # For replica sets, use ',' delimiter for multiple servers
 # Eg: MONGO_HOST_PORT="<host1:port1>,<host2:port2>..."
 MONGO_HOST_PORT="localhost:27017"

--- a/documentation/oo_deployment_guide_comprehensive.txt
+++ b/documentation/oo_deployment_guide_comprehensive.txt
@@ -1185,9 +1185,6 @@ CLOUD_DOMAIN="example.com"
 Edit the mongo variables to connect to the Mongo DB server
 
 ----
-#Set to true if MongoDB is set up in replica set mode
-MONGO_REPLICA_SETS=false
-
 # Comma seperated list of replica set servers. Eg: "<host-1>:<port-1>,<host-2>:<port-2>,..."
 MONGO_HOST_PORT="<mongodb server FQDN>:27017"
 


### PR DESCRIPTION
Remove references in the default broker.conf and documentation to the
MONGO_REPLICA_SETS setting, which was removed in commit
2449f2e62b47f8a7e1e69ea0c1db7419b82a167e and commit
4346b2c98717cd7f264973e1c2e2e206abef471c.  These references were
erroneously added in commit e4f862733adf9a5ed75dc3065a584a83de1797b8.
