### PR TITLE
[WIP] Added cartridges:lint rake task and YAML schema for manifest.yaml

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,6 @@ begin
       end
     end
   end
-rescue LoadError => e
-  print e.message
+rescue LoadError
   # YARD is not available
 end

--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/metadata/manifest.yml
@@ -5,6 +5,7 @@ Display-Name: 10gen Mongo Monitoring Service Agent
 Description: MongoDB Monitoring Service (MMS) instruments MongoDB and provides information
   about current and historical operational metrics of your system.
 Version: '0.1'
+License: ASL 2.0
 License-Url: https://mms.10gen.com/links/terms-of-service
 Cartridge-Version: 0.0.3
 Compatible-Versions:

--- a/cartridges/openshift-origin-cartridge-jenkins-client/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/metadata/manifest.yml
@@ -6,6 +6,7 @@ Description: The Jenkins client connects to your Jenkins application and enables
   and testing of your application. Requires the Jenkins Application to be created
   via the new application page. Based on Jenkins Client 1.509+
 Version: '1'
+Vendor: jenkins-ci.org
 License: ASL 2.0
 Cartridge-Version: 0.0.3
 Compatible-Versions:

--- a/node/Rakefile
+++ b/node/Rakefile
@@ -35,6 +35,36 @@ Rake::TestTask.new(:test) do |t|
   t.pattern = 'test/**/*_test.rb'
 end
 
+desc 'Syntax check of the cartridge manifests'
+task :test_cart_lint do
+  begin
+    require 'kwalify'
+    require 'yaml'
+  rescue LoadError
+    puts "The 'kwalify' gem is not installed, skipping cartridge manifest.yaml linst test"
+    exit(0)
+  end
+  schema_path = File.join(File.dirname(__FILE__), '..', 'util', 'manifest_schema.yml')
+  cart_directory = File.join(File.dirname(__FILE__), '..', 'cartridges', '*', 'metadata', 'manifest.yml*')
+  schema = Kwalify::Yaml.load_file(schema_path)
+  validator = Kwalify::Validator.new(schema)
+  return_code = 0
+  Dir[cart_directory].each do |path|
+    manifest = YAML::load_file(path)
+    pretty_path = path.split('/').slice(-3,3).join('/')
+    errors = validator.validate(manifest)
+    if errors.empty?
+      puts "[#{pretty_path}] VALID."
+    else
+      puts "#{pretty_path}: INVALID"
+      errors.each { |e| puts "  - [#{e.path}] #{e.message}" }
+      return_code = 1
+    end
+  end
+  exit(return_code)
+end
+
+
 desc "Generate RDoc"
 task :doc do
   sh "rdoc ."

--- a/util/manifest_schema.yml
+++ b/util/manifest_schema.yml
@@ -1,0 +1,151 @@
+&manifest
+type: map
+required: yes
+mapping:
+  "Name":
+    required: yes
+  "Cartridge-Short-Name":
+    required: yes
+  "Display-Name":
+    required: yes
+  "Architecture":
+    enum: [ 'noarch', 'i386', 'x86_64' ]
+  "Description":
+    required: yes
+  "Version":
+    required: yes
+    pattern: /^([\d\.]+)$/
+  "Versions":
+    type: seq
+    sequence:
+      - { unique: yes }
+  "License":
+    required: yes
+  "License-Url":
+    pattern: /^http(s?):\/\//
+  "Vendor":
+    required: yes
+  "Cartridge-Version":
+    required: yes
+    pattern: /^([\d\.]+)$/
+  "Compatible-Versions":
+    type: seq
+    sequence:
+      - { unique: yes }
+  "Cartridge-Vendor":
+    required: yes
+  "Categories":
+    type: seq
+    required: yes
+    sequence:
+      - { unique: yes }
+  "Website":
+    pattern: /^http(s?):\/\//
+  "Help-Topics":
+    type: any
+  "Cart-Data":
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          "Key":
+            required: true
+          "Type":
+            required: true
+          "Description":
+            required: true
+  "Publishes": &publishes
+    type: map
+    mapping:
+      "=": 
+        type: map
+        mapping:
+          "Type":
+            pattern: /^(ENV|STRING|NET_TCP|NET_UDP|FILESYSTEM)\:/
+  "Subscribes": &subscribes
+    type: map
+    mapping:
+      "=":
+        type: map
+        mapping:
+          "Type":
+            pattern: /^(ENV|STRING|NET_TCP|NET_UDP|FILESYSTEM)\:/
+          "Required":
+            type: bool
+  "Scaling": &scaling
+    type: map
+    mapping:
+      "Min": &scale_type
+        type: int
+        range: { max: 10, min: -10 }
+      "Max": *scale_type
+      "Multiplier": *scale_type
+  "Provides":
+    type: seq
+    sequence:
+      - { unique: yes }
+  "Endpoints":
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          "Private-IP-Name":
+          "Private-Port-Name":
+          "Private-Port": { type: int }
+          "Public-Port-Name": { unique: yes }
+          "WebSocket-Port": { type: int }
+          "WebSocket-Port-Name": { unique: yes }
+          "Protocols":
+            type: seq
+            sequence:
+              - { unique: yes }
+          "Options":
+            type: any
+          "Mappings":
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  "Frontend": { required: yes }
+                  "Backend": { required: yes }
+                  "Options":
+                    type: map
+                    mapping:
+                      "=": { type: any }
+  "Additional-Control-Actions":
+    type: seq
+    sequence:
+      - { unique: yes  }
+  "Configure-Order":
+    type: seq
+    sequence:
+      - { unique: yes }
+  "Group-Overrides":
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          "components":
+            type: seq
+            sequence:
+              - { type: str, unique: yes }
+  "Components":
+    type: map
+    mapping:
+      "=":
+        type: map
+        mapping:
+          "Publishes": *publishes
+          "Subscribes": *subscribes
+          "Scaling": *scaling
+  "Version-Overrides": { type: any }
+  "Conflicts":
+    type: seq
+    sequence:
+      - { unique: yes }
+  "Suggests":
+    type: seq
+    sequence:
+      - { unique: yes }
+  "Install-Build-Required":
+    type: bool

