### PR TITLE
node-util: RHBZ#1004512 oo-admin-ctl-gears gearstatus show locked status

### DIFF
--- a/node-util/bin/oo-admin-ctl-gears
+++ b/node-util/bin/oo-admin-ctl-gears
@@ -89,6 +89,10 @@ module OpenShift
         p_runner(false) do |gear|
           $stdout.puts("Checking application #{gear.container_name} (#{gear.uuid}) status:")
           $stdout.puts("-----------------------------------------------")
+          if gear.stop_lock?
+              $stdout.puts("Gear #{gear.uuid} is locked.")
+              $stdout.puts("")
+          end
           begin
             gear.cartridge_model.each_cartridge do |cart|
               $stdout.puts("Cartridge: #{cart.name}...")


### PR DESCRIPTION
Inform the user that the gear is locked.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1004512
