### PR TITLE
WIP Node Platform - Add support for OPENSHIFT_GEAR_MEMORY_MB

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -710,6 +710,10 @@ module OpenShift
         @container_plugin.set_rw_permission(paths)
       end
 
+      def memory_in_bytes
+        @container_plugin.memory_in_bytes(@uuid)
+      end
+
       def address_bound?(ip, port, hourglass)
         @container_plugin.address_bound?(ip, port, hourglass)
       end

--- a/node/lib/openshift-origin-node/model/application_container_ext/setup.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/setup.rb
@@ -125,6 +125,8 @@ module OpenShift
           add_env_var("TMPDIR", "/tmp/", false)
           add_env_var("TMP", "/tmp/", false)
 
+          add_env_var('GEAR_MEMORY_MB', (memory_in_bytes() / 1024**2).to_s, true)
+
           # Update all directory entries ~/app-root/*
           Dir[gearappdir + "/*"].entries.reject{|e| ['.', '..', 'repo', 'dependencies', 'build-dependencies'].include?(File.basename(e))}.each {|e|
             FileUtils.chmod_R(0750, e, :verbose => @debug)

--- a/node/test/test_helper.rb
+++ b/node/test/test_helper.rb
@@ -68,6 +68,7 @@ module OpenShift
       @cgroups_mock.stubs(:freeze).yields(:frozen)
       @cgroups_mock.stubs(:thaw).yields(:thawed)
       @cgroups_mock.stubs(:processes).returns([])
+      @cgroups_mock.stubs(:templates).returns({default: {'memory.limit_in_bytes' => '536870912'}})
 
       @tc_mock = mock('OpenShift::Runtime::Utils::TC')
       OpenShift::Runtime::Utils::TC.stubs(:new).returns(@tc_mock)

--- a/plugins/container/libvirt/lib/openshift/runtime/containerization/libvirt_container.rb
+++ b/plugins/container/libvirt/lib/openshift/runtime/containerization/libvirt_container.rb
@@ -439,6 +439,11 @@ Dir(after)    #{@container.uuid}/#{@container.uid} => #{list_home_dir(@container
           OpenShift::Runtime::Utils::SELinux.set_mcs_label(@mcs_label, paths)
         end
 
+        # retrieve the default maximum memory limit
+        def memory_in_bytes(uuid)
+          OpenShift::Runtime::Utils::Cgroups.new(uuid).templates[:default]['memory.limit_in_bytes'].to_i
+        end
+
         private
 
         def set_default_route

--- a/plugins/container/selinux/lib/openshift/runtime/containerization/selinux_container.rb
+++ b/plugins/container/selinux/lib/openshift/runtime/containerization/selinux_container.rb
@@ -357,7 +357,12 @@ Dir(after)    #{@container.uuid}/#{@container.uid} => #{list_home_dir(@container
           ::OpenShift::Runtime::Utils::SELinux.set_mcs_label(mcs_label, paths)
         end
 
-        private
+        # retrieve the default maximum memory limit
+        def memory_in_bytes(uuid)
+          OpenShift::Runtime::Utils::Cgroups.new(uuid).templates[:default]['memory.limit_in_bytes'].to_i
+        end
+
+      private
 
         def freeze_fs_limits
           ::OpenShift::Runtime::Node.pam_freeze(@container.uuid)


### PR DESCRIPTION
- Expose the cgroup template memory size to cartridge developers
