### PR TITLE
Bugs 995550,996751,998704: Multiple related throttler issues

### DIFF
--- a/node/conf/resource_limits.conf
+++ b/node/conf/resource_limits.conf
@@ -102,8 +102,9 @@ memory_memsw_limit_in_bytes=641728512 # 512M + 100M (100M swap)
 [cg_template_throttled]
   cpu_shares=128
   cpu_cfs_quota_us=30000
-  apply_period=10
-  apply_threshold=10
+  apply_period=120
+  apply_percent=30
+  restore_percent=70
 
 # Freeze and Thaw templates
 #

--- a/node/lib/openshift-origin-node/utils/cgroups/libcgroup.rb
+++ b/node/lib/openshift-origin-node/utils/cgroups/libcgroup.rb
@@ -139,6 +139,10 @@ module OpenShift
             @uid_cache ||= Etc.getpwnam(@uuid).uid
           end
 
+          # TODO: These could potentially be replaced by cgsnapshot if we can determine if its fast enough
+          # (str, err, rc = ::OpenShift::Runtime::Utils::oo_spawn('cgsnapshot 2> /dev/null')
+          # keys = %w(cpu.cfs_period_us cpu.cfs_quota_us cpuacct.usage)
+          # Hash[str.scan(/^group\sopenshift\/(.*?)\s(.*?)^}/m).map{|mg| [mg[0], Hash[mg[1].scan(/\s*(#{keys.join('|')})\s*=\s*"(.*)";/).map{|k,v| [k,v.to_i]}]] }]
           def self.usage
             cmd = 'grep -H "" */{cpu.stat,cpuacct.usage,cpu.cfs_quota_us} 2> /dev/null'
             (out, err, rc) = ::OpenShift::Runtime::Utils::oo_spawn(cmd, :chdir => cgroup_paths['cpu'], :quiet => true)

--- a/node/lib/openshift-origin-node/utils/cgroups/monitored_gear.rb
+++ b/node/lib/openshift-origin-node/utils/cgroups/monitored_gear.rb
@@ -47,6 +47,7 @@ module OpenShift
           @@delay = nil
           @@max = nil
           @@_delay = nil
+          MIN_DELAY = 5
 
           attr_accessor :thread, :times
           attr_reader :gear
@@ -162,11 +163,17 @@ module OpenShift
             end
 
             def delay
-              @@delay ||= (@@_delay || intervals.min.to_f / 2)
+              @@delay ||= (@@_delay || new_delay)
             end
 
             def intervals
               @@intervals
+            end
+
+            protected
+            def new_delay
+              new_delay = intervals.min.to_f / 4
+              [new_delay, MIN_DELAY].max
             end
           end
 

--- a/node/lib/openshift-origin-node/utils/cgroups/throttler.rb
+++ b/node/lib/openshift-origin-node/utils/cgroups/throttler.rb
@@ -23,17 +23,15 @@ module OpenShift
             @mutex = Mutex.new
             @uuids = []
 
-            throttler_config = ::OpenShift::Runtime::Utils::Cgroups::Config.new(@@conf_file).get_group('cg_template_throttled')
-
             # Set the interval to save
-            @interval = throttler_config.get('apply_period').to_i rescue nil
-            # The threshold to query against
-            @threshold = throttler_config.get('apply_threshold').to_i rescue nil
-
-            raise ArgumentError, "#{@@conf_file} requires 'apply_period' in '[cg_template_throttled]' group" if @interval.nil?
-            raise ArgumentError, "#{@@conf_file} requires 'apply_threshold' in '[cg_template_throttled]' group" if @threshold.nil?
+            @interval = config_val('apply_period'){|x| Integer(x) }
+            # Throttle at this percent
+            @throttle_percent = config_val('apply_percent'){|x| Float(x) }
+            # Restore at this percent
+            @restore_percent = config_val('restore_percent'){|x| Float(x) }
 
             MonitoredGear.intervals = [@interval]
+            MonitoredGear.delay = 5
 
             # Allow us to lazy initialize MonitoredGears
             @running_apps = Hash.new do |h,uuid|
