### PR TITLE
Bug 996491: Show warning when using snapshot and near disk quota

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -18,6 +18,7 @@ require 'rubygems'
 require 'openshift-origin-node/model/frontend_proxy'
 require 'openshift-origin-node/model/frontend_httpd'
 require 'openshift-origin-node/model/v2_cart_model'
+require 'openshift-origin-node/model/node'
 require 'openshift-origin-common/models/manifest'
 require 'openshift-origin-node/model/application_container_ext/environment'
 require 'openshift-origin-node/model/application_container_ext/setup'
@@ -563,6 +564,19 @@ module OpenShift
             end
           end
         end
+      end
+
+      ##
+      # Returns +true+ if the user's disk block usage meets or exceeds +max_percent+ of
+      # the configured block limit, otherwise +false+.
+      def disk_usage_exceeds?(max_percent)
+        raise "Percent must be between 1-100 (inclusive)" unless (1..100).member?(max_percent)
+
+        quota = OpenShift::Runtime::Node.get_quota(@uuid)
+
+        used_percent = ((quota[:blocks_used].to_f / quota[:blocks_limit].to_f) * 100.00).to_i
+
+        return used_percent >= max_percent
       end
 
       # run_in_container_context(command, [, options]) -> [stdout, stderr, exit status]

--- a/node/lib/openshift-origin-node/model/application_container_ext/snapshots.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/snapshots.rb
@@ -38,6 +38,11 @@ module OpenShift
         # The operations invoked by this method write user-facing output to the
         # client on STDERR.
         def snapshot
+          if disk_usage_exceeds?(90)
+            $stderr.puts "WARNING: The application's disk usage is very close to the quota limit. The snapshot may fail unexpectedly"
+            $stderr.puts "depending on the amount of data present and the snapshot procedure used by your application's cartridges."
+          end
+
           stop_gear
 
           scalable_snapshot = !!@cartridge_model.web_proxy
@@ -104,6 +109,11 @@ module OpenShift
         #
         # The operation invoked by this method write output to the client on STDERR.
         def restore(restore_git_repo)
+          if disk_usage_exceeds?(90)
+            $stderr.puts "WARNING: The application's disk usage is very close to the quota limit. The restore may fail unexpectedly"
+            $stderr.puts "depending on the amount of data to be restored and the restore procedure used by your application's cartridges."
+          end
+
           gear_env = ::OpenShift::Runtime::Utils::Environ.for_gear(@container_dir)
 
           scalable_restore = !!@cartridge_model.web_proxy


### PR DESCRIPTION
When the gear user's disk usage is >= 90% of quota, display a warning when
snapshotting or restoring (as these operations can fail in unexpected ways
when disk writes fail).
