### PR TITLE
node: abstract ssh "key" manangement and add support for k5login

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/kerberos.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/kerberos.rb
@@ -1,0 +1,351 @@
+#
+# Manage Kerberos5 k5login entries for a gear
+#
+require 'set'
+require 'fcntl'
+require 'etc'
+
+#
+# The k5login file 
+#
+# k5login man page
+# k5login URL
+#
+# The k5login file contains a principal string on each line.  When an auth/
+# access request is recieved and contains a principal which cannot be derived
+# from the local username, this file is checked to determine if the principal
+# will be granted access.
+# 
+# OpenShift wants to allow multiple openshift users to submit a principal to
+# a gear.  The principal is only removed when all owner IDs have been removed
+# from the principal.
+#
+# This class models that multiple ownership by inserting comment lines before
+# the principal line.  These comment lines have the form /^# id: <id string>$/
+# As the file is read these lines are accumulated and then when a non-comment
+# line is encountered, the collected ID strings are attached to the principal
+# string.
+#
+# Each time a new principal/id pair is added, if the principal is present, the
+# id is added to the ownership set.
+#
+# When a principal/id pair is removed, the id is first removed and then 
+# the principal removed only if the number of remaining ids is 0
+#
+# Example
+#
+# # id: longidstring1
+# # id: longidstring2
+# testuser1@EXAMPLE.COM
+#
+# # id: idstring1
+# testuser2@EXAMPLE.COM
+# 
+# ... 
+#
+# Since "comment" lines form invalid principal strings no real user will ever
+# try to authenticate with them and if they do access will be denied.
+# Well formated lines will match as normal
+#
+# The list of principals and their sets of associated IDs are represented as
+# a hash of Sets.  Each hash key is a Kerberos principal string.  The hash
+# value is a Set of strings corresponding to the associated ID strings.
+#
+# The K5login.clone and K5login.compare functions provide a deep copy and
+# deep comparison so that the k5login file is only written if changes are made.
+#
+
+
+module OpenShift
+  module Runtime
+    module ApplicationContainerExt
+      module Kerberos
+
+        # Public: manage kerberos principals allowed access to an account
+        #
+        # This class will use the system /etc/krb5.conf file and the
+        # [libdefaults] k5login_directory value to determine where to place
+        # the k5login file.  If the krb5.conf file does not exist or the
+        # k5login_directory is not defined, then the file will be placed in
+        # $HOME/.k5login for each account.
+        #
+        # SEE ALSO
+        #   man krb5.conf
+        #   man k5login
+        #
+        # Examples
+        #   k = K5login.new(username)
+        #
+        #   k.add_principal('user1@EXAMPLE.COM', id=nil)
+        #   k.del_principal('user2@EXAMPLE.COM', id=nil)
+        #
+        #   allowed = k.principals
+        #
+        #   k.principals = { 'user3@EXAMPLE.COM' => [<idlist], 
+        #                    'user4@EXAMPLE.COM' => [<idlist]
+        #                  }
+        class K5login
+
+          attr_reader :container, :username, :config_file, :filename
+          attr_accessor :owner, :group, :mode
+          attr_accessor :lockfile
+
+          @@mutex = Mutex.new
+          @@default_owner = 0
+          @@default_group = 0
+          @@default_mode = 0644
+
+          # Public: Create a new K5login manager
+          #
+          # username -    [String] the username to manage
+          # config_file - [String] optional kerberos configuration file
+          # filename -    [String] optional k5login file to manage
+          #
+          # Examples
+          #
+          #   Normal use: 
+          #     k = K5login.new(username)
+          #
+          #   Testing with a k5login_directory from a test configuration
+          #     testk = K5login.new('testuser', '/tmp/krb5.conf')
+          #
+          #   Testing with an explicit k5login filename
+          #     testk = K5login.new('testuser2', nil, '/tmp/test_k5login')
+          #
+          def initialize(container, config_file=nil, filename=nil)
+            @container = container
+            @username = container.uuid
+            @config_file = config_file ? File.expand_path(config_file) : '/etc/krb5.conf'
+            @filename = filename ? File.expand_path(filename) : k5login_file
+
+            # override for testing
+            user = Etc.getpwnam('root')
+            @owner = user.uid # root
+            begin
+              @group = Etc.getpwnam(@username).gid
+            rescue ArgumentError => e
+              @group = @@default_group
+            end
+            @mode = @@default_mode
+
+            @lockfile = "/var/lock/oo-k5login.#{@username}"
+          end
+          
+          # Public: Determine the location of the user's k5login file
+          #
+          # It resides in the user's home directory unless otherwise specified
+          # in the system /etc/krb5.conf
+          #
+          # Returns: String - The absolute path to the k5login file
+          #
+          def k5login_file(config_file=nil)
+            
+            config_file ||= @config_file
+            if File.exists? config_file
+
+              krb5_config = ParseConfig.new config_file
+
+              if krb5_config['k5login_directory']
+                return krb5_config['k5login_directory'] + "/" + @username
+              end
+
+            end
+
+            @container.container_dir + "/.k5login"
+          end
+
+          # Public: retrieve and return the current contents of the k5login file
+          #
+          # @return [Array] the list of allowed Kerberos principals
+          #
+          # Examples
+          #   k = K5login.new(username)
+          #   p = k.principals
+          #
+          def principals
+            modify
+          end
+
+          # Public: add a single principal to the current set
+          #
+          # principal: String - a Kerberos principal
+          # key_name: String - an identifier to manage duplicate principals
+          #                    from different users
+          #                    currently discarded pending additional work
+          def add_principal(principal, id=nil)
+            modify do |_principals|
+              if _principals.member? principal
+                # add an id to the existing principal (dup safe for sets)
+                _principals[principal] << id if not id == nil
+              else 
+                # add the principal # id set is empty if id is nil
+                _principals.merge!({principal => Set.new(id ? [id] : [])})
+              end
+            end
+          end
+          
+          # Public: delete a single principal from the current set
+          # 
+          # principal: String - a Kerberos principal
+          # key_name: String - an identifier to manage duplicate principals
+          #                    from different users
+          #                    currently discarded pending additional work
+          def remove_principal(principal, id=nil)
+            modify do |_principals|
+              _principals.select! do |p, idset|
+                # keep non-match or matches with non-empty id sets
+                p != principal or idset.delete(id).length > 0
+              end
+            end
+          end
+
+          # Public: replace all principals
+          # 
+          # new_principals: Array of Hashes:
+          #    {'key' => String,  a kerberos principal
+          #     'type' => String == 'krb5-principal',
+          #     'comment' => String - an identifier to manage duplicate
+          #                           principals from different users
+          #                           currently discarded pending more work
+          def replace_principals(new_principals)
+            modify do | _principals |
+              # remove all entries
+              _principals.delete_if {|p| true }
+              
+              # add all of the new entries
+              new_principals.each do |p|
+                _principals[p['key']] = Set.new if not _principals[p['key']]
+                _principals[p['key']] << p['comment'] if p['comment'] and p['comment'].strip.length > 0
+              end
+            end
+
+          end
+
+
+          private
+
+          # return a deep copy of a principal hash
+          def self.clone(phash)
+            nhash = phash.clone
+            nhash.each_key {|k| nhash[k] = nhash[k].clone }
+          end
+          
+          # deep compare of two principal hashes
+          #
+          # check that the array of keys is the same and then that
+          # the contents of all sets is identical
+          #
+          def self.compare(h0, h1)
+            h0.keys === h1.keys && h0.map {|k, v| h1[k] === v}.reduce(:&)
+          end
+
+          # Private: retrieve and update the contents of the k5login file
+          #
+          # @yields [Array] the current list of allowed user principals
+          # @return [Array] the final list of allowed user principals
+          #
+          # This method performs both synchronization (via a mutex) and file
+          # locking to avoid race conditions and collisions.  It requires the
+          # priviledges necessary to read and write files owned by arbitrary
+          # users as well as to establish system wide shared locks.
+          # 
+          def modify
+
+            _principals = {}
+            @@mutex.synchronize do
+
+              # prevent external race conditions/collisions
+              lockfile_flags = File::RDWR|File::CREAT|File::TRUNC
+              lockfile_mode = 0600
+
+              File.open(@lockfile, lockfile_flags, lockfile_mode) do | lock |
+                lock.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+                lock.flock(File::LOCK_EX)
+                
+                begin
+                  flags =  File::RDWR|File::CREAT
+                  mode = 0640
+
+                  changed = false
+                  File.open(@filename, flags, mode) do | file |
+
+                    id_set = Set.new
+
+                    #
+                    # Create the list of principals and a set of ids for each
+                    #
+                    file.readlines.each do |line|
+                      line.strip!
+
+                      # skip empty lines
+                      next if line.length == 0
+
+                      # build up principal "ids" who have placed this principal
+                      m = line.match /#\s*id\s*:\s*(.*)$/
+                      if m
+                        id_set << (m[1] == '' ? nil : m[1])
+                        next
+                      end
+
+                      # principals are non-comment non-empty lines
+                      id_set << nil if not line.start_with?('#') and
+                        id_set.length == 0
+
+                      # add the principal to the hash
+                      _principals[line] = id_set
+                      # and reset for the next iteration
+                      id_set = Set.new
+  
+                    end
+
+                    if block_given?
+                      old_principals = K5login.clone(_principals)
+
+                      yield _principals
+                      
+                      if not K5login.compare(old_principals, _principals)
+                        file.seek(0, IO::SEEK_SET)
+                        # write all of the ids and then the principal string
+                        _principals.each {|principal, id_list|
+                          id_list.each {|id|
+                            file.write "# id: #{id}\n"
+                          }
+                          file.write principal + "\n\n"
+                        }
+                        # remove the extra newline
+                        file.truncate(file.tell - 1) if file.tell > 0
+                        changed = true
+                      end
+                    end
+                  end
+                  if changed
+                    # set ownership
+                    File.chown @owner, @group, @filename 
+
+                    # set permissions
+                    File.chmod @mode, @filename if @mode
+
+                    # set SELinux labels
+                    cmd = "restorecon  #{@filename}"
+                    ::OpenShift::Runtime::Utils::oo_spawn(cmd)
+                  end
+                ensure
+                  lock.flock(File::LOCK_UN)
+                  lock.close
+                  File.delete lockfile
+                end
+              end
+            end
+            
+            @principals = _principals
+            File.delete @filename if @principals.length == 0
+            @principals
+          end
+
+
+        end
+
+      end
+    end
+  end
+end

