### PR TITLE
Bug999837: Throttler will keep trying to restore the throttled gears even if they had been deleted from node

### DIFF
--- a/node/lib/openshift-origin-node/utils/cgroups/throttler.rb
+++ b/node/lib/openshift-origin-node/utils/cgroups/throttler.rb
@@ -168,6 +168,11 @@ module OpenShift
             # NOTE: There is a corner case where we won't find non-running throttled applications
             @old_bad_gears ||= find(state: :throttled).first
 
+            # Remove any previously throttled gears that are no longer running
+            @mutex.synchronize do
+              @old_bad_gears.select!{|k,v| running_apps.keys.include?(k) }
+            end
+
             # Restore any gears we have utilization values for that are <= restore_percent
             (restore_gears, @old_bad_gears) = @old_bad_gears.partition do |uuid, gear|
               util.has_key?(uuid) && util[uuid] <= @restore_percent


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=999837

Fixed a corner case where apps were deleted while in the throttled state.
