### PR TITLE
Card origin_runtime_102 - use secret token for auth_value in JGroups

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/control
@@ -351,6 +351,8 @@ function threaddump() {
     fi
 }
 
+export OPENSHIFT_SECRET_TOKEN=${OPENSHIFT_SECRET_TOKEN:-OPENSHIFT_APP_UUID}
+
 case "$1" in
   build)           build ;;
   deploy)          deploy ;;

--- a/cartridges/openshift-origin-cartridge-jbossas/versions/7/standalone/configuration/standalone.xml
+++ b/cartridges/openshift-origin-cartridge-jbossas/versions/7/standalone/configuration/standalone.xml
@@ -290,7 +290,7 @@
                 <protocol type="AUTH">
                         <property name="auth_class">org.jgroups.auth.MD5Token</property>
                         <property name="token_hash">SHA</property>
-                        <property name="auth_value">${env.OPENSHIFT_APP_UUID}</property>
+                        <property name="auth_value">${env.OPENSHIFT_SECRET_TOKEN}</property>
                 </protocol>
                 <protocol type="pbcast.GMS"/>
                 <protocol type="UFC"/>

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/control
@@ -351,6 +351,8 @@ function threaddump() {
     fi
 }
 
+export OPENSHIFT_SECRET_TOKEN=${OPENSHIFT_SECRET_TOKEN:-OPENSHIFT_APP_UUID}
+
 case "$1" in
   build)           build ;;
   deploy)          deploy ;;

--- a/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/standalone/configuration/standalone.xml
+++ b/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/standalone/configuration/standalone.xml
@@ -327,7 +327,7 @@
 				<protocol type="AUTH">
 					<property name="auth_class">org.jgroups.auth.MD5Token</property>
 					<property name="token_hash">SHA</property>
-					<property name="auth_value">${env.OPENSHIFT_APP_UUID}</property>
+					<property name="auth_value">${env.OPENSHIFT_SECRET_TOKEN}</property>
 				</protocol>
 				<protocol type="pbcast.GMS" />
 				<protocol type="UFC" />


### PR DESCRIPTION
- Refactor JBossAS and JBossEAP cartridges to use OPENSHIFT_SECRET_TOKEN
  when building a JGroups cluster
