### PR TITLE
Fix Jenkins builds by correctly restricting builder permissions

### DIFF
--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -91,9 +91,9 @@ Broker::Application.configure do
 
   config.auth = {
     :salt => conf.get("AUTH_SALT", ""),
-    :privkeyfile => conf.get("AUTH_PRIVKEYFILE", "/var/www/openshift/broker/config/server_priv.pem"),
-    :privkeypass => conf.get("AUTH_PRIVKEYPASS", ""),
-    :pubkeyfile  => conf.get("AUTH_PUBKEYFILE", "/var/www/openshift/broker/config/server_pub.pem"),
+    :privkeyfile => conf.get("AUTH_PRIV_KEY_FILE", "/var/www/openshift/broker/config/server_priv.pem"),
+    :privkeypass => conf.get("AUTH_PRIV_KEY_PASS", ""),
+    :pubkeyfile  => conf.get("AUTH_PUB_KEY_FILE", "/var/www/openshift/broker/config/server_pub.pem"),
     :rsync_keyfile => conf.get("AUTH_RSYNC_KEY_FILE", "/etc/openshift/rsync_id_rsa")
   }
 

--- a/broker/config/environments/production.rb
+++ b/broker/config/environments/production.rb
@@ -88,9 +88,9 @@ Broker::Application.configure do
 
   config.auth = {
     :salt => conf.get("AUTH_SALT", ""),
-    :privkeyfile => conf.get("AUTH_PRIVKEYFILE", "/var/www/openshift/broker/config/server_priv.pem"),
-    :privkeypass => conf.get("AUTH_PRIVKEYPASS", ""),
-    :pubkeyfile  => conf.get("AUTH_PUBKEYFILE", "/var/www/openshift/broker/config/server_pub.pem"),
+    :privkeyfile => conf.get("AUTH_PRIV_KEY_FILE", "/var/www/openshift/broker/config/server_priv.pem"),
+    :privkeypass => conf.get("AUTH_PRIV_KEY_PASS", ""),
+    :pubkeyfile  => conf.get("AUTH_PUB_KEY_FILE", "/var/www/openshift/broker/config/server_pub.pem"),
     :rsync_keyfile => conf.get("AUTH_RSYNC_KEY_FILE", "/etc/openshift/rsync_id_rsa")
   }
 

--- a/broker/config/environments/test.rb
+++ b/broker/config/environments/test.rb
@@ -85,9 +85,9 @@ Broker::Application.configure do
 
   config.auth = {
     :salt => conf.get("AUTH_SALT", ""),
-    :privkeyfile => conf.get("AUTH_PRIVKEYFILE", "/var/www/openshift/broker/config/server_priv.pem"),
-    :privkeypass => conf.get("AUTH_PRIVKEYPASS", ""),
-    :pubkeyfile  => conf.get("AUTH_PUBKEYFILE", "/var/www/openshift/broker/config/server_pub.pem"),
+    :privkeyfile => conf.get("AUTH_PRIV_KEY_FILE", "/var/www/openshift/broker/config/server_priv.pem"),
+    :privkeypass => conf.get("AUTH_PRIV_KEY_PASS", ""),
+    :pubkeyfile  => conf.get("AUTH_PUB_KEY_FILE", "/var/www/openshift/broker/config/server_pub.pem"),
     :rsync_keyfile => conf.get("AUTH_RSYNC_KEY_FILE", "/etc/openshift/rsync_id_rsa")
   }
 

--- a/broker/test/functional/application_controller_test.rb
+++ b/broker/test/functional/application_controller_test.rb
@@ -101,17 +101,16 @@ class ApplicationControllerTest < ActionController::TestCase
     assert_response :created
     app = assigns(:application)
 
-    CloudUser.any_instance.stubs(:scopes).returns(Scope::Scopes.new << Scope::Application.new(:id => app._id, :app_scope => :build))
+    CloudUser.any_instance.stubs(:scopes).returns(Scope::Scopes.new << Scope::DomainBuilder.new(app))
 
-    # prohibits non matching cartridges
-    @app_name = "appx#{@random}"
-    post :create, {"name" => @app_name, "cartridge" => RUBY_VERSION, "domain_id" => @domain.namespace}
-    assert_response :forbidden
-
-    # allows creation of the same builder type
+    # allows creation of a builder
     @app_name = "appx#{@random}"
     post :create, {"name" => @app_name, "cartridge" => PHP_VERSION, "domain_id" => @domain.namespace}
     assert_response :created
+    builder_app = assigns(:application)
+    # records that the builder is associated
+    assert_equal builder_app.builder_id, app._id
+    assert_equal builder_app.builder, app
   end
 
   test "attempt to create when all gear sizes are disabled" do

--- a/broker/test/unit/broker_auth_test.rb
+++ b/broker/test/unit/broker_auth_test.rb
@@ -16,30 +16,68 @@ class BrokerAuthTest < Test::Unit::TestCase
     @auth_service
   end
 
