### PR TITLE
Removing test dependencies from Broker/Console build and runtime.

### DIFF
--- a/broker/Gemfile.runtime
+++ b/broker/Gemfile.runtime
@@ -1,0 +1,73 @@
+source 'http://rubygems.org'
+
+gem 'rails', '~> 3.2.8'
+gem 'json'
+gem 'json_pure'
+gem 'parseconfig', '~> 1.0.2'
+gem 'xml-simple'
+gem 'rack'
+gem 'regin'
+gem 'open4'
+gem 'systemu'
+gem 'mongoid'
+gem 'bson'
+gem 'bson_ext'
+gem 'pry', :require => 'pry' if ENV['PRY']
+# Fedora 19 splits psych out into its own gem.
+if Gem::Specification.respond_to?(:find_all_by_name) and not Gem::Specification::find_all_by_name('psych').empty?
+  gem 'psych'
+end
+
+# For performance reasons, the following scripts will not be
+# refactored to use mongoid exclusively:
+#  * broker-util/oo-admin-chk
+#  * broker-util/oo-admin-fix-sshkeys
+#  * broker-util/oo-stats
+# These scripts use the OpenShift::DataStore API, and thus depend on
+# the mongo rubygem:
+gem 'mongo'
+
+if ENV['BROKER_SOURCE'] || ENV['BROKER_PLUGINS_FILE']
+  gem 'openshift-origin-common', :path => '../common'
+  gem 'openshift-origin-controller', :path => '../controller'
+  gem 'netrc' # rest-client has an undeclared prereq on netrc
+
+  # Load broker plugins according to local file, but keep paths relative to ./
+  eval IO.read(File.expand_path(ENV['BROKER_PLUGINS_FILE'] || '~/.openshift/broker_plugins.rb'))
+else
+  gem 'openshift-origin-controller'
+
+  # Load broker plugin gems specified by .conf files in plugins.d/
+  # Load if either .conf or -dev.conf is present;
+  # Plugins use -dev.conf only in development mode.
+  plugins = Dir[(ENV['OPENSHIFT_CONF_DIR'] || "/etc/openshift") + '/plugins.d/*.conf'].
+              map {|file| File.basename(file, ".conf") }
+  # in development, load if there is a -dev.conf file, even if no prod.conf
+  group :development do
+    plugins.map! {|name| name.sub(/-dev$/, '')}
+  end
+  # otherwise, ignore presence of -dev.conf files
+  group :test, :production do
+    plugins.reject! {|name| name.match /-dev$/}
+  end
+  plugins.sort.uniq.each {|name| gem name}
+end
+
+# Bundle edge Rails instead:
+# gem 'rails', :git => 'git://github.com/rails/rails.git'
+
+# Use unicorn as the web server
+# gem 'unicorn'
+
+# Deploy with Capistrano
+# gem 'capistrano'
+
+# To use debugger (ruby-debug for Ruby 1.8.7+, ruby-debug19 for Ruby 1.9.2+)
+# gem 'ruby-debug'
+# gem 'ruby-debug19', :require => 'ruby-debug'
+
+# Bundle the extra gems:
+# gem 'bj'
+# gem 'nokogiri'
+# gem 'sqlite3-ruby', :require => 'sqlite3'
+# gem 'aws-s3', :require => 'aws/s3'

--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -39,7 +39,6 @@ Requires:      %{?scl:%scl_prefix}mod_passenger
 Requires:      %{?scl:%scl_prefix}rubygem-bson_ext
 Requires:      %{?scl:%scl_prefix}rubygem-json
 Requires:      %{?scl:%scl_prefix}rubygem-json_pure
-Requires:      %{?scl:%scl_prefix}rubygem-minitest
 # This gem is required by oo-admin-chk, oo-admin-fix-sshkeys, and
 # oo-stats, for OpenShift::DataStore API support
 Requires:      %{?scl:%scl_prefix}rubygem-mongo
@@ -52,7 +51,6 @@ Requires:      %{?scl:%scl_prefix}rubygem-passenger-native-libs
 Requires:      %{?scl:%scl_prefix}rubygem-rails
 Requires:      %{?scl:%scl_prefix}rubygem-regin
 Requires:      %{?scl:%scl_prefix}rubygem-rest-client
