### PR TITLE
Card origin_runtime_255: Publish district uid limits to nodes

### DIFF
--- a/broker-util/oo-admin-ctl-district
+++ b/broker-util/oo-admin-ctl-district
@@ -5,7 +5,7 @@ require 'getoptlong'
 require 'pp'
 require "/var/www/openshift/broker/config/environment"
 
-CTL_DISTRICT_COMMANDS = "(add-node|remove-node|deactivate-node|activate-node|add-capacity|remove-capacity|create|destroy)"
+CTL_DISTRICT_COMMANDS = "(add-node|remove-node|deactivate-node|activate-node|add-capacity|remove-capacity|create|destroy|publish-uids)"
 
 def usage
   puts <<USAGE
@@ -89,7 +89,7 @@ if node_profile && !Gear::valid_gear_size?(node_profile)
   exit 1
 end
   
-if command && !(command =~ /\A(add-node|remove-node|deactivate-node|activate-node|add-capacity|remove-capacity|create|destroy)\z/)
+if command && !(command =~ /\A(add-node|remove-node|deactivate-node|activate-node|add-capacity|remove-capacity|create|destroy|publish-uids)\z/)
   puts "Command must be one of: #{CTL_DISTRICT_COMMANDS}"
   exit 255
 end
@@ -114,7 +114,7 @@ if uuid || name
     puts "--size is required with command: #{command}"
     exit 1
   end
-elsif command
+elsif command && (command != 'publish-uids')
   if command != 'create'
     puts "--uuid or --name is required with command: #{command}"
   else
@@ -144,6 +144,19 @@ begin
   when "remove-capacity"
     district.remove_capacity(size)
     reply.resultIO << "Success!"
+  when "publish-uids"
+    districts = district ? [district] : District.find_all
+
+    reply.resultIO << "No districts created yet.  Use 'oo-admin-ctl-district -c create' to create one." if districts.empty?
+    districts.each do |district|
+      if district.server_identities.empty?
+        reply.resultIO << "District: #{district.name} does not have any server identities, skipping.\n"
+      else
+        reply.resultIO << "Publishing district UIDs for district: #{district.name} (#{district.uuid})\n"
+        OpenShift::ApplicationContainerProxy.set_district_uid_limits("#{district.uuid}", district.first_uid, district.max_uid)
+        reply.resultIO << "District: #{district.name} done\n"
+      end
+    end
   when "create"
     default_gear_size = Rails.application.config.openshift[:default_gear_size]
     puts "node_profile not specified.  Using default: #{default_gear_size}" unless node_profile
@@ -189,7 +202,7 @@ WARNING
       end
     end
   end
-  if (uuid || name) && command && command != 'destroy'
+  if (uuid || name) && command && command != 'destroy' && command != 'publish-uids'
     district = get_district(uuid, name)
     append_district(district, reply.resultIO)
   end

--- a/controller/lib/openshift/application_container_proxy.rb
+++ b/controller/lib/openshift/application_container_proxy.rb
@@ -74,6 +74,10 @@ module OpenShift
       @proxy_provider.get_details_for_all_impl(name_list)
     end
 
+    def self.set_district_uid_limits(uuid, first_uid, max_uid)
+      @proxy_provider.set_district_uid_limits_impl(uuid, first_uid, max_uid) 
+    end
+
     attr_accessor :id
   end
 end

--- a/controller/test/cucumber/runtime-district-info.feature
+++ b/controller/test/cucumber/runtime-district-info.feature
@@ -1,0 +1,10 @@
+@runtime
+@runtime1
+Feature: District Configuration
+  Scenario: Write and update district file
+    Given a new active district with first_uid 1000 and max_uid 6999
+    Then the district info file should match the district
+    And the file /etc/openshift/district.conf does not exist
+    When the district is updated with first_uid 10000 and max_uid 15000
+    Then the district info file should match the district
+    Then remove the district info file

--- a/controller/test/cucumber/step_definitions/runtime-district-info_steps.rb
+++ b/controller/test/cucumber/step_definitions/runtime-district-info_steps.rb
@@ -1,0 +1,48 @@
+require 'rubygems'
+require 'parseconfig'
+require 'mcollective'
+
+include MCollective::RPC
+options = MCollective::Util.default_options
+
+district_info_file = "/var/lib/openshift/.settings/district.info"
+
+Given /^a new active district with first_uid (\d+) and max_uid (\d+)$/ do |first_uid, max_uid|
+  # Clean up anything left over
+  FileUtils.rm_f district_info_file
+  uuid = SecureRandom.hex(16)
+  @district = {:uuid => uuid, :active => 'true', :first_uid => first_uid, :max_uid => max_uid}
+  mc = rpcclient("openshift", {:options => options})
+  reply = mc.set_district(:uuid => uuid, :active => true, :first_uid => first_uid.to_i, :max_uid => max_uid.to_i)
+  reply[0][:data][:exitcode].should be == 0
+end
+
+When /^the district is updated with first_uid (\d+) and max_uid (\d+)$/ do |first_uid, max_uid|
+  @district[:first_uid] = first_uid
+  @district[:max_uid] = max_uid
+  mc = rpcclient("openshift", {:options => options})
+  reply = mc.set_district_uid_limits(:uuid => @district[:uuid], :first_uid => first_uid.to_i, :max_uid => max_uid.to_i)
+  reply[0][:data][:exitcode].should be == 0
+end
+
+Then /^the district info file should match the district$/ do
+  assert_file_exist district_info_file
+
+  config = ParseConfig.new district_info_file
+  config['uuid'].should == @district[:uuid]
+  config['active'].should == @district[:active] 
+  config['first_uid'].should == @district[:first_uid]
+  config['max_uid'].should == @district[:max_uid]
+end
+
+Then /^the file (.*) does( not)? exist$/ do |file, negate|
+  if negate
+    refute_file_exist file
+  else
+    assert_file_exist file
+  end
+end
+
+Then /^remove the district info file/ do
+  FileUtils.rm_f district_info_file
+end