-  def test_broker_auth
+  def mock_access(carts=['jenkins-1'])
     app = mock('app')
     user = mock('user')
-    domain = mock('domain')
-    domains = [domain]
     t = Time.new
 
-    user.expects(:login).returns('1')
-
-    domain.expects(:owner).returns(user)
-
-    app.expects(:_id).at_least_once.returns("51ed4adbb8c2e70a72000294")
-    app.expects(:name).at_least_once.returns("foo")
-    app.expects(:domain).returns(domain)
+    app.stubs(:_id).returns("51ed4adbb8c2e70a72000294")
+    app.stubs(:name).returns("foo")
+    app.stubs(:domain_id).returns("51ed4adbb8c2e70a72000000")
     app.expects(:created_at).at_least_once.returns(t)
+    app.expects(:owner).returns(user)
+    app.expects(:requires).returns(carts)
+    app.stubs(:downloaded_cartridges).returns({})
+
+    Application.expects(:find).with(app._id).returns(app)
+
+    [app, user]
+  end
+
+  def test_broker_auth_for_jenkins
+    app, user = mock_access
+    iv,token = svc.generate_broker_key(app)
+    assert auth = svc.validate_broker_key(iv,token)
+    assert_equal user, auth[:user]
+    assert_equal :broker_auth, auth[:auth_method]
+    assert_equal [Scope::Application.new(:id => '51ed4adbb8c2e70a72000294', :app_scope => :scale), Scope::DomainBuilder.new(app)], auth[:scopes]
+  end
+
+  def test_broker_auth
+    app, user = mock_access([])
+    iv,token = svc.generate_broker_key(app)
+    assert auth = svc.validate_broker_key(iv,token)
+    assert_equal user, auth[:user]
+    assert_equal :broker_auth, auth[:auth_method]
+    assert_equal [Scope::Application.new(:id => '51ed4adbb8c2e70a72000294', :app_scope => :scale)], auth[:scopes]
+  end
+
+
+  def test_legacy_broker_auth
+    app = mock('app')
+    user = mock('user')
+    t = Time.new
+
+    user.stubs(:login).returns('1')
+
+    app.stubs(:_id).returns("51ed4adbb8c2e70a72000294")
+    app.stubs(:domain_id).returns("51ed4adbb8c2e70a72000000")
+    app.stubs(:name).returns("foo")
+    app.expects(:created_at).at_least_once.returns(t)
+    app.expects(:requires).returns(['jenkins-1'])
+    app.expects(:downloaded_cartridges).returns({})
 
     Application.expects(:find_by_user).with(user, "foo").at_least_once.returns(app)
     CloudUser.expects(:find_by_identity).at_least_once.returns(user)
+
+    legacy_json = {:app_name => app.name, :creation_time => app.created_at, svc.send(:token_login_key) => user.login }.to_json
+    Hash.any_instance.expects(:to_json).returns(legacy_json)
 
     iv,token = svc.generate_broker_key(app)
     assert auth = svc.validate_broker_key(iv,token)
     assert_equal user, auth[:user]
     assert_equal :broker_auth, auth[:auth_method]
-    assert_equal [Scope::Application.new(:id => '51ed4adbb8c2e70a72000294', :app_scope => :scale), Scope::Application.new(:id => '51ed4adbb8c2e70a72000294', :app_scope => :build)], auth[:scopes]
+    assert_equal [Scope::Application.new(:id => '51ed4adbb8c2e70a72000294', :app_scope => :scale), Scope::DomainBuilder.new(app)], auth[:scopes]
   end
 
   def test_authenticate_request_passes_through

--- a/broker/test/unit/scope_test.rb
+++ b/broker/test/unit/scope_test.rb
@@ -95,7 +95,6 @@ class ScopeTest < ActiveSupport::TestCase
     assert !Scope::Read.new.allows_action?(controller)
 
     assert  Scope::Application.new(:id => '51ed4adbb8c2e70a72000294', :app_scope => :scale).allows_action?(nil)
-    assert  Scope::Application.new(:id => '51ed4adbb8c2e70a72000294', :app_scope => :build).allows_action?(nil)
 
     assert !Scope::Userinfo.new.allows_action?(nil)
     assert !Scope::Userinfo.new.allows_action?(UserController.new)

--- a/console/test/integration/rest_api/cartridge_type_test.rb
+++ b/console/test/integration/rest_api/cartridge_type_test.rb
@@ -36,7 +36,7 @@ class RestApiCartridgeTypeTest < ActiveSupport::TestCase
     assert type.requires.find{ |r| r.starts_with?('mysql-') }, type.requires.inspect
     assert type.tags.include? :administration
     assert_not_equal type.name, type.display_name
-    
+
     assert type = types.find{ |t| t.name.starts_with?('rockmongo-') }
     assert type.requires.find{ |r| r.starts_with?('mongodb-') }, type.requires.inspect
     assert type.tags.include? :administration

