### PR TITLE
oo-exec-ruby: Unset X_SCLS before scl enable

### DIFF
--- a/util-scl/oo-exec-ruby
+++ b/util-scl/oo-exec-ruby
@@ -3,4 +3,4 @@
 # If it did we would use:  exec scl enable ruby193 "$@"
 
 COMMAND="$(printf "%q " "$@")"
-exec scl enable ruby193 "$COMMAND"
+X_SCLS="${X_SCLS//ruby193 }" exec scl enable ruby193 "$COMMAND"


### PR DESCRIPTION
Modify oo-exec-ruby to delete any occurrence of 'ruby193 ' from the X_SCLS environment variable before running scl enable ruby193.

scl enable sets the X_SCLS environment variable to keep track of what collections have been enabled in the current environment.  If a collection is already enabled, scl enable does not re-enable it (this behaviour is by design; see bug 1016962).

This commit forces the scl enable invocation in oo-exec-ruby to set up the ruby193 environment even in nested invocations so that oo-ruby works properly even if it is run in an environment that was set up by an earlier scl enable invocation (e.g., from an earlier oo-ruby invocation) in case that environment was modified (e.g., PATH was munged) between the two scl enable invocations.

This commit fixes bug 1017248.
