### PR TITLE
change mirror.openshift.com to mirror1.ops.rhcloud.com for aws mirroring

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/versions/7/standalone/configuration/settings.rhcloud.xml
+++ b/cartridges/openshift-origin-cartridge-jbossas/versions/7/standalone/configuration/settings.rhcloud.xml
@@ -3,7 +3,7 @@
     <mirror>
       <id>nexus</id>
       <mirrorOf>central</mirrorOf>
-      <url>http://mirror.openshift.com/nexus/content/groups/public</url>
+      <url>http://mirror1.ops.rhcloud.com/nexus/content/groups/public</url>
     </mirror>
   </mirrors>
   <profiles>

--- a/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/standalone/configuration/settings.rhcloud.xml
+++ b/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/standalone/configuration/settings.rhcloud.xml
@@ -3,7 +3,7 @@
     <mirror>
       <id>nexus</id>
       <mirrorOf>central</mirrorOf>
-      <url>http://mirror.openshift.com/nexus/content/groups/public</url>
+      <url>http://mirror1.ops.rhcloud.com/nexus/content/groups/public</url>
     </mirror>
   </mirrors>
   <profiles>

--- a/cartridges/openshift-origin-cartridge-jbossews/versions/shared/configuration/settings.prod.xml
+++ b/cartridges/openshift-origin-cartridge-jbossews/versions/shared/configuration/settings.prod.xml
@@ -3,7 +3,7 @@
     <mirror>
       <id>nexus</id>
       <mirrorOf>central</mirrorOf>
-      <url>http://mirror.openshift.com/nexus/content/groups/public</url>
+      <url>http://mirror1.ops.rhcloud.com/nexus/content/groups/public</url>
     </mirror>
   </mirrors>
   <profiles>

--- a/cartridges/openshift-origin-cartridge-jbossews/versions/shared/configuration/settings.rhcloud.xml
+++ b/cartridges/openshift-origin-cartridge-jbossews/versions/shared/configuration/settings.rhcloud.xml
@@ -3,7 +3,7 @@
     <mirror>
       <id>nexus</id>
       <mirrorOf>central</mirrorOf>
-      <url>http://mirror.openshift.com/nexus/content/groups/public</url>
+      <url>http://mirror1.ops.rhcloud.com/nexus/content/groups/public</url>
     </mirror>
   </mirrors>
   <profiles>

--- a/cartridges/openshift-origin-cartridge-jbossews/versions/shared/configuration/settings.stg.xml
+++ b/cartridges/openshift-origin-cartridge-jbossews/versions/shared/configuration/settings.stg.xml
@@ -3,7 +3,7 @@
     <mirror>
       <id>nexus</id>
       <mirrorOf>central</mirrorOf>
-      <url>http://mirror.openshift.com/nexus/content/groups/public</url>
+      <url>http://mirror1.ops.rhcloud.com/nexus/content/groups/public</url>
     </mirror>
   </mirrors>
   <profiles>

--- a/cartridges/openshift-origin-cartridge-perl/bin/build
+++ b/cartridges/openshift-origin-cartridge-perl/bin/build
@@ -14,7 +14,7 @@ MIRROR="--mirror http://search.cpan.org/CPAN"
 
 if [[ "$LINUX_DISTRO" =~ $RED_HAT_DISTRO_NAME* && $OPENSHIFT_GEAR_DNS =~ .*\.rhcloud\.com$ ]]
 then
-  MIRROR="--mirror http://mirror.openshift.com/mirror/perl/CPAN/ $MIRROR"
+  MIRROR="--mirror http://mirror1.ops.rhcloud.com/mirror/perl/CPAN/ $MIRROR"
 fi
 
 if [ -f ${OPENSHIFT_REPO_DIR}deplist.txt ]

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-community/bin/build
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-community/bin/build
@@ -19,7 +19,7 @@ if [ -f "${OPENSHIFT_REPO_DIR}setup.py" ]; then
    echo " - Found setup.py. Processing it ..."
 
    if `echo $OPENSHIFT_GEAR_DNS | egrep -qe "\.rhcloud\.com"`; then
-      mirror_opts="-i http://mirror.openshift.com/mirror/python/web/simple"
+      mirror_opts="-i http://mirror1.ops.rhcloud.com/mirror/python/web/simple"
    fi
 
    pushd "$OPENSHIFT_REPO_DIR" > /dev/null

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
@@ -114,7 +114,7 @@ function tidy() {
 function build() {
     if `echo $OPENSHIFT_GEAR_DNS | egrep -qe "\.rhcloud\.com"`
     then
-        OPENSHIFT_PYTHON_MIRROR="-i http://mirror.openshift.com/mirror/python/web/simple"
+        OPENSHIFT_PYTHON_MIRROR="-i http://mirror1.ops.rhcloud.com/mirror/python/web/simple"
     fi
 
     if marker_present 'force_clean_build'; then

--- a/documentation/oo_cartridge_guide.txt
+++ b/documentation/oo_cartridge_guide.txt
@@ -970,7 +970,7 @@ config.ru          This file is used by Rack-based servers to start the applicat
 <1> link:oo_user_guide.html#action-hooks[Action Hooks] documentation
 
 === Ruby Mirror
-OpenShift is mirroring rubygems.org at http://mirror.openshift.com/mirror/ruby/
+OpenShift is mirroring rubygems.org at http://mirror1.ops.rhcloud.com/mirror/ruby/
 This mirror is on the same network as your application, and your gem download should be faster.
 
 To use the OpenShift mirror:
@@ -984,7 +984,7 @@ source 'http://rubygems.org'
 with
 +
 ....
-source 'http://mirror.openshift.com/mirror/ruby/'
+source 'http://mirror1.ops.rhcloud.com/mirror/ruby/'
 ....
 . Edit your Gemfile.lock and replace
 +
@@ -995,7 +995,7 @@ remote: http://rubygems.org/
 with
 +
 ....
-remote: http://mirror.openshift.com/mirror/ruby/
+remote: http://mirror1.ops.rhcloud.com/mirror/ruby/
 ....
 
 === Rails 3.0


### PR DESCRIPTION
change mirror.openshift.com to mirror1.ops.rhcloud.com for aws mirroring
This is to fix the previous mirror fix.
If you point a machine inside aws to mirror.openshift.com, it will not got directly there.  It will travel outside of aws and then back in.  This causes the "aws internal" mirror areas to be forbidden.  It also negates the purpose of having a mirror internal to aws.
