### PR TITLE
add infoblox plugin for DNS updates

### DIFF
--- a/broker-util/oo-admin-ctl-app
+++ b/broker-util/oo-admin-ctl-app
@@ -176,6 +176,7 @@ begin
       end
     end
     reply.resultIO << "Successfully deleted application: #{app.name}" if reply.resultIO.string.empty?
+    Rails.logger.info "Successfully deleted application: #{app.name} with id: #{app._id} on behalf of user: #{login}"
   when "remove-cartridge"
     unless cartridge
       puts "Cartridge is required to remove-dependency"

--- a/plugins/dns/infoblox/.gitignore
+++ b/plugins/dns/infoblox/.gitignore
@@ -1,0 +1,3 @@
+AWSCONFIG
+doc
+.yardoc

--- a/plugins/dns/infoblox/COPYRIGHT
+++ b/plugins/dns/infoblox/COPYRIGHT
@@ -1,0 +1,1 @@
+Copyright 2013 Red Hat, Inc. and/or its affiliates.

--- a/plugins/dns/infoblox/Gemfile
+++ b/plugins/dns/infoblox/Gemfile
@@ -1,0 +1,3 @@
+source "http://rubygems.org"
+
+gemspec

--- a/plugins/dns/infoblox/LICENSE
+++ b/plugins/dns/infoblox/LICENSE
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/plugins/dns/infoblox/README.md
+++ b/plugins/dns/infoblox/README.md
@@ -1,0 +1,40 @@
+# Openshift Origin Dynamic DNS plugin for Infoblox
+
+This package is a Dynamic DNS plugin for OpenShift Origin.
+
+It allows OpenShift Origin to use Infoblox DNS services to publish applications
+
+* http://www.infoblox.com
+* http://www.infoblox.com/community/content/getting-started-infoblox-web-api-wapi
+
+It uses the Infoblox REST API version N.N
+
+## Installation and Configuration
+
+* Install package *rubygem-openshift-origin-dns-infoblox*
+
+Requires rubygem-json and rubygem-rest-client
+     
+* Create config file:
+
+  */etc/openshift/plugins.d/openshift-origin-dns-infoblox.conf*
+ 
+<code><pre>
+    # Settings related to the Amazon Web Services Route53 DNS service
+    # The AWS zone identifier
+    INFOBLOX_SERVER="hostname or IP address"
+    #
+    # AWS Access credentials
+    INFOBLOX_USERNAME=""
+    INFOBLOX_PASSWORD=""
+</pre></code>
+
+* Check gems using <code>cd /var/log/bundle --local</code>
+* Verify service with <code>rails console</code>
+
+## References:
+
+* InfoBlox corporate web site.
+  http://www.infoblox.com
+* Introduction to Infoblox WEB/REST API 
+  http://www.infoblox.com/community/content/getting-started-infoblox-web-api-wapi

--- a/plugins/dns/infoblox/conf/openshift-origin-dns-infoblox.conf.example
+++ b/plugins/dns/infoblox/conf/openshift-origin-dns-infoblox.conf.example
@@ -1,0 +1,6 @@
+#
+# Infoblox DNS just requires a server host, usename and password
+#
+INFOBLOX_SERVER='unset'
+INFOBLOX_USERNAME='unset'
+INFOBLOX_PASSWORD='unset'

--- a/plugins/dns/infoblox/config/initializers/openshift-origin-dns-infoblox.rb
+++ b/plugins/dns/infoblox/config/initializers/openshift-origin-dns-infoblox.rb
@@ -1,0 +1,21 @@
+require 'openshift-origin-common'
+
+Broker::Application.configure do
+  conf_file = File.join(OpenShift::Config::PLUGINS_DIR, File.basename(__FILE__, '.rb') + '.conf')
+  if Rails.env.development?
+    dev_conf_file = File.join(OpenShift::Config::PLUGINS_DIR, File.basename(__FILE__, '.rb') + '-dev.conf')
+    if File.exist? dev_conf_file
+      conf_file = dev_conf_file
+    else
+      Rails.logger.info "Development configuration for #{File.basename(__FILE__, '.rb')} not found. Using production configuration."
+    end
+  end
+  conf = OpenShift::Config.new(conf_file)
+
+  config.dns = {
+    :infoblox_server => conf.get("INFOBLOX_SERVER", "unset"),
+    :infoblox_username => conf.get("INFOBLOX_USERNAME", "unset"),
+    :infoblox_password => conf.get("INFOBLOX_PASSWORD", "unset"),
+    :ttl => conf.get("TTL", 30) # default record TTL: 30 sec
+  }
+end

