### PR TITLE
<nodejs cartridge> Fix npm link for SCL versions

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/bin/install
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/install
@@ -7,16 +7,16 @@ source "${OPENSHIFT_NODEJS_DIR}/lib/nodejs_context"
 
 case "$1" in
   -v|--version)
-    version="$2"
+    OPENSHIFT_NODEJS_VERSION="$2"
 esac
 
 ln -s ${OPENSHIFT_DEPENDENCIES_DIR}nodejs/node_modules ${OPENSHIFT_HOMEDIR}.node_modules
 
 ## npm link
 pushd $OPENSHIFT_NODEJS_DIR > /dev/null
-  npmgl=$OPENSHIFT_NODEJS_DIR/versions/$version/configuration/npm_global_module_list
-  module_list=$(perl -ne 'print if /^\s*[^#\s]/' "$npmgl" | tr '\n' ' ')
-  npm link $module_list >/dev/null 2>&1
+  npmgl=$OPENSHIFT_NODEJS_DIR/versions/$OPENSHIFT_NODEJS_VERSION/configuration/npm_global_module_list
+  module_list=$(comm -12 <(perl -ne 'print if /^\s*[^#\s]/' "$npmgl" | sort ) <(nodejs_context "npm ls -g 2> /dev/null" | grep '@' | awk -F'[ @]' '{print $2}' | sort ) | tr '\n' ' ')
+  nodejs_context "npm link $module_list >/dev/null 2>&1"
 popd > /dev/null
 
 # npm keeps per-user config in ~/.npmrc and cache in ~/.npm/  and
@@ -27,5 +27,5 @@ mkdir "$OPENSHIFT_HOMEDIR"/.node-gyp
 chown `id -u $OPENSHIFT_GEAR_UUID` -R "$OPENSHIFT_HOMEDIR"/.npmrc "$OPENSHIFT_HOMEDIR"/.node-gyp
 nodejs_context "npm config set tmp $OPENSHIFT_TMP_DIR"
 
-echo "$version" > $OPENSHIFT_NODEJS_DIR/env/OPENSHIFT_NODEJS_VERSION
-update-configuration $version
+echo "$OPENSHIFT_NODEJS_VERSION" > $OPENSHIFT_NODEJS_DIR/env/OPENSHIFT_NODEJS_VERSION
+update-configuration $OPENSHIFT_NODEJS_VERSION


### PR DESCRIPTION
npm link was being run in the system context instead of the SCL context
during install if an SCL version is chosen.

nodejs_context uses $OPENSHIFT_NODEJS_VERSION, but since this variable
is also set in the bin/install script, need to explicitly set the
variable to prevent errors with using nodejs_context in bin/install

Removing modules from the npm_global_module_list that do not exist in
the installed SCL package set.
