### PR TITLE
Bug 997861 - Report presence of the force_clean_build marker for Python...

### DIFF
--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
@@ -116,11 +116,14 @@ function build() {
         OPENSHIFT_PYTHON_MIRROR="-i http://mirror1.ops.rhcloud.com/mirror/python/web/simple"
     fi
 
-    if [ -f "${OPENSHIFT_REPO_DIR}/.openshift/markers/force_clean_build" -o ! -f $VIRTUAL_ENV/bin/python ]
-    then
-        echo "Recreating virtenv" 1>&2
+    if marker_present 'force_clean_build'; then
+        echo ".openshift/markers/force_clean_build found!" 1>&2
         rm -rf $VIRTUAL_ENV/*
-        create-virtenv
+    fi
+
+    if [ ! -f $VIRTUAL_ENV/bin/python ]; then
+      echo "Recreating virtenv" 1>&2
+      create-virtenv
     fi
 
     if [ -f ${OPENSHIFT_REPO_DIR}/setup.py ]


### PR DESCRIPTION
This is just a minor fix, where if 'force_clean_build' marker exists, print it to console.

Now (devenv_3661) you get this:

```
remote: Stopping PYTHON cart
remote: Waiting for stop to finish
remote: Recreating virtenv
```

With this patch you will get this:

```
remote: .openshift/markers/force_clean_build found!
remote: Recreating virtenv

```