--- a/plugins/dns/infoblox/lib/infoblox_dns_engine.rb
+++ b/plugins/dns/infoblox/lib/infoblox_dns_engine.rb
@@ -1,0 +1,7 @@
+require 'openshift-origin-controller'
+require 'rails'
+
+module OpenShift
+  class InfobloxDnsEngine < Rails::Engine
+  end
+end

--- a/plugins/dns/infoblox/lib/openshift-origin-dns-infoblox.rb
+++ b/plugins/dns/infoblox/lib/openshift-origin-dns-infoblox.rb
@@ -1,0 +1,10 @@
+require "openshift-origin-common"
+
+module OpenShift
+  module InfobloxDnsModule
+    require 'infoblox_dns_engine' if defined?(Rails) && Rails::VERSION::MAJOR == 3
+  end
+end
+
+require "openshift/infoblox_plugin.rb"
+OpenShift::DnsService.provider=OpenShift::InfobloxPlugin

--- a/plugins/dns/infoblox/lib/openshift/infoblox_plugin.rb
+++ b/plugins/dns/infoblox/lib/openshift/infoblox_plugin.rb
@@ -1,0 +1,252 @@
+#
+# OpenShift DNS update plugin for Infoblox DNS service
+#
+require 'rubygems'
+require 'json'
+require 'rest-client'
+
+module OpenShift
+
+  # OpenShift DNS plugin to provide dynamic DNS using the 
+  # {http://www.infoblox Infoblox(r)} service via the
+  # {http://www.infoblox.com/community/content/getting-started-infoblox-web-api-wapi Infoblox Web API (WAPI)}
+  #
+  # Implements the OpenShift::DnsService interface
+  #
+  # This class uses the {https://rubygems.org/gems/rest-client rest-client} 
+  # rubygem to communicate with the Infoblox service.
+  #
+  # The object can be configured either by providing the access_info
+  # parameter or by pulling the settings from the Rails.application.config
+  # object (if it exists).
+  #
+  # When pulling from the Rails configuration this plugin expects to find
+  # the domain_suffix in 
+  #   Rails.application.config.openshift[:domain_suffix]
+  # and the rest of the parameters in a hash at
+  #   Rails.application.config.dns
+  #
+  # @example infoblox plugin configuration hash
+  #  {:infoblox_server => 'infobloxserver',
+  #   :infoblox_username => 'infobloxuser',
+  #   :infoblox_password => 'infobloxsecret',
+  #  }
+  #
+  # @!attribute [r] server
+  #   @return [String] Hostname or IP address of the Infoblox server
+  # @!attribute [r] username
+  #   @return [String] user name to be used for update authentication
+  # @!attribute [r] password
+  #   @return [String] password to be used to authenticate the update user
+  class InfobloxPlugin < OpenShift::DnsService
+    @oo_dns_provider = OpenShift::InfobloxPlugin
+
+    attr_reader :server, :username, :password, :ttl
+    attr_reader :record_type, :base_url
+
+    # Establish the parameters for a connection to the DNS update service
+    #
+    # @param access_info [Hash] communication configuration settings
+    # @see InfobloxPlugin InfobloxPlugin class Examples
+    def initialize(access_info = nil)
+
+      if access_info != nil
+        @domain_suffix = access_info[:domain_suffix]
+      elsif defined? Rails
+        access_info = Rails.application.config.dns
+        @domain_suffix = Rails.application.config.openshift[:domain_suffix]
+      else
+        raise Exception.new("Infoblox DNS service is not initialized")
+      end
+
+      @server = access_info[:infoblox_server]
+      @username = access_info[:infoblox_username]
+      @password = access_info[:infoblox_password]
+      @ttl = access_info[:ttl] == nil ? 30 : access_info[:ttl].to_i
+
+      @api_path = 'wapi'
+      @api_version = '1.1'
+      @record_type = 'cname'
+
+      # Construct the base URL for update queries
+      @base_url = "https://#{@username}:#{@password}@#{@server}/" +
+        "#{@api_path}/v#{@api_version}/" 
+
+      @record_url = @base_url + "record:#{@record_type}"
+      
+      # attempt to connect to the Infoblox service and request the SOA record
+      # for the application update zone
+      zone_record_string = execute(RestClient.method(:get),
+                                   @base_url + "zone_auth",
+                                   nil,
+                                   { :fqdn => @domain_suffix })
+
+
+      if ([nil, '', '[]'].member? zone_record_string)
+        raise DNSException.new("Infoblox DNS service does not control zone: #{@domain_suffix}")
+      end
+
+      zone_record = JSON.parse(zone_record_string)
+
+  
+      # check that the zone is there?
+      #zones = JSON.parse(zone_result_string)
+  
+    end
+    
+    # Publish an application - create DNS record
+    #
+    # @param [String] app_name
+    #   The name of the application to publish
+    # @param [String] namespace
+    #   The namespace which contains the application
+    # @param [String] public_hostname
+    #   The name of the location where the application resides
+    # @return [Object]
+    #   The response from the service provider in what ever form
+    #   that takes
+    def register_application(app_name, namespace, public_hostname)
+      # in this case, public_hostname is the hostname of the node the
+      # application is running on
+
+      # create a cname record for the application in the domain
+      fqdn = "#{app_name}-#{namespace}.#{@domain_suffix}"
+
+      # build the json data to submit to create the cname record
+      data_to_send = {'canonical' => public_hostname, 'name' => fqdn}
+
+      res = execute(RestClient.method(:post), @record_url, data_to_send)
+
+      #if not success
+      if res == nil
+        raise DNSException.new("error adding app record #{fqdn}")
+      end
+      res
+
+    end
+
+    # Unpublish an application - remove DNS record
+    #
+    # @param [String] app_name
+    #   The name of the application to publish
+    # @param [String] namespace
+    #   The namespace which contains the application
+    # @return [Object]
+    #   The response from the service provider in what ever form
+    #   that takes    
+    def deregister_application(app_name, namespace)
+      # delete the CNAME record for the application in the domain
+
+      # build the fqdn string for the application
+      fqdn = "#{app_name}-#{namespace}.#{@domain_suffix}"
+
+      # we need to get the infoblox id for the record we wish to delete
+      record_id = get_record_id(fqdn)
+    
+      res = execute(RestClient.method(:delete), @base_url + record_id)
+
+      #if not success
+      if res == nil
+        raise DNSException.new("error adding app record #{fqdn}")
+      end
+      res
+
+    end
+
+    # Change the published location of an application - Modify DNS record
+    #
+    # @param [String] app_name
+    #   The name of the application to publish
+    # @param [String] namespace
+    #   The namespace which contains the application
+    # @param [String] public_hostname
+    #   The name of the location where the application resides
+    # @return [Object]
+    #   The response from the service provider in what ever form
+    #   that takes
+    def modify_application(app_name, namespace, new_public_hostname)
+      # modify the CNAME record for the application in the domain
+
+      # build the fqdn string for the application
+      fqdn = "#{app_name}-#{namespace}.#{@domain_suffix}"
+
+      # we need to get the infoblox id for the record we wish to modify
+      record_id = get_record_id(fqdn)
+    
+      # build the json data to submit to modify the cname record
+      data_to_send = {'canonical' => new_public_hostname, 'name' => fqdn}
+
+      res = execute(RestClient.method(:put), @base_url + record_id, data_to_send)
+
+      #if not success
+      if res == nil
+        raise DNSException.new("error adding app record #{fqdn}")
+      end
+      res
+
+    end
+
+    # get a DNS record id string from the Infoblox service
+    #
+    # @param [String] fqdn
+    #   The fully qualified domain name of the record to query
+    # @return [String]
+    #   The Infoblox record ID string for the requested record
+    def get_record_id(fqdn)
+
+      res = execute(RestClient.method(:get), @record_url, nil, {:name => fqdn})
+
+      return nil if res == nil
+
+      # Can return uncaught ArgumentError ('') or TypeError (nil)
+      res = JSON.parse(res)
+
+      return nil if (not res or res.length == 0)
+      res[0]["_ref"]
+
+    end
+
+    # placeholder for possible bulk update behavior
+    def publish
+
+    end
+
+    # placeholder for possible persistant connection behavior
+    def close
+
+    end
+
+    private
+
+    def execute(rest_function, resource_url, data=nil, params=nil)
+      begin
+        if not data == nil
+          result_string = rest_function.call(resource_url, data,
+                                             :params => params,
+                                             :accept => :json
+                                           )
+        else
+          result_string = rest_function.call(resource_url,
+                                            :params => params,
+                                             :accept => :json)
+        end
+
+      rescue Errno::EHOSTUNREACH => e
+        raise DNSException.new("unable to reach Infoblox server: #{@server}\n#{e}")
+
+      rescue SocketError => e
+        raise DNSException.new("unknown Infoblox server: #{@server}\n#{e}")
+
+      rescue RestClient::Unauthorized => e
+        raise DNSException.new("Infoblox service authentication failed: server: #{@server}, username: #{@username}\n#{e}")
+        
+      rescue RestClient::BadRequest => e
+        raise DNSException.new("unknown REST request error: fqdn=#{@domain_suffix}\nresource: #{resource_url}\ndata: #{data}\n#{e}")
+      
+      end
+
+      result_string
+    end
+
+  end
+end

