### PR TITLE
Remove the icon font shadow unless explicitly included with a class.

### DIFF
--- a/console/app/assets/stylesheets/_iconfont.scss
+++ b/console/app/assets/stylesheets/_iconfont.scss
@@ -12,10 +12,13 @@
 .font-icon {
   display: inline-block;
   top: 0;
-  @include icon-text-shadow();
   &.font-icon-inline  {
     position: relative;
   }
+}
+
+.font-icon-shadow {
+  @include icon-text-shadow();
 }
 
 .font-icon

--- a/console/app/assets/stylesheets/_openshift-icon.css.scss
+++ b/console/app/assets/stylesheets/_openshift-icon.css.scss
@@ -40,7 +40,6 @@ you can use the generic selector below, but it's slower:
 	 left: -4px;
    margin-left: 4px;
    position: relative;
-   @include icon-text-shadow();
 }
 .icon-lock:before {
 	content: "\e000";


### PR DESCRIPTION
Causes problems with varied background colors.
