### PR TITLE
Card origin_broker_136: Replace curl with httpclient when downloading cartridges

### DIFF
--- a/broker/conf/broker.conf
+++ b/broker/conf/broker.conf
@@ -93,7 +93,14 @@ MAX_DOWNLOADED_CARTS_PER_APP="5"
 MAX_DOWNLOAD_REDIRECTS="2"
 MAX_DOWNLOAD_TIME="10"
 # Maximum size for downloadable manifest file (in bytes)
-MAX_CART_SIZE="20480" 
+MAX_CART_SIZE="20480"
+# Maximum number of seconds for connection to be established when downloading
+# a cartridge.
+CART_DOWNLOAD_CONN_TIMEOUT="2"
+
+# Set a HTTP proxy server for downloading cartridges
+#
+# HTTP_PROXY="proxy.server.com:3128"
 
 # Team collaboration settings
 MAX_MEMBERS_PER_RESOURCE="100"

--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -106,6 +106,8 @@ Broker::Application.configure do
     :max_downloaded_carts_per_app => conf.get("MAX_DOWNLOADED_CARTS_PER_APP", "5").to_i,
     :max_download_redirects => conf.get("MAX_DOWNLOAD_REDIRECTS", "2").to_i,
     :max_cart_size => conf.get("MAX_CART_SIZE", "20480").to_i,
-    :max_download_time => conf.get("MAX_DOWNLOAD_TIME", "10").to_i
+    :max_download_time => conf.get("MAX_DOWNLOAD_TIME", "10").to_i,
+    :connection_timeout => conf.get("CART_DOWNLOAD_CONN_TIMEOUT", "2").to_i,
+    :http_proxy => conf.get('HTTP_PROXY', '')
   }
 end

--- a/broker/config/environments/production.rb
+++ b/broker/config/environments/production.rb
@@ -95,6 +95,8 @@ Broker::Application.configure do
     :max_downloaded_carts_per_app => conf.get("MAX_DOWNLOADED_CARTS_PER_APP", "5").to_i,
     :max_download_redirects => conf.get("MAX_DOWNLOAD_REDIRECTS", "2").to_i,
     :max_cart_size => conf.get("MAX_CART_SIZE", "20480").to_i,
-    :max_download_time => conf.get("MAX_DOWNLOAD_TIME", "10").to_i
+    :max_download_time => conf.get("MAX_DOWNLOAD_TIME", "10").to_i,
+    :connection_timeout => conf.get("CART_DOWNLOAD_CONN_TIMEOUT", "2").to_i,
+    :http_proxy => conf.get('HTTP_PROXY', '')
   }
 end

--- a/controller/app/helpers/cartridge_cache.rb
+++ b/controller/app/helpers/cartridge_cache.rb
@@ -132,10 +132,10 @@ class CartridgeCache
   def self.download_from_url(url)
     cartridge_conf = Rails.application.config.downloaded_cartridges || {}
 
-    if cartridge_conf[:http_proxy]
-      client = HTTPClient.new(!cartridge_conf[:http_proxy].empty? ? cartridge_conf[:http_proxy] : nil)
+    client = if cartridge_conf[:http_proxy].present?
+      HTTPClient.new(cartridge_conf[:http_proxy])
     else
-      client = HTTPClient.new
+      HTTPClient.new
     end
 
     # Configuration

--- a/controller/app/helpers/cartridge_cache.rb
+++ b/controller/app/helpers/cartridge_cache.rb
@@ -152,11 +152,13 @@ class CartridgeCache
         Timeout.timeout(client.receive_timeout) do
           client.get_content(url) do |chunk|
             manifest << chunk
-            raise "Manifest file too big" if manifest.length > client.read_block_size
+            if manifest.length > client.read_block_size
+              raise OpenShift::UnfulfilledRequirementException.new(url)
+            end
           end
         end
       rescue Timeout::Error
-        raise "Manifest download timed out"
+        raise OpenShift::UnfulfilledRequirementException.new(url)
       end
     end
 

--- a/controller/openshift-origin-controller.gemspec
+++ b/controller/openshift-origin-controller.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency "openshift-origin-common"
   s.add_dependency('state_machine')
   s.add_dependency('dnsruby')
+  s.add_dependency('httpclient')
   s.add_dependency 'mongoid', '>= 3.0.17'
   s.add_development_dependency('rake', '>= 0.8.7', '<= 0.9.6')  
   s.add_development_dependency('rspec')

--- a/controller/rubygem-openshift-origin-controller.spec
+++ b/controller/rubygem-openshift-origin-controller.spec
@@ -23,6 +23,7 @@ Requires:      %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
 Requires:      %{?scl:%scl_prefix}rubygems
 Requires:      %{?scl:%scl_prefix}rubygem(state_machine)
 Requires:      %{?scl:%scl_prefix}rubygem(dnsruby)
+Requires:      %{?scl:%scl_prefix}rubygem(httpclient)
 Requires:      rubygem(openshift-origin-common)
 %if 0%{?fedora}%{?rhel} <= 6
 BuildRequires: %{?scl:%scl_prefix}build


### PR DESCRIPTION
This pull request aims to replace the 'curl' command which we are using now to download cartridges
with a 'httpclient' library.

The issue was originally described in this RFE: https://bugzilla.redhat.com/show_bug.cgi?id=1015187

The original problem was to support HTTP proxy when downloading cartridges, which this pull request allows as well.
Two new configuration variables are available for broker.conf:

`HTTP_PROXY` set the HTTP proxy server used for downloading cartridges
`CONNECTION_TIMEOUT` to address the issue reported here: https://github.com/openshift/origin-server/issues/3546
