### PR TITLE
remote git error

### DIFF
--- a/node/lib/openshift-origin-node/model/application_repository.rb
+++ b/node/lib/openshift-origin-node/model/application_repository.rb
@@ -315,6 +315,9 @@ git archive --format=tar HEAD | (cd <%= @target_dir %> && tar --warning=no-times
   name = OpenShift System User
 [gc]
   auto = 100
+[pack]
+  windowMemory = 10m
+  packSizeLimit = 20m
 }
 
       PRE_RECEIVE = %q{


### PR DESCRIPTION
With a git repo contains big files (Java WAR for exemple), it's possible to get the following git error:

```
$ git clone ssh://51e6fc8867c989ef1b00008b@nodeX.example.com/~/git/tomcatapp.git/ /tmp/tomcatapp
Initialized empty Git repository in /tmp/tomcatapp/.git/
remote: Counting objects: 279, done.
error: pack-objects died of signal 941/246)
error: git upload-pack: git-pack-objects died with error.
remote: aborting due to possible repository corruption on the remote side.
fatal: early EOF
fatal: git upload-pack: aborting due to possible repository corruption on the remote side.
fatal: index-pack failed
```

I was able to fix this issue as root on the node by appending this in the gitconfig of the user `vim /var/lib/openshift/51e6fc8867c989ef1b00008b/.gitconfig`

```
[pack]
  windowMemory = 10m
  packSizeLimit = 20m
```

I found this solution here:
http://stackoverflow.com/questions/4826639/repack-of-git-repository-fails

This pull request change the default git config, to avoid this error next time.