--- a/controller/app/models/scope/application.rb
+++ b/controller/app/models/scope/application.rb
@@ -5,7 +5,6 @@ class Scope::Application < Scope::Parameterized
   APP_SCOPES = {
     :view => 'Grant read-only access to a single application.',
     :scale => nil,
-    :build => nil,
     :edit => 'Grant edit access to a single application.',
     :admin => 'Grant full administrative access to a single application.',
   }.freeze
@@ -57,14 +56,6 @@ class Scope::Application < Scope::Parameterized
           #:destroy,
           #:change_members,
         ].include?(permission)
-    when :build
-      return false unless resource === Domain && :create_builder_application == permission && other_resources[0]
-      params = other_resources[0]
-      app = Application.find(app_id)
-      framework = app.requires(true).each{ |feature| cart = CartridgeCache.find_cartridge(feature, app); break cart if cart.categories.include? 'web_framework' }
-      if framework && [framework.name] == params[:cartridges] && app.domain_id === params[:domain_id]
-        true
-      end
     when :scale
       resource === Application && resource._id === app_id && :scale_cartridge == permission
     end

--- a/controller/app/models/scope/domain.rb
+++ b/controller/app/models/scope/domain.rb
@@ -52,7 +52,7 @@ class Scope::Domain < Scope::Parameterized
     DOMAIN_SCOPES.map{ |k,v| s = with_params(nil, k); [s, v, default_expiration(s), maximum_expiration(s)] unless v.nil? }.compact
   end
 
-  private
+  protected
     def id=(s)
       s = s.to_s
       raise Scope::Invalid, "id must be less than 40 characters" unless s.length < 40

--- a/controller/app/models/scope/domain_builder.rb
+++ b/controller/app/models/scope/domain_builder.rb
@@ -1,0 +1,70 @@
+#
+# This is a programmatic scope applied to ci_builders
+#
+class Scope::DomainBuilder < Scope::Parameterized
+  matches 'domain/:id/builder'
+  description "Grant access to build applications in a domain."
+
+  def initialize(app)
+    self.id = app.domain_id
+    self.app = app
+  end
+
+  def allows_action?(controller)
+    true
+  end
+
+  def authorize_action?(permission, resource, other_resources, user)
+    case resource
+    when Domain
+      if :create_builder_application == permission && other_resources[0]
+        params = other_resources[0]
+        (app.domain_id === params[:domain_id])
+      end
+    when Application
+      if app.domain_id === resource.domain_id
+        b = Ability.has_permission?(user, permission, Application, :admin, resource, *other_resources)
+        if Rails.configuration.openshift[:membership_enabled]
+          b && resource.builder_id == builder_id
+        else
+          # DEPRECATED Will be removed after migrations
+          b
+        end
+      end
+    end
+  end
+
+  def limits_access(criteria)
+    case criteria.klass
+    when Application then
+      if Rails.configuration.openshift[:membership_enabled]
+        (criteria.options[:conditions] ||= []).concat([{:domain_id => @id, :builder => app}, {:_id => app._id}])
+      else
+          # DEPRECATED Will be removed after migrations
+        (criteria.options[:conditions] ||= []) << {:domain_id => @id}
+      end
+    when Domain then (criteria.options[:for_ids] ||= []) << @id
+    else criteria.options[:visible] ||= false
+    end
+    criteria
+  end
+
+  def self.describe
+    s = with_params(nil)
+    [s, scope_description, default_expiration(s), maximum_expiration(s)]
+  end
+
+  def builder_id
+    app._id
+  end
+
+  private
+    def id=(s)
+      s = s.to_s
+      raise Scope::Invalid, "id must be less than 40 characters" unless s.length < 40
+      s = Moped::BSON::ObjectId.from_string(s)
+      @id = s
+    end
+
+    attr_accessor :app
+end

--- a/controller/app/rest_models/rest_application.rb
+++ b/controller/app/rest_models/rest_application.rb
@@ -79,7 +79,7 @@ class RestApplication < OpenShift::Model
     self.embedded = {}
     app.requires(true).each do |feature|
       cart = CartridgeCache.find_cartridge(feature, app)
-      if cart.categories.include? "web_framework"
+      if cart.is_web_framework?
         self.framework = cart.name
       else
         self.embedded[cart.name] = {info: ""}


### PR DESCRIPTION
- When using broker auth on a REST API call, a "ci_server" app will get a DomainBuilder scope which allows the app to create a builder application that is linked to the creating application.  
  - When membership_enabled is true the domain builder only has access to change applications that it created
  - If the app isn't ci_server, it only gets the scale scope
- Fix a bug that prevent domain ssh key propagation
- Allow scopes to limit ids and queries at the same time
- Switch broker auth keys to being generated using the id, and continue to support the old way. 
