### PR TITLE
[TO_STAGE]: Bug 1013673: MySQL upgrade fails

### DIFF
--- a/cartridges/openshift-origin-cartridge-mysql/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-mysql/bin/upgrade
@@ -1,1 +1,4 @@
-mv data/ib_logfile* /tmp
+files=$(shopt -s nullglob; shopt -s dotglob; echo data/ib_logfile*)
+if [ ${#files} -gt 0 ]; then
+  mv data/ib_logfile* /tmp
+fi


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1013673

Due to a previous hotfix, some migrations fail is `data/ib_logfile*` is missing. This checks for the existence before attempting to move these files.
