### PR TITLE
origin_runtime_293 - tune JBoss cartridges to use OPENSHIFT_GEAR_MEMORY_MB

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/control
@@ -193,8 +193,7 @@ function build() {
       OPENSHIFT_MAVEN_MIRROR="${CONFIG_DIR}/settings.rhcloud.xml"
   fi
 
-  max_memory_bytes=$(oo-cgroup-read memory.limit_in_bytes)
-  max_memory_mb=$(expr $max_memory_bytes / 1048576)
+  max_memory_mb=${OPENSHIFT_GEAR_MEMORY_MB}
 
   # If hot deploy is enabled, we need to restrict the Maven memory size to fit
   # alongside the running application server. For now, just hard-code it to 64

--- a/cartridges/openshift-origin-cartridge-jbossas/versions/7/bin/standalone.conf
+++ b/cartridges/openshift-origin-cartridge-jbossas/versions/7/bin/standalone.conf
@@ -41,29 +41,23 @@ then
     POSTGRESQL_ENABLED="true"
 fi
 
-# Redirect stderr for oo-cgroup-read since it tries to open a file handle to /tmp/jbosseap.log
-max_memory_bytes=$(oo-cgroup-read memory.limit_in_bytes 2> /dev/null)
 max_threads=$(ulimit -u)
-
-if ! [[ "$max_memory_bytes" =~ ^[0-9]+$ ]] ; then
-        max_memory_bytes=536870912
-fi
 
 if ! [[ "$max_threads" =~ ^[0-9]+$ ]] ; then
         max_threads=1024
 fi
 
 if [ -z "$JVM_HEAP_RATIO" ]; then
-	JVM_HEAP_RATIO=0.5
+  JVM_HEAP_RATIO=0.5
 fi
 if [ -z "$JVM_PERMGEN_RATIO" ]; then
-	JVM_PERMGEN_RATIO=0.2
+  JVM_PERMGEN_RATIO=0.2
 fi
 if [ -z "$MESSAGING_THREAD_RATIO" ]; then
-	MESSAGING_THREAD_RATIO=0.2
+  MESSAGING_THREAD_RATIO=0.2
 fi
 
-max_memory_mb=$(expr $max_memory_bytes / 1048576)
+max_memory_mb=${OPENSHIFT_GEAR_MEMORY_MB}
 max_heap=$( echo "$max_memory_mb * $JVM_HEAP_RATIO" | bc | awk '{print int($1+0.5)}')
 max_permgen=$( echo "$max_memory_mb * $JVM_PERMGEN_RATIO" | bc | awk '{print int($1+0.5)}')
 

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/control
@@ -196,8 +196,7 @@ function build() {
       OPENSHIFT_MAVEN_MIRROR="${CONFIG_DIR}/settings.rhcloud.xml"
   fi
 
-  max_memory_bytes=$(oo-cgroup-read memory.limit_in_bytes)
-  max_memory_mb=$(expr $max_memory_bytes / 1048576)
+  max_memory_mb=${OPENSHIFT_GEAR_MEMORY_MB}
 
   # If hot deploy is enabled, we need to restrict the Maven memory size to fit
   # alongside the running application server. For now, just hard-code it to 64

--- a/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/bin/standalone.conf
+++ b/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/bin/standalone.conf
@@ -41,13 +41,7 @@ then
     POSTGRESQL_ENABLED="true"
 fi
        
-# Redirect stderr for oo-cgroup-read since it tries to open a file handle to /tmp/jbosseap.log
-max_memory_bytes=$(oo-cgroup-read memory.limit_in_bytes 2> /dev/null)
 max_threads=$(ulimit -u)
-
-if ! [[ "$max_memory_bytes" =~ ^[0-9]+$ ]] ; then
-        max_memory_bytes=536870912
-fi
 
 if ! [[ "$max_threads" =~ ^[0-9]+$ ]] ; then
         max_threads=1024
@@ -63,7 +57,7 @@ if [ -z "$MESSAGING_THREAD_RATIO" ]; then
 	MESSAGING_THREAD_RATIO=0.2
 fi
 
-max_memory_mb=$(expr $max_memory_bytes / 1048576)
+max_memory_mb=${OPENSHIFT_GEAR_MEMORY_MB}
 max_heap=$( echo "$max_memory_mb * $JVM_HEAP_RATIO" | bc | awk '{print int($1+0.5)}')
 max_permgen=$( echo "$max_memory_mb * $JVM_PERMGEN_RATIO" | bc | awk '{print int($1+0.5)}')
 

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/build
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/build
@@ -36,8 +36,7 @@ if force_clean_build_enabled_for_latest_deployment; then
 fi
 
 # Calculate build heap size
-max_memory_bytes=`oo-cgroup-read memory.limit_in_bytes`
-max_memory_mb=`expr $max_memory_bytes / 1048576`
+max_memory_mb=${OPENSHIFT_GEAR_MEMORY_MB}
 MAVEN_JVM_HEAP_RATIO=0.75
 max_heap=$( echo "$max_memory_mb * $MAVEN_JVM_HEAP_RATIO" | bc | awk '{print int($1+0.5)}')
 OPENSHIFT_MAVEN_XMX="-Xmx${max_heap}m"

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/tomcat
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/tomcat
@@ -5,12 +5,7 @@ source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 export_java_home
 
-max_memory_bytes=`oo-cgroup-read memory.limit_in_bytes`
 max_threads=`ulimit -u`
-
-if ! [[ "$max_memory_bytes" =~ ^[0-9]+$ ]] ; then
-  max_memory_bytes=536870912
-fi
 
 if ! [[ "$max_threads" =~ ^[0-9]+$ ]] ; then
   max_threads=1024
@@ -23,7 +18,7 @@ if [ -z "$JVM_PERMGEN_RATIO" ]; then
 	JVM_PERMGEN_RATIO=0.2
 fi
 
-max_memory_mb=`expr $max_memory_bytes / 1048576`
+max_memory_mb=${OPENSHIFT_GEAR_MEMORY_MB}
 max_heap=$( echo "$max_memory_mb * $JVM_HEAP_RATIO" | bc | awk '{print int($1+0.5)}')
 max_permgen=$( echo "$max_memory_mb * $JVM_PERMGEN_RATIO" | bc | awk '{print int($1+0.5)}')
 


### PR DESCRIPTION
PR for [origin_runtime_293](https://trello.com/c/hQW3Dx0u).

Updated JBoss cartridges to use OPENSHIFT_GEAR_MEMORY_MB for memory calculations
