### PR TITLE
Bug 1021355

### DIFF
--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -65,7 +65,7 @@ end
 
 def valid_git_ref?(ref)
   Dir.chdir(@repo.path) do
-    system "git show-ref #{ref} >/dev/null 2>&1"
+    system "git rev-parse --quiet --verify #{ref} >/dev/null 2>&1"
   end
 end
 


### PR DESCRIPTION
Check for git objects with `git rev-parse` rather than for references with
`git show-ref`.
