### PR TITLE
Add dependency dirs to managed_files.yml

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/bin/install
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/install
@@ -9,12 +9,6 @@ esac
 
 echo "$version" > "$OPENSHIFT_JBOSSAS_DIR/env/OPENSHIFT_JBOSSAS_VERSION"
 
-mkdir -p ${OPENSHIFT_BUILD_DEPENDENCIES_DIR}/.m2
-ln -sf ${OPENSHIFT_BUILD_DEPENDENCIES_DIR}/.m2 ${OPENSHIFT_HOMEDIR}/.m2
-
-mkdir -p ${OPENSHIFT_DEPENDENCIES_DIR}deployments
-ln -sf ${OPENSHIFT_DEPENDENCIES_DIR}deployments standalone/deployments
-
 ln -s ${OPENSHIFT_JBOSSAS_DIR}/standalone/log ${OPENSHIFT_JBOSSAS_DIR}/logs
 
 shopt -s dotglob

--- a/cartridges/openshift-origin-cartridge-jbossas/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-jbossas/metadata/managed_files.yml
@@ -16,3 +16,7 @@ locked_files:
 - env/M2_HOME
 processed_templates:
 - 'metadata/jenkins_artifacts_glob.erb'
+dependency_dirs:
+- standalone/deployments: deployments
+build_dependency_dirs:
+- ~/.m2

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/install
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/install
@@ -9,12 +9,6 @@ esac
 
 echo "$version" > "$OPENSHIFT_JBOSSEAP_DIR/env/OPENSHIFT_JBOSSEAP_VERSION"
 
-mkdir -p ${OPENSHIFT_BUILD_DEPENDENCIES_DIR}/.m2
-ln -sf ${OPENSHIFT_BUILD_DEPENDENCIES_DIR}/.m2 ${OPENSHIFT_HOMEDIR}/.m2
-
-mkdir -p ${OPENSHIFT_DEPENDENCIES_DIR}deployments
-ln -sf ${OPENSHIFT_DEPENDENCIES_DIR}deployments standalone/deployments
-
 ln -s ${OPENSHIFT_JBOSSEAP_DIR}/standalone/log ${OPENSHIFT_JBOSSEAP_DIR}/logs
 
 shopt -s dotglob