@@ -41,11 +39,26 @@ module OpenShift
             end
 
             Syslog.open(File.basename($0), Syslog::LOG_PID, Syslog::LOG_DAEMON) unless Syslog.opened?
-            Syslog.info("Starting throttler => threshold: #{@threshold.to_f}%%/#{@interval}s, check_interval: #{MonitoredGear.delay}")
+            # Need to "escape" the percents here for use in Syslog.info
+            str = "throttle at: %0.2f%%%%, restore at: %0.2f%%%%, period: %d, check_interval: %0.2f" % [@throttle_percent, @restore_percent, @interval, MonitoredGear.delay]
+            Syslog.info("Starting throttler => #{str}")
 
             # Start our collector thread
             start
           end
+
+          # Allow us to get the config value from the cgroups_config
+          # It also allows us to try to cast it into a particular type or raise an error it that fails
+          def config_val(key)
+            begin
+              @config ||= ::OpenShift::Runtime::Utils::Cgroups::Config.new(@@conf_file).get_group('cg_template_throttled')
+              val = @config.get(key)
+              yield val
+            rescue
+              raise ArgumentError, "#{@@conf_file} requires '#{key}' in '[cg_template_throttled]' group"
+            end
+          end
+
 
           def start
             Thread.new do
@@ -122,7 +135,8 @@ module OpenShift
               end
               # Find any gears over the threshold
               over_usage = with_period.select do |k,v|
-                v[:usage_percent] >= usage
+                percent = v[:usage_percent]
+                percent && percent >= usage
               end.keys
               apps.select!{|k,v| over_usage.include?(k) }
             end
@@ -141,52 +155,72 @@ module OpenShift
             [apps, cur_util]
           end
 
-          def throttle(args)
-            (@bad_gears, cur_util) = find(args)
-            # If this is our first run, make sure we find any previously throttled gears
-            # NOTE: There is a corner case where we won't find non-running throttled applications
-            @old_bad_gears ||= find(state: :throttled).first
+          def throttle(cur_uuids)
+            self.uuids = cur_uuids
+            (bad_gears, cur_util) = find(period: @interval, usage: @throttle_percent)
 
-            apply_action({
-              :restore => @old_bad_gears,
-              :throttle => @bad_gears,
-            }, cur_util)
-          end
-
-          def apply_action(hash, cur_util)
             util = cur_util.inject({}) do |h,(uuid,vals)|
               h[uuid] = (vals.map{|k,v| v[:usage_percent] }.first || '???')
               h
             end
 
+            # If this is our first run, make sure we find any previously throttled gears
+            # NOTE: There is a corner case where we won't find non-running throttled applications
+            @old_bad_gears ||= find(state: :throttled).first
+
+            # Restore any gears we have utilization values for that are <= restore_percent
+            (restore_gears, @old_bad_gears) = @old_bad_gears.partition do |uuid, gear|
+              util.has_key?(uuid) && util[uuid] <= @restore_percent
+            end.map{|a| Hash[a] }
+
+            @old_bad_gears.each do |uuid, gear|
+              u = util[uuid]
+              msg = (u.nil? || u == '???') ? 'unknown utilization' : "still over threshold (#{util[uuid]})"
+              refuse_action(:restore, uuid, msg)
+            end
+
+            # Do not attempt to throttle any gears that are already throttled
+            bad_gears.reject! do |uuid, gear|
+              @old_bad_gears.has_key?(uuid)
+            end
+
+            # Find any "bad" gears that are boosted
+            (boosted_gears, bad_gears) = bad_gears.partition do |uuid,gear|
+              gear.gear.boosted?
+            end.map{|a| Hash[a] }
+
+            boosted_gears.each do |uuid, gear|
+              refuse_action(:throttle, uuid, "gear is boosted")
+            end
+
+            apply_action({
+              :restore => restore_gears,
+              :throttle => bad_gears,
+            }, util)
+          end
+
+          def apply_action(hash, util)
             hash.each do |action, gears|
               gears.each do |uuid, g|
                 begin
