### PR TITLE
Bug 983605 - Allow to administrator to change the default 'rhc ssh' motd

### DIFF
--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -45,3 +45,5 @@ LIBVIRT_PRIVATE_IP_GW=172.16.0.1
 
 CONTAINERIZATION_PLUGIN=openshift-origin-container-selinux
 QUOTA_WARNING_PERCENT=90.0
+
+# MOTD_FILE=" /etc/openshift/welcome.rhcsh"                   # Change the default rhcs welcome message

--- a/node/misc/bin/rhcsh
+++ b/node/misc/bin/rhcsh
@@ -48,6 +48,9 @@ done
 source /etc/openshift/node.conf
 
 function welcome {
+    if [ -n "$MOTD_FILE" -a -f "$MOTD_FILE" ]; then
+        cat $MOTD_FILE
+    else
     cat 1>&2 <<EOF
 
     *********************************************************************
@@ -74,6 +77,7 @@ function welcome {
     Type "help" for more info.
 
 EOF
+  fi
 
   # Quota returns nonzero if you are over limit
   quota >/dev/null 2>&1


### PR DESCRIPTION
This patch will allow to administrator change the default `rhc ssh APP` welcome message from the default 'Online' message to a custom one via the `MOTD_FILE` option in node.conf.

By default the Online message will be used. Also, since on Online AFAIK the /etc/motd has the same content, the default message could be removed from the `rhcsh` entirely and the default value for MOTD_FILE could be '/etc/motd'.. Thoughts? 
