### PR TITLE
Bump cartridge versions

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/metadata/manifest.yml
@@ -6,10 +6,11 @@ Description: MongoDB Monitoring Service (MMS) instruments MongoDB and provides i
   about current and historical operational metrics of your system.
 Version: '0.1'
 License-Url: https://mms.10gen.com/links/terms-of-service
-Cartridge-Version: 0.0.3
+Cartridge-Version: 0.0.4
 Compatible-Versions:
 - 0.0.1
 - 0.0.2
+- 0.0.3
 Cartridge-Vendor: redhat
 Vendor: 10gen.com
 Categories:

--- a/cartridges/openshift-origin-cartridge-cron/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-cron/metadata/manifest.yml
@@ -10,11 +10,12 @@ Description: The Cron cartridge allows you to run command line programs at sched
 License: ASL 2.0
 License-Url: http://www.apache.org/licenses/LICENSE-2.0.txt
 Website: http://www.openshift.com/
-Cartridge-Version: 0.0.6
+Cartridge-Version: 0.0.7
 Compatible-Versions:
 - 0.0.3
 - 0.0.4
 - 0.0.5
+- 0.0.6
 Cartridge-Vendor: redhat
 Categories:
 - embedded

--- a/cartridges/openshift-origin-cartridge-haproxy/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-haproxy/metadata/manifest.yml
@@ -10,7 +10,7 @@ Version: '1.4'
 License: GPLv2+
 License-Url: http://www.gnu.org/licenses/gpl-2.0.html
 Vendor: http://haproxy.1wt.eu/
-Cartridge-Version: 0.0.6
+Cartridge-Version: 0.0.7
 Cartridge-Vendor: redhat
 Categories:
 - web_proxy

--- a/cartridges/openshift-origin-cartridge-jbossas/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jbossas/metadata/manifest.yml
@@ -8,7 +8,7 @@ Version: '7'
 License: LGPL
 License-Url: http://www.gnu.org/copyleft/lesser.txt
 Vendor: Red Hat
-Cartridge-Version: 0.0.6
+Cartridge-Version: 0.0.7
 Cartridge-Vendor: redhat
 Categories:
 - service
@@ -123,6 +123,4 @@ Endpoints:
   Private-Port: 9990
 Additional-Control-Actions:
 - threaddump
-Compatible-Versions:
-- 0.0.4
-- 0.0.5
+Compatible-Versions: []

--- a/cartridges/openshift-origin-cartridge-jbosseap/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jbosseap/metadata/manifest.yml
@@ -9,7 +9,7 @@ Version: '6'
 License: LGPL
 License-Url: http://www.gnu.org/copyleft/lesser.txt
 Vendor: Red Hat
-Cartridge-Version: 0.0.6
+Cartridge-Version: 0.0.7
 Cartridge-Vendor: redhat
 Categories:
 - service
@@ -120,5 +120,4 @@ Endpoints:
   Private-Port: 9990
 Additional-Control-Actions:
 - threaddump
-Compatible-Versions:
-- 0.0.5
+Compatible-Versions: []

--- a/cartridges/openshift-origin-cartridge-jbossews/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jbossews/metadata/manifest.yml
@@ -2,13 +2,14 @@
 Name: jbossews
 Cartridge-Short-Name: JBOSSEWS
 Cartridge-Vendor: redhat
-Cartridge-Version: 0.0.7
+Cartridge-Version: 0.0.8
 Compatible-Versions:
 - 0.0.2
 - 0.0.3
 - 0.0.4
 - 0.0.5
 - 0.0.6
+- 0.0.7
 Display-Name: Tomcat 7 (JBoss EWS 2.0)
 Description: JBoss Enterprise Web Server is the enterprise-class Java web container
   for large-scale lightweight web applications based on Tomcat 7. Build and deploy

--- a/cartridges/openshift-origin-cartridge-jenkins-client/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/metadata/manifest.yml
@@ -7,10 +7,11 @@ Description: The Jenkins client connects to your Jenkins application and enables
   via the new application page. Based on Jenkins Client 1.509+
 Version: '1'
 License: ASL 2.0
-Cartridge-Version: 0.0.3
+Cartridge-Version: 0.0.4
 Compatible-Versions:
 - 0.0.1
 - 0.0.2
+- 0.0.3
 Cartridge-Vendor: redhat
 Categories:
 - ci_builder

--- a/cartridges/openshift-origin-cartridge-mariadb/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mariadb/metadata/manifest.yml
@@ -7,7 +7,7 @@ Description: MariaDB is a multi-user, multi-threaded SQL database server.
 Version: '5.5'
 Versions:
 - '5.5'
