### PR TITLE
Fixing code to allow admin to restrict # of domains to be less than # of gears allocated to a user.

### DIFF
--- a/broker/test/functional/domains_controller_test.rb
+++ b/broker/test/functional/domains_controller_test.rb
@@ -88,6 +88,8 @@ class DomainsControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
     #try name that exists
     namespace = "ns#{@random}"
+
+    OpenShift::ApplicationContainerProxy.stubs(:max_user_domains).returns(2)
     post :create, {"name" => namespace}
     assert_response :created
     post :create, {"name" => namespace}

--- a/controller/lib/openshift/application_container_proxy.rb
+++ b/controller/lib/openshift/application_container_proxy.rb
@@ -15,7 +15,7 @@ module OpenShift
     end
 
     def self.max_user_domains_impl(user)
-      [user.max_gears || 1, Rails.configuration.openshift[:max_domains_per_user]].max
+      [user.max_gears || 1, Rails.configuration.openshift[:max_domains_per_user]].min
     end
 
     def self.provider=(provider_class)


### PR DESCRIPTION
In exiting code:

```
  [user.max_gears || 1, Rails.configuration.openshift[:max_domains_per_user]].max
```

means that even if max_domains_per_user is set to 1, if the user has access to 3 gears,
they are able to create 3 domains.
