### PR TITLE
plugins/dns/nsupdate: Delete duplicate kinit

### DIFF
--- a/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
+++ b/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
@@ -211,10 +211,6 @@ EOF
       fqdn = "#{app_name}-#{namespace}.#{@domain_suffix}"
 
       cmd = del_cmd(fqdn)
-      # authenticate if credentials have been given
-      if @krb_principal
-        cmd = "kinit -kt #{@krb_keytab} #{@krb_principal} &&" + cmd
-      end
 
       success = system cmd
       if not success


### PR DESCRIPTION
In the nsupdate DNS plug-in, delete the kinit command from the deregister_application method because the del_cmd method already adds a kinit command, so were getting a duplicate.

Both kinit commands were added in commit adeb3522775f671efc78da8eebff735337b64c70.