--- a/cartridges/openshift-origin-cartridge-jbosseap/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-jbosseap/metadata/managed_files.yml
@@ -17,3 +17,7 @@ processed_templates:
 - 'metadata/jenkins_artifacts_glob.erb'
 setup_rewritten:
 - versions/*
+dependency_dirs:
+- standalone/deployments: deployments
+build_dependency_dirs:
+- ~/.m2

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/install
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/install
@@ -10,12 +10,6 @@ source ${OPENSHIFT_JBOSSEWS_DIR}/bin/util
 
 echo "$version" > "$OPENSHIFT_JBOSSEWS_DIR/env/OPENSHIFT_JBOSSEWS_VERSION"
 
-mkdir -p ${OPENSHIFT_DEPENDENCIES_DIR}webapps
-ln -sf ${OPENSHIFT_DEPENDENCIES_DIR}webapps webapps
-
-mkdir -p ${OPENSHIFT_BUILD_DEPENDENCIES_DIR}/.m2
-ln -sf ${OPENSHIFT_BUILD_DEPENDENCIES_DIR}/.m2 ${OPENSHIFT_HOMEDIR}/.m2
-
 sed -i "s/{APP_NAME}/${OPENSHIFT_APP_NAME}/g" ${OPENSHIFT_JBOSSEWS_DIR}/template/pom.xml
 
 # Create and install the initial template WAR

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/setup
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/setup
@@ -12,18 +12,6 @@ if [ ! -d ${SYSTEM_JBOSSEWS_DIR} ]; then
   exit 127
 fi
 
-# If there's a symlinked webapps directory, we're migrating to 0.0.2
-migrate_webapps=false
-if [ -h "${OPENSHIFT_JBOSSEWS_DIR}/webapps" ]; then
-  migrate_webapps=true
-fi
-
-# If migrating, replace the old symlinked 'webapps' with a physical directory
-if $migrate_webapps; then
-  rm -f ${OPENSHIFT_JBOSSEWS_DIR}/webapps
-fi
-
-
 mkdir -p ${OPENSHIFT_JBOSSEWS_DIR}/{run,tmp,conf,logs}
 
 # Set up the config directory in the user repository template
@@ -45,12 +33,3 @@ ln -sf ${OPENSHIFT_REPO_DIR}/.openshift/config/postgresql_module.xml ${OPENSHIFT
 ln -sf ${OPENSHIFT_REPO_DIR}/.openshift/config/catalina.properties ${OPENSHIFT_JBOSSEWS_DIR}/conf
 ln -sf ${OPENSHIFT_REPO_DIR}/.openshift/config/catalina.policy ${OPENSHIFT_JBOSSEWS_DIR}/conf
 ln -sf ${OPENSHIFT_REPO_DIR}/.openshift/config/logging.properties ${OPENSHIFT_JBOSSEWS_DIR}/conf
-
-# If migrating, copy the existing app repo contents to the new webapps directory
-if $migrate_webapps; then
-  if [ -d ${OPENSHIFT_REPO_DIR}/webapps ]; then
-    shopt -s dotglob
-    mv ${OPENSHIFT_REPO_DIR}/webapps/* ${OPENSHIFT_JBOSSEWS_DIR}/webapps/
-    shopt -u dotglob
-  fi
-fi

--- a/cartridges/openshift-origin-cartridge-jbossews/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-jbossews/metadata/managed_files.yml
@@ -13,3 +13,7 @@ locked_files:
 - env/M2_HOME
 processed_templates:
 - 'metadata/jenkins_artifacts_glob.erb'
+dependency_dirs:
+- webapps
+build_dependency_dirs:
+- ~/.m2

--- a/cartridges/openshift-origin-cartridge-nodejs/bin/install
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/install
@@ -10,24 +10,21 @@ case "$1" in
     version="$2"
 esac
 
+ln -s ${OPENSHIFT_DEPENDENCIES_DIR}nodejs/node_modules ${OPENSHIFT_HOMEDIR}.node_modules
+
 ## npm link
 pushd $OPENSHIFT_NODEJS_DIR > /dev/null
   npmgl=$OPENSHIFT_NODEJS_DIR/versions/$version/configuration/npm_global_module_list
   module_list=$(perl -ne 'print if /^\s*[^#\s]/' "$npmgl" | tr '\n' ' ')
   npm link $module_list >/dev/null 2>&1
-  mv node_modules $OPENSHIFT_DEPENDENCIES_DIR/node_modules
-  ln -s ${OPENSHIFT_DEPENDENCIES_DIR}node_modules node_modules
-  ln -s ${OPENSHIFT_DEPENDENCIES_DIR}node_modules ${OPENSHIFT_HOMEDIR}.node_modules
 popd > /dev/null
 
 # npm keeps per-user config in ~/.npmrc and cache in ~/.npm/  and
 # node-gyp (add-on build tool) uses ~/.node-gyp
 # Create files/directories, change ownership and SELinux file security context.
 touch "$OPENSHIFT_HOMEDIR"/.npmrc
-mkdir "$OPENSHIFT_HOMEDIR"/.npm
 mkdir "$OPENSHIFT_HOMEDIR"/.node-gyp
-chown `id -u $OPENSHIFT_GEAR_UUID` -R "$OPENSHIFT_HOMEDIR"/.npm "$OPENSHIFT_HOMEDIR"/.npmrc  \
-                            "$OPENSHIFT_HOMEDIR"/.node-gyp
+chown `id -u $OPENSHIFT_GEAR_UUID` -R "$OPENSHIFT_HOMEDIR"/.npmrc "$OPENSHIFT_HOMEDIR"/.node-gyp
 nodejs_context "npm config set tmp $OPENSHIFT_TMP_DIR"
 
 echo "$version" > $OPENSHIFT_NODEJS_DIR/env/OPENSHIFT_NODEJS_VERSION

--- a/cartridges/openshift-origin-cartridge-nodejs/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-nodejs/metadata/managed_files.yml
@@ -15,3 +15,6 @@ processed_templates:
 - '**/*.erb'
 setup_rewritten:
 - 'versions/**/*'
+dependency_dirs:
+- ~/.npm
+- node_modules

--- a/cartridges/openshift-origin-cartridge-perl/bin/install
+++ b/cartridges/openshift-origin-cartridge-perl/bin/install
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# Create dependencies symlink
-mkdir -p $OPENSHIFT_DEPENDENCIES_DIR/.cpanm
-ln -sf ${OPENSHIFT_DEPENDENCIES_DIR}.cpanm ${OPENSHIFT_HOMEDIR}.cpanm
-
 # Create additional directories required by PERL and httpd
 ln -s /usr/lib64/httpd/modules $OPENSHIFT_PERL_DIR
 ln -s /etc/httpd/conf/magic $OPENSHIFT_PERL_DIR/etc/magic

