### PR TITLE
Bug 989225 - Check container_plugin

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -184,7 +184,7 @@ module OpenShift
       def destroy(skip_hooks=false)
         notify_observers(:before_container_destroy)
 
-        if @uid.nil? or (@container_dir.nil? or !File.directory?(@container_dir.to_s))
+        if @uid.nil? or (@container_plugin.nil? or !File.directory?(@container_dir.to_s))
           # gear seems to have been deleted already... suppress any error
           # TODO : remove remaining stuff if it exists, e.g. .httpd/#{uuid}* etc
           return ['', '', 0]


### PR DESCRIPTION
Bug 989225 - the logic changed so that @container_dir is always set and @container_plugin is nil if the container no longer exists.
