### PR TITLE
Bug 10004740: Fix hot_deploy in NodeJS cartridge

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/bin/control
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/control
@@ -3,6 +3,22 @@
 STOPTIMEOUT=10
 FMT="%a %b %d %Y %H:%M:%S GMT%z (%Z)"
 
+supervisor_exe(){
+  nodejs_context "which supervisor"
+}
+
+supervisor_pid(){
+  pgrep -f "^node $(supervisor_exe)\s" -u $(id -u)
+}
+
+node_pid(){
+  # Get all node proceses
+  node_pgrep=$(pgrep -fl '^node\s' -u $(id -u))
+  # Print only pids node containing supervisor exec
+  sup_exe=$(supervisor_exe)
+  echo "${node_pgrep}" | awk "!/${sup_exe//\//\/}/ {print \$1}"
+}
+
 function check_hot_deploy_marker() {
   if marker_present "hot_deploy"; then
     echo "hot_deploy marker found. Switching to using supervisor. Subsequent pushes won't require restart until the marker is removed."
@@ -34,20 +50,6 @@ function print_deprecation_warning() {
 DEPRECATED
 }
 
-function is_node_service_running() {
-    if [ -f $OPENSHIFT_NODEJS_PID_DIR/node.pid ]; then
-        node_pid=$( cat $OPENSHIFT_NODEJS_PID_DIR/node.pid 2> /dev/null )
-        myid=$( id -u )
-        if `ps --pid $node_pid 2>&1 | grep node > /dev/null 2>&1`  ||  \
-           `pgrep -x node -u $myid > /dev/null 2>&1`; then
-            return 0
-        fi
-    fi
-
-    return 1
-
-}  #  End of function  _is_node_running.
-
 function is_node_module_installed() {
     module_name=${1:-""}
     if [ -n "$module_name" ]; then
@@ -63,7 +65,7 @@ function is_node_module_installed() {
 }
 
 function status() {
-    if is_node_service_running; then
+    if is_supervisor_running; then
         client_result "Application is running"
     else
         client_result "Application is not running"
@@ -118,64 +120,60 @@ function start() {
 
     if [ -f "$OPENSHIFT_REPO_DIR/package.json" ]; then
         script_n_opts="$(get_main_script_from_package_json)"
-        executor_cmdline="npm start -d"
     else
         #  Backward compatibility.
         print_missing_package_json_warning
         script_n_opts="$node_opts $node_app $node_app_args"
-        executor_cmdline="node $node_opts $node_app $node_app_args"
     fi
 
-    if marker_present "hot_deploy"; then
-        nodejs_context "nohup supervisor -e 'node|js|coffee' -- $script_n_opts  >> $logf 2>&1 &"
-    else
-        nodejs_context "nohup $executor_cmdline >> $logf 2>&1 &"
-    fi
+    nodejs_context "nohup supervisor -e 'node|js|coffee' -- $script_n_opts  >> $logf 2>&1 &"
 
     ret=$?
-    npid=$(pgrep -x node -u $(id -u))
+    spid=$(supervisor_pid)
     popd > /dev/null
     if [ $ret -eq 0 ]; then
-        echo "$npid" > "$OPENSHIFT_NODEJS_PID_DIR/node.pid"
+        echo "$spid" > "$OPENSHIFT_NODEJS_PID_DIR/supervisor.pid"
     else
         echo "Application '$OPENSHIFT_APP_NAME' failed to start - $ret" 1>&2
         exit $ret
     fi
-
 }  #  End of function  start.
 
 
 function stop() {
     echo "Stopping NodeJS cartridge"
-    if [ -f $OPENSHIFT_NODEJS_PID_DIR/node.pid ]; then
-        node_pid=$( cat $OPENSHIFT_NODEJS_PID_DIR/node.pid 2> /dev/null )
-    fi
-
-    if [ -n "$node_pid" ]; then
+    if [ -f $OPENSHIFT_NODEJS_PID_DIR/supervisor.pid ]; then
+      s_pid=$( cat $OPENSHIFT_NODEJS_PID_DIR/supervisor.pid 2> /dev/null )
+      if [ "${s_pid}" -ne $(supervisor_pid) ]; then
+        error "Warning: Application '$OPENSHIFT_APP_NAME' supervisor PID does not match '\$OPENSHIFT_NODEJS_PID_DIR/supervisor.pid'.  Use force-stop to kill." 70
+      else
         logf="$OPENSHIFT_NODEJS_LOG_DIR/node.log"
         echo "`date +"$FMT"`: Stopping application '$OPENSHIFT_APP_NAME' ..." >> $logf
-        /bin/kill $node_pid
+        /bin/kill $s_pid
         ret=$?
         if [ $ret -eq 0 ]; then
-            TIMEOUT="$STOPTIMEOUT"
-            while [ $TIMEOUT -gt 0 ]  &&  is_node_service_running ; do
-                /bin/kill -0 "$node_pid" >/dev/null 2>&1 || break
-                sleep 1
-                let TIMEOUT=${TIMEOUT}-1
-            done
+          TIMEOUT="$STOPTIMEOUT"
+          while [ $TIMEOUT -gt 0 ]  && is_supervisor_running ; do
+            /bin/kill -0 "$s_pid" >/dev/null 2>&1 || break
+            sleep 1
+            let TIMEOUT=${TIMEOUT}-1
+          done
         fi
 
         # Make Node go down forcefully if it is still running.
-        if is_node_service_running ; then
-           killall -9 node > /dev/null 2>&1  ||  :
+        if is_supervisor_running ; then
+          pkill -f "$(supervisor_exe)" 2>&1 || :
         fi
 
         echo "`date +"$FMT"`: Stopped Node application '$OPENSHIFT_APP_NAME'" >> $logf
-        rm -f $OPENSHIFT_NODEJS_PID_DIR/node.pid
+        rm -f $OPENSHIFT_NODEJS_PID_DIR/supervisor.pid
+      fi
     else
-        if `pgrep -x node -u $(id -u)  > /dev/null 2>&1`; then
-            echo "Warning: Application '$OPENSHIFT_APP_NAME' Node server exists without a pid file.  Use force-stop to kill." 1>&2
-        fi
+      if -n "$(supervisor_pid)"; then
+        error "Warning: Application '$OPENSHIFT_APP_NAME' supervisor exists without a pid file.  Use force-stop to kill." 70
+      elif -n "$(node_pid)"; then
+        error "Warning: Application '$OPENSHIFT_APP_NAME' Node server exists without a pid file.  Use force-stop to kill." 70
+      fi
     fi
 }  #  End of function stop.
 
@@ -258,15 +256,14 @@ function build() {
 
 function is_supervisor_running() {
     #  Have a pid file, use it - otherwise return not supervisor.
-    [ -f "$OPENSHIFT_NODEJS_PID_DIR/node.pid" ]  ||  return 1
+    [ -f "$OPENSHIFT_NODEJS_PID_DIR/supervisor.pid" ]  ||  return 1
 
     #  Have a valid pid, use it - otherwise return not supervisor.
-    nodepid=$(cat "${OPENSHIFT_NODEJS_PID_DIR}/node.pid")
+    nodepid=$(cat "${OPENSHIFT_NODEJS_PID_DIR}/supervisor.pid")
     [ -n "$nodepid" ]  ||  return 1
 
     #  Is the pid a supervisor process.
-    if ps --no-heading -ocmd -p $nodepid |  \
-       egrep -e "^node\s*/usr/bin/supervisor(.*)" > /dev/null 2>&1; then
+    if [[ $(ps --no-heading -ocmd -p $nodepid) =~ $(supervisor_exe) ]]; then
        #  Yes, the app server is a supervisor process.
        return 0
     fi
@@ -278,11 +275,9 @@ function is_supervisor_running() {
 function post-deploy() {
     check_hot_deploy_marker
 
-    if marker_present "hot_deploy"; then
-        # Check if supervisor is already running. If not do a restart.
-        if ! is_supervisor_running ; then
-            restart
-        fi
+    # Check if supervisor is already running. If not do a restart.
+    if marker_present "hot_deploy" && ! is_supervisor_running ; then
+      restart
     fi
 }
 

--- a/cartridges/openshift-origin-cartridge-nodejs/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/upgrade
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source $OPENSHIFT_CARTRIDGE_SDK_BASH
+source "${OPENSHIFT_NODEJS_DIR}/lib/util"
+source "${OPENSHIFT_NODEJS_DIR}/lib/nodejs_context"
+
+nodejs_version="$1"
+old_cart_version="$2"
+new_cart_version="$3"
+
+if [[ $old_cart_version =~ 0.0.[0-4] ]]; then
+  echo "$nodejs_version" > $OPENSHIFT_NODEJS_DIR/env/OPENSHIFT_NODEJS_VERSION
+  update-configuration $nodejs_version
+fi

--- a/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml.fedora
+++ b/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml.fedora
@@ -10,10 +10,8 @@ License: MIT License
 License-Url: https://raw.github.com/joyent/node/v0.10/LICENSE
 Vendor: www.nodejs.org
 Website: http://www.nodejs.org/
-Cartridge-Version: 0.0.4
-Compatible-Versions:
-- 0.0.2
-- 0.0.3
+Cartridge-Version: 0.0.5
+Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:
 - service

--- a/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml.rhel
@@ -13,10 +13,8 @@ License: MIT License
 License-Url: https://raw.github.com/joyent/node/v0.10/LICENSE
 Vendor: www.nodejs.org
 Website: http://www.nodejs.org/
-Cartridge-Version: 0.0.4
-Compatible-Versions:
-- 0.0.2
-- 0.0.3
+Cartridge-Version: 0.0.5
+Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:
 - service


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1004740

Hot deploy was not detecting the `supervisor` script properly. We changed both scl and non-scl uses to use `supervisor` to run the application.