-Cartridge-Version: 0.2.2
+Cartridge-Version: 0.2.3
 Cartridge-Vendor: redhat
 License: GPL
 Vendor: MariaDB Foundation
@@ -48,8 +48,7 @@ Endpoints:
   Private-Port-Name: DB_PORT
   Private-Port: 3306
   Public-Port-Name: DB_PROXY_PORT
-  Protocols: [mysql]
+  Protocols:
+  - mysql
 Install-Build-Required: false
-Compatible-Versions:
-- 0.2.0
-- 0.2.1
+Compatible-Versions: []

--- a/cartridges/openshift-origin-cartridge-mongodb/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mongodb/metadata/manifest.yml
@@ -2,14 +2,15 @@
 Name: mongodb
 Cartridge-Short-Name: MONGODB
 Architecture: noarch
-Display-Name: MongoDB 2.2 
+Display-Name: MongoDB 2.2
 Description: MongoDB is a scalable, high-performance, open source NoSQL database.
 Version: '2.2'
 Versions:
 - '2.2'
-Cartridge-Version: 0.2.3
+Cartridge-Version: 0.2.4
 Compatible-Versions:
 - 0.2.2
+- 0.2.3
 Cartridge-Vendor: redhat
 License: ASL 2.0
 Vendor: 10gen
@@ -52,4 +53,5 @@ Endpoints:
   Private-Port-Name: DB_PORT
   Private-Port: 27017
   Public-Port-Name: DB_PROXY_PORT
-  Protocols: [mongodb]
+  Protocols:
+  - mongodb

--- a/cartridges/openshift-origin-cartridge-mysql/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mysql/metadata/manifest.yml
@@ -7,7 +7,7 @@ Description: MySQL is a multi-user, multi-threaded SQL database server.
 Version: '5.1'
 Versions:
 - '5.1'
-Cartridge-Version: 0.2.3
+Cartridge-Version: 0.2.4
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 License: GPL
@@ -49,4 +49,5 @@ Endpoints:
   Private-Port-Name: DB_PORT
   Private-Port: 3306
   Public-Port-Name: DB_PROXY_PORT
-  Protocols: [mysql]
+  Protocols:
+  - mysql

--- a/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml.fedora
+++ b/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml.fedora
@@ -10,7 +10,7 @@ License: MIT License
 License-Url: https://raw.github.com/joyent/node/v0.10/LICENSE
 Vendor: www.nodejs.org
 Website: http://www.nodejs.org/
-Cartridge-Version: 0.0.6
+Cartridge-Version: 0.0.7
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:

--- a/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml.rhel
@@ -13,7 +13,7 @@ License: MIT License
 License-Url: https://raw.github.com/joyent/node/v0.10/LICENSE
 Vendor: www.nodejs.org
 Website: http://www.nodejs.org/
-Cartridge-Version: 0.0.6
+Cartridge-Version: 0.0.7
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:

--- a/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml.fedora19
+++ b/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml.fedora19
@@ -9,8 +9,9 @@ Version: '5.5'
 License: The PHP License, version 3.0
 License-Url: http://www.php.net/license/3_0.txt
 Vendor: php.net
-Cartridge-Version: 0.0.5
-Compatible-Versions: []
+Cartridge-Version: 0.0.6
+Compatible-Versions:
+- 0.0.5
 Cartridge-Vendor: redhat
 Categories:
 - service

--- a/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml.rhel
@@ -9,8 +9,9 @@ Version: '5.3'
 License: The PHP License, version 3.0
 License-Url: http://www.php.net/license/3_0.txt
 Vendor: php.net
-Cartridge-Version: 0.0.5
-Compatible-Versions: []
+Cartridge-Version: 0.0.6
+Compatible-Versions:
+- 0.0.5
 Cartridge-Vendor: redhat
 Categories:
 - service
@@ -71,7 +72,9 @@ Endpoints:
   Private-Port-Name: PORT
   Private-Port: 8080
   Public-Port-Name: PROXY_PORT
-  Protocols: [http, ws]
+  Protocols:
+  - http
+  - ws
   Options:
     primary: true
   Mappings:

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/metadata/manifest.yml.f19
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/metadata/manifest.yml.f19
@@ -7,8 +7,9 @@ Description: Web based MySQL admin tool. Requires the MySQL cartridge to be inst
 Version: '3'
 License: GPLv2
 Vendor: Red Hat
-Cartridge-Version: 0.0.5
-Compatible-Versions: []
+Cartridge-Version: 0.0.6
+Compatible-Versions:
+- 0.0.5
 Cartridge-Vendor: redhat
 Website: http://www.phpmyadmin.net/
 Categories:
@@ -39,7 +40,8 @@ Endpoints:
   Private-Port-Name: PORT
   Private-Port: 8080
   Public-Port-Name: PROXY_PORT
