### PR TITLE
Fix check in rpc_get_fact_direct and rpc_get_facts_direct

### DIFF
--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -3124,7 +3124,7 @@ module OpenShift
           rpc_client = MCollectiveApplicationContainerProxy.get_rpc_client('rpcutil', options)
           begin
             result = rpc_client.custom_request('get_fact', {:fact => fact}, @id, {'identity' => @id})[0]
-            if (result && defined? result.results && result.results.has_key?(:data))
+            if (result && (defined? result.results) && result.results.has_key?(:data))
               value = result.results[:data][:value]
             else
               raise OpenShift::NodeException.new("Node execution failure (error getting fact).", 143)
@@ -3161,7 +3161,7 @@ module OpenShift
           rpc_client = MCollectiveApplicationContainerProxy.get_rpc_client('openshift', options)
           begin
             result = rpc_client.custom_request('get_facts', {:facts => facts}, @id, {'identity' => @id})[0]
-            if (result && defined? result.results && result.results.has_key?(:data))
+            if (result && (defined? result.results) && result.results.has_key?(:data))
               value = result.results[:data][:output]
             else
               raise OpenShift::NodeException.new("Node execution failure (error getting facts).", 143)


### PR DESCRIPTION
Fix the parentheses in a check in rpc_get_fact_direct and rpc_get_facts_direct.

In Ruby, 'defined? a && b' is grouped not as '(defined? a) && b' but rather as 'defined? (a && b)', so the non-parenthesised form will always return non-nil (specifically, the string "expression") without checking the operand b.  (The foregoing describes the behaviour in Ruby 1.9; Ruby 1.8 returns "expression" as long as the operand a is defined.)