--- a/msg-common/agent/openshift.ddl
+++ b/msg-common/agent/openshift.ddl
@@ -175,7 +175,7 @@ action "get_all_gears_sshkeys", :description => "get all sshkeys for all gears" 
            :display_as => "Exit Code"
 end
 
-action "set_district", :description => "run a cartridge action" do
+action "set_district", :description => "Set the District of a Node" do
     display :always
 
     input :uuid,
@@ -190,6 +190,46 @@ action "set_district", :description => "run a cartridge action" do
         :prompt         => "District active boolean",
         :description    => "District active boolean",
         :type           => :boolean,
+        :optional       => false
+
+    input :first_uid,
+        :prompt         => "First uid",
+        :description    => "First uid",
+        :type           => :integer,
+        :optional       => false
+
+    input :max_uid,
+        :prompt         => "Max uid",
+        :description    => "Max uid",
+        :type           => :integer,
+        :optional       => false
+
+    output  :time,
+            :description => "The time as a message",
+            :display_as => "Time"
+
+    output  :output,
+            :description => "Output from script",
+            :display_as => "Output"
+
+    output :exitcode,
+           :description => "Exit code",
+           :display_as => "Exit Code"
+end
+
+action "set_district_uid_limits", :description => "Set District uid limits for a Node" do
+    display :always
+
+    input :first_uid,
+        :prompt         => "First uid",
+        :description    => "First uid",
+        :type           => :integer,
+        :optional       => false
+
+    input :max_uid,
+        :prompt         => "Max uid",
+        :description    => "Max uid",
+        :type           => :integer,
         :optional       => false
 
     output  :time,

--- a/node-util/bin/oo-accept-node
+++ b/node-util/bin/oo-accept-node
@@ -24,6 +24,7 @@ require 'socket'
 require 'json'
 require 'etc'
 require 'safe_yaml'
+require 'facter'
 
 $OPTIONS = {}
 
@@ -415,16 +416,24 @@ def check_cgroup_procs
     ### Gather current procs running ###
     min_uid = $CONF.get('GEAR_MIN_UID').to_i
     max_uid = $CONF.get('GEAR_MAX_UID').to_i
-    uid_range = (min_uid..max_uid)
 
-    # Need to collect 3 and 4 digit uids since a non-district host could have a 3 digit uid
-    all_user_procs = %x[/bin/ps -e -o uid,pid | /bin/egrep "^\s+[0-9]{3,4}"].split("\n")
+    district_uuid = Facter.[]('district_uuid').value
+    verbose("find district uuid: #{district_uuid}")
+
+    if district_uuid.casecmp("None") != 0
+      min_uid = Facter.[]('district_first_uid').value.to_i
+      max_uid = Facter.[]('district_max_uid').value.to_i
+    end
+
+    verbose("determining node uid range: #{min_uid} to #{max_uid}")
+
+    all_user_procs = %x[/bin/ps -e -o uid,pid].split("\n")
     ps_procs = Hash.new{|hash, key| hash[key] = Array.new}
     all_user_procs.each do |line|
         uid,pid = line.split[0,2]
         uid = uid.to_i
 
-        if uid_range.include?(uid)
+        if uid.between?(min_uid, max_uid)
             passwd_lines = $USERS.select { |u| u.uid == uid }
 
             if passwd_lines.empty?

--- a/plugins/msg-node/mcollective/facts/openshift_facts.rb
+++ b/plugins/msg-node/mcollective/facts/openshift_facts.rb
@@ -22,9 +22,13 @@ if File.exists?(district_conf)
   config_file = ParseConfig.new(district_conf)
   district_uuid = config_file['uuid'] ? config_file['uuid'] : 'NONE'
   district_active = config_file['active'] ? config_file['active'] == "true" : false
+  district_first_uid = config_file['first_uid'] ? config_file['first_uid'] : 1000
+  district_max_uid = config_file['max_uid'] ? config_file['max_uid'] : 6999
 end
 Facter.add(:district_uuid) { setcode { district_uuid } }
 Facter.add(:district_active) { setcode { district_active } }
+Facter.add(:district_first_uid) { setcode { district_first_uid } }
+Facter.add(:district_max_uid) { setcode { district_max_uid } }
 
 #
 # Pull public_ip and public_hostname out of the node_data config


### PR DESCRIPTION
```
https://trello.com/c/cedK4ySU

Add facts for district_first_uid and district_max_uid

Update set_district mcollective action to record first_uid and
max_uid

Add set_district_uid_limits mcollective action to update first_uid
and max_uid or add them if they do not already exist

Update district model to update first_uid and max_uid when a node is
added, removed, activated, deactivated or if the capactiy for a
district is modified.

Update oo-accept-node to use district_first_uid and district_max_uid
facts instead of GEAR_MIN_UID and GEAR_MAX_UID on a district node.

Add flock around editing district.info

Move runtime district info cucumber test from private repo

Update runtime district info cucumber test for first_uid and max_uid

Add publish-uids command to oo-admin-ctl-district
```
