### PR TITLE
Bug 1020997 - Introduce etc_utils.rb

### DIFF
--- a/common/lib/openshift-origin-common.rb
+++ b/common/lib/openshift-origin-common.rb
@@ -17,6 +17,7 @@ require 'fileutils'
 require 'getoptlong'
 require 'json'
 require "openshift-origin-common/utils/path_utils"
+require "openshift-origin-common/utils/etc_utils"
 require "openshift-origin-common/config"
 require "openshift-origin-common/models/model"
 require "openshift-origin-common/exceptions/oo_exception"

--- a/common/lib/openshift-origin-common/utils/etc_utils.rb
+++ b/common/lib/openshift-origin-common/utils/etc_utils.rb
@@ -1,0 +1,41 @@
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+require 'etc'
+
+module EtcUtils
+  def getpwnam(user)
+    return nil unless user
+
+    (user.to_i > 4294967295) ?
+        Etc.getpwnam(user.to_s) :
+        Etc.getpwnam(user)
+  end
+
+  module_function :getpwnam
+
+
+  def getgrnam(group)
+    return nil unless group
+
+    (group.to_i > 4294967295) ?
+        Etc.getgrnam(group.to_s) :
+        Etc.getgrnam(group)
+  end
+
+  module_function :getgrnam
+
+end

--- a/common/lib/openshift-origin-common/utils/path_utils.rb
+++ b/common/lib/openshift-origin-common/utils/path_utils.rb
@@ -17,9 +17,10 @@
 require 'fileutils'
 require 'etc'
 require 'pathname'
+require 'openshift-origin-common/utils/etc_utils'
 
 module PathUtils
-  def self.private_module_function(name)   #:nodoc:
+  def self.private_module_function(name) #:nodoc:
     module_function name
     private_class_method name
   end
@@ -79,14 +80,8 @@ module PathUtils
 
   def pu_get_uid(user)
     return nil unless user
-    case user
-      when Integer
-        user < 4294967296 ? user : Etc.getpwnam(user.to_s).uid
-      when /\A\d{1,10}\z/
-        user.to_i
-      else
-        Etc.getpwnam(user).uid
-    end
+
+    EtcUtils.getpwnam(user).uid
   end
 
   private_module_function :pu_get_uid
@@ -94,14 +89,7 @@ module PathUtils
   def pu_get_gid(group)
     return nil unless group
 
-    case group
-      when Integer
-        group < 4294967296 ? group : Etc.getgrnam(group.to_s).gid
-      when /\A\d{1,10}\z/
-        group.to_i
-      else
-        Etc.getgrnam(group).gid
-    end
+    EtcUtils.getgrnam(group).gid
   end
 
   private_module_function :pu_get_gid

--- a/common/test/unit/etc_utils_test.rb
+++ b/common/test/unit/etc_utils_test.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env oo-ruby
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+#
+# Test the OpenShift manifest model
+#
+require_relative '../test_helper'
+require 'ostruct'
+require 'mocha/setup'
+
+class EtcUtilsTest < Test::Unit::TestCase
+  def setup
+    @pwent = OpenStruct.new(uid: 666, gid: 666)
+  end
+
+  def test_grpwname_fixnum
+    name = 921957316561229358039040
+    Etc.expects(:getpwnam).with(name.to_s).returns(@pwent)
+    assert_equal @pwent.uid, EtcUtils.getpwnam(name).uid
+  end
+
+  def test_getgrname_fixnum
+    name = 921957316561229358039040
+    Etc.expects(:getgrnam).with(name.to_s).returns(@pwent)
+    assert_equal @pwent.gid, EtcUtils.getgrnam(name).gid
+  end
+
+  def test_grpwname_int
+    uid = 666
+    Etc.expects(:getpwnam).with(uid).returns(@pwent)
+    assert_equal @pwent.uid, EtcUtils.getpwnam(uid).uid
+  end
+
+  def test_getgrname_int
+    uid = 666
+    Etc.expects(:getgrnam).with(uid).returns(@pwent)
+    assert_equal @pwent.gid, EtcUtils.getgrnam(uid).gid
+  end
+
+  def test_grpwname_string
+    uid = "666"
+    Etc.expects(:getpwnam).with(uid).returns(@pwent)
+    assert_equal @pwent.uid, EtcUtils.getpwnam(uid).uid
+  end
+
+  def test_getgrname_string
+    uid = "666"
+    Etc.expects(:getgrnam).with(uid).returns(@pwent)
+    assert_equal @pwent.gid, EtcUtils.getgrnam(uid).gid
+  end
+end

--- a/node/lib/openshift-origin-node/utils/selinux.rb
+++ b/node/lib/openshift-origin-node/utils/selinux.rb
@@ -79,11 +79,7 @@ module OpenShift
 
 
           begin
-            if name.to_i.to_s == name.to_s
-              uid = name.to_i
-            else
-              uid = Etc.getpwnam(name.to_s).uid
-            end
+              uid = EtcUtils.getpwnam(name).uid
           rescue ArgumentError, TypeError, NoMethodError
             raise ArgumentError, "Argument must be a numeric UID or existing username: #{name}"
           end

--- a/node/test/functional/path_utils_test.rb
+++ b/node/test/functional/path_utils_test.rb
@@ -31,16 +31,16 @@ class PathUtilsTest < OpenShift::NodeTestCase
   end
 
   def test_oo_chown
-    Etc.stubs(:getpwnam).never
-    Etc.stubs(:getgrnam).never
+    Etc.stubs(:getpwnam).with(kind_of(Integer)).returns(@stat).once
+    Etc.stubs(:getgrnam).with(kind_of(Integer)).returns(@stat).once
     FileUtils.stubs(:chown).with(@uid, @uid, '/mocked/a', {}).returns(nil).once
 
     PathUtils.oo_chown(@uid, @uid, '/mocked/a')
   end
 
   def test_oo_chown_R
-    Etc.stubs(:getpwnam).never
-    Etc.stubs(:getgrnam).never
+    Etc.stubs(:getpwnam).with(kind_of(Integer)).returns(@stat).once
+    Etc.stubs(:getgrnam).with(kind_of(Integer)).returns(@stat).once
     FileUtils.stubs(:chown_R).with(@uid, @uid, '/mocked/a', {}).returns(nil).once
 
     PathUtils.oo_chown_R(@uid, @uid, '/mocked/a')


### PR DESCRIPTION
- Add common/lib/openshift-origin-common/utils/etc_utils.rb to safely
  allow the Node and Broker code to map a login name to UNIX user uid
