### PR TITLE
Fix Jenkins build failures

### DIFF
--- a/cartridges/openshift-origin-cartridge-jenkins-client/metadata/jenkins_shell_command
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/metadata/jenkins_shell_command
@@ -2,8 +2,11 @@ alias rsync="rsync --delete-after -az -e '$GIT_SSH'"
 
 upstream_ssh="UPSTREAM_SSH"
 
+# don't fail if these rsyncs fail
+set +e
 rsync $upstream_ssh:'$OPENSHIFT_BUILD_DEPENDENCIES_DIR' $OPENSHIFT_BUILD_DEPENDENCIES_DIR
 rsync $upstream_ssh:'$OPENSHIFT_DEPENDENCIES_DIR' $OPENSHIFT_DEPENDENCIES_DIR
+set -e
 
 # Build/update libs and run user pre_build and build
 gear build
@@ -19,8 +22,8 @@ deployment_dir=`$GIT_SSH $upstream_ssh 'gear create_deployment_dir'`
 
 # Push content back to application
 rsync $WORKSPACE/ $upstream_ssh:app-deployments/$deployment_dir/repo/
-rsync $OPENSHIFT_BUILD_DEPENDENCIES_DIR $upstream_ssh:'$OPENSHIFT_BUILD_DEPENDENCIES_DIR' 
-rsync $OPENSHIFT_DEPENDENCIES_DIR $upstream_ssh:'$OPENSHIFT_DEPENDENCIES_DIR'
+rsync $OPENSHIFT_BUILD_DEPENDENCIES_DIR $upstream_ssh:app-deployments/$deployment_dir/build-dependencies/
+rsync $OPENSHIFT_DEPENDENCIES_DIR $upstream_ssh:app-deployments/$deployment_dir/dependencies/
 
 # Configure / start app
 $GIT_SSH $upstream_ssh "gear remotedeploy --deployment-datetime $deployment_dir"


### PR DESCRIPTION
Don't fail if rsync from upstream gear to builder gear fails

Correct destination dirs for build-dependencies and dependencies