-                  case action
-                  when :throttle
-                    if @old_bad_gears.has_key?(uuid)
-                      log_action("REFUSED #{action}", uuid, "gear already throttled", :warning)
-                      next
-                    elsif g.gear.boosted?
-                      log_action("REFUSED #{action}", uuid, "gear is boosted", :warning)
-                      next
-                    end
-                  when :restore
-                    if @bad_gears.has_key?(uuid)
-                      log_action("REFUSED #{action}", uuid, "still over threshold", :warning)
-                      next
-                    end
-                  end
                   g.gear.send(action)
                   if action == :throttle
                     @old_bad_gears[uuid] = g
                   end
                   log_action(action, uuid, util[uuid])
                 rescue RuntimeError => e
-                  log_action("FAILED #{action}", uuid, e.message, :warning)
+                  failed_action(action, uuid, e.message)
                 end
               end
             end
+          end
+
+          def refuse_action(action, uuid, reason)
+            log_action("REFUSED #{action}", uuid, reason, :warning)
+          end
+
+          def failed_action(action, uuid, reason)
+            log_action("FAILED #{action}", uuid, reason, :warning)
           end
 
           def log_action(action, uuid, value, level = :info)

--- a/node/test/unit/monitored_gear_test.rb
+++ b/node/test/unit/monitored_gear_test.rb
@@ -77,8 +77,14 @@ class MonitoredGearInstanceTest < OpenShift::NodeTestCase
   def test_delay
     @@impl.expects(:intervals).once.returns([50,100])
 
-    # Delay should be (intervals.min / 2)
-    assert_equal 25, @@impl.delay
+    # Delay should be (intervals.min / 4)
+    assert_equal 12.5, @@impl.delay
+  end
+
+  def test_min_delay
+    @@impl.expects(:intervals).once.returns([1])
+
+    assert_equal @@impl::MIN_DELAY, @@impl.delay
   end
 
   def test_explicit_delay

--- a/node/test/unit/throttler_test.rb
+++ b/node/test/unit/throttler_test.rb
@@ -13,15 +13,9 @@ class ThrottlerTest < OpenShift::NodeTestCase
     logger = OpenShift::Runtime::NodeLogger::NullLogger.new
     OpenShift::Runtime::NodeLogger.set_logger(logger)
 