--- a/node/lib/openshift-origin-node/model/application_container_ext/ssh_authorized_keys.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/ssh_authorized_keys.rb
@@ -1,0 +1,248 @@
+require 'fcntl'
+
+module OpenShift
+  module Runtime
+    module ApplicationContainerExt
+      module SecureShell
+        
+        # Manage a user (gear/container) SSH authorized_keys file and entries
+        class AuthorizedKeysFile
+
+
+          attr_reader :container, :username, :filename
+          attr_accessor :owner, :group, :mode
+          attr_accessor :lockfile
+
+          @@mutex = Mutex.new
+          @@default_owner = 0
+          @@default_group = 0
+          @@default_mode = 0440
+
+          def initialize(container, filename=nil)
+            @container = container
+            @username = container.uuid
+            @filename = filename || 
+              @container.container_dir + "/.ssh/authorized_keys"
+
+            # override for testing
+            user = Etc.getpwnam('root')
+            @owner = user.uid # root
+            begin
+              @group = Etc.getpwnam(@username).gid
+            rescue ArgumentError => e
+              @group = @@default_group
+            end
+            @mode = @@default_mode
+
+            @lockfile = "/var/lock/oo-modify-ssh-keys.#{@username}"
+          end
+          
+          def authorized_keys
+            modify
+          end
+
+          #
+          # Bodies from environment.rb globals
+          #
+          # Public: Append an SSH key to a users authorized_keys file
+          #
+          # key_string - The String value of the ssh key.
+          # key_type - The String value of the key type ssh-(rsa|dss)).
+          # comment - The String value of the comment to append to the key.
+          #
+          # Examples
+          #
+          #   add_ssh_key('AAAAB3NzaC1yc2EAAAADAQABAAABAQDE0DfenPIHn5Bq/...',
+          #               'ssh-rsa',
+          #               'example@example.com')
+          #   # => nil
+          #
+          # Returns nil on Success or raises on Failure
+          def add_key(key_string, key_type=nil, comment=nil)
+            comment = "" unless comment
+
+            modify do |keys|
+              keys[key_id(comment)] = key_entry(key_string, key_type, comment)
+            end
+
+          end
+
+          # Public: Remove an SSH key from a users authorized_keys file
+          #
+          # key_string - The String value of the ssh key.
+          # key_type - The String value of the key type ssh-(rsa|dss)).
+          # comment - The String value of the comment to append to the key.
+          #
+          # Examples
+          #
+          #   remove_ssh_key('AAAAB3NzaC1yc2EAAAADAQABAAABAQDE0DfenPIHn5Bq/...',
+          #                  'ssh-rsa',
+          #                  'example@example.com')
+          #   # => nil
+          #
+          # Returns nil on Success or raises on Failure
+          #
+          def remove_key(key_string, key_type=nil, comment=nil)
+            modify do |keys|
+              if comment
+                keys.delete_if{ |k, v| v.end_with?(key_id(comment)) }
+              else
+                keys.delete_if{ |k,v| v.include?(key_string) }
+              end
+            end
+          end
+
+          # Public: Replace all of the SSH authorized_keys file entries
+          #
+          # new_keys - an Array of Hashes, each containing
+          #    key => String,
+          #    type => String
+          #    comment => String
+          #
+          # Examples:
+          #   k = [
+          #       {'key' => 'AAA...', 
+          #        'type' => 'ssh-rsa', 
+          #        'comment' => 'String'
+          #       },
+          #       {'key' => 'bar...',
+          #        'type' => 'ssh-rsa',
+          #        'comment' => 'more'
+          #       },
+          #       {'key' => 'AAA...', 
+          #        'type' => 'ssh-rsa',
+          #        'comment' => 'String'},
+          #       ]
+          #   replace_keys(k)
+          # 
+          # Returns: nil on Success
+          # 
+          def replace_keys(new_keys)
+
+            modify do |keys|
+              # remove all keys
+              keys.delete_if{ |k, v| true }
+
+              # add the new keys in
+              new_keys.each do |key|
+                id = key_id(key['comment'])
+                entry = key_entry(key['key'], key['type'], key['comment'])
+                keys[id] = entry
+              end
+            end
+      
+            # set/reset the SELinux context for the .ssh directory
+            ssh_dir = PathUtils.join(@container.container_dir, "/.ssh")
+            cmd = "restorecon -R #{ssh_dir}"
+            ::OpenShift::Runtime::Utils::oo_spawn(cmd)
+
+          end
+
+          private
+
+          # validate the ssh keys to check for the required attributes
+          #
+          # ssh_keys must be an array
+          # ssh_keys[n] must be a hash
+          # ssh_keys[n]['key'] must be a non-empty string
+          # ssh_keys[n]['type'] must be a non-empty string
+          # ssh_keys[n]['comment'] must be nil or a non-empty string
+          #
+          def validate_keys(ssh_keys)
+            return false unless ssh_keys.is_a? Array
+            ssh_keys.each do |entry|
+              return false if entry.nil?
+              return false if not 
+                (entry['key'].is_a? String and entry['key'].length > 0)
+              return false if not
+                (entry['type'].is_a? String and entry['type'].length > 0)
+              return false if not
+                (entry['comment'].nil? or 
+                (entry['comment'].is_a? String and entry['comment'].length > 0))
+            end
+            true
+          end
+
+          # This version does exactly the same as the previous one but uses
+          # only lazy-evaluation boolean logic and map-reduce to collect
+          # the value for each entry
+          def clever_validate_keys(ssh_keys)
+            ssh_keys.is_a? Array and
+            # check each entry
+            ssh_keys.map { |entry|
+              not entry.nil? and
+              entry['key'].is_a? String and entry['key'].length > 0 and
+              entry['type'].is_a? String and entry['type'].length > 0 and
+              (entry['comment'].nil? or 
+               (entry['comment'].is_a? String and entry['comment'].length > 0))
+            # any false results invalidates the whole set
+            }.reduce(:&)
+          end
+
+          # This value is used both as a lookup id for add/remove operations
+          # and as the actual comment field of the authorized key line
+          def key_id(comment)
+            "OPENSHIFT-#{@container.uuid}-#{comment}"
+          end
+
+          # Create a single SSH Authorized keys entry
+          def key_entry(key_string, key_type, comment)
+            shell       = @container.container_plugin.gear_shell || "/bin/bash"
+            command   = "command=\"#{shell}\",no-X11-forwarding"
+            [command, key_type, key_string, key_id(comment)].join(' ')
+          end
+
+          # private: Modify ssh authorized_keys file
+          #
+          # @yields [Hash] authorized keys with the comment field as the key which will save if modified.
+          # @return [Hash] authorized keys with the comment field as the key
+          # private: Modify ssh authorized_keys file
+          #
+          # @yields [Hash] authorized keys with the comment field as the key which will save if modified.
+          # @return [Hash] authorized keys with the comment field as the key
+          def modify
+            authorized_keys_file = @filename
+            keys = Hash.new
+
+            @@mutex.synchronize do
+              File.open(@lockfile, File::RDWR|File::CREAT|File::TRUNC, 0600) do | lock |
+                lock.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+                lock.flock(File::LOCK_EX)
+                begin
+                  File.open(authorized_keys_file, File::RDWR|File::CREAT, @mode) do |file|
+                    file.each_line do |line|
+                      begin
+                        keys[line.split[-1].chomp] = line.chomp
+                      rescue
+                      end
+                    end
+
+                    if block_given?
+                      old_keys = keys.clone
+
+                      yield keys
+
+                      if old_keys != keys
+                        file.seek(0, IO::SEEK_SET)
+                        file.write(keys.values.join("\n")+"\n")
+                        file.truncate(file.tell)
+                      end
+                    end
+                    file.close
+                  end
+                  @container.set_ro_permission(authorized_keys_file)
+                  ::OpenShift::Runtime::Utils::oo_spawn("restorecon #{authorized_keys_file}")
+                ensure
+                  lock.flock(File::LOCK_UN)
+                end
+              end
+            end
+            keys
+          end # modify()
+
+        end # AuthorizedKeysFile
+
+      end # SecureShell
+    end # ApplicationContainerExt
+  end # RunTime
+end # OpenShift

