### PR TITLE
Bug 1013429

### DIFF
--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -647,7 +647,7 @@ class Application
                 client_result_io = ResultIO.new
                 uapp.run_jobs(client_result_io)
                 if client_result_io.exitcode == 0
-                  client_result_io.resultIO.string = "Removed corresponding client: #{feature_name}"
+                  client_result_io.resultIO.string = "Removed #{feature_name} from #{uapp.name}\n"
                 end
                 result_io.append(client_result_io)
                 result_io


### PR DESCRIPTION
Fix displayed text when the Jenkins server is deleted while applications
with Jenkins jobs remain.

Before:

```
Deleting application 'jenkins' ... deleted

Removed corresponding client: jenkins-client-1Removed corresponding client: jenkins-client-1
```

After:

```
Deleting application 'jenkins' ... deleted                                                                                                                                    

Removed jenkins-client-1 from rack2                                                                                                                                           
Removed jenkins-client-1 from rack                                                                                                                                            
```