-    @resources = mock().tap do |x|
-      x.stubs(:get).with('apply_period').returns(10)
-      x.stubs(:get).with('apply_threshold').returns(10)
-    end
-
-    @mock_config = mock('OpenShift::Runtime::Utils::Cgroups::Config')
-    @mock_config.stubs(:get_group).returns(@resources)
-
-    OpenShift::Runtime::Utils::Cgroups::Config.stubs(:new).with('/etc/openshift/resource_limits.conf').returns(@mock_config)
+    @@impl.any_instance.stubs(:config_val).with('apply_period').returns(120)
+    @@impl.any_instance.stubs(:config_val).with('apply_percent').returns(30)
+    @@impl.any_instance.stubs(:config_val).with('restore_percent').returns(70)
 
     @throttler = @@impl.new
     @mock_usage = {
@@ -51,8 +45,8 @@ class ThrottlerTest < OpenShift::NodeTestCase
     period = 9999
     threshold = 5555
 
-    @resources.expects(:get).with('apply_period').returns(period)
-    @resources.expects(:get).with('apply_threshold').returns(threshold)
+    @@impl.any_instance.stubs(:config_val).with('apply_period').returns(period)
+    @@impl.any_instance.stubs(:config_val).with('apply_percent').returns(threshold)
 
     @@mg.expects("intervals=").with([period])
     @@impl.any_instance.expects(:start).once
@@ -60,7 +54,38 @@ class ThrottlerTest < OpenShift::NodeTestCase
     throttler = @@impl.new
 
     assert_equal period, throttler.interval
-    assert_equal threshold, throttler.threshold
+  end
+
+  def test_init_missing_config
+    @@impl.any_instance.unstub(:config_val)
+    resources = mock().tap do |x|
+      x.stubs(:get).returns(nil)
+    end
+
+    mock_config = mock('OpenShift::Runtime::Utils::Cgroups::Config')
+    mock_config.stubs(:get_group).returns(resources)
+
+    OpenShift::Runtime::Utils::Cgroups::Config.stubs(:new).with('/etc/openshift/resource_limits.conf').returns(mock_config)
+
+    assert_raise ArgumentError do
+      @@impl.new
+    end
+  end
+
+  def test_init_invalid_config
+    @@impl.any_instance.unstub(:config_val)
+    resources = mock().tap do |x|
+      x.stubs(:get).returns("asdf")
+    end
+
+    mock_config = mock('OpenShift::Runtime::Utils::Cgroups::Config')
+    mock_config.stubs(:get_group).returns(resources)
+
+    OpenShift::Runtime::Utils::Cgroups::Config.stubs(:new).with('/etc/openshift/resource_limits.conf').returns(mock_config)
+
+    assert_raise ArgumentError do
+      @@impl.new
+    end
   end
 
   def test_update
@@ -220,82 +245,107 @@ class ThrottlerTest < OpenShift::NodeTestCase
 
   def test_throttle
     mock_apps = {
-      "A" => { },
-      "B" => { }
+      "A" => {
+        expects: {
+          boosted?: false
+        },
+      },
+      "B" => {
+        expects: {
+          boosted?: true
+        },
+      },
+      "C" => {
+        utilization: {
+          10  => {
+            usage_percent: 0
+          },
+        },
+      },
+      "D" => {
+        utilization: {
+          10  => {
+            usage_percent: 1000000
+          },
+        },
+      },
+      "E" => {},
+      "F" => {
+        utilization: {
+          10  => {
+            usage_percent: 1000000
+          },
+        },
+      },
     }
 
-    with_mock_apps(mock_apps) do |mock_apps, mock_util|
-      bad_gears = {
-        'A' => mock_apps['A']
-      }
-
-      # We should find any bad gears
-      @throttler.expects(:find).returns([bad_gears, {}])
-      # The first run should try to find previously throttled gears
-      @throttler.expects(:find).with(state: :throttled).returns([{},{}])
-      @throttler.expects(:apply_action).with({
-        restore: {},
-        throttle: bad_gears,
-      },{})
-
-      @throttler.throttle({})
+    applied = setup_throttler(mock_apps, {
+      bad: %w(A B F),
+      throttled: %w(C D E F)
+    }) do |t|
+      t.expects(:refuse_action).with(:throttle, 'B', "gear is boosted")
+      t.expects(:refuse_action).with(:restore, 'D', "still over threshold (1000000)")
+      t.expects(:refuse_action).with(:restore, 'E', "unknown utilization")
+      t.expects(:refuse_action).with(:restore, 'F', "still over threshold (1000000)")
     end
-  end
 
-  def test_throttle_previous_throttled
-    mock_apps = {
-      "A" => { },
-      "B" => { },
-      'C' => { }
-    }
+    throttled = applied[:throttle]
+    restored = applied[:restore]
 
-    with_mock_apps(mock_apps) do |mock_apps, mock_util|
-      bad_gears = {
-        'A' => mock_apps['A']
-      }
-      throttled_gears = {
-        'B' => mock_apps['B']
-      }
+    assert throttled.include?('A'), 'Bad gear not throttled'
+    refute restored.include?('A'),  'Attempted to restore bad gear'
 
-      # We should find any bad gears
-      @throttler.expects(:find).returns([bad_gears, {}])
-      # The first run should try to find previously throttled gears
-      @throttler.expects(:find).with(state: :throttled).returns([throttled_gears,{}])
-      @throttler.expects(:apply_action).with({
-        restore: throttled_gears,
-        throttle: bad_gears,
-      },{})
+    refute throttled.include?('B'), 'Attempted to throttle boosted gear'
+    refute restored.include?('B'),  'Attempted to restore boosted gear'
 
-      @throttler.throttle({})
-    end
+    assert restored.include?('C'),  'Previously throttled gear under utilization not restored'
+    refute throttled.include?('C'), 'Attempted to throttle previously throttled gear under utilization'
+
+    refute restored.include?('D'),  'Attempted to restore previously throttled gear over utilization'
+    refute throttled.include?('D'), 'Attempted to throttle previously throttled gear over utilization'
+
+    refute restored.include?('E'),  'Attempted to restore previously throttled gear with unknown utilization'
+    refute throttled.include?('E'), 'Attempted to throttle previously throttled gear with unknown utilization'
   end
 
   def test_throttle_second_run
     mock_apps = {
+      "A" => {
+        expects: {
+          boosted?: false
+        },
+      },
+    }
+
+    applied = setup_throttler(mock_apps, {
+      bad: %w(A),
+      throttled: [],
+      old_bad_gears: {}
+    })
+
+    assert applied[:throttle].include?('A'), 'Bad gear not throttled'
+    refute applied[:restore].include?('A'),  'Attempted to restore bad gear'
+  end
+
+  def test_apply_action_failure
+    mock_apps = {
       "A" => { },
-      "B" => { }
+      "B" => { },
     }
 
     with_mock_apps(mock_apps) do |mock_apps, mock_util|
       @throttler.instance_eval{
         @old_bad_gears = {}
+        @bad_gears = {}
       }
 
-      bad_gears = {
-        'A' => mock_apps['A']
-      }
+      a = mock_apps['A']
+      b = mock_apps['B']
 
-      # We should find any bad gears
-      @throttler.expects(:find).returns([bad_gears, {}])
-      # The first run should try to find previously throttled gears
-      @throttler.expects(:find).with(state: :throttled).never
+      a.gear.expects(:throttle).raises(RuntimeError)
+      b.gear.expects(:throttle)
 
-      @throttler.expects(:apply_action).with({
-        restore: {},
-        throttle: bad_gears,
-      },{})
-
-      @throttler.throttle({})
+      @throttler.expects(:failed_action).with(:throttle,"A","RuntimeError")
     end
   end
 
@@ -314,14 +364,10 @@ class ThrottlerTest < OpenShift::NodeTestCase
       a = mock_apps['A']
       b = mock_apps['B']
 
-      mock_apps.values.each do |g|
-        g.gear.expects(:boosted?).returns(false)
-      end
-
       a.gear.expects(:throttle).raises(RuntimeError)
       b.gear.expects(:throttle)
 
-      @throttler.expects(:log_action).with("FAILED throttle","A","RuntimeError", :warning)
+      @throttler.expects(:failed_action).with(:throttle,"A","RuntimeError")
       @throttler.expects(:log_action).with(:throttle, 'B', nil)
 
       apply_hash = {
@@ -354,7 +400,6 @@ class ThrottlerTest < OpenShift::NodeTestCase
         app.gear.tap do |g|
           g.expects(:throttle)
           g.expects(:restore).never
-          g.expects(:boosted?).returns(false)
         end
       end
       @throttler.expects(:log_action).with(:throttle, 'A', nil)
@@ -364,115 +409,6 @@ class ThrottlerTest < OpenShift::NodeTestCase
         }
       },{})
       assert_equal %w(A), @throttler.instance_variable_get('@old_bad_gears').keys
