### PR TITLE
[TO_STAGE] Bug 1000193: Use an Hourglass in the gear upgrader

### DIFF
--- a/broker-util/oo-admin-upgrade
+++ b/broker-util/oo-admin-upgrade
@@ -140,6 +140,7 @@ module OpenShift
       attr_accessor :login,
                     :app_name,
                     :gear_uuid,
+                    :hostname,
                     :version,
                     :errors,
                     :warnings,
@@ -707,6 +708,7 @@ class Upgrader
 
       if app && gear
         server_identity = gear.server_identity
+        gear_result.hostname = server_identity
 
         Timeout::timeout(420) do
           output = ''

--- a/node/lib/openshift-origin-node/model/upgrade.rb
+++ b/node/lib/openshift-origin-node/model/upgrade.rb
@@ -13,6 +13,7 @@ require 'openshift-origin-node/utils/application_state'
 require 'openshift-origin-node/utils/environ'
 require 'openshift-origin-node/utils/upgrade_progress'
 require 'openshift-origin-node/utils/upgrade_itinerary'
+require 'openshift-origin-node/utils/hourglass'
 require 'openshift-origin-common'
 require 'net/http'
 require 'uri'
@@ -67,21 +68,23 @@ module OpenShift
         raise "#{gear_extension_path} exists and failed to load" unless @@gear_extension_present
       end
 
-      attr_reader :uuid, :namespace, :version, :hostname, :ignore_cartridge_version, :gear_home, :gear_env, :progress, :container, :gear_extension, :config
+      attr_reader :uuid, :namespace, :version, :hostname, :ignore_cartridge_version,
+                  :gear_home, :gear_env, :progress, :container, :gear_extension, :config, :hourglass
 
-      def initialize(uuid, namespace, version, hostname, ignore_cartridge_version)
+      def initialize(uuid, namespace, version, hostname, ignore_cartridge_version, hourglass = nil)
         @uuid = uuid
         @namespace = namespace
         @version = version
         @hostname = hostname
         @ignore_cartridge_version = ignore_cartridge_version
         @config = OpenShift::Config.new
+        @hourglass = hourglass || OpenShift::Runtime::Utils::Hourglass.new(235)
 
         gear_base_dir = @config.get('GEAR_BASE_DIR')
         @gear_home = PathUtils.join(gear_base_dir, uuid)
         @gear_env = Utils::Environ.for_gear(gear_home)
         @progress = Utils::UpgradeProgress.new(gear_base_dir, gear_home, uuid)
-        @container = ApplicationContainer.from_uuid(uuid)
+        @container = ApplicationContainer.from_uuid(uuid, @hourglass)
         @gear_extension = nil
       end
 
@@ -272,7 +275,7 @@ module OpenShift
         progress.step "compute_itinerary" do |context, errors|
           itinerary            = OpenShift::Runtime::UpgradeItinerary.new(gear_home)
           state                = OpenShift::Runtime::Utils::ApplicationState.new(container)
-          cartridge_model      = OpenShift::Runtime::V2UpgradeCartridgeModel.new(config, container, state, OpenShift::Runtime::Utils::Hourglass.new(235))
+          cartridge_model      = OpenShift::Runtime::V2UpgradeCartridgeModel.new(config, container, state, hourglass)
           cartridge_repository = OpenShift::Runtime::CartridgeRepository.instance
 
           cartridge_model.each_cartridge do |manifest|
@@ -339,7 +342,7 @@ module OpenShift
         progress.log "Migrating gear at #{gear_home}"
 
         state                = OpenShift::Runtime::Utils::ApplicationState.new(container)
-        cartridge_model      = OpenShift::Runtime::V2UpgradeCartridgeModel.new(config, container, state, OpenShift::Runtime::Utils::Hourglass.new(235))
+        cartridge_model      = OpenShift::Runtime::V2UpgradeCartridgeModel.new(config, container, state, hourglass)
         cartridge_repository = OpenShift::Runtime::CartridgeRepository.instance
         restart_required     = false
         restart_time         = 0
@@ -611,8 +614,6 @@ module OpenShift
         progress.log "Starting gear on node '#{hostname}'"
 
         progress.step 'start_gear' do |context, errors|
-          container = OpenShift::Runtime::ApplicationContainer.from_uuid(uuid)
-
           begin
             output = container.start_gear(user_initiated: false)
             progress.log "Start gear output: #{output}"
@@ -642,7 +643,7 @@ module OpenShift
 
           if preupgrade_state.value != 'stopped' && preupgrade_state.value != 'idle'
             state  = OpenShift::Runtime::Utils::ApplicationState.new(container)
-            cart_model = OpenShift::Runtime::V2UpgradeCartridgeModel.new(config, container, state, OpenShift::Runtime::Utils::Hourglass.new(235))
+            cart_model = OpenShift::Runtime::V2UpgradeCartridgeModel.new(config, container, state, hourglass)
 
             # only validate via http query on the head gear
             if cart_model.primary_cartridge && (container.uuid == container.application_uuid)
@@ -654,6 +655,11 @@ module OpenShift
               num_tries = 1
               while true do
                 http = Net::HTTP.new(uri.host, uri.port)
+                http.read_timeout = hourglass.remaining
+                http.open_timeout = hourglass.remaining
+                http.ssl_timeout = hourglass.remaining
+                http.continue_timeout = hourglass.remaining
+
                 request = Net::HTTP::Get.new(uri.request_uri)
 
                 begin

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -207,7 +207,7 @@ module MCollective
         begin
           require 'openshift-origin-node/model/upgrade'
 
-          upgrader = OpenShift::Runtime::Upgrader.new(uuid, namespace, version, hostname, ignore_cartridge_version)
+          upgrader = OpenShift::Runtime::Upgrader.new(uuid, namespace, version, hostname, ignore_cartridge_version, OpenShift::Runtime::Utils::Hourglass.new(235))
           result = upgrader.execute
         rescue LoadError => e
           exitcode = 127


### PR DESCRIPTION
Improve Upgrader class to accept and use an Hourglass instance for timeout handling. Pass
through the hourglass to all ApplicationContainer and cartridge model instances, and use
the hourglass to configure Net::HTTP timeout values.

Ensure that no Upgrader operations will ever be timed out by a higher level Timeout block
such as MCollective.
