### PR TITLE
Bug 982434 - remove extraneous set_app_info usage

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/install
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/install
@@ -24,5 +24,3 @@ client_result ""
 client_result "Monitoring URL: https://mms.10gen.com/"
 
 cart_props "monitoring_url=https://mms.10gen.com/"
-
-set_app_info "Monitoring URL: https://mms.10gen.com/"

--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/install
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/install
@@ -63,5 +63,3 @@ else
 fi
 
 cart_props "job_url=${JENKINS_URL}job/${JOB_NAME}/"
-
-set_app_info "Job URL: ${JENKINS_URL}job/${JOB_NAME}/"

--- a/cartridges/openshift-origin-cartridge-mariadb/bin/install
+++ b/cartridges/openshift-origin-cartridge-mariadb/bin/install
@@ -40,5 +40,3 @@ cart_props 'connection_url=mysql://$OPENSHIFT_MARIADB_DB_HOST:$OPENSHIFT_MARIADB
 cart_props "username=$username"
 cart_props "password=$password"
 cart_props "database_name=$OPENSHIFT_APP_NAME"
-
-set_app_info "Connection URL: mysql://$OPENSHIFT_MARIADB_DB_HOST:$OPENSHIFT_MARIADB_DB_PORT"

--- a/cartridges/openshift-origin-cartridge-mongodb/bin/post_install
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/post_install
@@ -18,5 +18,3 @@ cart_props "connection_url=mongodb://\$OPENSHIFT_MONGODB_DB_HOST:\$OPENSHIFT_MON
 cart_props "username=admin"
 cart_props "password=${password}"
 cart_props "database_name=$OPENSHIFT_APP_NAME"
-
-set_app_info "Connection URL: mongodb://\$OPENSHIFT_MONGODB_DB_HOST:\$OPENSHIFT_MONGODB_DB_PORT/"

--- a/cartridges/openshift-origin-cartridge-mysql/bin/install
+++ b/cartridges/openshift-origin-cartridge-mysql/bin/install
@@ -34,5 +34,3 @@ cart_props 'connection_url=mysql://$OPENSHIFT_MYSQL_DB_HOST:$OPENSHIFT_MYSQL_DB_
 cart_props "username=$username"
 cart_props "password=$password"
 cart_props "database_name=$OPENSHIFT_APP_NAME"
-
-set_app_info 'Connection URL: mysql://$OPENSHIFT_MYSQL_DB_HOST:$OPENSHIFT_MYSQL_DB_PORT'

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/bin/install
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/bin/install
@@ -24,5 +24,3 @@ fi
 client_result "URL: https://$OPENSHIFT_GEAR_DNS/phpmyadmin/"
 
 cart_props "connection_url=https://$OPENSHIFT_GEAR_DNS/phpmyadmin/"
-
-set_app_info "URL: https://$OPENSHIFT_GEAR_DNS/phpmyadmin/"

--- a/cartridges/openshift-origin-cartridge-postgresql/bin/install
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/install
@@ -59,5 +59,3 @@ cart_props "connection_url=${conn_url}"
 cart_props "username=${username}"
 cart_props "password=${password}"
 cart_props "database_name=${OPENSHIFT_APP_NAME}"
-
-set_app_info "Connection URL: ${conn_url}"


### PR DESCRIPTION
- Cartridges no longer need to send client_message and set_app_info
