### PR TITLE
Bug 987758: do not add a dot at the end of the error message if it already exists

### DIFF
--- a/console/lib/console/formtastic/bootstrap_form_builder.rb
+++ b/console/lib/console/formtastic/bootstrap_form_builder.rb
@@ -128,7 +128,7 @@ module Console
       def error_list(errors, options = {}) #:nodoc:
         error_class = options[:error_class] || default_inline_error_class
         remove_dot = lambda { |s| s.chomp('.').strip }
-        template.content_tag(:p, errors.map { |e| e.flatten.map(&remove_dot)}.join.untaint, :class => error_class)
+        template.content_tag(:p, errors.flatten.map { |e| remove_dot.call(e) }.join.untaint, :class => error_class)
       end
 
       def inputs(*args, &block)

--- a/console/lib/console/formtastic/bootstrap_form_builder.rb
+++ b/console/lib/console/formtastic/bootstrap_form_builder.rb
@@ -127,7 +127,7 @@ module Console
 
       def error_list(errors, options = {}) #:nodoc:
         error_class = options[:error_class] || default_inline_error_class
-        template.content_tag(:p, errors.join('. ').untaint, :class => error_class)
+        template.content_tag(:p, errors.map { |e| "#{e.strip.chomp('.')}. " }.join.untaint, :class => error_class)
       end
 
       def inputs(*args, &block)

--- a/console/lib/console/formtastic/bootstrap_form_builder.rb
+++ b/console/lib/console/formtastic/bootstrap_form_builder.rb
@@ -127,7 +127,8 @@ module Console
 
       def error_list(errors, options = {}) #:nodoc:
         error_class = options[:error_class] || default_inline_error_class
-        template.content_tag(:p, errors.map { |e| "#{e.strip.chomp('.')}. " }.join.untaint, :class => error_class)
+        remove_dot = lambda { |s| s.chomp('.').strip }
+        template.content_tag(:p, errors.map { |e| e.flatten.map(&remove_dot)}.join.untaint, :class => error_class)
       end
 
       def inputs(*args, &block)


### PR DESCRIPTION
When joining error messages in formtastic, do not add a dot at the end of the sentence if it already exists.

Related bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=987758

Kudos to @mfojtik for helping me to fix this bug.
