### PR TITLE
Trello Runtime US253: Node.js 0.10 support

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/bin/control
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/control
@@ -72,7 +72,7 @@ function status() {
 
 
 function get_main_script_from_package_json() {
-    node <<NODE_EOF
+    nodejs_context "node" <<NODE_EOF
 try {
   var zmain = require('$OPENSHIFT_REPO_DIR/package.json').main;
   if (typeof zmain === 'undefined') {
@@ -91,7 +91,7 @@ NODE_EOF
 
 function start() {
     echo "Starting NodeJS cartridge"
- 
+
     envf="$OPENSHIFT_NODEJS_DIR/configuration/node.env"
     logf="$OPENSHIFT_NODEJS_LOG_DIR/node.log"
 
@@ -127,13 +127,13 @@ function start() {
     fi
 
     if marker_present "hot_deploy"; then
-        nohup supervisor -e 'node|js|coffee' -- $script_n_opts  >> $logf 2>&1 &
+        nodejs_context "nohup supervisor -e 'node|js|coffee' -- $script_n_opts  >> $logf 2>&1 &"
     else
-        nohup $executor_cmdline >> $logf 2>&1 &
+        nodejs_context "nohup $executor_cmdline >> $logf 2>&1 &"
     fi
 
     ret=$?
-    npid=$!
+    npid=$(pgrep -x node -u $(id -u))
     popd > /dev/null
     if [ $ret -eq 0 ]; then
         echo "$npid" > "$OPENSHIFT_NODEJS_PID_DIR/node.pid"
@@ -227,7 +227,7 @@ function build() {
     fi
 
     #  Newer versions of Node set tmp to $HOME/tmp, which is not available
-    npm config set tmp $OPENSHIFT_TMP_DIR
+    nodejs_context "npm config set tmp $OPENSHIFT_TMP_DIR"
 
     if [ -f "${OPENSHIFT_REPO_DIR}"/deplist.txt ]; then
         mods=$(perl -ne 'print if /^\s*[^#\s]/' "${OPENSHIFT_REPO_DIR}"/deplist.txt)
@@ -236,9 +236,9 @@ function build() {
             echo "Checking npm module: $m"
             echo
             if is_node_module_installed "$m"; then
-                (cd "${OPENSHIFT_NODEJS_DIR}"; npm update "$m")
+                (cd "${OPENSHIFT_NODEJS_DIR}"; nodejs_context "npm update '$m'")
             else
-                (cd "${OPENSHIFT_NODEJS_DIR}"; npm install "$m")
+                (cd "${OPENSHIFT_NODEJS_DIR}"; nodejs_context "npm install '$m'")
             fi
         done
     fi
@@ -251,7 +251,7 @@ function build() {
     unset GIT_WORK_TREE
 
     if [ -f "${OPENSHIFT_REPO_DIR}"/package.json ]; then
-        (cd "${OPENSHIFT_REPO_DIR}"; npm install -d)
+        (cd "${OPENSHIFT_REPO_DIR}"; nodejs_context "npm install -d")
     fi
 
 }
@@ -320,6 +320,8 @@ fi
 
 # Source utility functions.
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
+source "${OPENSHIFT_NODEJS_DIR}/lib/util"
+source "${OPENSHIFT_NODEJS_DIR}/lib/nodejs_context"
 
 # Handle commands.
 case "$1" in

--- a/cartridges/openshift-origin-cartridge-nodejs/bin/install
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/install
@@ -1,6 +1,10 @@
 #!/bin/bash
 #set -e
 
+source $OPENSHIFT_CARTRIDGE_SDK_BASH
+source "${OPENSHIFT_NODEJS_DIR}/lib/util"
+source "${OPENSHIFT_NODEJS_DIR}/lib/nodejs_context"
+
 case "$1" in
   -v|--version)
     version="$2"
@@ -23,4 +27,7 @@ mkdir "$OPENSHIFT_HOMEDIR"/.npm
 mkdir "$OPENSHIFT_HOMEDIR"/.node-gyp
 chown `id -u $OPENSHIFT_GEAR_UUID` -R "$OPENSHIFT_HOMEDIR"/.npm "$OPENSHIFT_HOMEDIR"/.npmrc  \
                             "$OPENSHIFT_HOMEDIR"/.node-gyp
-npm config set tmp $OPENSHIFT_TMP_DIR
+nodejs_context "npm config set tmp $OPENSHIFT_TMP_DIR"
+
+echo "$version" > $OPENSHIFT_NODEJS_DIR/env/OPENSHIFT_NODEJS_VERSION
+update-configuration $version

--- a/cartridges/openshift-origin-cartridge-nodejs/lib/nodejs_context.fedora
+++ b/cartridges/openshift-origin-cartridge-nodejs/lib/nodejs_context.fedora
@@ -1,0 +1,16 @@
+# Do not include this into the util file...
+# RHEL, Fedora18 and Fedora19 will overwrite this file to support invoking their NodeJS versions
+
+# Fedora OpenShift Online supported versions
+
+function nodejs_context {
+  case "$OPENSHIFT_NODEJS_VERSION" in
+    0.10) eval $1 ;;
+  esac
+}
+
+function update-configuration {
+  case "$1" in
+    0.10) set-configuration $1 native ;;
+  esac
+}

--- a/cartridges/openshift-origin-cartridge-nodejs/lib/nodejs_context.rhel
+++ b/cartridges/openshift-origin-cartridge-nodejs/lib/nodejs_context.rhel
@@ -1,0 +1,18 @@
+# Do not include this into the util file...
+# RHEL, Fedora18 and Fedora19 will overwrite this file to support invoking their NodeJS versions
+
+# RHEL OpenShift Online supported versions
+
+function nodejs_context {
+  case "$OPENSHIFT_NODEJS_VERSION" in
+    0.6)  eval $1 ;;
+    0.10) /usr/bin/scl enable nodejs010 "$1" ;;
+  esac
+}
+
+function update-configuration {
+  case "$1" in
+    0.6) set-configuration $1 native ;;
+    0.10) set-configuration $1 scl nodejs010 ;;
+  esac
+}

--- a/cartridges/openshift-origin-cartridge-nodejs/lib/util
+++ b/cartridges/openshift-origin-cartridge-nodejs/lib/util
@@ -2,47 +2,74 @@
 # Utility functions for use in the cartridge scripts.
 
 function wait_for_stop {
-        pid=$1
-    for i in {1..300}
-    do
-        if `ps --pid $pid > /dev/null 2>&1`
-        then
-            # only print every second
-            [ $((100 % 10)) -eq 0 ] && echo "Waiting for stop to finish"
-            sleep .1
-        else
-            break
-        fi
-    done
+  pid=$1
+  for i in {1..300}
+  do
+    if `ps --pid $pid > /dev/null 2>&1`
+    then
+      # only print every second
+      [ $((100 % 10)) -eq 0 ] && echo "Waiting for stop to finish"
+      sleep .1
+    else
+      break
+    fi
+  done
+}
+
+function set-configuration {
+  version="$1"
+  type="${2:-native}"
+  scl_string="${3}"
+
+  case "$type" in
+    scl)
+      local node_bin=$(echo -n "${OPENSHIFT_HOMEDIR}/.node_modules/.bin")
+      local scl_bin=$(dirname $(scl enable $scl_string "which node"))
+
+      echo "${node_bin}:${scl_bin}" >$OPENSHIFT_NODEJS_DIR/env/OPENSHIFT_NODEJS_PATH_ELEMENT
+
+      local ld_path=$(LD_LIBRARY_PATH="" scl enable $scl_string "printenv LD_LIBRARY_PATH")
+      path_append $LD_LIBRARY_PATH $ld_path >$OPENSHIFT_NODEJS_DIR/env/LD_LIBRARY_PATH
+
+      local man_path=$(MANPATH="" scl enable $scl_string "printenv MANPATH")
+      path_append $MANPATH $man_path >$OPENSHIFT_NODEJS_DIR/env/MANPATH
+      ;;
+    native)
+      rm -f $OPENSHIFT_NODEJS_DIR/env/{LD_LIBRARY_PATH,MANPATH}
+      echo -n "${OPENSHIFT_HOMEDIR}/.node_modules/.bin" > $OPENSHIFT_NODEJS_DIR/env/OPENSHIFT_NODEJS_PATH_ELEMENT
+      ;;
+  esac
 }
 
 function parse_args {
-    while :
-    do
-        case $1 in
-            -h | --help | -\?)
-                echo "usage: $0 [--version[=]<value>]"
-                exit 0
-                ;;
-            -v | --version)
-                version=$2     # You might want to check if you really got VERSION
-                shift 2
-                ;;
-            --version=*)
-                version=${1#*=}        # Delete everything up till "="
-                shift
-                ;;
-            --) # End of all options
-                shift
-                break
-                ;;
-            -*)
-                echo "WARN: Unknown option... Exiting: $1" >&2
-                exit 1
-                ;;
-            *)  # no more options. Stop while loop
-                break
-                ;;
-        esac
-    done
+  while :
+  do
+    case $1 in
+      -h | --help | -\?)
+        echo "usage: $0 [--version[=]<value>]"
+        exit 0
+        ;;
+      -v | --version)
+        version=$2     # You might want to check if you really got VERSION
+        shift 2
+        ;;
+      --version=*)
+        version=${1#*=}        # Delete everything up till "="
+        shift
+        ;;
+      --) # End of all options
+        shift
+        break
+        ;;
+      -*)
+        echo "WARN: Unknown option... Exiting: $1" >&2
+        exit 1
+        ;;
+      *)  # no more options. Stop while loop
+        break
+        ;;
+    esac
+  done
 }
