### PR TITLE
Bug 997825 - Fail to install gems with Gemfile & Gemfile.lock for ruby a...

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -189,8 +189,7 @@ function rails_app_name_check() {
   # Rails does not work if the application name starts with a number
   pushd ${OPENSHIFT_REPO_DIR} >/dev/null
   if [ -f Gemfile.lock ]; then
-    grep 'rails' Gemfile.lock 2>&1 >/dev/null
-    if [ $? -eq 0 ]; then
+    if grep -q ' rails ' Gemfile.lock; then
       if $(echo "$OPENSHIFT_APP_NAME" | grep '^[0-9]' >/dev/null); then
         client_error "Invalid Rails application name. Please delete this application and re-create it with a name which does not start with numbers"
         exit 1


### PR DESCRIPTION
For some reason the `grep 'rails' Gemfile.lock 2>&1 >/dev/null` cause the bash function to exit(1).  I can reproduce this problem on latest devenv:

```
 ~/ruby02 → git push
remote: Stopping Ruby cartridge
remote: Waiting for stop to finish
remote: An error occurred executing 'gear postreceive' (exit code: 1)
remote: Error message: Failed to execute: 'control pre-build' for /var/lib/openshift/867533080965376425066496/ruby
remote: 
remote: For more details about the problem, try running the command again with the '--trace' option.
```

With this fix, the pre-build function works the same but does not exits.... 

```
remote: Stopping Ruby cartridge
remote: Waiting for stop to finish
remote: Saving away previously bundled RubyGems
remote: Building Ruby cartridge
remote: Restoring previously bundled RubyGems (note: you can commit .openshift/markers/force_clean_build at the root of your repo to force a clean bundle)
remote: Bundling RubyGems based on Gemfile/Gemfile.lock to repo/vendor/bundle with 'bundle install --deployment'
remote: Using rack (1.5.2) 
remote: Using bundler (1.1.4) 
remote: Your bundle is complete! It was installed into ./vendor/bundle
remote: Starting application ruby02
remote: Starting Ruby cartridge
```
