### PR TITLE
misc: remove duplicate import in oo-trap-user

### DIFF
--- a/node/misc/bin/oo-trap-user
+++ b/node/misc/bin/oo-trap-user
@@ -1,7 +1,6 @@
 #!/usr/bin/python -tt
 
 import sys, os
-import syslog
 import pwd
 import syslog
 import glob


### PR DESCRIPTION
Removing a duplicate python import in oo-trap-user script.