-    end
-  end
-
-  def test_apply_throttle_already_throttled
-    mock_apps = {
-      'A' => {}
-    }
-
-    with_mock_apps(mock_apps) do |mock_apps, mock_util|
-      a = mock_apps['A'].tap do |app|
-        app.gear.tap do |g|
-          g.expects(:throttle).never
-          g.expects(:restore).never
-          g.expects(:boosted?).never
-        end
-      end
-
-      @throttler.instance_eval{
-        @old_bad_gears = { 'A' => a }
-      }
-      @throttler.expects(:log_action).with('REFUSED throttle', 'A', "gear already throttled", any_parameters)
-      @throttler.apply_action({
-        throttle: {
-          'A' => a
-        }
-      },{})
-      assert_equal %w(A), @throttler.instance_variable_get('@old_bad_gears').keys
-    end
-  end
-
-  def test_apply_throttle_to_boosted
-    mock_apps = {
-      'A' => {}
-    }
-
-    with_mock_apps(mock_apps) do |mock_apps, mock_util|
-      @throttler.instance_eval{
-        @old_bad_gears = {}
-      }
-      a = mock_apps['A'].tap do |app|
-        app.gear.tap do |g|
-          g.expects(:throttle).never
-          g.expects(:restore).never
-          g.expects(:boosted?).returns(true)
-        end
-      end
-
-      @throttler.expects(:log_action).with('REFUSED throttle', 'A', "gear is boosted", any_parameters)
-      @throttler.apply_action({
-        throttle: {
-          'A' => a
-        }
-      },{})
-      assert_empty @throttler.instance_variable_get('@old_bad_gears').keys
-    end
-  end
-
-  def test_apply_restore
-    mock_apps = {
-      'A' => {}
-    }
-
-    with_mock_apps(mock_apps) do |mock_apps, mock_util|
-      @throttler.instance_eval{
-        @old_bad_gears = {}
-        @bad_gears = {}
-      }
-      a = mock_apps['A'].tap do |app|
-        app.gear.tap do |g|
-          g.expects(:throttle).never
-          g.expects(:restore)
-          g.expects(:boosted?).never
-        end
-      end
-      @throttler.expects(:log_action).with(:restore, 'A', nil)
-      @throttler.apply_action({
-        restore: {
-          'A' => a
-        }
-      },{})
-      assert_empty @throttler.instance_variable_get('@old_bad_gears').keys
-    end
-  end
-
-  def test_apply_restore_over_threshold
-    mock_apps = {
-      'A' => {}
-    }
-
-    with_mock_apps(mock_apps) do |mock_apps, mock_util|
-      a = mock_apps['A'].tap do |app|
-        app.gear.tap do |g|
-          g.expects(:throttle).never
-          g.expects(:restore).never
-          g.expects(:boosted?).never
-        end
-      end
-
-      @throttler.instance_eval{
-        @old_bad_gears = {}
-        @bad_gears = { 'A' => a }
-      }
-      @throttler.expects(:log_action).with('REFUSED restore', 'A', 'still over threshold', any_parameters)
-      @throttler.apply_action({
-        restore: {
-          'A' => a
-        }
-      },{})
-      assert_empty @throttler.instance_variable_get('@old_bad_gears').keys
     end
   end
 
