### PR TITLE
Bug 1001480: openshift-origin-cartridge-cron: stop the cartridge only if started 

### DIFF
--- a/cartridges/openshift-origin-cartridge-cron/bin/control
+++ b/cartridges/openshift-origin-cartridge-cron/bin/control
@@ -35,7 +35,9 @@ function stop() {
 }
 
 function restart() {
-    stop
+    if _are_cronjobs_enabled; then
+        stop
+    fi
     start
 }
 


### PR DESCRIPTION
Check if the cartridge is really running before stopping it. 

Related bug https://bugzilla.redhat.com/show_bug.cgi?id=1001480