--- a/plugins/dns/infoblox/openshift-origin-dns-infoblox.gemspec
+++ b/plugins/dns/infoblox/openshift-origin-dns-infoblox.gemspec
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+config_dir  = File.join(File.join("config", "**"), "*")
+$:.push File.expand_path("../lib", __FILE__)
+lib_dir  = File.join(File.join("lib", "**"), "*")
+test_dir  = File.join(File.join("test", "**"), "*")
+bin_dir  = File.join("bin", "*")
+doc_dir  = File.join(File.join("doc", "**"), "*")
+conf_dir  = File.join(File.join("conf", "**"), "*")
+spec_file = "rubygem-openshift-origin-dns-infoblox.spec"
+
+Gem::Specification.new do |s|
+  s.name        = "openshift-origin-dns-infoblox"
+  s.version     = `rpm -q --define 'rhel 7' --qf "%{version}\n" --specfile #{spec_file}`.split[0]
+  s.license     = `rpm -q --define 'rhel 7' --qf "%{license}\n" --specfile #{spec_file}`.split[0]
+  s.authors     = ["Erik Jacobs", "Mark Lamourine"]
+  s.email       = ["ejacobs@redhat.com", "markllama@gmail.com"]
+  s.homepage    = `rpm -q --define 'rhel 7' --qf "%{url}\n" --specfile #{spec_file}`.split[0]
+  s.summary     = `rpm -q --define 'rhel 7' --qf "%{description}\n" --specfile #{spec_file}`.split[0]
+  s.description = `rpm -q --define 'rhel 7' --qf "%{description}\n" --specfile #{spec_file}`.split[0]
+
+  s.rubyforge_project = "openshift-origin-dns-infoblox"
+
+  s.files       = Dir[lib_dir] + Dir[doc_dir] + Dir[conf_dir] + Dir[config_dir]
+  s.test_files  = Dir[test_dir]
+  s.executables   = Dir[bin_dir]
+  s.files       += %w(README.md Gemfile rubygem-openshift-origin-dns-infoblox.spec openshift-origin-dns-infoblox.gemspec LICENSE COPYRIGHT)
+  s.require_paths = ["lib"]
+
+  s.add_dependency('json')
+  s.add_dependency('rest-client')
+  s.add_dependency('openshift-origin-controller')
+end