--- a/util/manifest_schema.yml
+++ b/util/manifest_schema.yml
@@ -6,6 +6,7 @@ mapping:
     required: yes
   "Cartridge-Short-Name":
     required: yes
+    pattern: /[A-Z_]+/
   "Display-Name":
     required: yes
   "Architecture":
@@ -27,22 +28,25 @@ mapping:
     required: yes
   "Cartridge-Version":
     required: yes
-    pattern: /^([\d\.]+)$/
+    pattern: /[0-9][0-9\.]*/
   "Compatible-Versions":
     type: seq
     sequence:
-      - { unique: yes }
+      - { unique: yes, pattern: "/[0-9][0-9\.]*/" }
   "Cartridge-Vendor":
     required: yes
   "Categories":
     type: seq
     required: yes
     sequence:
-      - { unique: yes }
+      - { unique: yes, required: true, pattern: "/[a-z][a-z_]*/" }
   "Website":
     pattern: /^http(s?):\/\//
   "Help-Topics":
-    type: any
+    type: map
+    mapping:
+      "Developer Center":
+      "=": { type: str }
   "Cart-Data":
     type: seq
     sequence:
@@ -52,6 +56,7 @@ mapping:
             required: true
           "Type":
             required: true
+            enum: [environment, cart_data]
           "Description":
             required: true
   "Publishes": &publishes
@@ -89,18 +94,20 @@ mapping:
     sequence:
       - type: map
         mapping:
-          "Private-IP-Name":
-          "Private-Port-Name":
-          "Private-Port": { type: int }
-          "Public-Port-Name": { unique: yes }
-          "WebSocket-Port": { type: int }
-          "WebSocket-Port-Name": { unique: yes }
+          "Private-IP-Name": { required: yes, pattern: "/[A-Z][A-Z_]+/" }
+          "Private-Port-Name": { required: yes, pattern: "/[A-Z][A-Z_]+/" }
+          "Private-Port": { type: int, range: { min-ex: 1024 } }
+          "Public-Port-Name": { unique: yes, pattern: "/[A-Z][A-Z_]+/" }
+          "WebSocket-Port": { type: int, range: { min-ex: 1024 } }
+          "WebSocket-Port-Name": { unique: yes, pattern: "/[A-Z][A-Z_]+/" }
           "Protocols":
             type: seq
             sequence:
               - { unique: yes }
           "Options":
-            type: any
+            type: map
+            mapping:
+              "ssl_to_gear": {type: bool}
           "Mappings":
             type: seq
             sequence:
@@ -111,15 +118,20 @@ mapping:
                   "Options":
                     type: map
                     mapping:
-                      "=": { type: any }
+                      "websocket": { type: any, enum: [true, false, 1, 0] }
+                      "health": {type: any, enum: [true, false, 1,0] }
+                      "target_update": { type: any, enum: [true, false, 1, 0] }
+                      "connections": { type: int }
+                      "file": {type: any, enum: [true, false, 1, 0] }
+                      "tohttps": {type: any, enum: [true, false, 1, 0] }
   "Additional-Control-Actions":
     type: seq
     sequence:
