### PR TITLE
Fix bug 999189: gear upgrade extension is a no-op if release version doe...

### DIFF
--- a/node/lib/openshift-origin-node/model/upgrade.rb
+++ b/node/lib/openshift-origin-node/model/upgrade.rb
@@ -202,7 +202,8 @@ module OpenShift
           extension_version = OpenShift::GearUpgradeExtension.version
 
           if version != extension_version
-            raise "Version mismatch between supplied release version (#{version}) and extension version (#{extension_version}"
+            progress.log "Version mismatch between supplied release version (#{version}) and extension version (#{extension_version}"
+            return  
           end
         rescue NameError => e
           raise "Unable to resolve OpenShift::GearUpgradeExtension: #{e.message}"


### PR DESCRIPTION
...sn't match supplied version
