### PR TITLE
oo-diagnostics: openshift-iptables-port-proxy

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -910,7 +910,7 @@ class OODiag
       warn_without += %w{ntpd}
     end
     if @is_node
-      fail_without += %w{httpd network sshd openshift-port-proxy openshift-gears
+      fail_without += %w{httpd network sshd openshift-iptables-port-proxy openshift-gears
                         cgconfig cgred crond openshift-node-web-proxy}
       scl_prefix = @project_is[:enterprise] ? "ruby193-" : ""
       fail_without << @scl_prefix + "mcollective"


### PR DESCRIPTION
test_services_enabled: Check for openshift-iptables-port-proxy instead of openshift-port-proxy (the former supersedes the latter).
