### PR TITLE
Console light theme changes

### DIFF
--- a/console/app/assets/stylesheets/_alerts.scss
+++ b/console/app/assets/stylesheets/_alerts.scss
@@ -7,6 +7,7 @@
   clear: left;
   margin: 15px 0;
   padding: 6px 18px;
+  border: 1px solid;
   @include border-radius(2px);
   > p:last-child {
     margin-bottom: 0;

--- a/console/app/assets/stylesheets/_buttons.scss
+++ b/console/app/assets/stylesheets/_buttons.scss
@@ -86,7 +86,6 @@ input[type="submit"].btn {
 .btn-large {
   padding: 8px 18px;
   font-size: $baseFontSize + .5px; // FIXME
-  line-height: normal;
 }
 .btn-large [class^="icon-"] {
   margin-top: 1px;
@@ -94,9 +93,8 @@ input[type="submit"].btn {
 
 // Small
 .btn-small {
-  padding: 3px 8px;
+  padding: 3px 9px;
   font-size: $baseFontSize - 2px; // FIXME
-  line-height: 1.5;
 }
 .btn-small [class^="icon-"] {
   margin-top: -1px;
@@ -104,9 +102,8 @@ input[type="submit"].btn {
 
 // Mini
 .btn-mini {
-  padding: 1px 4px;
-  font-size: $baseFontSize - 2px; // FIXME
-  line-height: 1.5;
+  padding: 0 5px;
+  font-size: $baseFontSize - 3px; // FIXME
 }
 
 
@@ -253,6 +250,15 @@ input[type="submit"].btn-primary:active,
 .btn-link[disabled]:focus {
   color: $grayDark;
   text-decoration: none;
+}
+
+
+// Icon buttons
+// --------------------------------------------------
+
+.btn [class*="icon-"] {
+  position: relative;
+  top: 1px;
 }
 
 

--- a/console/app/assets/stylesheets/_openshift-icon.css.scss
+++ b/console/app/assets/stylesheets/_openshift-icon.css.scss
@@ -17,8 +17,9 @@
 	font-weight: normal;
 	font-variant: normal;
 	text-transform: none;
-	//line-height: 1;
+	line-height: 1;
 	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 /* Use the following CSS code if you want to have a class per icon */
@@ -37,10 +38,7 @@ you can use the generic selector below, but it's slower:
 	text-transform: none;
 	line-height: 1;
 	-webkit-font-smoothing: antialiased;
-	 /* added for spacing the following */
-	 left: -4px;
-   margin-left: 4px;
-   position: relative;
+	-moz-osx-font-smoothing: grayscale;
 }
 .icon-lock:before {
 	content: "\e000";

--- a/console/app/assets/stylesheets/_openshift-logos-icon.css.scss
+++ b/console/app/assets/stylesheets/_openshift-logos-icon.css.scss
@@ -37,10 +37,7 @@ you can use the generic selector below, but it's slower:
 	text-transform: none;
 	line-height: 1;
 	-webkit-font-smoothing: antialiased;
-	 /* added for spacing the following */
-	 left: -4px;
-   margin-left: 4px;
-   position: relative;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 .icon-github:before {

--- a/console/app/assets/stylesheets/_type.scss
+++ b/console/app/assets/stylesheets/_type.scss
@@ -272,8 +272,8 @@ cite {
   font-style: normal;
 }
 
-.smaller {font-size: $smallFontSize;}
-.tiny-size {font-size:$tinyFontSize;}
+.smaller {font-size: $smallFontSize; line-height: 1.4;}
+.tiny-size {font-size:$tinyFontSize; line-height: 1.4;}
 
 a.external:after { 
   content: "\279A";

--- a/console/app/assets/stylesheets/_variables.scss
+++ b/console/app/assets/stylesheets/_variables.scss
@@ -126,19 +126,19 @@ $smallText:											11px;
 /* FIXME: Need to resolve these colors with _custom.scss */
 $warningText:             #222;
 $warningBackground:       #ffd24e;
-$warningBorder:           darken(adjust-hue($warningBackground, -10), 3%);
+$warningBorder:           darken($warningBackground, 3%);
 
 $errorText:               white;
 $errorBackground:         $openshiftRed;
-$errorBorder:             darken(adjust-hue($errorBackground, -10), 3%);
+$errorBorder:             darken($errorBackground, 3%);
 
 $successText:             #222;
 $successBackground:       #C4E5C5;
-$successBorder:           darken(adjust-hue($successBackground, -10), 5%);
+$successBorder:           darken($successBackground, 3%);
 
 $infoText:                #222;
 $infoBackground:          #bfd9f5;
-$infoBorder:              darken($infoBackground, 2%);
+$infoBorder:              darken($infoBackground, 3%);
 /* END */
 
 $hrBorder:                $openshiftBorderGray;

--- a/console/app/assets/stylesheets/_variables.scss
+++ b/console/app/assets/stylesheets/_variables.scss
@@ -2,15 +2,15 @@ $baseFontFamily:     "Open Sans", "Helvetica Neue", Helvetica, "Liberation Sans"
 $headerFontFamily:   "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 $monoFontFamily:      Menlo, Monaco, "Liberation Mono", Consolas, monospace !default;
 
-$baseLineHeight:          20px;
-$baseFontSize:						14px;
-$leadLineHeight:          $baseLineHeight * 1.5;
-$leadFontSize:            18px;
-$largeLineHeight:         $baseLineHeight * 1.2;
-$largeFontSize:           16px;
-$smallFontSize:           13.5px;
-$tinyFontSize:            12px;
-$extraTinyFontSize:       10.75px;
+$baseLineHeight:          	20px;
+$baseFontSize:				14px;
+$leadLineHeight:          	$baseLineHeight * 1.5;
+$leadFontSize:            	18px;
+$largeLineHeight:         	$baseLineHeight * 1.2;
+$largeFontSize:           	$baseFontSize + 2;
+$smallFontSize:           	$baseFontSize - 1;
+$tinyFontSize:            	$baseFontSize - 2;
+$extraTinyFontSize:       	$baseFontSize - 3.25;
 
 // For matching header sizes exactly
 $h1FontSize:              $baseFontSize * 1.7;

--- a/console/app/assets/stylesheets/console/_tables.scss
+++ b/console/app/assets/stylesheets/console/_tables.scss
@@ -94,6 +94,19 @@ table {
 }
 
 
+// NO BORDERS
+// ----------
+
+.table-no-borders {
+  td {
+    border: 0;
+    &:first-child {
+      padding-left: 0;
+    }
+  }
+}
+
+
 // ZEBRA-STRIPING
 // --------------
 

--- a/console/app/views/members/_members_form.html.haml
+++ b/console/app/views/members/_members_form.html.haml
@@ -26,13 +26,6 @@
     height: auto;
   }
 
-  .members table a.remove-member,
-  .members table a.remove-new-member {
-    font-size: 20px;
-    font-weight: bold;
-    height: 20px;
-  }
-
   .members aside {
     margin-top: 16px
   }
@@ -79,7 +72,7 @@
 
   = form_tag domain_members_path(domain), :method => :put, :class => "members warn-dirty #{'editing' if editing || members.count <= 1} #{'hidden-scripted' if !editing && members.count <= 1} #{'dirty' if new_members.present?}" do
 
-    %table.table.table-condensed
+    %table.table.table-condensed.table-no-borders
       %colgroup
         %col{:width => "45%"}
         %col{:width => "45%"}
@@ -105,7 +98,8 @@
               = select_tag('members[][role]', options_for_select(Role.role_descriptions(true), {:selected => member.role}))
           %td.script-only
             .edit-only
-              = link_to('&times;'.html_safe, 'javascript:;', :class => 'remove-member btn btn-mini')
+              = link_to('javascript:;', :class => 'remove-new-member btn btn-mini') do
+                %span.icon-remove{'aria-hidden'=>"true"}
 
       - new_members = (new_members || []).dup
       - new_members << Domain::Member.new(:role => :edit) if new_members.blank? and members.count == 1
@@ -120,7 +114,8 @@
           %td
             = select_tag('members[][role]', options_for_select(Role.role_descriptions(false), new_member.role))
           %td.script-only
-            = link_to('&times;'.html_safe, 'javascript:;', :class => 'remove-new-member btn btn-mini')
+            = link_to('javascript:;', :class => 'remove-new-member btn btn-mini') do
+              %span.icon-remove{'aria-hidden'=>"true"}
         - if error
           %tr.edit-only.control-group.error.error-row.borderless
             %td{:colspan => 3}
@@ -135,7 +130,7 @@
 
     .form-actions.edit-only
       = link_to "Cancel", domain_path(@domain), :class => 'btn btn-small cancel script-only'
-      = submit_tag "Save", :class => 'btn btn-primary-when-dirty btn-small'
+      = button_tag "Save", :type => :submit, :class => 'btn btn-primary-when-dirty btn-small'
 
     .edit-only
       %h6 What can members do?

--- a/console/app/views/settings/_authorizations.html.haml
+++ b/console/app/views/settings/_authorizations.html.haml
@@ -3,7 +3,8 @@
   Allow clients and 3rd parties to access your account via a secret token.
 
 - if authorizations.present?
-  %table.table
+
+  %table.table.table-condensed
     %thead
       %tr
         %th.nowrap{:scope => 'col'} Note


### PR DESCRIPTION
icons should have line-height
mozilla specific font smoothing
add line-height in ems to small and tiny sizes
variablize large, small, tiny, extratiny

Tweak padding and sizing
Create +.btn [class*="icon-"] style to position icon exact vertical center

Remove default left offset from icon class rule
- this was to add space btw icon and text, but it causes issues when icons used within .btn
- will have to add &nbsp; or come up with another option

Alert borders weren't showing b/c no border style & width set. Fixed it.
- also simplified their color function to just darken

Introduced .table-no-borders class which is used on the domain members table

Fixed "delete" x button on members form
