### PR TITLE
Remove unused code

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
@@ -163,12 +163,6 @@ module OpenShift
             public_port = create_public_endpoint(private_ip, endpoint.private_port)
             add_env_var(endpoint.public_port_name, public_port)
 
-            # Write the load balancer env var if primary option is set
-            if endpoint.options and endpoint.options["primary"]
-              logger.info("primary option set for the endpoint")
-              add_env_var('LOAD_BALANCER_PORT', public_port, true)
-            end
-
             config = ::OpenShift::Config.new
             endpoint_create_hash = { "external_address" => config.get('PUBLIC_IP'),
                                      "external_port" => public_port,

--- a/node/test/support/deployment_tester.rb
+++ b/node/test/support/deployment_tester.rb
@@ -78,7 +78,6 @@ class OpenShift::Runtime::DeploymentTester
       assert_equal "#{app_name}-#{@namespace}.dev.rhcloud.com", entry.dns
       local_hostname = `facter public_hostname`.chomp
       assert_equal local_hostname, entry.proxy_hostname
-      assert_equal IO.read(File.join(app_container.container_dir, '.env', 'OPENSHIFT_LOAD_BALANCER_PORT')).chomp, entry.proxy_port
 
       @api.assert_http_title_for_entry entry, DEFAULT_TITLE
 

--- a/node/test/unit/application_container_test.rb
+++ b/node/test/unit/application_container_test.rb
@@ -155,7 +155,6 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
     proxy.expects(:add).with(@user_uid.to_i, "127.0.0.2", 9090).returns(@ports_begin+3)
 
     @container.expects(:add_env_var).with('OPENSHIFT_MOCK_EXAMPLE_PUBLIC_PORT1', @ports_begin)
-    @container.expects(:add_env_var).with('LOAD_BALANCER_PORT', @ports_begin, true)
     @container.expects(:add_env_var).with('OPENSHIFT_MOCK_EXAMPLE_PUBLIC_PORT2', @ports_begin+1)
     @container.expects(:add_env_var).with('OPENSHIFT_MOCK_EXAMPLE_PUBLIC_PORT3', @ports_begin+2)
     @container.expects(:add_env_var).with('OPENSHIFT_MOCK_EXAMPLE_PUBLIC_PORT4', @ports_begin+3)


### PR DESCRIPTION
The OPENSHIFT_LOAD_BALANCER_PORT was part of the deploy WIP and ended
up not being necessary.
