### PR TITLE
Bug 985024: Remove haproxy status page as the backup page.

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-haproxy/bin/upgrade
@@ -1,0 +1,3 @@
+#!/bin/bash -eu
+
+sed -i '/server\s*filler/d' $OPENSHIFT_HAPROXY_DIR/conf/haproxy.cfg

--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/haproxy_ctld.rb
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/haproxy_ctld.rb
@@ -186,7 +186,7 @@ class Haproxy
           raise ShouldRetry, e.to_s
         end
 
-        @gear_count = self.stats['express'].count - 3
+        @gear_count = self.stats['express'].count - 2
         @gear_up_pct = 90.0
         if @gear_count > 1
           # Pick a percentage for removing gears which is a moderate amount below the threshold where the gear would scale back up.

--- a/cartridges/openshift-origin-cartridge-haproxy/versions/1.4/configuration/haproxy.cfg.erb
+++ b/cartridges/openshift-origin-cartridge-haproxy/versions/1.4/configuration/haproxy.cfg.erb
@@ -63,4 +63,3 @@ listen express <%= "#{ENV['OPENSHIFT_HAPROXY_IP']}:#{ENV['OPENSHIFT_HAPROXY_PORT
     cookie GEAR insert indirect nocache
     option httpchk GET /
     balance leastconn
-    server  filler <%= "#{ENV['OPENSHIFT_HAPROXY_STATUS_IP']}:#{ENV['OPENSHIFT_HAPROXY_STATUS_PORT']}" %> backup


### PR DESCRIPTION
[test][extended:runtime]