-  Protocols: [http]
+  Protocols:
+  - http
   Mappings:
   - Frontend: /phpmyadmin
     Backend: /phpmyadmin

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/metadata/manifest.yml.rhel
@@ -6,7 +6,7 @@ Description: Web based MySQL admin tool. Requires the MySQL cartridge to be inst
 Version: '4'
 License: GPLv2
 Vendor: Red Hat
-Cartridge-Version: 0.0.5
+Cartridge-Version: 0.0.6
 Cartridge-Vendor: redhat
 Website: http://www.phpmyadmin.net/
 Categories:
@@ -40,8 +40,10 @@ Endpoints:
   Private-Port-Name: PORT
   Private-Port: 8080
   Public-Port-Name: PROXY_PORT
-  Protocols: [http]
+  Protocols:
+  - http
   Mappings:
   - Frontend: /phpmyadmin
     Backend: /phpmyadmin
-Compatible-Versions: []
+Compatible-Versions:
+- 0.0.5

--- a/cartridges/openshift-origin-cartridge-postgresql/metadata/manifest.yml.f19
+++ b/cartridges/openshift-origin-cartridge-postgresql/metadata/manifest.yml.f19
@@ -2,7 +2,7 @@
 Name: postgresql
 Architecture: noarch
 Cartridge-Short-Name: POSTGRESQL
-Cartridge-Version: 0.3.3
+Cartridge-Version: 0.3.4
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 Display-Name: PostgreSQL 9.2
@@ -46,5 +46,6 @@ Endpoints:
   Private-Port-Name: DB_PORT
   Private-Port: 5432
   Public-Port-Name: DB_PROXY_PORT
-  Protocols: [postgresql]
+  Protocols:
+  - postgresql
 Install-Build-Required: false

--- a/cartridges/openshift-origin-cartridge-postgresql/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-postgresql/metadata/manifest.yml.rhel
@@ -2,7 +2,7 @@
 Name: postgresql
 Architecture: noarch
 Cartridge-Short-Name: POSTGRESQL
-Cartridge-Version: 0.3.3
+Cartridge-Version: 0.3.4
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 Display-Name: PostgreSQL 9.2
@@ -47,7 +47,8 @@ Endpoints:
   Private-Port-Name: DB_PORT
   Private-Port: 5432
   Public-Port-Name: DB_PROXY_PORT
-  Protocols: [postgresql]
+  Protocols:
+  - postgresql
 Version-Overrides:
   '8.4':
     Display-Name: PostgreSQL 8.4

--- a/cartridges/openshift-origin-cartridge-python/metadata/manifest.yml.f19
+++ b/cartridges/openshift-origin-cartridge-python/metadata/manifest.yml.f19
@@ -12,9 +12,10 @@ Versions:
 License: The Python License, version 2.7
 License-Url: http://docs.python.org/3/license.html
 Vendor: python.org
-Cartridge-Version: 0.0.5
+Cartridge-Version: 0.0.6
 Compatible-Versions:
 - 0.0.4
+- 0.0.5
 Cartridge-Vendor: redhat
 Categories:
 - service

--- a/cartridges/openshift-origin-cartridge-python/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-python/metadata/manifest.yml.rhel
@@ -13,9 +13,10 @@ Versions:
 License: The Python License, version 2.6
 License-Url: http://docs.python.org/3/license.html
 Vendor: python.org
-Cartridge-Version: 0.0.5
+Cartridge-Version: 0.0.6
 Compatible-Versions:
 - 0.0.4
+- 0.0.5
 Cartridge-Vendor: redhat
 Categories:
 - service

--- a/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml.f19
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml.f19
@@ -10,11 +10,12 @@ Versions:
 License: Ruby BSDL
 License-Url: http://www.ruby-lang.org/en/about/license.txt
 Vendor: ruby.org
-Cartridge-Version: 0.0.7
+Cartridge-Version: 0.0.8
 Compatible-Versions:
 - 0.0.4
 - 0.0.5
 - 0.0.6
+- 0.0.7
 Cartridge-Vendor: redhat
 Categories:
 - service

--- a/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml.rhel
@@ -11,11 +11,12 @@ Versions:
 License: Ruby BSDL
 License-Url: http://www.ruby-lang.org/en/about/license.txt
 Vendor: ruby.org
-Cartridge-Version: 0.0.7
+Cartridge-Version: 0.0.8
 Compatible-Versions:
 - 0.0.4
 - 0.0.5
 - 0.0.6
+- 0.0.7
 Cartridge-Vendor: redhat
 Categories:
 - service


### PR DESCRIPTION
Bump cartridge versions for 2.0.34

Depends on https://github.com/openshift/li/pull/1978
