### PR TITLE
Bug 999295: Improve mongodb startup verification reliability

### DIFF
--- a/cartridges/openshift-origin-cartridge-mongodb/bin/control
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/control
@@ -58,6 +58,11 @@ function start() {
     then
         echo "Starting MongoDB cartridge"
         _start_mongod  "$1"
+
+        if ! isrunning; then
+          client_error "Failed to start MongoDB"
+          exit 1
+        fi
     else
         echo "MongoDB already running"
     fi


### PR DESCRIPTION
Ensure that mongodb is actually running after calls to `control start`, taking care to return
an error if it's not running. Prevent false-positive reporting of started state.
