### PR TITLE
[TO_STAGE] Bug 1016917

### DIFF
--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -17,6 +17,7 @@
 
 require 'pp'
 require 'rubygems'
+require 'json'
 require 'openshift-origin-node/model/application_container'
 require 'openshift-origin-node/model/application_repository'
 require 'openshift-origin-node/utils/node_logger'


### PR DESCRIPTION
Ruby 1.8 results in SEGV when a wrong (in this particular case, `json`)
native extension is loaded.

In the long-term, we need to ensure that the load path is set up
correctly. This is an admittedly temporary fix.
