### PR TITLE
<oo-admin-ctl-usage> Bug 990451, use Mongo config options for Moped session

### DIFF
--- a/broker-util/oo-admin-ctl-usage
+++ b/broker-util/oo-admin-ctl-usage
@@ -80,7 +80,7 @@ end
 
 def get_mongo_session
   config = Mongoid::Config.sessions["default"]
-  session = Moped::Session.new(config["hosts"])
+  session = Moped::Session.new(config["hosts"], config["options"])
   session.use config["database"]
   session.login(config["username"], config["password"])
   session


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=990451

oo-admin-ctl-usage wasn't passing the Mongo session options to the
Moped::Session.new call, so certain MONGO_\* settings from broker.conf
weren't applied. Thus MONGO_SSL=true had no effect, causing
oo-admin-ctl-usage to fail on systems where Mongo was configured to
use SSL.