--- a/cartridges/openshift-origin-cartridge-perl/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-perl/metadata/managed_files.yml
@@ -15,3 +15,5 @@ locked_files:
 - etc/conf.d/openshift.conf
 processed_templates:
 - '**/*.erb'
+dependency_dirs:
+- .cpanm

--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -71,11 +71,9 @@ function tidy() {
 
 function build() {
     echo "Building PHP cartridge"
-    if [ -f "${OPENSHIFT_REPO_DIR}/.openshift/markers/force_clean_build" ]
-    then
-        echo ".openshift/markers/force_clean_build found!  Recreating pear libs" 1>&2
-        rm -rf "${OPENSHIFT_PHP_DIR}"/phplib/pear/*
-        mkdir -p "${OPENSHIFT_PHP_DIR}"/phplib/pear/{docs,ext,php,cache,cfg,data,download,temp,tests,www}
+    if force_clean_build_enabled_for_latest_deployment; then
+      echo "force_clean_build enabled - recreating pear libs" 1>&2
+      mkdir -p "${OPENSHIFT_PHP_DIR}"/phplib/pear/{docs,ext,php,cache,cfg,data,download,temp,tests,www}
     fi
 
     if [ -f ${OPENSHIFT_REPO_DIR}deplist.txt ]

--- a/cartridges/openshift-origin-cartridge-php/bin/install
+++ b/cartridges/openshift-origin-cartridge-php/bin/install
@@ -8,10 +8,6 @@ esac
 echo "$version" > "$OPENSHIFT_PHP_DIR/env/OPENSHIFT_PHP_VERSION"
 echo "$OPENSHIFT_PHP_DIR/configuration/etc/php.ini" > "$OPENSHIFT_PHP_DIR/env/PHPRC"
 
-# Create dependencies symlink
-mkdir -p $OPENSHIFT_DEPENDENCIES_DIR/phplib
-ln -sf ${OPENSHIFT_DEPENDENCIES_DIR}phplib phplib
-
 # Create additional directories required by PHP
 mkdir -p $OPENSHIFT_PHP_DIR/phplib/pear/{docs,ext,php,cache,cfg,data,download,temp,tests,www}
 mkdir -p $OPENSHIFT_PHP_DIR/{logs,run,tmp,sessions}

--- a/cartridges/openshift-origin-cartridge-php/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-php/metadata/managed_files.yml
@@ -21,3 +21,5 @@ locked_files:
 - hooks/*
 processed_templates:
 - '**/*.erb'
+dependency_dirs:
+- phplib

--- a/cartridges/openshift-origin-cartridge-python/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-python/metadata/managed_files.yml
@@ -18,3 +18,5 @@ locked_files:
 - env/OPENSHIFT_PYTHON_LOG_DIR
 processed_templates:
 - '**/*.erb'
+dependency_dirs:
+- virtenv

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-community/bin/install
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-community/bin/install
@@ -17,12 +17,6 @@ cp -r $OPENSHIFT_PYTHON_DIR/usr/versions/$version/template/* $OPENSHIFT_PYTHON_D
 # Source in the utility functions.
 source "${OPENSHIFT_PYTHON_DIR}/usr/versions/$version/lib/utils"
 
-# create the virtualenv symlink
-pushd $OPENSHIFT_PYTHON_DIR > /dev/null
-mkdir -p $OPENSHIFT_DEPENDENCIES_DIR/virtenv
-ln -s $OPENSHIFT_DEPENDENCIES_DIR/virtenv virtenv
-popd > /dev/null
-
 # Create the virtualenv.
 create_virtualenv
 

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/install
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/install
@@ -10,12 +10,6 @@ cp -r $OPENSHIFT_PYTHON_DIR/usr/versions/$version/template/* $OPENSHIFT_PYTHON_D
 ln -sf /usr/lib64/httpd/modules $OPENSHIFT_PYTHON_DIR
 ln -sf /etc/httpd/conf/magic $OPENSHIFT_PYTHON_DIR/etc/magic
 
-# Create the virtenv symlink
-pushd $OPENSHIFT_PYTHON_DIR > /dev/null
-mkdir -p $OPENSHIFT_DEPENDENCIES_DIR/virtenv
-ln -s $OPENSHIFT_DEPENDENCIES_DIR/virtenv virtenv
-popd > /dev/null
-
 # The virtual environment is assumed to exist going forward
 if [ ! -f $OPENSHIFT_PYTHON_DIR/virtenv/bin/python ]
 then

--- a/node/lib/openshift-origin-node/model/application_container_ext/setup.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/setup.rb
@@ -79,7 +79,7 @@ module OpenShift
           }
 
           # create initial deployment directory
-          create_deployment_dir
+          deployment_datetime = create_deployment_dir
 
           add_env_var("HISTFILE", PathUtils.join(data_dir, ".bash_history"))
           profile = PathUtils.join(data_dir, ".bash_profile")
@@ -108,8 +108,6 @@ module OpenShift
           add_env_var("BUILD_DEPENDENCIES_DIR", PathUtils.join(gearappdir, "runtime", "build-dependencies") + "/", true)
 
           add_env_var("REPO_DIR", PathUtils.join(gearappdir, "runtime", "repo") + "/", true) do |v|
-            # don't create the actual dir, since it's now a symlink
-            #FileUtils.mkdir_p(v, :verbose => @debug)
             FileUtils.cd gearappdir do |d|
               FileUtils.ln_s("runtime/repo", "repo", :verbose => @debug)
               FileUtils.ln_s("runtime/dependencies", "dependencies", :verbose => @debug)
@@ -132,6 +130,9 @@ module OpenShift
             FileUtils.chmod_R(0750, e, :verbose => @debug)
             set_rw_permission_R(e)
           }
+
+          update_build_dependencies_symlink(deployment_datetime)
+          update_dependencies_symlink(deployment_datetime)
 
           # Change symlink ownership
           PathUtils.oo_lchown(uid, gid, "#{gearappdir}/repo", "#{gearappdir}/dependencies", "#{gearappdir}/build-dependencies")

--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -208,7 +208,9 @@ command :postreceive do |c|
           end
         end
 
-        puts "Deployment completed"
+        puts "Deployment completed with status: #{result[:status]}"
+
+        raise "postreceive failed" unless result[:status] == RESULT_SUCCESS
       end
     end
   end

--- a/node/test/support/functional_api.rb
+++ b/node/test/support/functional_api.rb
@@ -104,7 +104,7 @@ class FunctionalApi
 Host #{app_name}-#{@namespace}.#{cloud_domain}
   StrictHostKeyChecking no
 EOFZ
-      f.write ssh_config      
+      f.write ssh_config
     end
   end
 
@@ -126,7 +126,7 @@ EOFZ
 
   def add_env_vars(app_name, vars)
     logger.info("Adding environment variables to app #{app_name}: #{vars}")
-    
+
     begin
       response = RestClient::Request.execute(method: :post,
                                              url: "#{@url_base}/domain/#{@namespace}/application/#{app_name}/environment-variables",
@@ -220,9 +220,11 @@ EOFZ
         content = Net::HTTP.get(uri)
       rescue SocketError => e
         logger.info("DNS lookup failure; retrying #{url}")
+        sleep 1
         next
       rescue Errno::ECONNREFUSED => e
         logger.info("connection refused; retrying #{url}")
+        sleep 1
         next
       end
 

--- a/node/test/unit/build_lifecycle_test.rb
+++ b/node/test/unit/build_lifecycle_test.rb
@@ -364,10 +364,6 @@ class BuildLifecycleTest < OpenShift::NodeTestCase
 
   def test_configure_defaults
     cart_name = 'mock-0.1'
-    latest_deployment_datetime = "now"
-    @container.expects(:latest_deployment_datetime).returns(latest_deployment_datetime)
-    @container.expects(:update_dependencies_symlink).with(latest_deployment_datetime)
-    @container.expects(:update_build_dependencies_symlink).with(latest_deployment_datetime)
     @cartridge_model.expects(:configure).with(cart_name, nil, nil)
     @container.configure(cart_name)
   end
@@ -376,10 +372,6 @@ class BuildLifecycleTest < OpenShift::NodeTestCase
     cart_name = 'mock-0.1'
     template_git_url = 'url'
     manifest = 'manifest'
-    latest_deployment_datetime = "now"
-    @container.expects(:latest_deployment_datetime).returns(latest_deployment_datetime)
-    @container.expects(:update_dependencies_symlink).with(latest_deployment_datetime)
-    @container.expects(:update_build_dependencies_symlink).with(latest_deployment_datetime)
     @cartridge_model.expects(:configure).with(cart_name, template_git_url, manifest)
     @container.configure(cart_name, template_git_url, manifest)
   end


### PR DESCRIPTION
Add dependency_dirs and build_dependency_dirs to managed_files.yml so
the platform can create
these dependency directories and symlinks when configuring the
cartridge and for clean builds.

Remove per-cartridge creation of dependency directories and symlinks in
each install script.

Remove per-cartridge force_clean_build logic wherever possible (some
cartridges may still need some, however)

Bug 1018387
Bug 1018969