-      - { unique: yes  }
+      - { unique: yes, enum: [threaddump]  }
   "Configure-Order":
     type: seq
     sequence:
-      - { unique: yes }
+      - { unique: yes, pattern: "/[a-z-]+/" }
   "Group-Overrides":
     type: seq
     sequence:
@@ -128,7 +140,7 @@ mapping:
           "components":
             type: seq
             sequence:
-              - { type: str, unique: yes }
+              - { type: str, unique: yes, pattern: "/[a-z-]+/" }
   "Components":
     type: map
     mapping:
@@ -138,11 +150,13 @@ mapping:
           "Publishes": *publishes
           "Subscribes": *subscribes
           "Scaling": *scaling
-  "Version-Overrides": { type: any }
-  "Conflicts":
-    type: seq
-    sequence:
-      - { unique: yes }
+  "Version-Overrides":
+    type: map
+    mapping:
+      "=":
+        type: map
+        mapping:
+          "=": { type: any }
   "Suggests":
     type: seq
     sequence:


### PR DESCRIPTION
This patch will add 'rake cartridges:lint' task, which should validate the syntax of all cartridge manifest.yml files.
For this, I use [kwalify|http://www.kuwata-lab.com/kwalify] YAML validator. Also I created the initial manifest YAML schema file (https://github.com/mfojtik/origin-server/blob/c2a7e28a99aeba0aa9af56db5875d06c5e6bc5cc/util/manifest_schema.yml)

The output of this rake task looks like this:

```
 ~/code/origin-server → rake cartridges:lint
[openshift-origin-cartridge-haproxy/metadata/manifest.yml] VALID.
[openshift-origin-cartridge-ruby/metadata/manifest.yml.rhel] VALID.
[openshift-origin-cartridge-ruby/metadata/manifest.yml.f19] VALID.
[openshift-origin-cartridge-postgresql/metadata/manifest.yml.rhel] VALID.
[openshift-origin-cartridge-postgresql/metadata/manifest.yml.f19] VALID.
[openshift-origin-cartridge-mock-plugin/metadata/manifest.yml] VALID.
[openshift-origin-cartridge-mock/metadata/manifest.yml] VALID.
[openshift-origin-cartridge-switchyard/metadata/manifest.yml] VALID.
[openshift-origin-cartridge-diy/metadata/manifest.yml] VALID.
[openshift-origin-cartridge-jbossews/metadata/manifest.yml] VALID.
openshift-origin-cartridge-10gen-mms-agent/metadata/manifest.yml: INVALID
  - [/] key 'License:' is required.
[openshift-origin-cartridge-jbosseap/metadata/manifest.yml] VALID.
[openshift-origin-cartridge-perl/metadata/manifest.yml.rhel] VALID.
[openshift-origin-cartridge-perl/metadata/manifest.yml.f19] VALID.
[openshift-origin-cartridge-cron/metadata/manifest.yml] VALID.
[openshift-origin-cartridge-mysql/metadata/manifest.yml] VALID.
[openshift-origin-cartridge-nodejs/metadata/manifest.yml.rhel] VALID.
[openshift-origin-cartridge-nodejs/metadata/manifest.yml.fedora] VALID.
[openshift-origin-cartridge-python/metadata/manifest.yml.rhel] VALID.
[openshift-origin-cartridge-python/metadata/manifest.yml.f19] VALID.
[openshift-origin-cartridge-phpmyadmin/metadata/manifest.yml.rhel] VALID.
[openshift-origin-cartridge-phpmyadmin/metadata/manifest.yml.f19] VALID.
[openshift-origin-cartridge-mongodb/metadata/manifest.yml] VALID.
[openshift-origin-cartridge-jbossas/metadata/manifest.yml] VALID.
[openshift-origin-cartridge-jenkins/metadata/manifest.yml] VALID.
[openshift-origin-cartridge-mariadb/metadata/manifest.yml] VALID.
[openshift-origin-cartridge-php/metadata/manifest.yml.rhel] VALID.
[openshift-origin-cartridge-php/metadata/manifest.yml.fedora19] VALID.
openshift-origin-cartridge-jenkins-client/metadata/manifest.yml: INVALID
  - [/] key 'Vendor:' is required.
```

The `manifest_schema.yml` will require some more love I guess, especially I was not sure what properties are mandatory and what are not. Also, since the schema is just a YAML file, it could be easy to produce nice table of allowed attributes for the documentation.

To run this rake task, you need to: `gem install kwalify`
