### PR TITLE
Revert "Bug 1005421 - the ps command was returning unicode characters, strip them out."

### DIFF
--- a/node-util/bin/oo-accept-node
+++ b/node-util/bin/oo-accept-node
@@ -447,7 +447,7 @@ def check_cgroup_procs
             missing = procs - controller_procs[uuid]
             if missing.length > 0
                 missing.each do |pid|
-                    proc_data = %x[/bin/ps -p #{pid} -o uid,pid,ppid,etime,cmd].encode({:invalid=>:replace, :undef=>:replace, :replace=>''}).split("\n")
+                    proc_data = %x[/bin/ps -p #{pid} -o uid,pid,ppid,etime,cmd].split("\n")
 
                     # ensure the process is still running and not defunct before failing
                     # this fixes both the transient process and the defunct process


### PR DESCRIPTION
I'm withdrawing this fix.  The deeper issue is that LANG appears to be messed up when the script is run and that needs to be diagnosed instead.

Revert "Bug 1005421 - the ps command was returning unicode characters, strip them out."

This reverts commit 70d7b0c718225f505be206cde27a5c9795f02d25.