--- a/node/misc/bin/oo-devel-node
+++ b/node/misc/bin/oo-devel-node
@@ -206,7 +206,7 @@ command :'authorized-ssh-key-add' do |c|
   c.option '-T', '--with-ssh-key-type TYPE', 'User provided ssh type'
   c.option '-m', '--with-ssh-key-comment COMMENT', 'User provided ssh comment'
   c.action do |args, options|
-    if  options.with_ssh_key && options.with_ssh_key_type && options.with_ssh_key_comment
+    if  options.with_ssh_key && options.with_ssh_key_type
       container = new_container(options.with_container_uuid, c)
       execute {
         container.add_ssh_key(options.with_ssh_key,
@@ -221,15 +221,16 @@ end
 
 command :'authorized-ssh-key-remove' do |c|
   c.syntax      = "#{$name} #{c.name} --with-container-uuid UUID \\
-     --with-ssh-key KEY --with-ssh-key-comment COMMENT"
+     --with-ssh-key KEY --with-ssh-key-type TYPE --with-ssh-key-comment COMMENT"
   c.description = 'Removes an authorized ssh key from the application'
 
   c.option '-k', '--with-ssh-key KEY', 'User provided ssh for application'
+  c.option '-T', '--with-ssh-key-type TYPE', 'User provided ssh type'
   c.option '-m', '--with-ssh-key-comment COMMENT', 'User provided ssh comment'
   c.action do |args, options|
-    if  options.with_ssh_key && options.with_ssh_key_comment
+    if  options.with_ssh_key && options.with_ssh_key_type
       container = new_container(options.with_container_uuid, c)
-      execute { container.remove_ssh_key(options.with_ssh_key, options.with_ssh_key_comment) }
+      execute { container.remove_ssh_key(options.with_ssh_key, options.with_ssh_key_type, options.with_ssh_key_comment) }
     else
       usage(c.syntax)
     end

--- a/node/test/unit/data/k5login_test_modify_read
+++ b/node/test/unit/data/k5login_test_modify_read
@@ -1,0 +1,20 @@
+# id: testuser1
+principal1@EXAMPLE.COM
+
+# id: testuser4
+#       id:    testuser5    
+# id: testuser6   
+#id:testuser7
+principal2@EXAMPLE.COM
+
+# comments that don't matter
+# spaces that don't matter
+
+# the next principal is un-owned
+
+notowned@EXAMPLE.COM
+
+# id: testuser2
+# id: testuser4
+# id: testuser6
+principal3@EXAMPLE.COM

--- a/node/test/unit/data/krb5.conf-k5login_directory
+++ b/node/test/unit/data/krb5.conf-k5login_directory
@@ -1,0 +1,1 @@
+k5login_directory = /random/location

--- a/node/test/unit/data/ssh_authorized_keys_init
+++ b/node/test/unit/data/ssh_authorized_keys_init
@@ -1,0 +1,5 @@
+command="/bin/false",no-X11-fowarding ssh-rsa aabbccddeeffgg0011223344556677889900 OPENSHIFT-testuser1-keyid1
+command="/bin/false",no-X11-fowarding ssh-rsa aabbccddeeffgg0011223344556677889900 OPENSHIFT-testuser1-keyid2
+command="/bin/false",no-X11-fowarding ssh-rsa aabbccddeeffgg0011223344556677889900 OPENSHIFT-testuser1-keyid3
+command="/bin/false",no-X11-fowarding ssh-rsa 0011223344556677889900aabbccddeeffgg OPENSHIFT-testuser1-keyid4
+command="/bin/false",no-X11-fowarding ssh-rsa 0011223344556677889900aabbccddeeffgg OPENSHIFT-testuser1-keyid5

--- a/node/test/unit/kerberos.rb
+++ b/node/test/unit/kerberos.rb
@@ -1,0 +1,595 @@
+# Test the OpenShift::ApplicationContainer::Kerberos module
+#
+#
+require 'test/unit'
+require 'mocha/setup'
+
+require 'parseconfig'
+require 'tempfile'
+
+require 'openshift-origin-node/model/application_container_ext/kerberos'
+
+include OpenShift::Runtime::ApplicationContainerExt::Kerberos
+
+module OpenShift
+  module Runtime
+    module Utils
+
+      # used to set the SELinux context of the k5login file
+      # stub for testing
+      def self.oo_spawn(command)
+        # noop
+        #puts "called oo_spawn with command #{command}"
+      end
+    end
+  end
+end
+
+#
+# The K5login class depends on the ApplicationContainer instance passed in
+# Specifically it uses the uuid and container_dir attributes
+#
+#class OpenShift::Runtime::ApplicationContainer
+class Container
+
+  attr_reader :uuid, :container_dir
+
+  def initialize(uuid, container_dir)
+    @uuid = uuid
+    @container_dir = container_dir
+  end
+
+end
+
+class TestK5login < Test::Unit::TestCase
+
+  # Test object initialization with default values
+  #
+  def setup
+    @initfile = File.expand_path "test/unit/data/k5login_test_modify_read"
+
+    @username = 'aabbccddeeff00112233445566778899'
+    @homedir = '/home/' + @username
+    @container = Container.new(@username, @homedir)
+
+  end
+
+  # Verify that object initialization produces the correct values for defaults
+  #  
+  def test_initialize_default
+
+    k = K5login.new(@container)
+
+    # All explicit 
+    assert_same(@container, k.container, "K5login container not set correctly")
+    assert_equal(@username, k.username, "K5login username not set correctly")
+    assert_equal('/etc/krb5.conf', k.config_file, 
+                 "K5login configuration file not defaulted correctly")
+    assert_equal(@homedir + "/.k5login", k.filename,
+                 "K5login principal file name not defaulted correctly")
+
+  end
+
+  # Test object initialization with explicit values
+  #
+  def test_initialize_explicit
+    
+    config_file = File.expand_path "test/unit/data/krb5.conf"
+    filename = File.expand_path "test/unit/tmp/test_k5login"
+
+    k = K5login.new(@container, config_file, filename)
+    k.owner = nil
+    k.group = nil
+    k.mode = nil
+
+    assert_same(@container, k.container, "K5login container not set correctly")
+    assert_equal(@username, k.username, "K5login username not set correctly")
+    assert_equal(config_file, k.config_file, 
+                 "K5login configuration file not set correctly")
+    assert_equal(filename, k.filename,
+                 "K5login principal file name not set correctly")
+
+  end
+
+  # Test object initialization with a config file
+  #
+  # Three cases:
+  #   Config file does not exist: return to defaults
+  #   Config file exists, k5login_directory not set: return to defaults
+  #   Config file exists, k5login_directory set: append username to path
+  # 
+  def test_init_config_file
+
+    nonexistent = "/no/such/file"
+    exists_unset = "/dev/null"
+    exists_set = File.expand_path "test/unit/data/krb5.conf-k5login_directory"
+
+    k_no_conf = K5login.new(@container, nonexistent)
+    assert_equal(@homedir + "/.k5login", k_no_conf.filename,
+      "K5login principal file name not set correctly: krb5.conf does not exist")
+
+    k_unset = K5login.new(@container, exists_unset)
+    assert_equal(@homedir + "/.k5login", k_unset.filename,
+      "K5login principal file name not set correctly: krb5.conf exists")
+
+    k_set = K5login.new(@container, exists_set)
+    assert_equal("/random/location/" + @username, k_set.filename,
+      "K5login principal file name not set correctly: krb5.conf override")
+    
+  end
+  
+  # Verify that the k5login_file method produces correct results
+  #
+  # This is almost, but not quite identical to the initialization test above
+  #
+  def test_k5login_file
+
+    nonexistent = "/no/such/file"
+    exists_unset = "/dev/null"
+    exists_set = File.expand_path "test/unit/data/krb5.conf-k5login_directory"
+
+    k_no_conf = K5login.new(@container, nonexistent)
+    assert_equal(@homedir + "/.k5login", k_no_conf.k5login_file,
+      "K5login principal file name not produced: krb5.conf does not exist")
+
+    k_unset = K5login.new(@container, exists_unset)
+    assert_equal(@homedir + "/.k5login", k_unset.k5login_file,
+      "K5login principal file name not produced: krb5.conf exists")
+
+    k_set = K5login.new(@container, exists_set)
+    assert_equal("/random/location/" + @username, k_set.k5login_file,
+      "K5login principal file name not produced: krb5.conf override")
+    
+  end
+
+  #
+  #
+  #
+  def test_add_principal_first
+
+    lockfile = Tempfile.new ["openshift-origin-node-test-kerberos-", "-lock"]
+
+    new_file = Tempfile.new ["openshift-origin-node-test-kerberos-", "-k5login"]
+    new_filename = new_file.path
+    # Tempfile creates the file but modify must do it
+    File.delete new_filename
+
+    # K5login.modify calls Etc.getpwname to set ownership. usually root
+    Etc.stubs(:getpwnam).returns(Struct::Passwd.new)
+
+    begin
+      assert((not File.exists?(new_filename)), "file exists before first access: #{new_filename}")
+
+      k_first = K5login.new(@container, nil, new_filename)
+      k_first.lockfile = lockfile.path
+
+      k_first.add_principal "testuser1@EXAMPLE.COM", "id1"
+
+      assert(File.exists?(new_filename), "add_principal did not create file #{new_filename}")
+
+      lines = open(new_filename) {|f| f.readlines }
+
+      assert_equal("# id: id1\n", lines[0], "invalid id line")
+      assert_equal("testuser1@EXAMPLE.COM\n", lines[1], "invalid principal line")
+    ensure
+      lockfile.delete
+      new_file.delete
+    end
+  end
+
+
+  def test_add_principal_new_id
+    
+    Etc.stubs(:getpwnam).with(@username).returns(Struct::Passwd.new)
+    Etc.stubs(:getpwnam).with('root').returns(Struct::Passwd.new)
+
+    lockfile = Tempfile.new(["node-test-kerberos-", "-new_id-lock"])
+    new_file = Tempfile.new(['node-test-kerberos-', '-new_id-k5login'])
+    new_filename = new_file.path
+
+    new_principal = 'newprincipal1@EXAMPLE.COM'
+    new_id = 'newid1'
+
+    begin
+      FileUtils.copy_file(@initfile, new_filename)
+
+      k_add = K5login.new(@container, nil, new_filename)
+      k_add.lockfile = lockfile.path
+
+      k_add.add_principal new_principal, new_id
+
+      assert(k_add.principals.member? new_principal)
+      assert_equal(1, k_add.principals[new_principal].length,
+                   "failed to add new principal #{new_principal}\n" +
+                   "-- ids = #{k_add.principals[new_principal].to_a.to_s}")
+
+      k_add.add_principal new_principal, 'newid2'
+
+      assert(k_add.principals.member? new_principal)
+      assert_equal(2, k_add.principals[new_principal].length,
+                   "failed to add new id to #{new_principal}\n" +
+                   "-- new id: newid2\n" +
+                   "-- ids = #{k_add.principals[new_principal].to_a.to_s}")
+      assert_equal(2, k_add.principals[new_principal].length,
+                   "failed to find two ids\n" +
+                   "-- #{k_add.principals[new_principal].to_a.to_s}")
+     
+      k_check = K5login.new(@container, nil, new_filename)
+      k_check.lockfile = lockfile.path
+
+      # verify that new object reads the same as the old one
+      assert(k_check.principals.member? new_principal)
+      assert_equal(2, k_check.principals[new_principal].length,
+                   "failed to find two ids\n" +
+                   "-- #{k_add.principals[new_principal].to_a.to_s}")
+    ensure
+      new_file.delete
+      lockfile.delete
+    end
+  end
+
+  def test_remove_principal_old_id
+    
+    lockfile = Tempfile.new(["node-test-kerberos-", "-rm_id-lock"])
+    old_file = Tempfile.new(['node-test-kerberos-', '-rm_id-k5login'])
+    old_filename = old_file.path
+
+    #old_principal = 'rmprincipal1@EXAMPLE.COM'
+    #old_id = 'rmid1'
+    old_principal = 'principal3@EXAMPLE.COM'
+    old_id = 'testuser4'
+
+    # K5login.modify calls Etc.getpwname to set ownership. usually root
+    Etc.stubs(:getpwnam).returns(Struct::Passwd.new)
+
+    begin
+      FileUtils.copy_file(@initfile, old_filename)
+
+      k_rm = K5login.new(@container, nil, old_filename)
+      k_rm.lockfile = lockfile.path
+
+      assert(k_rm.principals.member?(old_principal), 
+             "unchanged file does not contain principal #{old_principal}")
+
+      k_rm.remove_principal old_principal, old_id
+
+      assert(k_rm.principals.member? old_principal)
+      assert_equal(2, k_rm.principals[old_principal].length,
+                   "failed to remove old principal id #{old_principal} #{old_id}\n" +
+                   "-- ids = #{k_rm.principals[old_principal].to_a.to_s}")
+
+      assert_equal(Set.new(['testuser2', 'testuser6']),
+                   k_rm.principals[old_principal], 
+                   "incorrect remaining ids")
+      k_rm.remove_principal old_principal, 'testuser2'
+      k_rm.remove_principal old_principal, 'testuser6'
+
+      assert(not(k_rm.principals.member?old_principal))
+     
+      k_check = K5login.new(@container, nil, old_filename)
+      k_check.lockfile = lockfile.path
+
+      # verify that new object reads the same as the old one
+      assert(not(k_check.principals.member?(old_principal)))
+
+    ensure
+      old_file.delete
+      lockfile.delete
+    end
+  end
+
+  # Add a principal with no ID
+  # Then add the same principal with an ID
+  # 
+  def test_add_principal_nil_id
+    lockfile = Tempfile.new(["node-test-kerberos-", "-new_id-lock"])
+    new_file = Tempfile.new(['node-test-kerberos-', '-new_id-k5login'])
+    new_filename = new_file.path
+
+    new_principal = 'newprincipal1@EXAMPLE.COM'
+    new_id = 'newid1'
+
+    # K5login.modify calls Etc.getpwname to set ownership. usually root
+    Etc.stubs(:getpwnam).returns(Struct::Passwd.new)
+
+    begin
+      # 'touch' the test file
+      open(new_filename, 'w') { |f| f.write '# id: dummy\ndummy@EXAMPLE.COM\n' }
+
+      k_add = K5login.new(@container, nil, new_filename)
+      k_add.lockfile = lockfile.path
+
+      # Add a principal with nil id
+      k_add.add_principal new_principal, nil
+
+      assert(k_add.principals.member? new_principal)
+      assert_equal(1, k_add.principals[new_principal].length,
+                   "failed to add new principal #{new_principal} with nil id\n" +
+                   "-- ids = #{k_add.principals[new_principal].to_a.to_s}")
+
+      k_add.add_principal new_principal, 'newid2'
+
+      assert(k_add.principals.member? new_principal)
+      assert_equal(2, k_add.principals[new_principal].length,
+                   "failed to add new id to #{new_principal}\n" +
+                   "-- new id: newid2\n" +
+                   "-- ids = #{k_add.principals[new_principal].to_a.to_s}")
+     
+      k_check = K5login.new(@container, nil, new_filename)
+      k_check.lockfile = lockfile.path
+
+      # verify that new object reads the same as the old one
+      assert(k_check.principals.member? new_principal)
+      assert_equal(2, k_check.principals[new_principal].length,
+                   "failed to find one ids\n" +
+                   "-- #{k_add.principals[new_principal].to_a.to_s}")
+    ensure
+      new_file.delete
+      lockfile.delete
+    end
+
+  end
+
+  def test_remove_principal_nil_id
+
+    # write a file with a single principal/id
+
+    # remove the principal/id
+
+    # the k5login file should have been removed completely
+
+    lockfile = Tempfile.new(["node-test-kerberos-", "-rm_last-lock"])
+    old_file = Tempfile.new(['node-test-kerberos-', '-rm_last-k5login'])
+
+    # K5login.modify calls Etc.getpwname to set ownership. usually root
+    Etc.stubs(:getpwnam).returns(Struct::Passwd.new)
+
+    nilid1 = "nilid1@EXAMPLE.COM"
+    nilid2 = "nilid2@EXAMPLE.COM"
+
+    begin
+      # create two entries to be removed
+      # One has no id strings at all
+      # The other has a single ID entry with no content
+      # Both should be removed
+      open old_file.path, "w" do |f| 
+        f.write "#{nilid1}\n\n# id: \n#{nilid2}" 
+      end
+
+      k_rm = K5login.new(@container, nil, old_file.path)
+      k_rm.lockfile = lockfile.path
+
+      k_rm.remove_principal nilid1
+
+      assert(not(k_rm.principals.member?(nilid1)), 
+             "unchanged file does not contain principal #{nilid1}")
+
+      k_rm.remove_principal nilid2
+
+      assert(not(File.exists?(old_file.path)))
+
+    ensure
+      old_file.delete
+      lockfile.delete
+    end
+  end
+
+  # principals which have been placed originally with no id must be
+  # preserved when the last id is removed.
+  # This means the knowledge that the principal has a "null id" instance
+  # must be preserved even when other ids are added and removed.
+  #
+  # When a principal has only a null id, then no id: lines will be present
+  # If a principal has both a null id and OpenShift managed ids, the null id
+  # will be represented as an empty string '' in the id set.
+  #
+  # work with the "notowned@EXAMPLE.COM" principal in the sample_text
+  #
+  def test_preserve_null_id
+    
+    lockfile = Tempfile.new(["node-test-kerberos-", "-nullid-lock"])
+    k5login_file = Tempfile.new(['node-test-kerberos-', '-nullid-k5login'])
+
+    test_principal = 'notowned@EXAMPLE.COM'
+
+    # K5login.modify calls Etc.getpwname to set ownership. usually root
+    Etc.stubs(:getpwnam).returns(Struct::Passwd.new)
+
+    begin
+      # create the file to be removed
+      open k5login_file.path, "w" do |f| 
+        f.write @@k5login_sample_text
+      end
+
+      # create the k5login management object
+      # check that principal exists and indicates null id
+      k_preserve = K5login.new(@container, nil, k5login_file.path)
+      k_preserve.lockfile = lockfile.path
+
+      assert(k_preserve.principals.member? test_principal)
+
+      principal_ids = k_preserve.principals[test_principal]
+
+      # add an id
+      k_preserve.add_principal test_principal, 'id1'
+      
+      # check that principal retains null id
+      assert(k_preserve.principals[test_principal].member?(nil),
+             "nil id disappeared when new id added to principal"
+             )
+
+      # remove the new id
+      k_preserve.remove_principal test_principal, 'id1'
+
+      # check that principal still exists and indicates null id
+      assert(k_preserve.principals.member?(test_principal),
+             "principal removed when nil id remained"
+             )
+      assert(k_preserve.principals[test_principal].member?(nil),
+             "nil id disappeared when new id removed from principal"
+             )
+
+    ensure
+      k5login_file.close
+      k5login_file.delete
+      lockfile.close
+      lockfile.delete
+    end
+
+  end
+
+  def test_replace_principals
+
+
+    lockfile = Tempfile.new(["node-test-kerberos-", "-replace-lock"])
+    k5login_file = Tempfile.new(['node-test-kerberos-', '-replace-k5login'])
+    k5login_filename = k5login_file.path
+
+    # K5login.modify calls Etc.getpwname to set ownership. usually root
+    Etc.stubs(:getpwnam).returns(Struct::Passwd.new)
+
+    begin
+      # create the file to be removed
+      open k5login_filename, "w" do |f| 
+        f.write @@k5login_sample_text
+      end
+
+      k_replace = K5login.new(@container, nil, k5login_filename)
+      k_replace.lockfile = lockfile.path
+
+
+      k_replace.replace_principals @@k5login_replace_principals_input
+
+      assert_equal(Set.new(['replace1@EXAMPLE.COM',
+                            'replace2@EXAMPLE.COM',
+                            'replace3@EXAMPLE.COM']), 
+                   Set.new(k_replace.principals.keys),
+                   'key set does not match')
+
+      assert_equal(Set.new(['replaceid1', 'replaceid2', 
+                            'replaceid3', 'replaceid4']),
+                   k_replace.principals['replace1@EXAMPLE.COM'],
+                   'id set for key replace1@EXAMPLE.COM does not match')
+
+      assert_equal(Set.new(['replaceid2']),
+                   k_replace.principals['replace2@EXAMPLE.COM'],
+                   'id set for key replace2@EXAMPLE.COM does not match')
+
+      assert_equal(Set.new([nil]),
+                   k_replace.principals['replace3@EXAMPLE.COM'],
+                   'id set for key replace3@EXAMPLE.COM does not match')
+    ensure
+      k5login_file.delete
+      lockfile.delete
+    end
+
+  end
+
+  #
+  # Verify that the k5login file can be read and produces the expected
+  # data structure
+  #
+  def test_modify_read
+
+    k5_test = K5login.new(@container, nil, @initfile)
+    assert_equal(@initfile, k5_test.filename,
+      "K5login principal file name incorrectly set")
+
+    # place the lock file someplace sure to exist for now
+    lockfile = 
+      Tempfile.new(['openshift-origin-node-test', 'kerberos-modify-read'])
+    begin
+
+      k5_test.lockfile = lockfile.path
+      a = k5_test.principals
+
+      assert_equal(@@k5login_sample_principals, a)
+
+    ensure
+      # don't leave trash around
+      lockfile.delete
+    end
+  end
+
+  #
+  # Verify that the k5login file can be read and produces the expected
+  # data structure
+  #
+  def test_modify_write
+
+    k5_tempfile = Tempfile.new(['openshift-origin-node-test-', '-k5login'])
+    # place the lock file someplace sure to exist for now
+    lockfile = 
+      Tempfile.new(['openshift-origin-node-test', 'kerberos-modify-read'])
+
+    FileUtils.copy_file(@initfile, k5_tempfile)
+
+    # K5login.modify calls Etc.getpwname to set ownership. usually root
+    Etc.stubs(:getpwnam).returns(Struct::Passwd.new)
+
+    begin
+
+      k5_test = K5login.new(@container, nil, k5_tempfile)
+
+      k5_test.lockfile = lockfile.path
+      a = k5_test.principals
+
+      assert_equal(@@k5login_sample_principals, a)
+
+    ensure
+      # don't leave trash around
+      lockfile.delete
+      k5_tempfile.delete
+    end
+  end
+
+  @@k5login_sample_principals = {
+    "principal1@EXAMPLE.COM" => Set.new(["testuser1"]), 
+    "principal2@EXAMPLE.COM" => 
+      Set.new(["testuser4", "testuser5", "testuser6", "testuser7"]),
+    "# comments that don't matter" => Set.new,
+    "# spaces that don't matter" => Set.new,
+    "# the next principal is un-owned" => Set.new,
+    "notowned@EXAMPLE.COM" => Set.new([nil]),
+    "principal3@EXAMPLE.COM"=> Set.new(["testuser2", "testuser4", "testuser6"])
+  }
+
+  # type is irrelevent here: krb5-principal
+  @@k5login_replace_principals_input = 
+    [
+     { 'key' => 'replace1@EXAMPLE.COM', 'comment' => 'replaceid1' },
+     { 'key' => 'replace1@EXAMPLE.COM', 'comment' => 'replaceid2' },
+     { 'key' => 'replace1@EXAMPLE.COM', 'comment' => 'replaceid3' },
+     { 'key' => 'replace2@EXAMPLE.COM', 'comment' => 'replaceid2' },
+     { 'key' => 'replace1@EXAMPLE.COM', 'comment' => 'replaceid4' },
+     { 'key' => 'replace3@EXAMPLE.COM', 'comment' => nil },
+    ]
+  #
+  # This is the contents of a sample k5login file for testing
+  #
+  @@k5login_sample_text = <<EOF
+# id: testuser1
+principal1@EXAMPLE.COM
+
+# id: testuser4
+#       id:    testuser5    
+# id: testuser6   
+principal2@EXAMPLE.COM
+
+# comments that don't matter
+
+# spaces that don't matter
+
+# the next principal is un-owned
+
+notowned@EXAMPLE.COM
+
+# id: testuser2
+# id: testuser4
+# id: testuser6
+principal3@EXAMPLE.COM
+EOF
+
+end
+
+

--- a/node/test/unit/ssh_authorized_keys.rb
+++ b/node/test/unit/ssh_authorized_keys.rb
@@ -1,0 +1,689 @@
+#!/usr/bin/ruby
+#
+# Test the SecureShell::AuthorizedKeysFile
+#
+#
+require 'test/unit'
+require 'mocha/setup'
+
+require 'tempfile'
+require 'fileutils'
+
+require 'openshift-origin-node/model/application_container_ext/ssh_authorized_keys'
+
+include OpenShift::Runtime::ApplicationContainerExt::SecureShell
+
+module OpenShift::Runtime::Utils
+  # used to set the SELinux context of the k5login file
+  # stub for testing
+  def self.oo_spawn(command)
+    # noop
+    #puts "called oo_spawn with command #{command}"
+  end
+end
+
+module PathUtils
+  def self.join(string, *smth)
+    File.join(string, smth)
+  end
+end
+
+#
+# The AuthorizedKeys class depends on the ApplicationContainer instance
+# Specifically it uses the uuid and container_dir attributes
+#
+# This should be mocked properly MAL 20131017
+#
+#class OpenShift::Runtime::ApplicationContainer
+class Container
+
+  attr_reader :uuid, :container_dir, :container_plugin
+
+  def initialize(uuid, container_dir, container_plugin = nil)
+    @uuid = uuid
+    @container_dir = container_dir
+    # let container_plugin.gear_shell default if not provided
+    if container_plugin
+      @container_plugin = container_plugin
+    else
+      @container_plugin = Object.new
+      def @container_plugin.gear_shell
+        "/bin/bash"
+      end
+    end
+  end
+
+  def set_ro_permission(filename)
+
+  end
+
+end
+
+#OpenShift::Runtime::ApplicationContainerExt::SecureShell::K5login
+module OpenShift
+  module Runtime
+    class ApplicationContainer
+
+      attr_reader :uuid, :container_dir, :container_plugin
+      def initialize
+
+      end
+
+      def set_ro_permission(authorized_keys_file)
+
+      end
+
+    end
+
+    module ApplicationContainerExt
+    end
+
+  end
+end
+
+class TestAuthorizedKeysFile < Test::Unit::TestCase
+
+  # Define the location of an initial input file and
+  # the default test values
+  def setup
+    @initfile = File.expand_path "test/unit/data/ssh_authorized_keys_init"
+    @username = 'aabbccddeeff00112233445566778899'
+    @homedir = '/home/' + @username
+    @container = Container.new(@username, @homedir)
+  end
+
+  # Verify that new AuthorizedKeysFile objects are initialized correctly
+  #
+  def test_initialize_default
+    keyfile = AuthorizedKeysFile.new(@container)
+    assert_same(@container, keyfile.container, 
+                'AuthorizedKeysFile container not set correctly')
+    assert_equal(@username, keyfile.username, 
+                 'AuthorizedKeysFile username not set correctly')
+    assert_equal(@homedir + "/.ssh/authorized_keys", keyfile.filename, 
+                 'AuthorizedKeysFile filename not set correctly')
+    assert_equal('/bin/bash', @container.container_plugin.gear_shell, 
+                 'AuthorizedKeysFile container shell not set correctly')
+  end
+
+  def test_initialize_explicit
+    filename = File.expand_path "test/unit/tmp/test_authorized_keys"
+
+    keyfile = AuthorizedKeysFile.new(@container, filename)
+    keyfile.owner = nil
+    keyfile.group = nil
+    keyfile.mode = nil
+
+    assert_same(@container, keyfile.container, 
+                'AuthorizedKeysFile container not set correctly')
+    assert_equal(@username, keyfile.username, 
+                 'AuthorizedKeysFile username not set correctly')
+    assert_equal(filename, keyfile.filename, 
+                 'AuthorizedKeysFile filename not set correctly')
+    assert_equal('/bin/bash', @container.container_plugin.gear_shell, 
+                 'AuthorizedKeysFile container shell not set correctly')
+    
+  end
+
+  def test_authorized_keys_read
+    # define the temporary file locations
+    lockfile = Tempfile.new ['openshift-origin-node-test-authkey-', '-lock']
+    keyfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-',
+                            '-keyfile']
+
+    keyfile_name = keyfile.path
+
+    begin 
+      FileUtils.copy @initfile, keyfile_name
+
+      # initialize the authorized keys file
+
+      # create the AuthorizedKeysFile object
+      auth_keys = AuthorizedKeysFile.new(@container, keyfile_name)
+      auth_keys.lockfile = lockfile
+      auth_keys.owner = nil
+      auth_keys.group = nil
+      auth_keys.mode = nil
+
+      # pick three relatively at random
+      assert_equal("command=\"/bin/false\",no-X11-fowarding ssh-rsa aabbccddeeffgg0011223344556677889900 OPENSHIFT-testuser1-keyid1",
+                   auth_keys.authorized_keys['OPENSHIFT-testuser1-keyid1'])
+
+      assert_equal('command="/bin/false",no-X11-fowarding ssh-rsa aabbccddeeffgg0011223344556677889900 OPENSHIFT-testuser1-keyid2',
+                   auth_keys.authorized_keys['OPENSHIFT-testuser1-keyid2'])
+
+      assert_equal('command="/bin/false",no-X11-fowarding ssh-rsa 0011223344556677889900aabbccddeeffgg OPENSHIFT-testuser1-keyid5',
+                   auth_keys.authorized_keys['OPENSHIFT-testuser1-keyid5'])
+
+    ensure
+      lockfile.delete
+      keyfile.delete
+    end
+  end
+
+  def test_add_key_first
+
+    # define where the lock and authorized keys file will go
+    # define the temporary file locations
+    lockfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-firstkey',
+                             '-lock']
+    keyfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-firstkey',
+                            '-keyfile']
+
+    new_key = {
+      'key' => "testkey",
+      'type' => 'ssh-rsa',
+      'id' => 'id1'
+    }
+    
+    key_entry_sample = 
+      'command="/bin/bash",no-X11-forwarding ssh-rsa testkey OPENSHIFT-aabbccddeeff00112233445566778899-id1'
+
+    # Ensure the file does not exist before adding the first entry
+    File.delete keyfile.path
+
+    begin
+      auth_keys = AuthorizedKeysFile.new(@container, keyfile.path)
+      auth_keys.lockfile = lockfile
+      auth_keys.owner = nil
+      auth_keys.group = nil
+      auth_keys.mode = nil
+
+      # a sample key for input
+
+      auth_keys.add_key(new_key['key'], new_key['type'], new_key['id'])
+
+      assert(File.exists?(keyfile.path), 
+             "key file does not exist after add: #{keyfile.path}")
+
+      assert_equal(101, File.size(keyfile.path))
+
+      open(keyfile.path) {|f|
+        lines = f.readlines.map {|l| l.strip }
+        assert_equal(1, lines.length,
+                     "incorrect number of entries after one add")
+        assert_equal(100, lines[0].length,
+                     "incorrect number of characters in key entry 0")
+        assert_equal(key_entry_sample, lines[0],
+                     "key entry does not match")
+      }
+    ensure
+      keyfile.delete
+      lockfile.delete
+    end
+  end
+
+  def test_add_key_nil_id
+    # define where the lock and authorized keys file will go
+    # define the temporary file locations
+    lockfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-nilid',
+                             '-lock']
+    keyfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-nilid',
+                            '-keyfile']
+
+    new_key = {
+      'key' => "testkey",
+      'type' => 'ssh-rsa',
+      'id' => nil
+    }
+    
+    key_entry_sample = 
+      'command="/bin/bash",no-X11-forwarding ssh-rsa testkey OPENSHIFT-aabbccddeeff00112233445566778899-'
+
+    # Ensure the file does not exist before adding the first entry
+    File.delete keyfile.path
+
+    begin
+      auth_keys = AuthorizedKeysFile.new(@container, keyfile.path)
+      auth_keys.lockfile = lockfile
+      auth_keys.owner = nil
+      auth_keys.group = nil
+      auth_keys.mode = nil
+
+      # a sample key for input
+
+      auth_keys.add_key(new_key['key'], new_key['type'], new_key['id'])
+
+      assert(File.exists?(keyfile.path), 
+             "key file does not exist after add: #{keyfile.path}")
+
+      assert_equal(98, File.size(keyfile.path))
+
+      open(keyfile.path) {|f|
+        lines = f.readlines.map {|l| l.strip }
+        assert_equal(1, lines.length,
+                     "incorrect number of entries after one add")
+        assert_equal(97, lines[0].length,
+                     "incorrect number of characters in key entry 0")
+        assert_equal(key_entry_sample, lines[0],
+                     "key entry does not match")
+      }
+    ensure
+      keyfile.delete
+      lockfile.delete
+    end
+  end
+
+
+  def test_add_key_new_key
+    # define where the lock and authorized keys file will go
+    # define the temporary file locations
+    lockfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-newkey-',
+                             '-lock']
+    keyfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-newkey-',
+                            '-keyfile']
+
+    new_key = [
+                {
+                  'key' => "testkey1",
+                  'type' => 'ssh-rsa',
+                  'id' => 'id1'
+                },
+                {
+                  'key' => "testkey2",
+                  'type' => 'ssh-rsa',
+                  'id' => 'id2'
+                }
+               ]
+    
+    key_entry_sample = 
+      [
+       'command="/bin/bash",no-X11-forwarding ssh-rsa testkey1 OPENSHIFT-aabbccddeeff00112233445566778899-id1',
+       'command="/bin/bash",no-X11-forwarding ssh-rsa testkey2 OPENSHIFT-aabbccddeeff00112233445566778899-id2'
+      ]
+       
+    # Ensure the file does not exist before adding the first entry
+    File.delete keyfile.path
+
+    begin
+      auth_keys = AuthorizedKeysFile.new(@container, keyfile.path)
+      auth_keys.lockfile = lockfile
+      auth_keys.owner = nil
+      auth_keys.group = nil
+      auth_keys.mode = 0660
+
+      # a sample key for input
+
+      auth_keys.add_key(new_key[0]['key'], new_key[0]['type'], new_key[0]['id'])
+
+      assert(File.exists?(keyfile.path), 
+             "key file does not exist after add: #{keyfile.path}")
+      # Mask in only the standard permissions bits: rwx{3}
+      assert_equal(auth_keys.mode, File::Stat.new(keyfile.path).mode & 0777,
+             "incorrect file mode")
+      assert(File.writable?(keyfile.path),
+             "key file not writable after create: #{keyfile.path}")
+
+      auth_keys.add_key(new_key[1]['key'], new_key[1]['type'], new_key[1]['id'])
+
+      assert_equal(204, File.size(keyfile.path))
+
+      open(keyfile.path) {|f|
+        lines = f.readlines.map {|l| l.strip }
+        assert_equal(2, lines.length,
+                     "incorrect number of entries after one add")
+        assert_equal(101, lines[0].length,
+                     "incorrect number of characters in key entry 0")
+        assert_equal(key_entry_sample[0], lines[0],
+                     "key entry does not match")
+      }
+    ensure
+      keyfile.delete
+      lockfile.delete
+    end
+  end
+
+  def test_add_key_add_id
+
+    # define where the lock and authorized keys file will go
+    # define the temporary file locations
+    lockfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-newkey-',
+                             '-lock']
+    keyfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-newkey-',
+                            '-keyfile']
+
+    new_key = [
+                {
+                  'key' => "testkey1",
+                  'type' => 'ssh-rsa',
+                  'id' => 'id1'
+                },
+                {
+                  'key' => "testkey1",
+                  'type' => 'ssh-rsa',
+                  'id' => 'id2'
+                }
+               ]
+    
+    key_entry_sample = 
+      [
+       'command="/bin/bash",no-X11-forwarding ssh-rsa testkey1 OPENSHIFT-aabbccddeeff00112233445566778899-id1',
+       'command="/bin/bash",no-X11-forwarding ssh-rsa testkey1 OPENSHIFT-aabbccddeeff00112233445566778899-id2'
+      ]
+       
+    # Ensure the file does not exist before adding the first entry
+    File.delete keyfile.path
+
+    begin
+      auth_keys = AuthorizedKeysFile.new(@container, keyfile.path)
+      auth_keys.lockfile = lockfile
+      auth_keys.owner = nil
+      auth_keys.group = nil
+      auth_keys.mode = 0660
+
+      # a sample key for input
+
+      auth_keys.add_key(new_key[0]['key'], new_key[0]['type'], new_key[0]['id'])
+
+      assert(File.exists?(keyfile.path), 
+             "key file does not exist after add: #{keyfile.path}")
+      # Mask in only the standard permissions bits: rwx{3}
+      assert_equal(auth_keys.mode, File::Stat.new(keyfile.path).mode & 0777,
+             "incorrect file mode")
+      assert(File.writable?(keyfile.path),
+             "key file not writable after create: #{keyfile.path}")
+
+      auth_keys.add_key(new_key[1]['key'], new_key[1]['type'], new_key[1]['id'])
+
+      assert_equal(204, File.size(keyfile.path))
+
+      open(keyfile.path) {|f|
+        lines = f.readlines.map {|l| l.strip }
+        assert_equal(2, lines.length,
+                     "incorrect number of entries after one add")
+        assert_equal(101, lines[0].length,
+                     "incorrect number of characters in key entry 0")
+        assert_equal(key_entry_sample[0], lines[0],
+                     "key entry does not match")
+      }
+    ensure
+      keyfile.delete
+      lockfile.delete
+    end
+  end
+
+  def test_remove_key_id
+
+    # define the temporary file locations
+    lockfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-remove',
+                             '-lock']
+    keyfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-remove',
+                            '-keyfile']
+
+    begin 
+      # create a one-line file for replacement
+      open(keyfile.path, 'w') {|f|
+        f.write <<EOF
+command="/bin/false",no-X11-fowarding ssh-rsa aabbccddeeffgg0011223344556677889900 OPENSHIFT-#{@container.uuid}-keyid1
+command="/bin/false",no-X11-fowarding ssh-rsa aabbccddeeffgg0011223344556677889900 OPENSHIFT-#{@container.uuid}-keyid2
+command="/bin/false",no-X11-fowarding ssh-rsa keepccddeeffgg0011223344556677889900 OPENSHIFT-#{@container.uuid}-keyid3
+command="/bin/false",no-X11-fowarding ssh-rsa keepccddeeffgg0011223344556677889900 OPENSHIFT-#{@container.uuid}-keyid4
+EOF
+      }
+      
+      auth_keys = AuthorizedKeysFile.new(@container, keyfile.path)
+      auth_keys.lockfile = lockfile
+      auth_keys.owner = nil
+      auth_keys.group = nil
+      auth_keys.mode = 0660
+
+      assert_equal(4, auth_keys.authorized_keys.length,
+                   "incorrect number of remaining keys before remove")
+
+
+      auth_keys.remove_key('aabbccddeeffgg0011223344556677889900',
+                           'ssh-rsa',
+                           'keyid1')
+      assert_equal(3, auth_keys.authorized_keys.length,
+                   "incorrect number of remaining keys after one remove")
+
+      auth_keys.remove_key('aabbccddeeffgg0011223344556677889900',
+                           'ssh-rsa',
+                           'keyid2')
+
+      assert_equal(2, auth_keys.authorized_keys.length,
+                   "incorrect number of remaining keys after two removes")
+    ensure
+      keyfile.close
+      keyfile.delete
+
+      lockfile.close
+      lockfile.delete
+    end
+      
+  end
+
+  def test_remove_key_nil_id
+
+    # define the temporary file locations
+    lockfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-remove-nil',
+                             '-lock']
+    keyfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-remove-nil',
+                            '-keyfile']
+
+    begin 
+      # create a one-line file for replacement
+      open(keyfile.path, 'w') {|f|
+        f.write <<EOF
+command="/bin/false",no-X11-fowarding ssh-rsa aabbccddeeffgg0011223344556677889900 OPENSHIFT-#{@container.uuid}-keyid1
+command="/bin/false",no-X11-fowarding ssh-rsa aabbccddeeffgg0011223344556677889900
+command="/bin/false",no-X11-fowarding ssh-rsa keepccddeeffgg0011223344556677889900 OPENSHIFT-#{@container.uuid}-keyid3
+command="/bin/false",no-X11-fowarding ssh-rsa keepccddeeffgg0011223344556677889900 OPENSHIFT-#{@container.uuid}-keyid4
+EOF
+      }
+      
+      auth_keys = AuthorizedKeysFile.new(@container, keyfile.path)
+      auth_keys.lockfile = lockfile
+      auth_keys.owner = nil
+      auth_keys.group = nil
+      auth_keys.mode = 0660
+
+      assert_equal(4, auth_keys.authorized_keys.length,
+                   "incorrect number of remaining keys before remove")
+
+      # remove all instances of the key regardless of the id
+      auth_keys.remove_key('aabbccddeeffgg0011223344556677889900',
+                           'ssh-rsa',
+                           nil)
+      assert_equal(2, auth_keys.authorized_keys.length,
+                   "incorrect number of remaining keys after one remove")
+
+    ensure
+      keyfile.close
+      keyfile.delete
+
+      lockfile.close
+      lockfile.delete
+    end
+      
+  end
+
+  def test_remove_key_last_id
+
+    # define the temporary file locations
+    lockfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-remove-last',
+                             '-lock']
+    keyfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-remove-last',
+                            '-keyfile']
+
+    begin 
+      # create a one-line file for replacement
+      open(keyfile.path, 'w') {|f|
+        f.write <<EOF
+command="/bin/false",no-X11-fowarding ssh-rsa aabbccddeeffgg0011223344556677889900 OPENSHIFT-#{@container.uuid}-keyid1
+EOF
+      }
+      
+      auth_keys = AuthorizedKeysFile.new(@container, keyfile.path)
+      auth_keys.lockfile = lockfile
+      auth_keys.owner = nil
+      auth_keys.group = nil
+      auth_keys.mode = 0660
+
+      assert_equal(1, auth_keys.authorized_keys.length,
+                   "incorrect number of remaining keys before remove")
+
+      # remove all instances of the key regardless of the id
+      auth_keys.remove_key('aabbccddeeffgg0011223344556677889900',
+                           'ssh-rsa',
+                           'keyid1')
+      assert_equal(0, auth_keys.authorized_keys.length,
+                   "incorrect number of remaining keys after one remove")
+
+    ensure
+      keyfile.close
+      keyfile.delete
+
+      lockfile.close
+      lockfile.delete
+    end
+      
+
+  end
+
+  def test_replace_keys
+
+    # define the temporary file locations
+    lockfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-replace',
+                             '-lock']
+    keyfile = Tempfile.new ['openshift-origin-node-test-sshauthkey-replace',
+                            '-keyfile']
+
+    keyfile_name = keyfile.path
+
+    begin 
+      # create a one-line file for replacement
+      open(keyfile_name, 'w') {|f|
+        f.write 'command="/bin/false",no-X11-fowarding ssh-rsa aabbccddeeffgg0011223344556677889900 OPENSHIFT-testuser1-keyid1' + "\n"
+      }
+
+      # initialize the authorized keys file
+
+      # create the AuthorizedKeysFile object
+      auth_keys = AuthorizedKeysFile.new(@container, keyfile_name)
+      auth_keys.lockfile = lockfile
+      auth_keys.owner = nil
+      auth_keys.group = nil
+      auth_keys.mode = nil
+
+      new_keys = [
+                 {'key' => 'AAA', 
+                  'type' => 'ssh-rsa', 
+                  'comment' => 'id1'
+                 },
+                 {'key' => 'bar',
+                  'type' => 'ssh-rsa',
+                  'comment' => 'id2'
+                 },
+                 {'key' => 'AAA', 
+                  'type' => 'ssh-rsa',
+                  'comment' => 'id3'}
+                 ]
+    
+      auth_keys.replace_keys(new_keys)
+
+      assert(File.exists? keyfile_name)
+      lines = open(keyfile_name) {|f|
+        f.readlines { |l| l.strip }
+      }
+
+      assert_equal(3, lines.length)
+      
+      # Verify that all lines match format
+      lines.each {|l|
+        assert_match(/^command=\"\/bin\/bash\",no-X11-forwarding ssh-rsa \w+ \w+/,
+                     l)
+      }
+
+      # Verify that all three ids are in the result
+      assert_match(/id1$/, lines[0])
+      assert_match(/id2$/, lines[1])
+      assert_match(/id3$/, lines[2])
+    end
+
+  end
+
+  def test_validate_keys
+
+    a = AuthorizedKeysFile.new(@container)
+    
+    invalid_key_sets = 
+      [nil,
+       [{'key' => nil}],
+       [{'key' => ''}],
+       [{'key' => 'a'}],
+       [{'type' => nil}],
+       [{'type' => ''}],
+       [{'type' => 'a'}],
+       [{'key' => 'a', 'type' => ''}],
+       [{'key' => '', 'type' => 'a'}],
+       [{'key' => '', 'type' => 'a', 'comment' => ''}],
+       [
+        {'key' => 'a', 'type' => 'a'},
+        {}
+       ],
+       [
+        {},
+        {'key' => 'a', 'type' => 'a'},
+       ],
+       [
+        {'key' => 'a', 'type' => 'a'},
+        {},
+        {'key' => 'a', 'type' => 'a'}
+       ],
+      ]
+    
+    valid_key_sets = 
+      [
+       [],
+       [{'key' => 'a', 'type' => 'a'}],
+       [{'key' => 'a', 'type' => 'a', 'comment' => 'a'}],
+       [
+        {'key' => 'a', 'type' => 'a', 'comment' => 'a'},
+        {'key' => 'a', 'type' => 'a', 'comment' => 'a'}
+       ],
+       [
+        {'key' => 'a', 'type' => 'a', 'comment' => 'a'},
+        {'key' => 'a', 'type' => 'a', 'comment' => 'a'},
+        {'key' => 'a', 'type' => 'a', 'comment' => 'a'},
+       ],
+      ]
+
+    invalid_key_sets.each {|key_spec|
+      assert(!a.send(:validate_keys, key_spec),
+             "this key should be invalid: #{key_spec}")
+    }
+
+    valid_key_sets.each {|key_spec|
+      assert(a.send(:validate_keys, key_spec),
+             "this key should be valid: #{key_spec}")
+    }
+    
+  end
+
+  def test_key_id
+    a = AuthorizedKeysFile.new(@container)
+
+    comment_string = 'testcomment'
+    key_id = a.send(:key_id, comment_string)
+    assert_equal("OPENSHIFT-#{@username}-#{comment_string}", key_id,
+                 "invalid key id produced")
+  end
+
+  def test_key_entry
+    a = AuthorizedKeysFile.new(@container)
+
+    key_string = 'AAAAAverylongstringofcharacters'
+    key_type = 'ssh-rsa'
+    comment_string = 'testcomment'
+    key_entry = a.send(:key_entry, key_string, key_type, comment_string)
+
+    expected_key_entry = 
+      "command=\"#{@container.container_plugin.gear_shell}\"" +
+      ",no-X11-forwarding #{key_type} #{key_string} " + 
+      a.send(:key_id, comment_string)
+    assert_equal(expected_key_entry, key_entry, "invalid key entry produced")
+
+  end
+
+end


### PR DESCRIPTION
This change adds the capability for a node to accept Kerberos 5 principals for SSH access to gears.

The MCollective interface for managing SSH keys remains unchanged.  The node agent will now except keys with type _krb5-principal_.  It will place these "keys" in the users k5login file.

The existing code to manage traditional SSH public keys is refactored into its own management class and selector code has been added so that each key is placed in its proper location.

The only change to existing functionality is the addition of the _--with-ssh-key-type_ argument to _oo-devel-node authorized-ssh-key-remove_.  This is required so that the process can determine if the key is for ssh authorized keys or a krb5-principal.

All changes take affect in OpenShift::Runtime::ApplicationContainerExt::Environment
Three functions are directly affected:
- add_ssh_key
- remove_ssh_key
- replace_ssh_keys

The signatures and inputs for these functions do not change.
Each function will now accept and respond to "keys" with type _krb5-principal_ and take the appropriate action.
