### PR TITLE
<cartridge versions> origin_runtime_219, Fix up Display-Name: field in manifests

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbosseap/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jbosseap/metadata/manifest.yml
@@ -1,6 +1,6 @@
 Name: jbosseap
 Cartridge-Short-Name: JBOSSEAP
-Display-Name: JBoss Enterprise Application Platform 6
+Display-Name: JBoss Enterprise Application Platform 6.1.0
 Description: "Market-leading open source enterprise platform for next-generation, highly transactional enterprise Java applications. Build and deploy enterprise Java in the cloud."
 Version: '6'
 License: LGPL

--- a/cartridges/openshift-origin-cartridge-jenkins-client/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/metadata/manifest.yml
@@ -1,7 +1,7 @@
 Name: jenkins-client
 Cartridge-Short-Name: JENKINS_CLIENT
-Display-Name: Jenkins Client 1
-Description: "The Jenkins client connects to your Jenkins application and enables builds and testing of your application. Requires the Jenkins Application to be created via the new application page."
+Display-Name: Jenkins Client
+Description: "The Jenkins client connects to your Jenkins application and enables builds and testing of your application. Requires the Jenkins Application to be created via the new application page. Based on Jenkins Client 1.509+"
 Version: '1'
 License: ASL 2.0
 Cartridge-Version: 0.0.2

--- a/cartridges/openshift-origin-cartridge-jenkins/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jenkins/metadata/manifest.yml
@@ -1,8 +1,8 @@
 Name: jenkins
 Vendor: Jenkins CI
 Cartridge-Short-Name: JENKINS
-Display-Name: Jenkins Server 1
-Description: "Jenkins is a continuous integration (CI) build server that is deeply integrated into OpenShift. See the Jenkins info page for more."
+Display-Name: Jenkins Server
+Description: "Jenkins is a continuous integration (CI) build server that is deeply integrated into OpenShift. See the Jenkins info page for more. Based on Jenkins 1.509+"
 Version: '1'
 License: MIT license
 License-Url: http://jenkinsci.org/mitlicense

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/metadata/manifest.yml.f19
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/metadata/manifest.yml.f19
@@ -1,6 +1,6 @@
 Name: phpmyadmin
 Cartridge-Short-Name: PHPMYADMIN
-Display-Name: phpMyAdmin 3
+Display-Name: phpMyAdmin 3.5
 Description: "Web based MySQL admin tool. Requires the MySQL cartridge to be installed first."
 Version: 3
 License: GPLv2

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/metadata/manifest.yml.rhel
@@ -1,6 +1,6 @@
 Name: phpmyadmin
 Cartridge-Short-Name: PHPMYADMIN
-Display-Name: phpMyAdmin 3
+Display-Name: phpMyAdmin 3.4
 Description: "Web based MySQL admin tool. Requires the MySQL cartridge to be installed first."
 Version: 3
 License: GPLv2

--- a/cartridges/openshift-origin-cartridge-switchyard/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-switchyard/metadata/manifest.yml
@@ -1,6 +1,6 @@
 Name: switchyard
 Cartridge-Short-Name: SWITCHYARD
-Display-Name: SwitchYard 0
+Display-Name: SwitchYard 0.8.0
 Description: "SwitchYard is a lightweight service delivery framework providing full lifecycle support for developing, deploying, and managing service-oriented applications."
 Version: 0
 License: ASL 2.0


### PR DESCRIPTION
https://trello.com/c/evcTYKdn/219-3-adjust-out-of-date-cartridge-versions

Modified carts to make Display-Name attribute more precise

Jenkins and Jenkins-client carts have version info in Description
field as an exception
