### PR TITLE
Bug 1002685 - Downcase domain names when fetching applications by domain

### DIFF
--- a/broker/test/functional/application_controller_test.rb
+++ b/broker/test/functional/application_controller_test.rb
@@ -66,6 +66,12 @@ class ApplicationControllerTest < ActionController::TestCase
     assert_response :ok
   end
 
+  test "list applications in a non-lowercased domain" do
+    Domain.find_or_create_by(namespace: "abcD", owner: @user)
+    get :index, :domain_id => 'abcD'
+    assert_response :success
+  end
+
   test "attempt to create without create_application permission" do
     @app_name = "app#{@random}"
     scopes = Scope::Scopes.new

--- a/controller/app/controllers/applications_controller.rb
+++ b/controller/app/controllers/applications_controller.rb
@@ -17,9 +17,9 @@ class ApplicationsController < BaseController
     include_cartridges = (params[:include] == "cartridges")
     domain_id = params[:domain_id].presence
 
-    by = domain_id.present? ? {domain_namespace: Domain.check_name!(domain_id)} : {}
+    by = domain_id.present? ? {domain_namespace: Domain.check_name!(domain_id).downcase} : {}
     apps = Application.includes(:domain).accessible(current_user).where(by).map { |app| get_rest_application(app, include_cartridges) }
-    Domain.find_by(canonical_namespace: domain_id) if apps.empty? && domain_id.present? # check for a missing domain
+    Domain.find_by(canonical_namespace: domain_id.downcase) if apps.empty? && domain_id.present? # check for a missing domain
 
     render_success(:ok, "applications", apps, "Found #{apps.length} applications.")
   end


### PR DESCRIPTION
The domain_id lookup for applications scoped to a domain was not properly
lowercasing the namespace

[merge]
