### PR TITLE
Job error when changing members of app

### DIFF
--- a/console/app/views/application_types/show.html.haml
+++ b/console/app/views/application_types/show.html.haml
@@ -18,7 +18,6 @@
     - Array(@application_type.cartridges).each do |c|
       = hidden_field_tag 'application_type[cartridges][]', c
     = hidden_field_tag 'application_type[initial_git_url]', @application_type.initial_git_url
-    -#= hidden_field_tag 'application_type[initial_git_branch]', @application_type.initial_git_branch
 
   - e = @application.errors
   = f.semantic_errors :except => [:initial_git_url, :initial_git_branch, :name, :domain_name, :cartridges, :gear_profile]

--- a/controller/app/models/pending_ops/change_members_op_group.rb
+++ b/controller/app/models/pending_ops/change_members_op_group.rb
@@ -8,8 +8,8 @@ class ChangeMembersOpGroup < PendingAppOpGroup
     added_ids = (members_added || []).select{ |id| (role = app.role_for(id)) and Ability.has_permission?(id, :ssh_to_gears, Application, role, app) }
     removed_ids = (members_removed || []).dup
     (roles_changed || []).each do |(id, from, to)|
-      was = Ability.has_permission?(id, :ssh_to_gears, Application, from || app.default_role, app) 
-      is =  Ability.has_permission?(id, :ssh_to_gears, Application, to || app.default_role, app) 
+      was = Ability.has_permission?(id, :ssh_to_gears, Application, from || app.default_role, app)
+      is =  Ability.has_permission?(id, :ssh_to_gears, Application, to || app.default_role, app)
       next if is == was
       (is ? added_ids : removed_ids) << id
     end
@@ -19,17 +19,18 @@ class ChangeMembersOpGroup < PendingAppOpGroup
     remove_keys_attrs = CloudUser.members_of(removed_ids).map{ |u| app.get_updated_ssh_keys(u._id, u.ssh_keys) }.flatten(1)
 
     if add_keys_attrs.present? or remove_keys_attrs.present?
+      ops = []
       app.group_instances.each do |group_instance|
-        group_instance_id = group_instance._id.to_s
         group_instance.gears.each do |gear|
-          prereq = prereqs[gear._id.to_s].nil? ? [] : [prereqs[gear._id.to_s]]
-          gear_id = gear._id.to_s
-          pending_ops.push(UpdateAppConfigOp.new(add_keys_attrs: add_keys_attrs, 
-              remove_keys_attrs: remove_keys_attrs, group_instance_id: group_instance_id, 
-              gear_id: gear_id, prereq: prereq))
+          ops << UpdateAppConfigOp.new(
+            add_keys_attrs: add_keys_attrs,
+            remove_keys_attrs: remove_keys_attrs,
+            group_instance_id: group_instance.id.to_s,
+            gear_id: gear.id.to_s
+          )
         end
       end
+      pending_ops.concat(ops)
     end
   end
-  
 end


### PR DESCRIPTION
The ChangeMembersAppOp elaborate() method had old bad code, which caused
failures when moving members from edit -> view on an app

@abhgupta review please