-Requires:      %{?scl:%scl_prefix}rubygem-simplecov
 Requires:      %{?scl:%scl_prefix}rubygem-systemu
 Requires:      %{?scl:%scl_prefix}rubygem-xml-simple
 
@@ -67,11 +65,9 @@ Requires:      %{?scl:%scl_prefix}rubygem-bigdecimal
 Requires:      %{?scl:%scl_prefix}rubygem-bson
 Requires:      %{?scl:%scl_prefix}rubygem-builder
 Requires:      %{?scl:%scl_prefix}rubygem-bundler
-Requires:      %{?scl:%scl_prefix}rubygem-cucumber
 Requires:      %{?scl:%scl_prefix}rubygem-diff-lcs
 Requires:      %{?scl:%scl_prefix}rubygem-dnsruby
 Requires:      %{?scl:%scl_prefix}rubygem-erubis
-Requires:      %{?scl:%scl_prefix}rubygem-gherkin
 Requires:      %{?scl:%scl_prefix}rubygem-hike
 Requires:      %{?scl:%scl_prefix}rubygem-i18n
 Requires:      %{?scl:%scl_prefix}rubygem-journey
@@ -79,7 +75,6 @@ Requires:      %{?scl:%scl_prefix}rubygem-json
 Requires:      %{?scl:%scl_prefix}rubygem-mail
 Requires:      %{?scl:%scl_prefix}rubygem-metaclass
 Requires:      %{?scl:%scl_prefix}rubygem-mime-types
-Requires:      %{?scl:%scl_prefix}rubygem-mocha
 Requires:      %{?scl:%scl_prefix}rubygem-moped
 Requires:      %{?scl:%scl_prefix}rubygem-multi_json
 Requires:      %{?scl:%scl_prefix}rubygem-origin
@@ -90,11 +85,8 @@ Requires:      %{?scl:%scl_prefix}rubygem-rack-ssl
 Requires:      %{?scl:%scl_prefix}rubygem-rack-test
 Requires:      %{?scl:%scl_prefix}rubygem-rails
 Requires:      %{?scl:%scl_prefix}rubygem-railties
-Requires:      %{?scl:%scl_prefix}rubygem-rake
 Requires:      %{?scl:%scl_prefix}rubygem-rdoc
 Requires:      %{?scl:%scl_prefix}rubygem-regin
-Requires:      %{?scl:%scl_prefix}rubygem-simplecov
-Requires:      %{?scl:%scl_prefix}rubygem-simplecov-html
 Requires:      %{?scl:%scl_prefix}rubygem-sprockets
 Requires:      %{?scl:%scl_prefix}rubygem-state_machine
 Requires:      %{?scl:%scl_prefix}rubygem-stomp
