### PR TITLE
Bug 1018082

### DIFF
--- a/node/test/functional/multi_ha_func_test.rb
+++ b/node/test/functional/multi_ha_func_test.rb
@@ -38,8 +38,31 @@ class MultiHaFuncTest < OpenShift::NodeBareTestCase
 
     app_id = @api.create_application(app_name, [@framework_cartridge], true)
 
+    app_container = OpenShift::Runtime::ApplicationContainer.from_uuid(app_id)
+    gear_registry = OpenShift::Runtime::GearRegistry.new(app_container)
+
+    entries = gear_registry.entries
+    logger.info("Gear registry contents: #{entries}")
+
+    web_entries = entries[:web]
+    assert_equal 1, web_entries.keys.size
+
+    proxy_entries = entries[:proxy]
+    assert_equal 1, proxy_entries.keys.size
+
     logger.info "Enabling HA for #{app_name}"
     @api.make_ha(app_name)
+
+    gear_registry.load
+    entries = gear_registry.entries
+    logger.info("Gear registry contents: #{entries}")
+
+    web_entries = entries[:web]
+    assert_equal 2, web_entries.keys.size
+
+    proxy_entries = entries[:proxy]
+    assert_equal 2, proxy_entries.keys.size
+
   end
 
 end

--- a/node/test/unit/application_container_test.rb
+++ b/node/test/unit/application_container_test.rb
@@ -537,9 +537,10 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
     @container.expects(:deployment_metadata_for).with(current_deployment_datetime).returns(metadata)
     metadata.expects(:id).returns(deployment_id)
 
-    @container.expects(:activate).with(gears: [web_entry2, web_entry3].map { |e| "#{e.uuid}@#{e.proxy_hostname}" },
-                                            deployment_id: deployment_id,
-                                            init: true)
+    @container.expects(:activate).with(gears: [uuid2, uuid3],
+                                       deployment_id: deployment_id,
+                                       init: true)
+                                 .returns(status: 'success')
 
     @container.expects(:run_in_container_context).with("rsync -avz --delete --exclude hooks --rsh=/usr/bin/oo-ssh git/#{@app_name}.git/ #{proxy_entry3.uuid}@#{proxy_entry3.proxy_hostname}:git/#{@app_name}.git/",
                                                         env: gear_env,


### PR DESCRIPTION
Fix bug where calls to remote_deploy (i.e. Jenkins deployments) were
only operating on the local gear and weren't rotating the gear back in
correctly.

Convert activate to use with_gear_rotation.
