### PR TITLE
Reenable haproxy-status

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-haproxy/metadata/manifest.yml
@@ -63,6 +63,7 @@ Endpoints:
 - Private-IP-Name: STATUS_IP
   Private-Port-Name: STATUS_PORT
   Private-Port: 8080
+  Protocols: [http]
   Mappings:
   - Frontend: /haproxy-status
     Backend: /


### PR DESCRIPTION
Set haproxy status endpoint protocol to http so the haproxy-status page
is exposed again