@@ -195,6 +187,9 @@ mv %{buildroot}%{brokerdir}/httpd/broker-scl-ruby193.conf %{buildroot}%{brokerdi
 %else
 rm %{buildroot}%{brokerdir}/httpd/broker-scl-ruby193.conf
 %endif
+
+# Remove the test-only dependencies
+mv %{buildroot}%{brokerdir}/Gemfile.runtime %{buildroot}%{brokerdir}/Gemfile
 
 %files
 %doc LICENSE COPYRIGHT

--- a/console/Gemfile
+++ b/console/Gemfile
@@ -30,6 +30,7 @@ group :assets do
   gem 'uglifier',      '>= 1.2.6'
   gem 'therubyracer',  '>= 0.10'
   gem 'sass-twitter-bootstrap',  '2.0.1'
+  gem 'minitest',      '>= 3.5.0', :require => false
 end
 
 

--- a/console/Gemfile.runtime
+++ b/console/Gemfile.runtime
@@ -1,0 +1,19 @@
+source 'http://rubygems.org'
+
+gemspec
+
+gem 'pry', :require => 'pry' if ENV['PRY']
+gem 'perftools.rb', :require => 'perftools' if ENV['PERFTOOLS']
+
+group :assets do
+  gem 'compass-rails', '~> 1.0.3'
+  gem 'sass-rails',    '~> 3.2.5'
+  gem 'coffee-rails',  '~> 3.2.2'
+  gem 'jquery-rails',  '~> 2.0.2'
+  gem 'uglifier',      '>= 1.2.6'
+  gem 'therubyracer',  '>= 0.10'
+  gem 'sass-twitter-bootstrap',  '2.0.1'
+end
+
+
+

--- a/console/rubygem-openshift-origin-console.spec
+++ b/console/rubygem-openshift-origin-console.spec
@@ -27,20 +27,11 @@ Requires:      %{?scl:%scl_prefix}rubygem(rdiscount)
 Requires:      %{?scl:%scl_prefix}rubygem(formtastic)
 Requires:      %{?scl:%scl_prefix}rubygem(net-http-persistent)
 Requires:      %{?scl:%scl_prefix}rubygem(haml)
-Requires:      %{?scl:%scl_prefix}rubygem(ci_reporter)
 Requires:      %{?scl:%scl_prefix}rubygem(coffee-rails)
 Requires:      %{?scl:%scl_prefix}rubygem(compass-rails)
 Requires:      %{?scl:%scl_prefix}rubygem(jquery-rails)
-Requires:      %{?scl:%scl_prefix}rubygem(mocha)
 Requires:      %{?scl:%scl_prefix}rubygem(sass-rails)
-Requires:      %{?scl:%scl_prefix}rubygem(simplecov)
-Requires:      %{?scl:%scl_prefix}rubygem(test-unit)
 Requires:      %{?scl:%scl_prefix}rubygem(uglifier)
-Requires:      %{?scl:%scl_prefix}rubygem(webmock)
-Requires:      %{?scl:%scl_prefix}rubygem(poltergeist)
-Requires:      %{?scl:%scl_prefix}rubygem(konacha)
-Requires:      %{?scl:%scl_prefix}rubygem(minitest)
-Requires:      %{?scl:%scl_prefix}rubygem(rspec-core)
 Requires:      %{?scl:%scl_prefix}rubygem(sass-twitter-bootstrap)
 
 %if 0%{?fedora}%{?rhel} <= 6
@@ -49,27 +40,20 @@ BuildRequires: scl-utils-build
 %endif
 
 BuildRequires: %{?scl:%scl_prefix}rubygem(coffee-rails)
-BuildRequires: %{?scl:%scl_prefix}rubygem(sass-rails)
-BuildRequires: %{?scl:%scl_prefix}rubygem(jquery-rails)
-BuildRequires: %{?scl:%scl_prefix}rubygem(uglifier)
-BuildRequires: %{?scl:%scl_prefix}rubygem(rails)
 BuildRequires: %{?scl:%scl_prefix}rubygem(compass-rails)
-BuildRequires: %{?scl:%scl_prefix}rubygem(mocha)
-BuildRequires: %{?scl:%scl_prefix}rubygem(simplecov)
-BuildRequires: %{?scl:%scl_prefix}rubygem(test-unit)
-BuildRequires: %{?scl:%scl_prefix}rubygem(ci_reporter)
-BuildRequires: %{?scl:%scl_prefix}rubygem(webmock)
-BuildRequires: %{?scl:%scl_prefix}rubygem(sprockets)
-BuildRequires: %{?scl:%scl_prefix}rubygem(rdiscount)
 BuildRequires: %{?scl:%scl_prefix}rubygem(formtastic)
-BuildRequires: %{?scl:%scl_prefix}rubygem(net-http-persistent)
 BuildRequires: %{?scl:%scl_prefix}rubygem(haml)
-BuildRequires: %{?scl:%scl_prefix}rubygem(therubyracer)
-BuildRequires: %{?scl:%scl_prefix}rubygem(poltergeist)
-BuildRequires: %{?scl:%scl_prefix}rubygem(konacha)
+BuildRequires: %{?scl:%scl_prefix}rubygem(jquery-rails)
 BuildRequires: %{?scl:%scl_prefix}rubygem(minitest)
-BuildRequires: %{?scl:%scl_prefix}rubygem(rspec-core)
+BuildRequires: %{?scl:%scl_prefix}rubygem(net-http-persistent)
+BuildRequires: %{?scl:%scl_prefix}rubygem(rails)
+BuildRequires: %{?scl:%scl_prefix}rubygem(rdiscount)
+BuildRequires: %{?scl:%scl_prefix}rubygem(sass-rails)
 BuildRequires: %{?scl:%scl_prefix}rubygem(sass-twitter-bootstrap)
+BuildRequires: %{?scl:%scl_prefix}rubygem(sprockets)
+BuildRequires: %{?scl:%scl_prefix}rubygem(therubyracer)
+BuildRequires: %{?scl:%scl_prefix}rubygem(uglifier)
+
 
 BuildRequires: %{?scl:%scl_prefix}rubygems-devel
 %if 0%{?fedora} >= 19
@@ -101,6 +85,10 @@ mkdir -p .%{gem_dir}
 
 %if 0%{?fedora}%{?rhel} <= 6
 rm -f Gemfile.lock
+
+# Remove the test-only dependencies
+mv Gemfile.runtime Gemfile
+
 bundle install --local
 
 mkdir -p %{buildroot}%{_var}/log/openshift/console/

--- a/node/Gemfile.runtime
+++ b/node/Gemfile.runtime
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+# Specify your gem's dependencies in openshift-origin-node.gemspec
+gemspec

--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -25,7 +25,6 @@ Requires:      %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
 %endif
 Requires:      %{?scl:%scl_prefix}rubygem(commander)
 Requires:      %{?scl:%scl_prefix}rubygem(json)
-Requires:      %{?scl:%scl_prefix}rubygem(mocha)
 Requires:      %{?scl:%scl_prefix}rubygem(open4)
 Requires:      %{?scl:%scl_prefix}rubygem(parallel)
 %if 0%{?rhel} <= 6
@@ -34,7 +33,6 @@ Requires:      %{?scl:%scl_prefix}rubygem(parallel)
 Requires:      rubygem(open4)
 %endif
 Requires:      %{?scl:%scl_prefix}rubygem(parseconfig)
-Requires:      %{?scl:%scl_prefix}rubygem(rspec)
 Requires:      %{?scl:%scl_prefix}rubygem(safe_yaml)
 Requires:      %{?scl:%scl_prefix}rubygem(rest-client)
 Requires:      %{?scl:%scl_prefix}rubygems
@@ -81,6 +79,9 @@ This contains the Cloud Development Node packaged as a rubygem.
 %setup -q
 
 %build
+# Remove the test-only dependencies
+mv Gemfile.runtime Gemfile
+
 %{?scl:scl enable %scl - << \EOF}
 mkdir -p .%{gem_dir}
 # Create the gem as gem install only works on a gem file

--- a/openshift-console/Gemfile.runtime
+++ b/openshift-console/Gemfile.runtime
@@ -1,0 +1,23 @@
+source 'http://rubygems.org'
+
+# Fedora 19 splits psych out into its own gem.
+if Gem::Specification.respond_to?(:find_all_by_name) and not Gem::Specification::find_all_by_name('psych').empty?
+  gem 'psych'
+end
+
+gem 'openshift-origin-console', :require => 'console', :path => ENV['CONSOLE_PATH']
+
+gem 'rake', '> 0.9.2'
+gem 'pry', :require => 'pry' if ENV['PRY']
+gem 'perftools.rb', :require => 'perftools' if ENV['PERFTOOLS']
+
+group :assets do
+  gem 'compass-rails', '~> 1.0.3'
+  gem 'sass-rails',    '~> 3.2.5'
+  gem 'coffee-rails',  '~> 3.2.2'
+  gem 'jquery-rails',  '~> 2.0.2'
+  gem 'uglifier',      '>= 1.2.6'
+  gem 'therubyracer',  '>= 0.10'
+  gem 'sass-twitter-bootstrap', '2.0.1'
+end
+

--- a/openshift-console/openshift-origin-console.spec
+++ b/openshift-console/openshift-origin-console.spec
@@ -29,28 +29,21 @@ Requires:      %{?scl:%scl_prefix}mod_passenger
 
 %if 0%{?scl:1}
 Requires:      %{?scl:%scl_prefix}ruby-wrapper
-Requires:      %{?scl:%scl_prefix}rubygem-minitest
 Requires:      %{?scl:%scl_prefix}rubygem-therubyracer
 Requires:      openshift-origin-util-scl
 %endif
 Requires:      %{?scl:%scl_prefix}rubygem-rails
 Requires:      %{?scl:%scl_prefix}rubygem-compass-rails
-Requires:      %{?scl:%scl_prefix}rubygem-test-unit
-Requires:      %{?scl:%scl_prefix}rubygem-ci_reporter
 Requires:      %{?scl:%scl_prefix}rubygem-sprockets
 Requires:      %{?scl:%scl_prefix}rubygem-rdiscount
 Requires:      %{?scl:%scl_prefix}rubygem-formtastic
 Requires:      %{?scl:%scl_prefix}rubygem-net-http-persistent
 Requires:      %{?scl:%scl_prefix}rubygem-haml
 Requires:      %{?scl:%scl_prefix}rubygem-therubyracer
-Requires:      %{?scl:%scl_prefix}rubygem-minitest
 Requires:      %{?scl:%scl_prefix}rubygems-devel
 Requires:      %{?scl:%scl_prefix}rubygem-coffee-rails
 Requires:      %{?scl:%scl_prefix}rubygem-jquery-rails
 Requires:      %{?scl:%scl_prefix}rubygem-uglifier
-Requires:      %{?scl:%scl_prefix}rubygem-poltergeist
-Requires:      %{?scl:%scl_prefix}rubygem-webmock
-Requires:      %{?scl:%scl_prefix}rubygem-capybara
 
 %if 0%{?fedora}
 Requires:      openshift-origin-util
@@ -64,22 +57,18 @@ BuildRequires:  scl-utils-build
 %endif
 BuildRequires: %{?scl:%scl_prefix}rubygem-rails
 BuildRequires: %{?scl:%scl_prefix}rubygem-compass-rails
-BuildRequires: %{?scl:%scl_prefix}rubygem-test-unit
-BuildRequires: %{?scl:%scl_prefix}rubygem-ci_reporter
 BuildRequires: %{?scl:%scl_prefix}rubygem-sprockets
 BuildRequires: %{?scl:%scl_prefix}rubygem-rdiscount
 BuildRequires: %{?scl:%scl_prefix}rubygem-formtastic
 BuildRequires: %{?scl:%scl_prefix}rubygem-net-http-persistent
 BuildRequires: %{?scl:%scl_prefix}rubygem-haml
 BuildRequires: %{?scl:%scl_prefix}rubygem-therubyracer
+# Required by activesupport during the asset precompilation process
 BuildRequires: %{?scl:%scl_prefix}rubygem-minitest
 BuildRequires: %{?scl:%scl_prefix}rubygems-devel
 BuildRequires: %{?scl:%scl_prefix}rubygem-coffee-rails
 BuildRequires: %{?scl:%scl_prefix}rubygem-jquery-rails
 BuildRequires: %{?scl:%scl_prefix}rubygem-uglifier
-BuildRequires: %{?scl:%scl_prefix}rubygem-poltergeist
-BuildRequires: %{?scl:%scl_prefix}rubygem-webmock
-BuildRequires: %{?scl:%scl_prefix}rubygem-capybara
 
 %if 0%{?fedora} >= 19
 BuildRequires: ruby(release)
@@ -104,6 +93,9 @@ This includes the configuration necessary to run the console with mod_passenger.
 %{?scl:scl enable %scl - << \EOF}
 
 set -e
+# Remove the test-only dependencies
+mv Gemfile.runtime Gemfile
+
 %if 0%{?fedora}%{?rhel} <= 6
 rm -f Gemfile.lock
 bundle install --local
@@ -186,6 +178,7 @@ mv %{buildroot}%{consoledir}/httpd/httpd.conf.apache-2.4 %{buildroot}%{consoledi
 mv %{buildroot}%{consoledir}/httpd/httpd.conf.apache-2.3 %{buildroot}%{consoledir}/httpd/httpd.conf
 %endif
 rm %{buildroot}%{consoledir}/httpd/httpd.conf.apache-*
+
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
The approach is to use the broker/Gemfile for development and let the RPMs use
Gemfile.runtime.  This reduces the work for distro maintainers.