+
+# vim: ft=sh

--- a/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml.fedora
+++ b/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml.fedora
@@ -33,10 +33,10 @@ Cart-Data:
   Type: environment
   Description: Application root directory where application files reside. This directory
     is reset every time you do a git-push
-- Key: OPENSHIFT_INTERNAL_PORT
+- Key: OPENSHIFT_NODEJS_PORT
   Type: environment
   Description: Internal port to which the web-framework binds to.
-- Key: OPENSHIFT_INTERNAL_IP
+- Key: OPENSHIFT_NODEJS_IP
   Type: environment
   Description: Internal IP to which the web-framework binds to.
 - Key: OPENSHIFT_APP_DNS
@@ -73,6 +73,12 @@ Subscribes:
   set-env:
     Type: ENV:*
     Required: false
+  set-mysql-connection-info:
+    Type: NET_TCP:db:mysql
+    Required: false
+  set-postgres-connection-info:
+    Type: NET_TCP:db:postgres
+    Required: false
 Endpoints:
 - Private-IP-Name: IP
   Private-Port-Name: PORT
@@ -87,4 +93,3 @@ Endpoints:
     Backend: ''
     Options:
       health: true
-Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml.rhel
@@ -1,13 +1,16 @@
 ---
 Name: nodejs
 Cartridge-Short-Name: NODEJS
