### PR TITLE
Card origin_runtime_86 Ruby development mode

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -73,6 +73,13 @@ function build() {
     echo "Building Ruby cartridge"
     update-configuration $OPENSHIFT_RUBY_VERSION
 
+    if ruby_in_development_mode; then
+      if ! gemfile_modified; then
+        echo "Skipping 'bundle install' because development mode is enabled..."
+        return 0
+      fi
+    fi
+
     USED_BUNDLER=false
     if [ -d $OPENSHIFT_RUBY_DIR/tmp/.bundle ]
     then

--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -111,6 +111,10 @@ function build() {
 }
 
 function deploy() {
+  if ruby_in_development_mode; then
+    echo "The 'rake assets:precompile' is disabled when Ruby is in development mode."
+    return 0
+  fi
   pushd ${OPENSHIFT_REPO_DIR} > /dev/null
   if [ -f Gemfile ]
   then

--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -9,6 +9,12 @@ HTTPD_PASSENV_FILE=$OPENSHIFT_RUBY_DIR/etc/conf.d/passenv.conf
 HTTPD_PID_FILE=$OPENSHIFT_RUBY_DIR/run/httpd.pid
 
 function start() {
+    if process_running 'httpd', $HTTPD_PID_FILE; then
+      if ruby_in_development_mode; then
+        echo "Ruby cartridge in development mode, skipping start..."
+        return 0
+      fi
+    fi
     echo "Starting Ruby cartridge"
     write_httpd_passenv $HTTPD_PASSENV_FILE
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
@@ -16,6 +22,10 @@ function start() {
 }
 
 function stop() {
+    if ruby_in_development_mode; then
+      echo "Ruby cartridge in development mode, skipping stop..."
+      return 0
+    fi
     echo "Stopping Ruby cartridge"
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     if [ -f "$HTTPD_PID_FILE" ]; then

--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -7,24 +7,29 @@ source "${OPENSHIFT_RUBY_DIR}/lib/ruby_context"
 HTTPD_CFG_FILE=$OPENSHIFT_RUBY_DIR/etc/conf/httpd_nolog.conf
 HTTPD_PASSENV_FILE=$OPENSHIFT_RUBY_DIR/etc/conf.d/passenv.conf
 HTTPD_PID_FILE=$OPENSHIFT_RUBY_DIR/run/httpd.pid
+RAILS_ENV=${RAILS_ENV:-$OPENSHIFT_RUBY_ENV}
 
 function start() {
     if process_running 'httpd', $HTTPD_PID_FILE; then
-      if ruby_in_development_mode; then
+      if ruby_in_development_mode && httpd_in_development_mode; then
         echo "Ruby cartridge in development mode, skipping start..."
         return 0
+      else
+        update_rails_env
       fi
     fi
     echo "Starting Ruby cartridge"
     write_httpd_passenv $HTTPD_PASSENV_FILE
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
-    ruby_context "/usr/sbin/httpd -C 'Include $OPENSHIFT_RUBY_DIR/etc/conf.d/*.conf' -f $HTTPD_CFG_FILE -k start"
+    ruby_context "RAILS_ENV=${RAILS_ENV:-production} /usr/sbin/httpd -C 'Include $OPENSHIFT_RUBY_DIR/etc/conf.d/*.conf' -f $HTTPD_CFG_FILE -k start"
 }
 
 function stop() {
     if ruby_in_development_mode; then
-      echo "Ruby cartridge in development mode, skipping stop..."
-      return 0
+      if httpd_in_development_mode; then
+        echo "Ruby cartridge in development mode, skipping stop..."
+        return 0
+      fi
     fi
     echo "Stopping Ruby cartridge"
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
@@ -40,7 +45,7 @@ function restart() {
     write_httpd_passenv $HTTPD_PASSENV_FILE
     touch $OPENSHIFT_REPO_DIR/tmp/restart.txt
     ensure_httpd_restart_succeed "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
-    ruby_context "/usr/sbin/httpd -C 'Include $OPENSHIFT_RUBY_DIR/etc/conf.d/*.conf' -f $HTTPD_CFG_FILE -k restart"
+    ruby_context "RAILS_ENV=${RAILS_ENV:-production} /usr/sbin/httpd -C 'Include $OPENSHIFT_RUBY_DIR/etc/conf.d/*.conf' -f $HTTPD_CFG_FILE -k restart"
 }
 
 function status() {
@@ -83,13 +88,6 @@ function build() {
     echo "Building Ruby cartridge"
     update-configuration $OPENSHIFT_RUBY_VERSION
 
-    if ruby_in_development_mode; then
-      if ! gemfile_modified; then
-        echo "Skipping 'bundle install' because development mode is enabled..."
-        return 0
-      fi
-    fi
-
     USED_BUNDLER=false
     if [ -d $OPENSHIFT_RUBY_DIR/tmp/.bundle ]
     then
@@ -112,6 +110,12 @@ function build() {
     # If .bundle isn't currently committed and a Gemfile is then bundle install
     if [ -f ${OPENSHIFT_REPO_DIR}/Gemfile ]
     then
+        if ruby_in_development_mode; then
+          if ! gemfile_is_modified; then
+            echo "Skipping 'bundle install' because development mode is enabled..."
+            return 0
+          fi
+        fi
         pushd "${OPENSHIFT_HOMEDIR}/git/${OPENSHIFT_APP_NAME}.git" 1>/dev/null
           if ! git show master:.bundle > /dev/null 2>&1
           then
@@ -120,6 +124,7 @@ function build() {
                 SAVED_GIT_DIR=$GIT_DIR
                 unset GIT_DIR
                 ruby_context "bundle install --deployment"
+                update_gemfile_sum
                 export GIT_DIR=$SAVED_GIT_DIR
               popd 1> /dev/null
           fi

--- a/cartridges/openshift-origin-cartridge-ruby/lib/util
+++ b/cartridges/openshift-origin-cartridge-ruby/lib/util
@@ -7,6 +7,30 @@ function ruby_in_development_mode {
   return 1
 }
 
+function gemfile_modified {
+
+  local bundler_md5_file="${OPENSHIFT_RUBY_DIR}tmp/.bundler_md5sum"
+
+  [ ! -f "${OPENSHIFT_REPO_DIR}Gemfile" ] && return 1
+
+  if [ ! -f "${bundler_md5_file}" ]; then
+    md5sum "${OPENSHIFT_REPO_DIR}Gemfile" > "${bundler_md5_file}"
+    return 1
+  else
+
+    pushd $OPENSHIFT_REPO_DIR 1>/dev/null
+    md5sum --status --check "${bundler_md5_file}"
+    success=$?
+    popd 1>/dev/null
+
+    if success; then
+      return 0
+    else
+      return 1
+    fi
+  fi
+}
+
 function wait_for_stop {
         pid=$1
     for i in {1..300}

--- a/cartridges/openshift-origin-cartridge-ruby/lib/util
+++ b/cartridges/openshift-origin-cartridge-ruby/lib/util
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Utility functions for use in the cartridge scripts.
 
+function ruby_in_development_mode {
+  [ "$RAILS_ENV" == "development" ] && return 0
+  [ "$RACK_ENV" == "development" ] && return 0
+  return 1
+}
+
 function wait_for_stop {
         pid=$1
     for i in {1..300}

--- a/cartridges/openshift-origin-cartridge-ruby/lib/util
+++ b/cartridges/openshift-origin-cartridge-ruby/lib/util
@@ -2,28 +2,78 @@
 # Utility functions for use in the cartridge scripts.
 
 function ruby_in_development_mode {
-  [ "$RAILS_ENV" == "development" ] && return 0
-  [ "$RACK_ENV" == "development" ] && return 0
-  return 1
+  if [ "$RAILS_ENV" == "development" ]; then
+    return 0
+  elif [ "$OPENSHIFT_RUBY_ENV" == "development" ]; then
+    return 0
+  else
+    return 1
+  fi
 }
 
-function gemfile_modified {
+# When in development mode, the 'bundler install' is skipped
+# until developer touch the Gemfile/Gemfile.lock files, to
+# speed up deployment.
+#
+function update_gemfile_sum {
 
-  local bundler_md5_file="${OPENSHIFT_RUBY_DIR}tmp/.bundler_md5sum"
+  local gemfile_md5_file="${OPENSHIFT_RUBY_DIR}tmp/.gemfile_md5sum"
+
+  pushd $OPENSHIFT_REPO_DIR 1>/dev/null
+  if [ -f Gemfile.lock ]; then
+    md5sum Gemfile Gemfile.lock > "${gemfile_md5_file}"
+  else
+    md5sum Gemfile > "${gemfile_md5_file}"
+  fi
+  popd 1>/dev/null
+}
+
+function update_rails_env {
+  if [ ! -z "${OPENSHIFT_RUBY_ENV}" ]; then
+    echo $OPENSHIFT_RUBY_ENV > "${OPENSHIFT_RUBY_DIR}tmp/rails_env"
+  else
+    echo $RAILS_ENV > "${OPENSHIFT_RUBY_DIR}tmp/rails_env"
+  fi
+}
+
+# Apache is in development mode when the RAILS_ENV is set to the development.
+#
+function httpd_in_development_mode {
+  if ruby_in_development_mode; then
+    if [ ! -f "${OPENSHIFT_RUBY_DIR}tmp/rails_env" ]; then
+      current_rails_env="production"
+    else
+      current_rails_env=$(cat "${OPENSHIFT_RUBY_DIR}tmp/rails_env")
+    fi
+    if [ "$current_rails_env" == "production" ]; then
+      update_rails_env
+      return 1
+    fi
+  else
+    update_rails_env
+    return 0
+  fi
+}
+
+function gemfile_is_modified {
+
+  local gemfile_md5_file="${OPENSHIFT_RUBY_DIR}tmp/.gemfile_md5sum"
 
   [ ! -f "${OPENSHIFT_REPO_DIR}Gemfile" ] && return 1
+  [ ! -f "${OPENSHIFT_REPO_DIR}Gemfile.lock" ] && return 1
 
-  if [ ! -f "${bundler_md5_file}" ]; then
-    md5sum "${OPENSHIFT_REPO_DIR}Gemfile" > "${bundler_md5_file}"
+  if [ ! -f "${gemfile_md5_file}" ]; then
+    update_gemfile_sum
     return 1
   else
-
     pushd $OPENSHIFT_REPO_DIR 1>/dev/null
-    md5sum --status --check "${bundler_md5_file}"
+    md5sum --status --check "${gemfile_md5_file}"
     success=$?
     popd 1>/dev/null
 
-    if success; then
+    # md5sum returns '1' when the Gemfile(.lock) was modified
+    #
+    if [ "$success" == "1" ]; then
       return 0
     else
       return 1

--- a/cartridges/openshift-origin-cartridge-ruby/versions/shared/etc/conf.d/openshift.conf.erb
+++ b/cartridges/openshift-origin-cartridge-ruby/versions/shared/etc/conf.d/openshift.conf.erb
@@ -22,6 +22,12 @@ PassengerUser <%= ENV['OPENSHIFT_GEAR_UUID'] %>
 PassengerPreStart http://<%= ENV['OPENSHIFT_RUBY_IP'] %>:<%= ENV['OPENSHIFT_RUBY_PORT'] %>/
 PassengerSpawnIPAddress <%= ENV['OPENSHIFT_RUBY_IP'] %>
 PassengerUseGlobalQueue off
+
+# These must be passed on this place to make sure we set the right Rails/Rack
+# environment
+PassEnv RAILS_ENV
+PassEnv RACK_ENV
+
 <Directory <%= ENV['OPENSHIFT_REPO_DIR'] %>/public/>
     AllowOverride All
     Options -Multiviews


### PR DESCRIPTION
Hi,

This is a WIP of the Ruby/Rails in development mode proof of concept. The main goal here is to make deploying the Ruby/Rails applications faster when running in the development mode by disabling some of the deployment procedures.

For now, this set does:
- Pass the RAILS_ENV to Passenger, so you can run Rails app in different environment than 'production'
- Disable 'rake assets:precompile' when running in the development mode
- Detect changes in the Gemfile and disable 'bundle install' when in development mode
- Restart Apache when switching to development mode (and back to production) but not when doing regular 'git push'

To use this, you need to set the RAILS_ENV variable:

```
$ rhc env set RAILS_ENV=development
```

The you need to push/restart your application. The output should look like this:

```
 ~/ruby03 → git push
Counting objects: 9, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (5/5), done.
Writing objects: 100% (5/5), 420 bytes | 0 bytes/s, done.
Total 5 (delta 3), reused 0 (delta 0)
remote: Ruby cartridge in development mode, skipping stop...
remote: Stopping MySQL cartridge
remote: Saving away previously bundled RubyGems
remote: Building Ruby cartridge
remote: Restoring previously bundled RubyGems (note: you can commit .openshift/markers/force_clean_build at the root of your repo to force a clean bundle)
remote: Skipping 'bundle install' because development mode is enabled...
remote: Starting application ruby03
remote: Starting MySQL cartridge
remote: The 'rake assets:precompile' is disabled when Ruby is in development mode.
remote: Ruby cartridge in development mode, skipping start...
To ssh://52385ac5e174c573b00000cf@ruby03-mfojtik.dev.rhcloud.com/~/git/ruby03.git/
   bb8afcc..d5d49c9  master -> master
```

The deploy time went down from ~2 minutes to about 30 seconds. The app is restarted and `Rails.env` is reporting 'development'.

TODO:
- ~~Deal with production vs. development databases~~
- ~~Deal with the MySQL restarts when 'gemfile_modified' is false.~~
- ~~Update the 'rails-example' quickstart to run migrations in proper environment (`rake db:migrate RAILS_ENV=${RAILS_ENV:-production}`)~~
