### PR TITLE
Added environment variable name limitations

### DIFF
--- a/controller/app/controllers/environment_variables_controller.rb
+++ b/controller/app/controllers/environment_variables_controller.rb
@@ -35,6 +35,8 @@ class EnvironmentVariablesController < BaseController
       return render_error(:unprocessable_entity, "Specify parameters 'name'/'value' or 'environment_variables'", 191)
     end
     if name
+      match = /\A([a-zA-Z_][\w]*)\z/.match(name)
+      return render_error(:unprocessable_entity, "Name can only contain letters, digits and underscore and can't begin with a digit.", 194, "name") if match.nil?
       return render_error(:unprocessable_entity, "Value not specified for environment variable '#{name}'", 190, "value") unless params.has_key?(:value)
       value = params[:value]
       env_hash = @application.list_user_env_variables([name])

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -2736,6 +2736,8 @@ class Application
         end
         raise OpenShift::UserException.new("Invalid environment variable name #{name}: specified multiple times", 188, "environment_variables") if keys[name]
         keys[name] = true
+        match = /\A([a-zA-Z_][\w]*)\z/.match(name)
+        raise OpenShift::UserException.new("Name can only contain letters, digits and underscore and can't begin with a digit.", 194, "name") if match.nil?
       end
       if no_delete
         set_vars, unset_vars = sanitize_user_env_variables(user_env_vars)

--- a/node/lib/openshift-origin-node/model/application_container_ext/environment.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/environment.rb
@@ -4,7 +4,8 @@ module OpenShift
       module Environment
 
         USER_VARIABLE_MAX_COUNT = 25
-        USER_VARIABLE_MAX_SIZE = 512
+        USER_VARIABLE_NAME_MAX_SIZE = 128
+        USER_VARIABLE_VALUE_MAX_SIZE = 512
         RESERVED_VARIABLE_NAMES = [
                                    'OPENSHIFT_PRIMARY_CARTRIDGE_DIR', 'OPENSHIFT_NAMESPACE', 'PATH',
                                    'IFS', 'USER', 'SHELL', 'HOSTNAME', 'LOGNAME'
@@ -277,8 +278,11 @@ module OpenShift
               return 127, "CLIENT_ERROR: #{name} cannot be overridden"
             end
 
-            if value.to_s.length > USER_VARIABLE_MAX_SIZE
-              return 127, "CLIENT_ERROR: #{name} value exceeds maximum size of #{USER_VARIABLE_MAX_SIZE}b"
+            if name.to_s.length > USER_VARIABLE_NAME_MAX_SIZE
+              return 127, "CLIENT_ERROR: name '#{name}' exceeds maximum size of #{USER_VARIABLE_NAME_MAX_SIZE}b"
+            end
+            if value.to_s.length > USER_VARIABLE_VALUE_MAX_SIZE
+              return 127, "CLIENT_ERROR: '#{name}' value exceeds maximum size of #{USER_VARIABLE_VALUE_MAX_SIZE}b"
             end
           end
 

--- a/node/test/unit/application_container_test.rb
+++ b/node/test/unit/application_container_test.rb
@@ -334,6 +334,6 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
 
     rc, msg = @container.user_var_add({'TOO_BIG' => '*' * 513})
     assert_equal 127, rc
-    assert_equal 'CLIENT_ERROR: TOO_BIG value exceeds maximum size of 512b', msg
+    assert_equal "CLIENT_ERROR: 'TOO_BIG' value exceeds maximum size of 512b", msg
   end
 end

--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -1247,9 +1247,7 @@ module OpenShift
       #
       def set_user_env_vars(gear, env_vars, gears_ssh_endpoint)
         args = build_base_gear_args(gear)
-        if env_vars.present?
-          args['--with-variables'] = env_vars.map {|ev| "#{ev['name']}=#{ev['value']}"}.join(' ')
-        end
+        args['--with-variables'] = env_vars.to_json if env_vars.present?
         args['--with-gears'] = gears_ssh_endpoint.join(';') if gears_ssh_endpoint.present?
         result = execute_direct(@@C_CONTROLLER, 'user-var-add', args)
         parse_result(result)

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -375,9 +375,11 @@ module MCollective
       end
 
       def oo_user_var_add(args)
-        variables, gears = {}, []
-        args['--with-variables'].split(' ').each { |a| token = a.split('=', 2); variables[token.first] = token.last } if args['--with-variables']
-        gears = args['--with-gears'].split(';') if args['--with-gears']
+        variables = {}
+        if args['--with-variables']
+          JSON.parse(args['--with-variables']).each {|env| variables[env['name']] = env['value']}
+        end
+        gears = args['--with-gears'] ? args['--with-gears'].split(';') : []
 
         if variables.empty? and gears.empty?
           return -1, "In #{__method__} at least user environment variables or gears must be provided for #{args['--with-app-name']}"


### PR DESCRIPTION
- Limit length to 128 bytes.
- Allow letters, digits and underscore but can't begin with digit