-Display-Name: Node.js 0.6
+Display-Name: Node.js 0.10
 Description: Node.js is a platform built on Chrome's JavaScript runtime for easily
   building fast, scalable network applications. Node.js is perfect for data-intensive
   real-time applications that run across distributed devices.
-Version: '0.6'
+Version: '0.10'
+Versions:
+- '0.10'
+- '0.6'
 License: MIT License
-License-Url: https://raw.github.com/joyent/node/v0.6/LICENSE
+License-Url: https://raw.github.com/joyent/node/v0.10/LICENSE
 Vendor: www.nodejs.org
 Website: http://www.nodejs.org/
 Cartridge-Version: 0.0.4
@@ -57,7 +60,7 @@ Cart-Data:
   Type: environment
   Description: Unique ID which identified the gear. This value changes between gears.
 Provides:
-- nodejs-0.6
+- nodejs-0.10
 - nodejs
 Scaling:
   Min: 1
@@ -93,3 +96,12 @@ Endpoints:
     Backend: ''
     Options:
       health: true
+Install-Build-Required: false
+Version-Overrides:
+  '0.6':
+    Display-Name: Node.js 0.6
+    Provides:
+      - nodejs-0.6
+      - nodejs
+    License-Url: https://raw.github.com/joyent/node/v0.6/LICENSE
+    Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-nodejs/openshift-origin-cartridge-nodejs.spec
+++ b/cartridges/openshift-origin-cartridge-nodejs/openshift-origin-cartridge-nodejs.spec
@@ -1,17 +1,42 @@
+# RHEL has 0.6 and 0.10. but 0.10 has a prefix for SCL
+# Fedora 18 and 19 has 0.10 as the default
+%if 0%{?rhel}
+  %global scl nodejs010
+  %global scl_prefix nodejs010-
+%endif
+
 %global cartridgedir %{_libexecdir}/openshift/cartridges/nodejs
 
 Summary:       Provides Node.js support
 Name:          openshift-origin-cartridge-nodejs
-Version: 1.15.1
+Version:       1.15.1
 Release:       1%{?dist}
 Group:         Development/Languages
 License:       ASL 2.0
 URL:           http://www.openshift.com
 Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-BuildRequires: nodejs >= 0.6
