### PR TITLE
<oo-diagnostics> Improve regexes for tests on Origin

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -1066,7 +1066,7 @@ class OODiag
     # Under certain circumstances they would not have the dominating MCS label
     # (s0-s0:c0.c1023) and not be able to affect gears.
     scl_root = @project_is[:enterprise] ? "/opt/rh/ruby193/root" : ""
-    context = `ps -o label= $(pgrep -f ruby[[:space:]]#{scl_root}/usr/sbin/mcollectived)`.chomp.split ":"
+    context = `ps -o label= $(pgrep -f 'ruby[^[:space:]]*[[:space:]]/usr/sbin/mcollectived([[:space:]]|$)')`.chomp.split ":"
     context.shift
     context = context.join ":"
     expected = "system_r:openshift_initrc_t:s0-s0:c0.c1023"
@@ -1160,7 +1160,7 @@ class OODiag
       do_warn "Using a self-signed certificate for the broker"
     end
 
-    apacheconfig = `httpd -S 2> /dev/null`.slice(/^\*:443.*\*:80/m)
+    apacheconfig = `httpd -S 2> /dev/null`.slice(/^\*:443.*\n[[:space:]][^\n]*\n[^[:space:]]/m)
     servername = apacheconfig.scan(/(?:(?:default server )|(?:port 443 namevhost ))(\S+) \((?:[^:]+)/)
     badnames = []
     servername.each do |sn|


### PR DESCRIPTION
The mcollective SELinux context check and the Apache certificate check
both failed in Origin on Fedora 19. This was due to regexes which
weren't robust enough to account for the use of ruby-mri to run
mcollective in Fedora and the inversion of the vhost output from
Fedora's "httpd -S". This commit updates the regexes to account for
these conditions while maintaining existing compatibility with
RHEL-based hosts.
