### PR TITLE
resource_limits: Delete settings for httpd

### DIFF
--- a/node/conf/resource_limits.conf
+++ b/node/conf/resource_limits.conf
@@ -56,17 +56,6 @@ limits_nproc=250        # max number of processes
 # limits_nice=19   # max nice priority allowed to raise to values: [-20, 19]
 # limits_rtprio=19 # max realtime priority
 
-#
-# Apache bandwidth limit
-# 
-apache_bandwidth="all 500000"
-apache_maxconnection="all 20"
-apache_bandwidtherror="510"
-#
-# Apache rotatelogs tuning
-rotatelogs_interval=86400
-rotatelogs_format="-%Y%m%d-%H%M%S-%Z"
-
 # Traffic control.  used by /etc/init.d/openshift-tc
 tc_max_bandwidth=800   # mbit/sec - Total bandwidth allowed for Libra
 tc_user_share=2    # mbit/sec - one user is allotted...


### PR DESCRIPTION
Delete settings in resource_limits.conf that are no longer used.  In particular, commit 3b74dd3d162a9a3b63a7ac4e1eaccea6b889e186 (removing v1 cartridges) removed all use of the apache_bandwidth, apache_maxconnection, apache_bandwidtherror, rotatelogs_interval, and rotatelogs_format settings.
