### PR TITLE
RHBZ#1006712: prevent duplicate messages in cron cartridge

### DIFF
--- a/cartridges/openshift-origin-cartridge-cron/bin/control
+++ b/cartridges/openshift-origin-cartridge-cron/bin/control
@@ -12,14 +12,14 @@ function _status_cron_service() {
     then
         client_result "$output"
     else
-        client_result "Cron is either stopped or inaccessible"
+        client_result "Cron is either stopped or inaccessible for gear $OPENSHIFT_GEAR_UUID"
     fi
 }  #  End of function  _status_cron_service.
 
 function start() {
     echo "Starting Cron cartridge"
     if _are_cronjobs_enabled; then
-        client_result "cron scheduling service is already enabled"
+        client_result "cron scheduling service is already enabled for gear $OPENSHIFT_GEAR_UUID"
     else
         touch "$OPENSHIFT_CRON_DIR/run/jobs.enabled"
     fi
@@ -30,7 +30,7 @@ function stop() {
     if _are_cronjobs_enabled; then
         rm -f $OPENSHIFT_CRON_DIR/run/jobs.enabled
     else
-        client_result "cron scheduling service is already disabled"
+        client_result "cron scheduling service is already disabled for gear $OPENSHIFT_GEAR_UUID"
     fi
 }
 
@@ -51,17 +51,17 @@ function status() {
          fi
       done
       if test 0 -ge ${njobs:-0}; then
-         client_result "Application has no scheduled jobs"
+         client_result "Application has no scheduled jobs for gear $OPENSHIFT_GEAR_UUID"
       fi
    else
-      client_result "Application has no scheduled jobs"
+      client_result "Application has no scheduled jobs for gear $OPENSHIFT_GEAR_UUID"
       client_result "   - Missing .openshift/cron/ directory."
    fi
 
    if _are_cronjobs_enabled; then
-      client_result "cron scheduling service is enabled"
+      client_result "cron scheduling service is enabled for gear $OPENSHIFT_GEAR_UUID"
    else
-      client_result "cron scheduling service is disabled"
+      client_result "cron scheduling service is disabled for gear $OPENSHIFT_GEAR_UUID"
    fi
 }
 

--- a/cartridges/openshift-origin-cartridge-cron/bin/install
+++ b/cartridges/openshift-origin-cartridge-cron/bin/install
@@ -2,9 +2,8 @@
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
-check_webproxy=$(has_web_proxy)
 # check if we're in a non-scaled environment or if we're the web-proxy
-if [ "$OPENSHIFT_GEAR_DNS" == "$OPENSHIFT_APP_DNS" ] || [ "$check_webproxy" == "1" ]; then
+if [ "$OPENSHIFT_GEAR_DNS" == "$OPENSHIFT_APP_DNS" ] || has_web_proxy; then
     frequencies=$(cat $OPENSHIFT_CRON_DIR/configuration/frequencies | tr '\n' ',')
     client_result ""
     client_result "To schedule your scripts to run on a periodic basis, add the scripts to "

--- a/cartridges/openshift-origin-cartridge-cron/bin/install
+++ b/cartridges/openshift-origin-cartridge-cron/bin/install
@@ -2,14 +2,18 @@
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
-frequencies=$(cat $OPENSHIFT_CRON_DIR/configuration/frequencies | tr '\n' ',')
-client_result ""
-client_result "To schedule your scripts to run on a periodic basis, add the scripts to " 
-client_result "your application's .openshift/cron/{${frequencies%?}}/"
-client_result "directories (and commit and redeploy your application)."
-client_result ""
-client_result "Example: A script .openshift/cron/hourly/crony added to your application"
-client_result "         will be executed once every hour."
-client_result "         Similarly, a script .openshift/cron/weekly/chronograph added"
-client_result "         to your application will be executed once every week."
-client_result ""
+check_webproxy=$(has_web_proxy)
+# check if we're in a non-scaled environment or if we're the web-proxy
+if [ "$OPENSHIFT_GEAR_DNS" == "$OPENSHIFT_APP_DNS" ] || [ "$check_webproxy" == "1" ]; then
+    frequencies=$(cat $OPENSHIFT_CRON_DIR/configuration/frequencies | tr '\n' ',')
+    client_result ""
+    client_result "To schedule your scripts to run on a periodic basis, add the scripts to "
+    client_result "your application's .openshift/cron/{${frequencies%?}}/"
+    client_result "directories (and commit and redeploy your application)."
+    client_result ""
+    client_result "Example: A script .openshift/cron/hourly/crony added to your application"
+    client_result "         will be executed once every hour."
+    client_result "         Similarly, a script .openshift/cron/weekly/chronograph added"
+    client_result "         to your application will be executed once every week."
+    client_result ""
+fi

--- a/node/misc/usr/lib/cartridge_sdk/bash/sdk
+++ b/node/misc/usr/lib/cartridge_sdk/bash/sdk
@@ -545,3 +545,15 @@ function sync_gear_repos {
 
   return $exc
 }
+
+# Returns 1 if we have a web_proxy cartridge installed
+function has_web_proxy() {
+    has_web_proxy_cart=0
+    for manifest in ${HOME}/*/metadata/manifest.yml; do
+        check_for_web_proxy=$(awk '/:$/ {section=$1} /^- web_proxy/ {if (section == "Categories:") print 1}' $manifest)
+        if  [ "$check_for_web_proxy" == "1" ]; then
+            bash_web_proxy_cart=1
+        fi
+    done
+    echo -n "${has_web_proxy_cart}"
+}

--- a/node/misc/usr/lib/cartridge_sdk/bash/sdk
+++ b/node/misc/usr/lib/cartridge_sdk/bash/sdk
@@ -552,8 +552,8 @@ function has_web_proxy() {
     for manifest in ${HOME}/*/metadata/manifest.yml; do
         check_for_web_proxy=$(awk '/:$/ {section=$1} /^- web_proxy/ {if (section == "Categories:") print 1}' $manifest)
         if  [ "$check_for_web_proxy" == "1" ]; then
-            bash_web_proxy_cart=1
+            return 0
         fi
     done
-    echo -n "${has_web_proxy_cart}"
+    return 1
 }


### PR DESCRIPTION
- Make the control script display specific gear uuid
- Display the install message only if we're in a non-scaled environment **or** only if we are the web_proxy in scaled

Both bugs are related to https://bugzilla.redhat.com/show_bug.cgi?id=1006712
