### PR TITLE
User env var bug fixes

### DIFF
--- a/controller/app/controllers/environment_variables_controller.rb
+++ b/controller/app/controllers/environment_variables_controller.rb
@@ -29,14 +29,14 @@ class EnvironmentVariablesController < BaseController
   # POST /applications/[app_id]/environment-variables
   def create
     name = params[:name].presence
-    value = params[:value].presence
     user_env_vars = params[:environment_variables].presence
 
     if (user_env_vars.present? && name) or (!user_env_vars.present? && !name)
       return render_error(:unprocessable_entity, "Specify parameters 'name'/'value' or 'environment_variables'", 191)
     end
     if name
-      return render_error(:unprocessable_entity, "Value not specified for environment variable '#{name}'", 190, "value") unless value
+      return render_error(:unprocessable_entity, "Value not specified for environment variable '#{name}'", 190, "value") unless params.has_key?(:value)
+      value = params[:value]
       env_hash = @application.list_user_env_variables([name])
       return render_error(:unprocessable_entity, "Environment name '#{name}' already exists in application", 192) if env_hash[name]
 
@@ -57,9 +57,9 @@ class EnvironmentVariablesController < BaseController
   # PUT /applications/[app_id]/environment-variables/[id]
   def update
     name = params[:id].presence
-    value = params[:value].presence
 
-    return render_error(:unprocessable_entity, "Value not specified for environment variable '#{name}'", 190, "value") unless value
+    return render_error(:unprocessable_entity, "Value not specified for environment variable '#{name}'", 190, "value") unless params.has_key?(:value)
+    value = params[:value]
     env_hash = @application.list_user_env_variables([name])
     return render_error(:unprocessable_entity, "Environment name '#{name}' not found in application", 189) unless env_hash[name]
 

--- a/node/lib/openshift-origin-node/model/application_container_ext/environment.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/environment.rb
@@ -290,7 +290,7 @@ module OpenShift
             set_ro_permission(path)
           end
 
-          return user_var_push(gears) unless gears.empty?
+          return user_var_push(gears, true) unless gears.empty?
           return 0, ''
         end
 
@@ -307,11 +307,12 @@ module OpenShift
         end
 
         # update user environment variable(s) on other gears
-        def user_var_push(gears)
+        def user_var_push(gears, env_add=false)
           output, gear_dns, threads = '', '', {}
           target  = PathUtils.join('.env', 'user_vars').freeze
           source  = PathUtils.join(@container_dir, target).freeze
-          return 0, '' unless File.directory?(source) and !(Dir.entries(source) - %w{. ..}).empty?
+          return 0, '' unless File.directory?(source)
+          return 0, '' if env_add and (Dir.entries(source) - %w{. ..}).empty?
 
           begin
             gears.each do |gear|

--- a/node/lib/openshift-origin-node/utils/environ.rb
+++ b/node/lib/openshift-origin-node/utils/environ.rb
@@ -85,7 +85,6 @@ module OpenShift
 
               begin
                 contents = IO.read(file).chomp
-                next if contents.empty?
 
                 if contents.start_with? 'export '
                   index           = contents.index('=')

--- a/node/misc/bin/oo-user-var-add
+++ b/node/misc/bin/oo-user-var-add
@@ -61,7 +61,7 @@ begin
       when '--with-container-uuid'
         container_uuid = arg
       when '--with-variables'
-        arg.split(' ').each { |a| token = a.split('='); variables[token.first] = token.last }
+        arg.split(' ').each { |a| token = a.split('=', 2); variables[token.first] = token.last }
       when '--with-gears'
         gears = arg.split(';')
       when '--help'

--- a/node/test/unit/application_container_test.rb
+++ b/node/test/unit/application_container_test.rb
@@ -281,7 +281,7 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
     filename = "#{source}/UNIT_TEST"
     gears    = ['unit_test.example.com']
 
-    @container.expects(:user_var_push).with(gears)
+    @container.expects(:user_var_push).with(gears, true)
 
     @container.user_var_add({'UNIT_TEST' => 'true'}, gears)
 
@@ -292,7 +292,8 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
     path  = "/var/lib/openshift/#{@gear_uuid}/.env/user_vars/UNIT_TEST"
     gears = ['unit_test.example.com']
 
-    @container.expects(:user_var_push).with(gears).twice
+    @container.expects(:user_var_push).with(gears, true)
+    @container.expects(:user_var_push).with(gears)
 
     @container.user_var_add({'UNIT_TEST' => 'true'}, gears)
     assert_path_exist path
@@ -317,7 +318,13 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
   def test_bad_user_var()
     env = {'OPENSHIFT_TEST_IDENT'            => 'x:x:x:x',
            'OPENSHIFT_NAMESPACE'             => 'namespace',
-           'OPENSHIFT_PRIMARY_CARTRIDGE_DIR' => 'mine'}
+           'OPENSHIFT_PRIMARY_CARTRIDGE_DIR' => 'mine',
+           'PATH'                            => '/usr/bin',
+           'IFS'                             => '/',
+           'USER'                            => 'none',
+           'SHELL'                           => 'tcsh',
+           'HOSTNAME'                        => 'remotehost',
+           'LOGNAME'                         => '/tmp/log'}
 
     env.each do |key, value|
       rc, msg = @container.user_var_add({key => value})

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -376,7 +376,7 @@ module MCollective
 
       def oo_user_var_add(args)
         variables, gears = {}, []
-        args['--with-variables'].split(' ').each { |a| token = a.split('='); variables[token.first] = token.last } if args['--with-variables']
+        args['--with-variables'].split(' ').each { |a| token = a.split('=', 2); variables[token.first] = token.last } if args['--with-variables']
         gears = args['--with-gears'].split(';') if args['--with-gears']
 
         if variables.empty? and gears.empty?


### PR DESCRIPTION
Bug 998794 - Allow blank value for a user environment variable

Bug 998768 - Allow char '=' in the enviroment variable

Bug 998891 - Remove env var should always call rsync on all other gears from head gear
