### PR TITLE
Bug 1020177: Bail out on upgrade in a more shell-friendly way

### DIFF
--- a/cartridges/openshift-origin-cartridge-mysql/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-mysql/bin/upgrade
@@ -3,14 +3,10 @@ mysql_version="$1"
 old_cart_version="$2"                                                              
 new_cart_version="$3"   
 
-v_major=${new_cart_version%%.*} # first component of .-delimited list
-v_minor=${${new_cart_version#*.}%%.*} # second component
-
-if [ $v_major -ne 1 -o $v_minor -ne 17 ]; then
-	exit 0 # no migrations
+if [[ $new_cart_version =~ 0.2.4 ]]; then
+	files=$(shopt -s nullglob; shopt -s dotglob; echo data/ib_logfile*)
+	if [ ${#files} -gt 0 ]; then
+	  mv data/ib_logfile* /tmp
+	fi
 fi
 
-files=$(shopt -s nullglob; shopt -s dotglob; echo data/ib_logfile*)
-if [ ${#files} -gt 0 ]; then
-  mv data/ib_logfile* /tmp
-fi


### PR DESCRIPTION
Manipulating env var might be problematic
