### PR TITLE
[TO STAGE] Update REST API objects to point to singular routes

### DIFF
--- a/controller/app/rest_models/rest_alias.rb
+++ b/controller/app/rest_models/rest_alias.rb
@@ -8,12 +8,12 @@ class RestAlias < OpenShift::Model
     app_id = app._id
     unless nolinks
       self.links = {
-        "GET" => Link.new("Get alias", "GET", URI::join(url, "applications/#{app_id}/aliases/#{self.id}")),
-        "UPDATE" => Link.new("Update alias", "PUT", URI::join(url, "applications/#{app_id}/aliases/#{self.id}"),
+        "GET" => Link.new("Get alias", "GET", URI::join(url, "application/#{app_id}/alias/#{self.id}")),
+        "UPDATE" => Link.new("Update alias", "PUT", URI::join(url, "application/#{app_id}/alias/#{self.id}"),
           [Param.new("ssl_certificate", "string", "Content of SSL Certificate"), 
             Param.new("private_key", "string", "Private key for the certificate.  Required if adding a certificate")], 
             [OptionalParam.new("pass_phrase", "string", "Optional passphrase for the private key")]),
-        "DELETE" => Link.new("Delete alias", "DELETE", URI::join(url, "applications/#{app_id}/aliases/#{self.id}"))
+        "DELETE" => Link.new("Delete alias", "DELETE", URI::join(url, "application/#{app_id}/alias/#{self.id}"))
       }
     end
   end

--- a/controller/app/rest_models/rest_alias15.rb
+++ b/controller/app/rest_models/rest_alias15.rb
@@ -9,12 +9,12 @@ class RestAlias15 < OpenShift::Model
     app_id = app.name
     unless nolinks
       self.links = {
-        "GET" => Link.new("Get alias", "GET", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/aliases/#{self.id}")),
-        "UPDATE" => Link.new("Update alias", "PUT", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/aliases/#{self.id}"),
+        "GET" => Link.new("Get alias", "GET", URI::join(url, "domain/#{domain_id}/application/#{app_id}/alias/#{self.id}")),
+        "UPDATE" => Link.new("Update alias", "PUT", URI::join(url, "domain/#{domain_id}/application/#{app_id}/alias/#{self.id}"),
           [Param.new("ssl_certificate", "string", "Content of SSL Certificate"),
             Param.new("private_key", "string", "Private key for the certificate.  Required if adding a certificate")],
             [OptionalParam.new("pass_phrase", "string", "Optional passphrase for the private key")]),
-        "DELETE" => Link.new("Delete alias", "DELETE", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/aliases/#{self.id}"))
+        "DELETE" => Link.new("Delete alias", "DELETE", URI::join(url, "domain/#{domain_id}/application/#{app_id}/alias/#{self.id}"))
       }
     end
   end

--- a/controller/app/rest_models/rest_authorization.rb
+++ b/controller/app/rest_models/rest_authorization.rb
@@ -8,11 +8,11 @@ class RestAuthorization < OpenShift::Model
     self.identity = auth.identity_id
 
     self.links = {
-      "GET" => Link.new("Get authorization", "GET", URI::join(url, "user/authorizations/#{id}")),
-      "UPDATE" => Link.new("Update authorization", "PUT", URI::join(url, "user/authorizations/#{id}"), [
+      "GET" => Link.new("Get authorization", "GET", URI::join(url, "user/authorization/#{id}")),
+      "UPDATE" => Link.new("Update authorization", "PUT", URI::join(url, "user/authorization/#{id}"), [
         Param.new("note", "string", "A note to remind you what this token is for."),
       ]),
-      "DELETE" => Link.new("Delete authorization", "DELETE", URI::join(url, "user/authorizations/#{id}"))
+      "DELETE" => Link.new("Delete authorization", "DELETE", URI::join(url, "user/authorization/#{id}"))
     } unless nolinks
   end
 

--- a/controller/app/rest_models/rest_embedded_cartridge.rb
+++ b/controller/app/rest_models/rest_embedded_cartridge.rb
@@ -183,25 +183,25 @@ class RestEmbeddedCartridge < OpenShift::Model
       app_id = app._id
       if not app_id.nil?
         self.links = {
-            "GET" => Link.new("Get cartridge", "GET", URI::join(url, "applications/#{app_id}/cartridges/#{name}")),
-            "UPDATE" => Link.new("Update cartridge configuration", "PUT", URI::join(url, "applications/#{app_id}/cartridges/#{name}"), nil, [
+            "GET" => Link.new("Get cartridge", "GET", URI::join(url, "application/#{app_id}/cartridge/#{name}")),
+            "UPDATE" => Link.new("Update cartridge configuration", "PUT", URI::join(url, "application/#{app_id}/cartridge/#{name}"), nil, [
               OptionalParam.new("additional_gear_storage", "integer", "Additional filesystem storage in gigabytes on each gear having cartridge #{name}"),
               OptionalParam.new("scales_from", "integer", "Minimum number of gears having cartridge #{name}"),
               OptionalParam.new("scales_to", "integer", "Maximum number of gears having cartridge #{name}")
             ]),
-            "START" => Link.new("Start cartridge", "POST", URI::join(url, "applications/#{app_id}/cartridges/#{name}/events"), [
+            "START" => Link.new("Start cartridge", "POST", URI::join(url, "application/#{app_id}/cartridge/#{name}/events"), [
               Param.new("event", "string", "event", "start")
             ]),
-            "STOP" => Link.new("Stop cartridge", "POST", URI::join(url, "applications/#{app_id}/cartridges/#{name}/events"), [
+            "STOP" => Link.new("Stop cartridge", "POST", URI::join(url, "application/#{app_id}/cartridge/#{name}/events"), [
               Param.new("event", "string", "event", "stop")
             ]),
-            "RESTART" => Link.new("Restart cartridge", "POST", URI::join(url, "applications/#{app_id}/cartridges/#{name}/events"), [
+            "RESTART" => Link.new("Restart cartridge", "POST", URI::join(url, "application/#{app_id}/cartridge/#{name}/events"), [
               Param.new("event", "string", "event", "restart")
             ]),
-            "RELOAD" => Link.new("Reload cartridge", "POST", URI::join(url, "applications/#{app_id}/cartridges/#{name}/events"), [
+            "RELOAD" => Link.new("Reload cartridge", "POST", URI::join(url, "application/#{app_id}/cartridge/#{name}/events"), [
               Param.new("event", "string", "event", "reload")
             ]),
-            "DELETE" => Link.new("Delete cartridge", "DELETE", URI::join(url, "applications/#{app_id}/cartridges/#{name}"))
+            "DELETE" => Link.new("Delete cartridge", "DELETE", URI::join(url, "application/#{app_id}/cartridge/#{name}"))
           }
       end
     end

--- a/controller/app/rest_models/rest_embedded_cartridge15.rb
+++ b/controller/app/rest_models/rest_embedded_cartridge15.rb
@@ -184,25 +184,25 @@ class RestEmbeddedCartridge15 < OpenShift::Model
       app_id = app.name
       if not app_id.nil? and not domain_id.nil?
         self.links = {
-            "GET" => Link.new("Get cartridge", "GET", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/cartridges/#{name}")),
-            "UPDATE" => Link.new("Update cartridge configuration", "PUT", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/cartridges/#{name}"), nil, [
+            "GET" => Link.new("Get cartridge", "GET", URI::join(url, "domain/#{domain_id}/application/#{app_id}/cartridge/#{name}")),
+            "UPDATE" => Link.new("Update cartridge configuration", "PUT", URI::join(url, "domain/#{domain_id}/application/#{app_id}/cartridge/#{name}"), nil, [
               OptionalParam.new("additional_gear_storage", "integer", "Additional filesystem storage in gigabytes on each gear having cartridge #{name}"),
               OptionalParam.new("scales_from", "integer", "Minimum number of gears having cartridge #{name}"),
               OptionalParam.new("scales_to", "integer", "Maximum number of gears having cartridge #{name}")
             ]),
-            "START" => Link.new("Start embedded cartridge", "POST", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/cartridges/#{name}/events"), [
+            "START" => Link.new("Start embedded cartridge", "POST", URI::join(url, "domain/#{domain_id}/application/#{app_id}/cartridge/#{name}/events"), [
               Param.new("event", "string", "event", "start")
             ]),
-            "STOP" => Link.new("Stop cartridge", "POST", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/cartridges/#{name}/events"), [
+            "STOP" => Link.new("Stop cartridge", "POST", URI::join(url, "domain/#{domain_id}/application/#{app_id}/cartridge/#{name}/events"), [
               Param.new("event", "string", "event", "stop")
             ]),
-            "RESTART" => Link.new("Restart cartridge", "POST", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/cartridges/#{name}/events"), [
+            "RESTART" => Link.new("Restart cartridge", "POST", URI::join(url, "domain/#{domain_id}/application/#{app_id}/cartridge/#{name}/events"), [
               Param.new("event", "string", "event", "restart")
             ]),
-            "RELOAD" => Link.new("Reload cartridge", "POST", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/cartridges/#{name}/events"), [
+            "RELOAD" => Link.new("Reload cartridge", "POST", URI::join(url, "domain/#{domain_id}/application/#{app_id}/cartridge/#{name}/events"), [
               Param.new("event", "string", "event", "reload")
             ]),
-            "DELETE" => Link.new("Delete cartridge", "DELETE", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/cartridges/#{name}"))
+            "DELETE" => Link.new("Delete cartridge", "DELETE", URI::join(url, "domain/#{domain_id}/application/#{app_id}/cartridge/#{name}"))
           }
       end
     end

--- a/controller/app/rest_models/rest_environment_variable.rb
+++ b/controller/app/rest_models/rest_environment_variable.rb
@@ -7,10 +7,10 @@ class RestEnvironmentVariable < OpenShift::Model
     app_id = app.uuid
     unless nolinks      
       self.links = {
-        "GET" => Link.new("Get environment variable", "GET", URI::join(url, "applications/#{app_id}/environment-variables/#{self.name}")),
-        "UPDATE" => Link.new("Update environment variable", "PUT", URI::join(url, "applications/#{app_id}/environment-variables/#{self.name}"),
+        "GET" => Link.new("Get environment variable", "GET", URI::join(url, "application/#{app_id}/environment-variable/#{self.name}")),
+        "UPDATE" => Link.new("Update environment variable", "PUT", URI::join(url, "application/#{app_id}/environment-variable/#{self.name}"),
           [Param.new("value", "string", "Value of the environment variable")]), 
-        "DELETE" => Link.new("Delete environment variable", "DELETE", URI::join(url, "applications/#{app_id}/environment-variables/#{self.name}"))
+        "DELETE" => Link.new("Delete environment variable", "DELETE", URI::join(url, "application/#{app_id}/environment-variable/#{self.name}"))
       }
     end
   end

--- a/controller/app/rest_models/rest_environment_variable15.rb
+++ b/controller/app/rest_models/rest_environment_variable15.rb
@@ -8,10 +8,10 @@ class RestEnvironmentVariable15 < OpenShift::Model
     app_id = app.name
     unless nolinks      
       self.links = {
-        "GET" => Link.new("Get environment variable", "GET", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/environment-variables/#{self.name}")),
-        "UPDATE" => Link.new("Update environment variable", "PUT", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/environment-variables/#{self.name}"),
+        "GET" => Link.new("Get environment variable", "GET", URI::join(url, "domain/#{domain_id}/application/#{app_id}/environment-variable/#{self.name}")),
+        "UPDATE" => Link.new("Update environment variable", "PUT", URI::join(url, "domain/#{domain_id}/application/#{app_id}/environment-variable/#{self.name}"),
           [Param.new("value", "string", "Value of the environment variable")]), 
-        "DELETE" => Link.new("Delete environment variable", "DELETE", URI::join(url, "domains/#{domain_id}/applications/#{app_id}/environment-variables/#{self.name}"))
+        "DELETE" => Link.new("Delete environment variable", "DELETE", URI::join(url, "domain/#{domain_id}/application/#{app_id}/environment-variable/#{self.name}"))
       }
     end
   end


### PR DESCRIPTION
Old paths preserved in 1.2 or older.  Existing function continues to be
exposed.
