### PR TITLE
plugins/dns/nsupdate: Support unauthenticated use

### DIFF
--- a/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
+++ b/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
@@ -123,7 +123,8 @@ module OpenShift
       end
 
       # If the config gave a TSIG key, use it
-      keystring = @keyname ? "key #{@keyalgorithm}:#{@keyname} #{keyvalue}" : "gsstsig"
+      keystring = @keyname ? "key #{@keyalgorithm}:#{@keyname} #{keyvalue}" :
+                  @krb_principal ?  "gsstsig" : ""
 
       zonestring = @zone ? "zone #{@zone}" : ""
 
@@ -156,7 +157,8 @@ EOF
       end
 
       # If the config gave a TSIG key, use it
-      keystring = @keyname ? "key #{@keyname} #{keyvalue}" : "gsstsig"
+      keystring = @keyname ? "key #{@keyname} #{keyvalue}" :
+                  @krb_principal ?  "gsstsig" : ""
 
       zonestring = @zone ? "zone #{@zone}" : ""
 


### PR DESCRIPTION
Modify the nsupdate DNS plug-in to support unauthenticated DNS updates by omitting the key and gsstsig commands if neither a key nor a Kerberos principal is specified.
