### PR TITLE
Wrap the port range indefinitely.

### DIFF
--- a/node/lib/openshift-origin-node/model/frontend_proxy.rb
+++ b/node/lib/openshift-origin-node/model/frontend_proxy.rb
@@ -57,30 +57,19 @@ module OpenShift
         @uid_begin = (config.get("UID_BEGIN") || "500").to_i
       end
 
-      # Note, due to a mismatch between dev and prod this is
-      # intentionally not GEAR_MIN_UID and the range must
-      # wrap back around on itself.
-      def wrap_uid
-        ((65536 - @port_begin) / @ports_per_user) + @uid_begin
-      end
-
       # Returns a Range representing the valid proxy port values for the
       # given UID.
       #
       # The port proxy range is determined by configuration and must
       # produce identical results to the abstract cartridge provided
       # range.
+      #
+      # Note, due to a mismatch between dev and prod this is
+      # intentionally not GEAR_MIN_UID and the range must
+      # wrap back around on itself.
       def port_range(uid)
-        if uid >= wrap_uid
-          tuid = uid - wrap_uid + @uid_begin
-        else
-          tuid = uid
-        end
-
-        proxy_port_begin = (tuid-@uid_begin) * @ports_per_user + @port_begin
-        proxy_port_range = (proxy_port_begin ... (proxy_port_begin + @ports_per_user))
-
-        return proxy_port_range
+        proxy_port_begin = (uid - @uid_begin) % ((65536 - @port_begin) / @ports_per_user) * @ports_per_user + @port_begin
+        (proxy_port_begin ... (proxy_port_begin + @ports_per_user))
       end
 
       # Deletes an existing proxy mapping for the specified UID, IP and port.

--- a/node/test/unit/frontend_proxy_test.rb
+++ b/node/test/unit/frontend_proxy_test.rb
@@ -37,13 +37,6 @@ class FrontendProxyTest < OpenShift::NodeTestCase
     @config.stubs(:get).with("UID_BEGIN").returns(@uid_begin.to_s)
   end
 
-  # Ensure that the wrapped UID is calculated properly
-  def test_wrap_uid
-    proxy = OpenShift::Runtime::FrontendProxyServer.new
-
-    assert_equal @wrap_uid, proxy.wrap_uid
-  end
-
   # Simple test to validate the port range computation given
   # a certain UID.
   def test_port_range


### PR DESCRIPTION
Note:
Provides different results from the old function for UIDs _below_ @uid_begin.
