### PR TITLE
Card origin_runtime_293  - Tune framework carts to account the different gear size

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
+source "${OPENSHIFT_PHP_DIR}/lib/util"
 
 HTTPD_CFG_FILE=$OPENSHIFT_PHP_DIR/configuration/etc/conf/httpd_nolog.conf
 HTTPD_CFG_DIR=$OPENSHIFT_PHP_DIR/configuration/etc/conf.d
@@ -8,7 +9,10 @@ HTTPD_PASSENV_FILE=$HTTPD_CFG_DIR/passenv.conf
 HTTPD_PID_FILE=$OPENSHIFT_PHP_DIR/run/httpd.pid
 
 function apache() {
-    [ "$1" != "stop" ] && write_httpd_passenv $HTTPD_PASSENV_FILE
+    if [ "$1" != "stop" ]; then
+      write_httpd_passenv $HTTPD_PASSENV_FILE
+      oo-erb conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
+    fi
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     /usr/sbin/httpd -C "Include $HTTPD_CFG_DIR/*.conf" -f $HTTPD_CFG_FILE -k $1
     ret=$?
@@ -23,6 +27,7 @@ function apache() {
 
 function restart() {
     write_httpd_passenv $HTTPD_PASSENV_FILE
+    oo-erb conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
     ensure_httpd_restart_succeed "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     /usr/sbin/httpd -C "Include $HTTPD_CFG_DIR/*.conf" -f $HTTPD_CFG_FILE -k restart
     return $?

--- a/cartridges/openshift-origin-cartridge-php/bin/setup
+++ b/cartridges/openshift-origin-cartridge-php/bin/setup
@@ -11,6 +11,9 @@ shopt -s dotglob
 mkdir -p $OPENSHIFT_PHP_DIR/configuration/etc/
 cp -Hr $OPENSHIFT_PHP_DIR/versions/shared/configuration/etc/* $OPENSHIFT_PHP_DIR/configuration/etc/
 
-
 # Create/truncate Apache PassEnv configuration file
 echo > $OPENSHIFT_PHP_DIR/configuration/etc/conf.d/passenv.conf
+echo > $OPENSHIFT_PHP_DIR/configuration/etc/conf.d/performance.conf
+
+cp versions/shared/configuration/etc/conf.d/performance.conf.erb conf/performance.conf.erb
+cp conf/performance.conf.erb conf/performance.conf.erb.hidden

--- a/cartridges/openshift-origin-cartridge-php/lib/util
+++ b/cartridges/openshift-origin-cartridge-php/lib/util
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Utility functions for use in the cartridge scripts
+
+# Set the 'memory_limit' than PHP script can allocated to gear memory size - 20%
+# (left for the database/cron/etc...)
+#

--- a/cartridges/openshift-origin-cartridge-php/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-php/metadata/managed_files.yml
@@ -4,7 +4,7 @@ locked_files:
 - bin/
 - bin/*
 - conf/
-- conf/*
+- conf/performance.conf.erb.hidden
 - configuration/
 - configuration/etc/
 - configuration/etc/conf/

--- a/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml.rhel
@@ -9,9 +9,10 @@ Version: '5.3'
 License: The PHP License, version 3.0
 License-Url: http://www.php.net/license/3_0.txt
 Vendor: php.net
-Cartridge-Version: 0.0.6
+Cartridge-Version: 0.0.7
 Compatible-Versions:
 - 0.0.5
+- 0.0.6
 Cartridge-Vendor: redhat
 Categories:
 - service

--- a/cartridges/openshift-origin-cartridge-php/versions/shared/configuration/etc/conf.d/performance.conf.erb
+++ b/cartridges/openshift-origin-cartridge-php/versions/shared/configuration/etc/conf.d/performance.conf.erb
@@ -1,0 +1,4 @@
+<IfModule prefork.c>
+  ServerLimit <%=(((ENV['OPENSHIFT_GEAR_MEMORY_MB'].to_i*0.8)/120)*5).to_i%>
+  MaxClients <%=(((ENV['OPENSHIFT_GEAR_MEMORY_MB'].to_i*0.8)/120)*5).to_i%>
+</IfModule>

--- a/cartridges/openshift-origin-cartridge-php/versions/shared/configuration/etc/conf/httpd.conf
+++ b/cartridges/openshift-origin-cartridge-php/versions/shared/configuration/etc/conf/httpd.conf
@@ -12,8 +12,6 @@ Include /etc/httpd/conf.modules.d/00-mpm.conf
 StartServers       1
 MinSpareServers    1
 MaxSpareServers    2
-ServerLimit        60
-MaxClients         60
 MaxRequestsPerChild  0
 </IfModule>
 <IfVersion >= 2.4>

--- a/cartridges/openshift-origin-cartridge-python/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-python/metadata/managed_files.yml
@@ -11,6 +11,8 @@ locked_files:
 - hooks/*
 - metadata/
 - metadata/*
+- conf/
+- conf/performance.conf.erb.hidden
 - env/
 - env/OPENSHIFT_PYTHON_DIR
 - env/OPENSHIFT_PYTHON_LOG_DIR

--- a/cartridges/openshift-origin-cartridge-python/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-python/metadata/manifest.yml.rhel
@@ -13,10 +13,11 @@ Versions:
 License: The Python License, version 2.6
 License-Url: http://docs.python.org/3/license.html
 Vendor: python.org
-Cartridge-Version: 0.0.6
+Cartridge-Version: 0.0.7
 Compatible-Versions:
 - 0.0.4
 - 0.0.5
+- 0.0.6
 Cartridge-Vendor: redhat
 Categories:
 - service

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/2.7-scl/etc/conf.d/openshift.conf.erb
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/2.7-scl/etc/conf.d/openshift.conf.erb
@@ -23,5 +23,3 @@ Alias /static "<%= ENV['OPENSHIFT_REPO_DIR'] %>wsgi/static/"
 WSGIPassAuthorization On
 
 WSGIProcessGroup <%= ENV['OPENSHIFT_GEAR_UUID'] %>
-WSGIDaemonProcess <%= ENV['OPENSHIFT_GEAR_UUID'] %> user=<%= ENV['OPENSHIFT_GEAR_UUID'] %> group=<%= ENV['OPENSHIFT_GEAR_UUID'] %> processes=2 threads=25 python-path="<%= ENV['OPENSHIFT_REPO_DIR'] %>/libs:<%= ENV['OPENSHIFT_REPO_DIR'] %>/wsgi:<%= ENV['OPENSHIFT_PYTHON_DIR'] %>/virtenv/lib/python/"
-

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
@@ -4,12 +4,12 @@ source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_PYTHON_DIR}/usr/versions/${OPENSHIFT_PYTHON_VERSION}/lib/create-virtenv"
 
 HTTPD_CFG_FILE=$OPENSHIFT_PYTHON_DIR/etc/conf/httpd_nolog.conf
-HTTPD_PASSENV_FILE=$OPENSHIFT_PYTHON_DIR/etc/conf.d/passenv.conf
+HTTPD_CFG_DIR=$OPENSHIFT_PYTHON_DIR/etc/conf.d
+HTTPD_PASSENV_FILE=$HTTPD_CFG_DIR/passenv.conf
 HTTPD_PID_FILE=$OPENSHIFT_PYTHON_DIR/run/httpd.pid
 
 # For backwards compatibility
 export APPDIR=$OPENSHIFT_PYTHON_DIR
-
 
 function start_app() {
     cd "$OPENSHIFT_REPO_DIR"
@@ -25,6 +25,7 @@ function start_apache() {
 
 function start() {
     echo "Starting PYTHON cart"
+    oo-erb conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
     if [ -f "$OPENSHIFT_REPO_DIR/app.py" ]
     then
         start_app
@@ -76,6 +77,7 @@ function restart() {
         start
     else
         stop_app
+        oo-erb conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
         write_httpd_passenv $HTTPD_PASSENV_FILE
         ensure_httpd_restart_succeed "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
         /usr/sbin/httpd -C "Include $OPENSHIFT_PYTHON_DIR/etc/conf.d/*.conf" -f $HTTPD_CFG_FILE -k restart

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/setup
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/setup
@@ -9,3 +9,6 @@ cp -rf $OPENSHIFT_PYTHON_DIR/usr/versions/$version/metadata/* $OPENSHIFT_PYTHON_
 
 # Create/truncate Apache PassEnv configuration file
 echo > $OPENSHIFT_PYTHON_DIR/etc/conf.d/passenv.conf
+
+cp $OPENSHIFT_PYTHON_DIR/usr/versions/$version/etc/conf.d/performance.conf.erb $OPENSHIFT_PYTHON_DIR/conf/performance.conf.erb
+cp $OPENSHIFT_PYTHON_DIR/conf/performance.conf.erb $OPENSHIFT_PYTHON_DIR/conf/performance.conf.erb.hidden

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/etc/conf.d/openshift.conf.erb
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/etc/conf.d/openshift.conf.erb
@@ -23,5 +23,3 @@ Alias /static "<%= ENV['OPENSHIFT_REPO_DIR'] %>wsgi/static/"
 WSGIPassAuthorization On
 
 WSGIProcessGroup <%= ENV['OPENSHIFT_GEAR_UUID'] %>
-WSGIDaemonProcess <%= ENV['OPENSHIFT_GEAR_UUID'] %> user=<%= ENV['OPENSHIFT_GEAR_UUID'] %> group=<%= ENV['OPENSHIFT_GEAR_UUID'] %> processes=2 threads=25 python-path="<%= ENV['OPENSHIFT_REPO_DIR'] %>/libs:<%= ENV['OPENSHIFT_REPO_DIR'] %>/wsgi:<%= ENV['OPENSHIFT_PYTHON_DIR'] %>/virtenv/lib/python/"
-

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/etc/conf.d/performance.conf.erb
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/etc/conf.d/performance.conf.erb
@@ -1,0 +1,4 @@
+# Set the stack-size based on the memory available in gear and based on the
+# number of processes and threads
+#
+WSGIDaemonProcess <%= ENV['OPENSHIFT_GEAR_UUID'] %> user=<%= ENV['OPENSHIFT_GEAR_UUID'] %> group=<%= ENV['OPENSHIFT_GEAR_UUID'] %> processes=2 threads=25 stack-size=<%= (((ENV['OPENSHIFT_GEAR_MEMORY_MB'].to_i * 0.8)/25) * 1024).to_i/2 %> python-path="<%= ENV['OPENSHIFT_REPO_DIR'] %>/libs:<%= ENV['OPENSHIFT_REPO_DIR'] %>/wsgi:<%= ENV['OPENSHIFT_PYTHON_DIR'] %>/virtenv/lib/python/"

--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -4,13 +4,15 @@ source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_RUBY_DIR}/lib/util"
 source "${OPENSHIFT_RUBY_DIR}/lib/ruby_context"
 
+HTTPD_CFG_DIR=${OPENSHIFT_RUBY_DIR}/etc/conf.d
 HTTPD_CFG_FILE=$OPENSHIFT_RUBY_DIR/etc/conf/httpd_nolog.conf
-HTTPD_PASSENV_FILE=$OPENSHIFT_RUBY_DIR/etc/conf.d/passenv.conf
+HTTPD_PASSENV_FILE=${HTTPD_CFG_DIR}/passenv.conf
 HTTPD_PID_FILE=$OPENSHIFT_RUBY_DIR/run/httpd.pid
 
 function start() {
     echo "Starting Ruby cartridge"
     write_httpd_passenv $HTTPD_PASSENV_FILE
+    oo-erb conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     ruby_context "/usr/sbin/httpd -C 'Include $OPENSHIFT_RUBY_DIR/etc/conf.d/*.conf' -f $HTTPD_CFG_FILE -k start"
 }
@@ -28,6 +30,7 @@ function stop() {
 function restart() {
     echo "${1}ing Ruby cart"
     write_httpd_passenv $HTTPD_PASSENV_FILE
+    oo-erb conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
     touch $OPENSHIFT_REPO_DIR/tmp/restart.txt
     ensure_httpd_restart_succeed "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     ruby_context "/usr/sbin/httpd -C 'Include $OPENSHIFT_RUBY_DIR/etc/conf.d/*.conf' -f $HTTPD_CFG_FILE -k restart"

--- a/cartridges/openshift-origin-cartridge-ruby/bin/setup
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/setup
@@ -29,3 +29,6 @@ if [ $version == '1.9' ]; then
     scl enable ruby193 "printenv LD_LIBRARY_PATH" > $OPENSHIFT_RUBY_DIR/env/LD_LIBRARY_PATH
     scl enable ruby193 "printenv MANPATH"         > $OPENSHIFT_RUBY_DIR/env/MANPATH
 fi
+
+cp versions/shared/etc/conf.d/performance.conf.erb conf/performance.conf.erb
+cp conf/performance.conf.erb conf/performance.conf.erb.hidden

--- a/cartridges/openshift-origin-cartridge-ruby/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/managed_files.yml
@@ -6,6 +6,8 @@ locked_files:
 - metadata/*
 - hooks/
 - hooks/*
+- conf/
+- conf/performance.conf.erb.hidden
 - etc/
 - etc/conf/
 - etc/conf/*
@@ -15,4 +17,4 @@ locked_files:
 - env/OPENSHIFT_RUBY_DIR
 - env/OPENSHIFT_RUBY_LOG_DIR
 processed_templates:
-- 'etc/conf.d/openshift.conf.erb'
+- 'etc/conf.d/*.erb'

--- a/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml.rhel
@@ -11,12 +11,13 @@ Versions:
 License: Ruby BSDL
 License-Url: http://www.ruby-lang.org/en/about/license.txt
 Vendor: ruby.org
-Cartridge-Version: 0.0.8
+Cartridge-Version: 0.0.9
 Compatible-Versions:
 - 0.0.4
 - 0.0.5
 - 0.0.6
 - 0.0.7
+- 0.0.8
 Cartridge-Vendor: redhat
 Categories:
 - service

--- a/cartridges/openshift-origin-cartridge-ruby/versions/1.8/etc/conf.d/performance.conf.erb
+++ b/cartridges/openshift-origin-cartridge-ruby/versions/1.8/etc/conf.d/performance.conf.erb
@@ -1,0 +1,1 @@
+../../../shared/etc/conf.d/performance.conf.erb

--- a/cartridges/openshift-origin-cartridge-ruby/versions/1.9-scl/etc/conf.d/performance.conf.erb
+++ b/cartridges/openshift-origin-cartridge-ruby/versions/1.9-scl/etc/conf.d/performance.conf.erb
@@ -1,0 +1,1 @@
+../../../shared/etc/conf.d/performance.conf.erb

--- a/cartridges/openshift-origin-cartridge-ruby/versions/2.0/etc/conf.d/performance.conf.erb
+++ b/cartridges/openshift-origin-cartridge-ruby/versions/2.0/etc/conf.d/performance.conf.erb
@@ -1,0 +1,1 @@
+../../../shared/etc/conf.d/performance.conf.erb

--- a/cartridges/openshift-origin-cartridge-ruby/versions/shared/etc/conf.d/performance.conf.erb
+++ b/cartridges/openshift-origin-cartridge-ruby/versions/shared/etc/conf.d/performance.conf.erb
@@ -1,0 +1,5 @@
+# This will take 80% of the gear memory and devide it by the number
+# of average Passenger thread size. The result is a size of the Passeger
+# pool, where each worker is supposed to use 120 MB of RAM.
+#
+PassengerMaxPoolSize <%=((ENV['OPENSHIFT_GEAR_MEMORY_MB'].to_i*0.75)/120).to_i%>


### PR DESCRIPTION
This pull request include various tweaks for there cartridges:
- PHP: Set the MaxClient and ServerLimit values according to the current gear memory configuration
- Ruby: Set the PassengerPoolSize based on the gear memory
- Python: Set the 'stack-size' for the WSGI based on the gear memory
