### PR TITLE
Bug 997848 - Inherited capabilities not in REST API

### DIFF
--- a/broker/test/unit/cloud_user_test.rb
+++ b/broker/test/unit/cloud_user_test.rb
@@ -15,10 +15,10 @@ class CloudUserTest < ActiveSupport::TestCase
       user = CloudUser.new(login: @login)
       user.add_ssh_key(UserSshKey.new(name: 'default', content: "ssh#{invalid_chars[i].chr}key"))
       assert user.invalid?
-      
+
       assert !user.errors[:ssh_keys].empty?
     end
-    
+
     user = CloudUser.new(login: @login)
     user.add_ssh_key(UserSshKey.new(name: 'default', content: "ABCdef012+/="))
     assert user.valid?
@@ -29,24 +29,24 @@ class CloudUserTest < ActiveSupport::TestCase
     user = CloudUser.new(login: @login)
     user.add_ssh_key(UserSshKey.new(name: 'default', content: ssh))
     observer_seq = sequence("observer_seq")
-         
+
     CloudUser.expects(:notify_observers).with(:before_cloud_user_create, user).in_sequence(observer_seq).at_least_once
     CloudUser.expects(:notify_observers).with(:cloud_user_create_success, user).in_sequence(observer_seq).at_least_once
     CloudUser.expects(:notify_observers).with(:after_cloud_user_create, user).in_sequence(observer_seq).at_least_once
 
     user.save!
-    
+
     found_user = CloudUser.find_by(login: @login)
     assert_equal_users(user, found_user)
   end
-  
+
   test "update cloud user" do
     login = "user_" + gen_uuid
     orig_cu = CloudUser.new(login: login)
     orig_cu.save!
 
     orig_cu.set(:consumed_gears, 2)
-  
+
     updated_cu = CloudUser.find_by(login: login)
     assert_equal(orig_cu.consumed_gears, updated_cu.consumed_gears)
   end
@@ -67,7 +67,7 @@ class CloudUserTest < ActiveSupport::TestCase
     orig_cu = CloudUser.new(login: login)
     orig_cu.save!
     orig_cu.delete
-  
+
     cu = nil
     begin
       cu = CloudUser.find_by(login: login)
@@ -77,18 +77,18 @@ class CloudUserTest < ActiveSupport::TestCase
 
     assert_equal(nil, cu)
   end
-  
+
   test "create user fails if user already exists" do
     ssh = "AAAAB3NzaC1yc2EAAAABIwAAAQEAvzdpZ/3+PUi3SkYQc3j8v5W8+PUNqWe7p3xd9r1y4j60IIuCS4aaVqorVPhwrOCPD5W70aeLM/B3oO3QaBw0FJYfYBWvX3oi+FjccuzSmMoyaYweXCDWxyPi6arBqpsSf3e8YQTEkL7fwOQdaZWtW7QHkiDCfcB/LIUZCiaArm2taIXPvaoz/hhHnqB2s3W/zVP2Jf5OkQHsVOTxYr/Hb+/gV3Zrjy+tE9+z2ivL+2M0iTIoSVsUcz0d4g4XpgM8eG9boq1YGzeEhHe1BeliHmAByD8PwU74tOpdpzDnuKf8E9Gnwhsp2yqwUUkkBUoVcv1LXtimkEyIl0dSeRRcMw=="
     user = CloudUser.new(login: @login)
     user.add_ssh_key(UserSshKey.new(name: 'default', content: ssh))
     observer_seq = sequence("observer_seq")
-         
+
     CloudUser.expects(:notify_observers).with(:before_cloud_user_create, user).in_sequence(observer_seq).at_least_once
     CloudUser.expects(:notify_observers).with(:cloud_user_create_error, user).in_sequence(observer_seq).at_least_once
     CloudUser.expects(:notify_observers).with(:after_cloud_user_create, user).in_sequence(observer_seq).at_least_once
     user.expects(:mongoid_save).raises(OpenShift::UserException, 'User exists')
-    
+
     begin
       user.save
     rescue OpenShift::UserException => e
@@ -121,11 +121,27 @@ class CloudUserTest < ActiveSupport::TestCase
     assert a === c.capabilities
   end
 
+  test "inherited capabilities" do
+    parent = CloudUser.create(login: "#{@login}_parent") do |u|
+      u._capabilities = u.default_capabilities
+      u.capabilities['gear_sizes'] = ['foo', 'bar']
+      u.capabilities['inherit_on_subaccounts'] = ['gear_sizes']
+    end
+    c = CloudUser.create(login: @login){ |u| u.parent_user_id = parent._id }
+
+    assert_equal ['foo', 'bar'], c.allowed_gear_sizes
+    assert_equal ['foo', 'bar'], c.capabilities['gear_sizes']
+    assert_equal ['foo', 'bar'], c.capabilities.to_hash['gear_sizes']
+    assert_equal ['foo', 'bar'], c.capabilities.deep_dup['gear_sizes']
+    # fails today
+    #assert_equal ['foo', 'bar'], JSON.parse(c.capabilities.to_json)['gear_sizes']
+  end
+
   test "user ssh keys" do
     ssh = "AAAAB3NzaC1yc2EAAAABIwAAAQEAvzdpZ/3+PUi3SkYQc3j8v5W8+PUNqWe7p3xd9r1y4j60IIuCS4aaVqorVPhwrOCPD5W70aeLM/B3oO3QaBw0FJYfYBWvX3oi+FjccuzSmMoyaYweXCDWxyPi6arBqpsSf3e8YQTEkL7fwOQdaZWtW7QHkiDCfcB/LIUZCiaArm2taIXPvaoz/hhHnqB2s3W/zVP2Jf5OkQHsVOTxYr/Hb+/gV3Zrjy+tE9+z2ivL+2M0iTIoSVsUcz0d4g4XpgM8eG9boq1YGzeEhHe1BeliHmAByD8PwU74tOpdpzDnuKf8E9Gnwhsp2yqwUUkkBUoVcv1LXtimkEyIl0dSeRRcMw=="
     user = CloudUser.new(login: @login)
     user.add_ssh_key(UserSshKey.new(name: 'default', content: ssh))