--- a/plugins/dns/infoblox/rubygem-openshift-origin-dns-infoblox.spec
+++ b/plugins/dns/infoblox/rubygem-openshift-origin-dns-infoblox.spec
@@ -1,0 +1,114 @@
+%if 0%{?fedora}%{?rhel} <= 6
+    %global scl ruby193
+    %global scl_prefix ruby193-
+%endif
+%{!?scl:%global pkg_name %{name}}
+%{?scl:%scl_package rubygem-%{gem_name}}
+%global gem_name openshift-origin-dns-infoblox
+%global rubyabi 1.9.1
+
+Summary:       OpenShift plugin for InfoBlox DNS update
+Name:          rubygem-%{gem_name}
+Version:       0.1.5
+Release:       1%{?dist}
+Group:         Development/Languages
+License:       ASL 2.0
+URL:           http://www.openshift.com
+Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
+%if 0%{?fedora} >= 19
+Requires:      ruby(release)
+%else
+Requires:      %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
+%endif
+Requires:      %{?scl:%scl_prefix}rubygems
+Requires:      rubygem(openshift-origin-common)
+Requires:      openshift-origin-broker
+Requires:      %{?scl:%scl_prefix}rubygem-json
+Requires:      %{?scl:%scl_prefix}rubygem-rest-client
+%if 0%{?fedora}%{?rhel} <= 6
+BuildRequires: ruby193-build
+BuildRequires: scl-utils-build
+%endif
+%if 0%{?fedora} >= 19
+BuildRequires: ruby(release)
+%else
+BuildRequires: %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
+%endif
+BuildRequires: %{?scl:%scl_prefix}rubygems
+BuildRequires: %{?scl:%scl_prefix}rubygems-devel
+BuildArch:     noarch
+Provides:      rubygem(%{gem_name}) = %version
+
+%description
+Provides a plugin for Infoblox DNS service
+
+%prep
+%setup -q
+
+%build
+%{?scl:scl enable %scl - << \EOF}
+mkdir -p ./%{gem_dir}
+# Create the gem as gem install only works on a gem file
+gem build %{gem_name}.gemspec
+rdoc
+export CONFIGURE_ARGS="--with-cflags='%{optflags}'"
+# gem install compiles any C extensions and installs into a directory
+# We set that to be a local directory so that we can move it into the
+# buildroot in %%install
+gem install -V \
+        --local \
+        --install-dir ./%{gem_dir} \
+        --force \
+        --rdoc \
+        %{gem_name}-%{version}.gem
+%{?scl:EOF}
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -a ./%{gem_dir}/* %{buildroot}%{gem_dir}/
+
+# Add documents/examples
+mkdir -p %{buildroot}%{_docdir}/%{name}-%{version}/
+cp -r doc/* %{buildroot}%{_docdir}/%{name}-%{version}/
+
+#Config file
+mkdir -p %{buildroot}/etc/openshift/plugins.d
+cp %{buildroot}/%{gem_dir}/gems/%{gem_name}-%{version}/conf/openshift-origin-dns-infoblox.conf.example %{buildroot}/etc/openshift/plugins.d/openshift-origin-dns-infoblox.conf.example
+
+
+%files
+%doc %{gem_docdir}
+%doc %{_docdir}/%{name}-%{version}
+%{gem_instdir}
+%{gem_spec}
+%{gem_cache}
+/etc/openshift/plugins.d/openshift-origin-dns-infoblox.conf.example
+
+
+%changelog
+* Wed Oct 09 2013 Mark Lamourine <<mlamouri@redhat.com>> 0.1.5-1
+- completed init conversion for error checking (markllama@gmail.com)
+- add infoblox plugin for DNS updates (mlamouri@redhat.com)
+
+* Wed Sep 04 2013 Mark Lamourine <<mlamouri@redhat.com>> 0.1.4-1
+- add infoblox plugin for DNS updates (mlamouri@redhat.com)
+
+* Tue Aug 27 2013 Mark Lamourine <mlamouri@redhat.com> 0.1.3-1
+- Automatic commit of package [rubygem-openshift-origin-dns-infoblox] release
+  [0.1.2-1]. (mlamouri@redhat.com)
+- added example config file (mlamouri@redhat.com)
+- updated package name in gemspec (mlamouri@redhat.com)
+- Automatic commit of package [rubygem-openshift-origin-dns-infoblox] release
+  [0.1.1-1]. (mlamouri@redhat.com)
+- reverted version to 0.1.0 (mlamouri@redhat.com)
+- added module and class wrapper to plugin methods (mlamouri@redhat.com)
+- added plugin package elements (mlamouri@redhat.com)
+- add infoblox plugin for DNS updates (mlamouri@redhat.com)
+
+* Mon Aug 26 2013 Mark Lamourine <mlamouri@redhat.com> 0.1.2-1
+- added example config file (mlamouri@redhat.com)
+- updated package name in gemspec (mlamouri@redhat.com)
+
+* Mon Aug 26 2013 Mark Lamourine <mlamouri@redhat.com> 0.1.1-1
+- first attempt to package infoblox DNS plugin
+

--- a/rel-eng/packages/rubygem-openshift-origin-dns-infoblox
+++ b/rel-eng/packages/rubygem-openshift-origin-dns-infoblox
@@ -1,0 +1,1 @@
+0.1.5-1 plugins/dns/infoblox/


### PR DESCRIPTION
Add a DNS plugin to manage updates through an Infoblox DNS service.

package name: rubygem-openshift-origin-dns-infoblox

DNS configuration: 

>    {
>        :infoblox_server => 'ip or hostname', 
>        :infoblox_username => 'identity',
>        :infoblox_password => 'secret'
>       }

or `/etc/openshift/plugins.d/openshift-origin-dns-infoblox.conf`

>  #
>     # Infoblox DNS just requires a server host, usename and password
>     #
>     INFOBLOX_SERVER='hostname or ip'
>     INFOBLOX_USERNAME='identity'
>     INFOBLOX_PASSWORD='secret'

This plugin uses the Infoblox WAPI version 1.1