@@ -490,6 +426,12 @@ class ThrottlerTest < OpenShift::NodeTestCase
         mg.stubs(:utilization).returns(util)
         mock_util[uuid] = util
       end
+
+      if (e = vals[:expects])
+        e.each do |k,v|
+          gear.expects(k).returns(v)
+        end
+      end
       h[uuid] = mg
       h
     end
@@ -499,5 +441,36 @@ class ThrottlerTest < OpenShift::NodeTestCase
     }
 
     yield mock_apps, mock_util
+  end
+
+  def setup_throttler(apps, _opts)
+    default = Hash.new({})
+    opts = default.merge(_opts)
+
+    with_mock_apps(apps) do |mock_apps, mock_util|
+      bad = mock_apps.select{|k,v| opts[:bad].include?(k) }
+      throttled = mock_apps.select{|k,v| opts[:throttled].include?(k) }
+
+      @throttler.expects(:find).returns([bad, mock_util])
+      if (old = _opts[:old_bad_gears])
+        @throttler.instance_eval{
+          @old_bad_gears = old
+        }
+        @throttler.expects(:find).with(state: :throttled).never
+      else
+        @throttler.expects(:find).with(state: :throttled).returns([throttled, {}])
+      end
+      @throttler.expects(:apply_action).with() do |h|
+        @retval = h
+      end
+
+      @throttler.expects("uuids=").with(mock_apps.keys)
+
+      yield @throttler if block_given?
+
+      @throttler.throttle(mock_apps.keys)
+
+      @retval
+    end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=995550
https://bugzilla.redhat.com/show_bug.cgi?id=996751
https://bugzilla.redhat.com/show_bug.cgi?id=998704

This PR fixes multiple issues with throttler
- [Bug995550](https://bugzilla.redhat.com/show_bug.cgi?id=995550) - Fixed the logic to not throttle already boosted gears
- [Bug996751](https://bugzilla.redhat.com/show_bug.cgi?id=996751) - Force throttler to only restore applications under a certain threshold (different from throttle threshold)
- [Bug998704](https://bugzilla.redhat.com/show_bug.cgi?id=998704) - NoMethodError when checking utilization for certain
  gears