-    
+
     user.add_ssh_key(UserSshKey.new(name: 'keyname', content: 'key'))
     found_key = false
     user.ssh_keys.each do |key|
@@ -148,7 +164,7 @@ class CloudUserTest < ActiveSupport::TestCase
     assert found_key
 
     user.remove_ssh_key('keyname')
-    
+
     found_key = false
     user.ssh_keys.each do |key|
       if key.name == 'keyname' && key.content == 'key'
@@ -156,15 +172,15 @@ class CloudUserTest < ActiveSupport::TestCase
         break
       end
     end
-    
+
     assert !found_key
-    
+
     user = CloudUser.find_by(login: @login)
-    
+
     # Make sure everything works with a domain
     domain = Domain.new(namespace: user._id.to_s[0..15], owner: user)
     domain.save!
-    
+
     user.add_ssh_key(UserSshKey.new(name: 'keyname', content: 'key'))
     user = CloudUser.find_by(login: @login)
     found_key = false
@@ -175,11 +191,11 @@ class CloudUserTest < ActiveSupport::TestCase
       end
     end
     assert found_key
-    
+
     domain.delete
 
     user.remove_ssh_key('keyname')
-    
+
     found_key = false
     user.ssh_keys.each do |key|
       if key.name == 'keyname' && key.content == 'key'
@@ -187,18 +203,18 @@ class CloudUserTest < ActiveSupport::TestCase
         break
       end
     end
-    
+
     assert !found_key
-    
+
     # Make sure the user is still there
     CloudUser.find_by(login: @login)
   end
-  
+
   def assert_equal_users(user1, user2)
     assert_equal(user1.login, user2.login)
     assert_equal(user1._id, user2._id)
   end
-  
+
   def teardown
     user = CloudUser.find_by(login: @login) rescue nil
     user.force_delete if user

--- a/common/lib/openshift-origin-common/models/model.rb
+++ b/common/lib/openshift-origin-common/models/model.rb
@@ -10,8 +10,8 @@ module OpenShift
     self.include_root_in_json = false
     include ActiveModel::Serializers::Xml
     include ActiveModel::AttributeMethods
-    include ActiveModel::Observing    
-    
+    include ActiveModel::Observing
+
     def attributes
       a = {}
       self.instance_variable_names.each do |name|
@@ -24,7 +24,7 @@ module OpenShift
     def attribute(name)
       instance_variable_get("@#{name}")
     end
-    
+
     def to_xml(options = {})
       to_xml_opts = {:skip_types => true}
       to_xml_opts.merge!(options.slice(:builder, :skip_instruct))

--- a/controller/app/models/cloud_user.rb
+++ b/controller/app/models/cloud_user.rb
@@ -241,6 +241,15 @@ class CloudUser
     def [](key)
       @inherited[key] || super
     end
+    def deep_dup
+      __getobj__.deep_dup.merge!(@inherited.deep_dup)
+    end
+    def to_hash
+      deep_dup
+    end
+    def serializable_hash
+      to_hash
+    end
   end
 
   #

--- a/controller/app/rest_models/rest_user.rb
+++ b/controller/app/rest_models/rest_user.rb
@@ -43,7 +43,7 @@ class RestUser < OpenShift::Model
   def initialize(cloud_user, url, nolinks=false)
     [:id, :login, :consumed_gears, :plan_id, :plan_state, :usage_account_id, :created_at].each{ |sym| self.send("#{sym}=", cloud_user.send(sym)) }
 
-    self.capabilities = cloud_user.capabilities.deep_dup
+    self.capabilities = cloud_user.capabilities.serializable_hash
     self.max_gears = cloud_user.max_gears
     self.capabilities.delete("max_gears")
 

--- a/controller/app/rest_models/rest_user10.rb
+++ b/controller/app/rest_models/rest_user10.rb
@@ -42,7 +42,7 @@ class RestUser10 < OpenShift::Model
     self.login = cloud_user.login
     self.consumed_gears = cloud_user.consumed_gears
 
-    self.capabilities = cloud_user.capabilities.deep_dup
+    self.capabilities = cloud_user.capabilities.serializable_hash
     self.max_gears = self.capabilities["max_gears"]
     self.capabilities.delete("max_gears")
 


### PR DESCRIPTION
With the changes to use CapabilityProxy, the default API serialization (Rails)
was serializing the user's underlying attribute from Mongoid, not the proxy
overlay of inherited capabilities.  Changed to use serializable_hash which
uses the proper values

[merge]
