### PR TITLE
plugins/dns/nsupdate: Specify zone

### DIFF
--- a/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
+++ b/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
@@ -125,10 +125,13 @@ module OpenShift
       # If the config gave a TSIG key, use it
       keystring = @keyname ? "key #{@keyalgorithm}:#{@keyname} #{keyvalue}" : "gsstsig"
 
+      zonestring = @zone ? "zone #{@zone}" : ""
+
       # compose the nsupdate add command
       cmd += %{nsupdate <<EOF
 #{keystring}
 server #{@server} #{@port}
+#{zonestring}
 update add #{fqdn} 60 CNAME #{value}
 send
 quit
@@ -155,10 +158,13 @@ EOF
       # If the config gave a TSIG key, use it
       keystring = @keyname ? "key #{@keyname} #{keyvalue}" : "gsstsig"
 
+      zonestring = @zone ? "zone #{@zone}" : ""
+
       # compose the nsupdate add command
       cmd += %{nsupdate <<EOF
 #{keystring}
 server #{@server} #{@port}
+#{zonestring}
 update delete #{fqdn}
 send
 quit


### PR DESCRIPTION
Make the nsupdate DNS plug-in send the zone, if it is set, to the DNS server.  The nsupdate plug-in inherits the BIND_ZONE setting from the bind plug-in on which it was based, but it was not actually sending the zone even when it had it.

This commit fixes bug 1000184.
