### PR TITLE
Adding application and domain icon to their respective page heading

### DIFF
--- a/console/app/assets/stylesheets/_iconfont.scss
+++ b/console/app/assets/stylesheets/_iconfont.scss
@@ -62,16 +62,13 @@
 .font-icon-size-44      {font-size: 44px !important;}
 
 
-h1[class*="icon-"]:before,
-h2[class*="icon-"]:before {
-  left: -8px;
-  margin-left: 8px;
+h1 .font-icon {
+  margin-right: 4px;
+  color: #aaa;
+  @include icon-text-shadow($color: rgba(255, 255, 255, 1));
 }
-h3[class*="icon-"]:before,
-h4[class*="icon-"]:before,
-h5[class*="icon-"]:before {
-  left: -6px;
-  margin-left: 6px;
+h1 .font-icon {
+  font-size: $h1FontSize - 3; 
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -138,7 +135,3 @@ dl.font-icon-legend {
     font-size: $leadFontSize;
   }
 }
-
-
-
- 

--- a/console/app/assets/stylesheets/_mixins.scss
+++ b/console/app/assets/stylesheets/_mixins.scss
@@ -122,7 +122,7 @@
 
 
 @mixin icon-text-shadow($color: rgba(255, 255, 255, 0.5)) {
-  text-shadow: 0 1px 0 $color;
+  text-shadow: 0 0 3px $color;
 }
 
 // Requires inline-block or block

--- a/console/app/views/applications/index.html.haml
+++ b/console/app/views/applications/index.html.haml
@@ -6,7 +6,9 @@
 - content_for :top do
   .grid-wrapper.section-header
     %nav.span12.applications
-      %h1 Applications
+      %h1.applications
+        %span.font-icon{:'data-icon' => "\uee48", 'aria-hidden'=>"true"}
+        Applications
 
 :css
   @media (max-width: 767px) {

--- a/console/app/views/domains/index.html.haml
+++ b/console/app/views/domains/index.html.haml
@@ -3,7 +3,8 @@
 - content_for :top do
   .grid-wrapper.section-header
     %nav.span12.domains
-      %h1.flow
+      %h1
+        %span.font-icon{:'data-icon' => "\uee45", 'aria-hidden'=>"true"}
         Domains
 
 %section#app-list


### PR DESCRIPTION
Adjustments to icon-text-shadow mixin to optimize contrast of icon on light background

Removed h_[class_="icon-"]:before rules which were old and not used.
