### PR TITLE
Add Node.js 0.10 tests to runtime-cartridge-nodejs.feature

### DIFF
--- a/controller/test/cucumber/cartridge-lifecycle-nodejs.feature
+++ b/controller/test/cucumber/cartridge-lifecycle-nodejs.feature
@@ -1,4 +1,5 @@
 @runtime_extended3
+@cartridge_nodejs
 @runtime_extended
 @not-enterprise
 Feature: Cartridge Lifecycle NodeJS Verification Tests

--- a/controller/test/cucumber/runtime-cartridge-nodejs.feature
+++ b/controller/test/cucumber/runtime-cartridge-nodejs.feature
@@ -1,19 +1,41 @@
 @runtime_extended3
-@cartridge_v2_nodejs
+@cartridge_nodejs
 @not-enterprise
 Feature: V2 SDK Node.js Cartridge
 
-  Scenario: Add cartridge
-    Given a new nodejs type application
+  Scenario Outline: Add cartridge
+    Given a new nodejs-<nodejs_version> type application
     Then the application git repo will exist
     And the platform-created default environment variables will exist
-    And the nodejs cartridge private endpoints will be exposed
-    And the nodejs NODEJS_DIR env entry will exist
-    And the nodejs NODEJS_LOG_DIR env entry will exist
+    And the nodejs-<nodejs_version> cartridge private endpoints will be exposed
+    And the nodejs-<nodejs_version> NODEJS_DIR env entry will exist
+    And the nodejs-<nodejs_version> NODEJS_LOG_DIR env entry will exist
     When I destroy the application
     Then the application git repo will not exist
 
-  Scenario: Destroy application
-    Given a new nodejs type application
+    @rhel-only
+    Scenarios: RHEL
+      | nodejs_version |
+      |  0.10          |
+      |  0.6           |
+
+    @fedora-only
+    Scenarios: Fedora-19
+      | nodejs_version |
+      |  0.10          |
+
+  Scenario Outline: Destroy application
+    Given a new nodejs-<nodejs_version> type application
     When I destroy the application
     Then the application git repo will not exist
+
+    @rhel-only
+    Scenarios: RHEL
+      | nodejs_version |
+      |  0.10          |
+      |  0.6           |
+      
+    @fedora-only
+    Scenarios: Fedora-19
+      | nodejs_version |
+      |  0.10          |

--- a/controller/test/cucumber/step_definitions/application_steps.rb
+++ b/controller/test/cucumber/step_definitions/application_steps.rb
@@ -564,11 +564,9 @@ Then /^the application should not be accessible$/ do
   @app.is_inaccessible?.should be_true
 end
 
-
 Then /^the application should not be accessible via node\-web\-proxy$/ do
   @app.is_inaccessible?(60, 8000).should be_true
 end
-
 
 Then /^the application should be assigned to the supplementary groups? "([^\"]*)" as shown by the node's \/etc\/group$/ do | supplementary_groups|
   added_supplementary_group = supplementary_groups.split(",")


### PR DESCRIPTION
Add complementary tests for Node.js 0.10 apps to runtime-cartridge-nodejs.feature.