+
 Requires:      facter
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
+
+%if 0%{?rhel} <= 6
+
+Requires:      %{scl}
+Requires:      %{?scl:%scl_prefix}npm
+Requires:      %{?scl:%scl_prefix}nodejs-pg
+Requires:      %{?scl:%scl_prefix}nodejs-options
+Requires:      %{?scl:%scl_prefix}nodejs-supervisor
+Requires:      %{?scl:%scl_prefix}nodejs-async
+
+Requires:      %{?scl:%scl_prefix}nodejs-express
+Requires:      %{?scl:%scl_prefix}nodejs-connect
+Requires:      %{?scl:%scl_prefix}nodejs-mongodb
+Requires:      %{?scl:%scl_prefix}nodejs-mysql
+Requires:      %{?scl:%scl_prefix}nodejs-node-static
+%endif
+
+Requires:      nodejs
 Requires:      nodejs-async
 Requires:      nodejs-connect
 Requires:      nodejs-express
@@ -21,6 +46,7 @@ Requires:      nodejs-node-static
 Requires:      nodejs-pg
 Requires:      nodejs-supervisor
 Requires:      nodejs-options
+
 %if 0%{?fedora} >= 19
 Requires:      npm
 %endif
@@ -42,16 +68,17 @@ Provides Node.js support to OpenShift. (Cartridge Format V2)
 %__mkdir -p %{buildroot}%{cartridgedir}
 %__cp -r * %{buildroot}%{cartridgedir}
 
-echo "NodeJS version is `/usr/bin/node -v`"
-if [[ $(/usr/bin/node -v) == v0.6* ]]; then
-%__rm -f %{buildroot}%{cartridgedir}/versions/0.10
-%__mv %{buildroot}%{cartridgedir}/metadata/manifest.yml.0.6 %{buildroot}%{cartridgedir}/metadata/manifest.yml;
-fi
-
-if [[ $(/usr/bin/node -v) == v0.10* ]]; then
+%if 0%{?rhel}
+%__mv %{buildroot}%{cartridgedir}/metadata/manifest.yml.rhel %{buildroot}%{cartridgedir}/metadata/manifest.yml
+%__mv %{buildroot}%{cartridgedir}/lib/nodejs_context.rhel %{buildroot}%{cartridgedir}/lib/nodejs_context
+%endif
+%if 0%{?fedora}
 %__rm -f %{buildroot}%{cartridgedir}/versions/0.6
-%__mv %{buildroot}%{cartridgedir}/metadata/manifest.yml.0.10 %{buildroot}%{cartridgedir}/metadata/manifest.yml;
-fi
+%__mv %{buildroot}%{cartridgedir}/metadata/manifest.yml.fedora %{buildroot}%{cartridgedir}/metadata/manifest.yml
+%__mv %{buildroot}%{cartridgedir}/lib/nodejs_context.fedora %{buildroot}%{cartridgedir}/lib/nodejs_context
+%endif
+%__rm -f %{buildroot}%{cartridgedir}/lib/nodejs_context.*
+%__rm -f %{buildroot}%{cartridgedir}/metadata/manifest.yml.*
 
 %files
 %dir %{cartridgedir}

--- a/controller/test/cucumber/cartridge-lifecycle-nodejs.feature
+++ b/controller/test/cucumber/cartridge-lifecycle-nodejs.feature
@@ -2,12 +2,12 @@
 @runtime_extended
 @not-enterprise
 Feature: Cartridge Lifecycle NodeJS Verification Tests
-  Scenario: Application Creation
+  Scenario Outline: Application Creation
     Given the libra client tools
-    When 1 nodejs applications are created
+    When 1 <cart_name> applications are created
     Then the applications should be accessible
     #Scenario: Application Modification
-    Given an existing nodejs application
+    Given an existing <cart_name> application
     When the application is changed
     Then it should be updated successfully
     And the application should be accessible
@@ -23,3 +23,14 @@ Feature: Cartridge Lifecycle NodeJS Verification Tests
     #Scenario: Application Destroying
     When the application is destroyed
     Then the application should not be accessible
+
+    @rhel-only
+    Scenarios: RHEL scenarios
+      |  cart_name  |
+      | nodejs-0.6  |
+      | nodejs-0.10 |
+
+    @fedora-19-only
+    Scenarios: Fedora 19 scenarios
+      |  cart_name  |
+      | nodejs-0.10 |


### PR DESCRIPTION
https://trello.com/c/kdWX0nQp

This PR adds support for running node.js 0.10 in online via SCL.
