### PR TITLE
Bug 1011721- Fixed wrong namespace for Cartridge Ruby SDK

### DIFF
--- a/node/misc/usr/lib/cartridge_sdk/bash/sdk
+++ b/node/misc/usr/lib/cartridge_sdk/bash/sdk
@@ -561,7 +561,7 @@ function has_web_proxy() {
 # Wrapper for the OpenShift Ruby SDK
 #
 function ruby_sdk() {
-  oo-ruby -I/usr/lib/openshift/cartridge_sdk -rruby/sdk -e "include OpenShift::Cartridge::Sdk; puts $1"
+  oo-ruby -I/usr/lib/openshift/cartridge_sdk -rruby/sdk -e "include OpenShift::CartridgeSdk; puts $1"
 }
 
 function primary_cartridge_short_name() {

--- a/node/misc/usr/lib/cartridge_sdk/ruby/sdk.rb
+++ b/node/misc/usr/lib/cartridge_sdk/ruby/sdk.rb
@@ -17,21 +17,19 @@
 require 'openshift-origin-node/model/application_container'
 
 module OpenShift
-  module Cartridge
-    module Sdk
+  module CartridgeSdk
 
-      def primary_cartridge
-        return @primary_cartridge unless @primary_cartridge.nil?
-        OpenShift::Runtime::NodeLogger.disable
-        container = OpenShift::Runtime::ApplicationContainer.from_uuid(ENV['OPENSHIFT_GEAR_UUID'])
-        @primary_cartridge = container.cartridge_model.primary_cartridge
-      end
-
-      def primary_cartridge_manifest
-        primary_cartridge.manifest
-      end
-
+    def primary_cartridge
+      return @primary_cartridge unless @primary_cartridge.nil?
+      OpenShift::Runtime::NodeLogger.disable
+      container = OpenShift::Runtime::ApplicationContainer.from_uuid(ENV['OPENSHIFT_GEAR_UUID'])
+      @primary_cartridge = container.cartridge_model.primary_cartridge
     end
+
+    def primary_cartridge_manifest
+      primary_cartridge.manifest
+    end
+
   end
 end
 


### PR DESCRIPTION
The 'OpenShift::Cartridge' namespace is taken already, because 'Cartridge' is a class, so we cannot use it as a module. For that I choose 'CartridgeSdk' which should not conflict with anything.
