### PR TITLE
Bug 1014768 - Performance improvements for node_utilization

### DIFF
--- a/node/lib/openshift-origin-node/utils/application_state.rb
+++ b/node/lib/openshift-origin-node/utils/application_state.rb
@@ -43,7 +43,6 @@ module OpenShift
           @container = container
           @uuid = @container.uuid
 
-          config      = ::OpenShift::Config.new
           @state_file = File.join(@container.container_dir, "app-root", "runtime", ".state")
         end
 


### PR DESCRIPTION
Allow self.all to pass the pwnam structure rather than having to call getpwnam each time.  Lazy load the MCS labels and get rid of an extraneous call to Config.
