### PR TITLE
oo-diagnostics: Fix check for mlocate package

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -1012,14 +1012,15 @@ class OODiag
   end
 
   def test_altered_package_owned_configs
-     mlocate = `rpm -q mlocate`
-     if mlocate.empty?
+     `rpm -q mlocate`
+     have_mlocate_pkg = 0 == $?.to_i
+     unless have_mlocate_pkg
        do_warn <<-WARN
           The mlocate package is not installed. mlocate is not a required runtime package; however,
           you may install mlocate to enable further diagnostics checking.
        WARN
      end
-     unless mlocate.empty?
+     if have_mlocate_pkg
         `updatedb`
         out = `locate --regex \\.rpmsave\$ \\.rpmnew\$`
 


### PR DESCRIPTION
test_altered_package_owned_configs: Check the exit code of `rpm -q mlocate` instead of checking the output.

The old code erroneously assumed that the rpm command would give no output if the package were not installed, and so it would always return true even if mlocate were not present.
