### PR TITLE
[TO_STAGE] Bug 998704: Throttler throws NoMethodError

### DIFF
--- a/node/lib/openshift-origin-node/utils/cgroups/throttler.rb
+++ b/node/lib/openshift-origin-node/utils/cgroups/throttler.rb
@@ -135,8 +135,13 @@ module OpenShift
               end
               # Find any gears over the threshold
               over_usage = with_period.select do |k,v|
-                percent = v[:usage_percent]
-                percent && percent >= usage
+                begin
+                  percent = v[:usage_percent]
+                  percent && percent >= usage
+                rescue
+                  Syslog.log(:info, "Throttler: problem in find for #{k} (#{v[:usage_percent]})")
+                  return false
+                end
               end.keys
               apps.select!{|k,v| over_usage.include?(k) }
             end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=998704

I cannot reproduce this, but since `>=` is only used in 2 places, we know where it should be occurring.
I believe this is a corner case where we are checking utilization during an unstable part of gear creation/deletion.
This should be ok to ignore, but we will add some debugging information just in case.
