### PR TITLE
oo-admin-ctl-iptables-port-proxy: SELinux fix

### DIFF
--- a/node/misc/sbin/oo-admin-ctl-iptables-port-proxy
+++ b/node/misc/sbin/oo-admin-ctl-iptables-port-proxy
@@ -9,11 +9,11 @@
 case "$1" in
     start)
         if [ -f /etc/openshift/iptables.filter.rules ]; then
-           iptables-restore -n <(echo "*filter"; cat /etc/openshift/iptables.filter.rules; echo "COMMIT")
+          { echo "*filter"; cat /etc/openshift/iptables.filter.rules; echo "COMMIT"; } | iptables-restore -n
         fi
 
         if [ -f /etc/openshift/iptables.nat.rules ]; then
-           iptables-restore -n <(echo "*nat"; cat /etc/openshift/iptables.nat.rules; echo "COMMIT")
+          { echo "*nat"; cat /etc/openshift/iptables.nat.rules; echo "COMMIT"; } | iptables-restore -n
         fi
         ;;
     stop)


### PR DESCRIPTION
Give input to iptables-restore on standard input instead of using command substitution.

Bash was expanding the <(...) command-substitution to a fifo, which oo-admin-ctl-iptables-port-proxy was then passing to the iptables-restore command as a command-line argument.  If oo-admin-ctl-iptables-port-proxy was being run from the /etc/init.d/openshift-iptables-port-proxy initscript, then Bash would have an SELinux context with type initrc_t, and it thus would create the fifo also with type initrc_t.  However, iptables-restore transitions SELinux contexts so that it is running with the iptables_t type.  The iptables-restore command would thus fail when it tried to open the fifo because SELinux policy blocks processes with type iptables_t from reading fifos with type initrc_t.

(Interestingly, the manpage for iptables-restore does not indicate that iptables-restore is even supposed to take a filename as an argument.)

This commit fixes bug 1020391.
