### PR TITLE
do not overwrite the {min,max}_uid value if not defined in facter

### DIFF
--- a/node-util/bin/oo-accept-node
+++ b/node-util/bin/oo-accept-node
@@ -432,8 +432,8 @@ def check_cgroup_procs
     verbose("find district uuid: #{district_uuid}")
 
     if district_uuid.casecmp("None") != 0
-      min_uid = Facter.[]('district_first_uid').value.to_i
-      max_uid = Facter.[]('district_max_uid').value.to_i
+      min_uid = Facter.[]('district_first_uid').value.to_i unless Facter.[]('district_first_uid').nil?
+      max_uid = Facter.[]('district_max_uid').value.to_i unless Facter.[]('district_max_uid').nil?
     end
 
     verbose("determining node uid range: #{min_uid} to #{max_uid}")


### PR DESCRIPTION
This pull request is related to https://bugzilla.redhat.com/show_bug.cgi?id=1012830

This validation will prevent breaking oo-accept-node in case we do not have proper values in facter
