### PR TITLE
Adding a specific class for icons associated with h1 headings so as to n...

### DIFF
--- a/console/app/assets/stylesheets/_iconfont.scss
+++ b/console/app/assets/stylesheets/_iconfont.scss
@@ -62,12 +62,12 @@
 .font-icon-size-44      {font-size: 44px !important;}
 
 
-h1 .font-icon {
+h1.icon-heading .font-icon {
   margin-right: 4px;
   color: #aaa;
   @include icon-text-shadow($color: rgba(255, 255, 255, 1));
 }
-h1 .font-icon {
+h1.icon-heading .font-icon {
   font-size: $h1FontSize - 3; 
 }
 

--- a/console/app/assets/stylesheets/console/_application.scss
+++ b/console/app/assets/stylesheets/console/_application.scss
@@ -33,16 +33,13 @@
       }
     }
   }
-	.gear-numbers {
-		color: #bcbdbc;
-	}
 }
 
 .application, #app-cartridges {
   .flow-block {
     .font-icon-link {
       &:visited, &:link {
-        color: inherit;
+        color: $grayLight;
       }
       &:hover, &:active {
         color: $openshiftBrightRed;

--- a/console/app/assets/stylesheets/console/_tile.scss
+++ b/console/app/assets/stylesheets/console/_tile.scss
@@ -120,7 +120,6 @@
       }
       .gear-icon, {
         font-size: 20px;
-        font-size: $smallFontSize;
       }
       .restart {
         &.confirm-container {

--- a/console/app/views/applications/index.html.haml
+++ b/console/app/views/applications/index.html.haml
@@ -6,7 +6,7 @@
 - content_for :top do
   .grid-wrapper.section-header
     %nav.span12.applications
-      %h1.applications
+      %h1.icon-heading.applications
         %span.font-icon{:'data-icon' => "\uee48", 'aria-hidden'=>"true"}
         Applications
 

--- a/console/app/views/domains/index.html.haml
+++ b/console/app/views/domains/index.html.haml
@@ -3,7 +3,7 @@
 - content_for :top do
   .grid-wrapper.section-header
     %nav.span12.domains
-      %h1
+      %h1.icon-heading
         %span.font-icon{:'data-icon' => "\uee45", 'aria-hidden'=>"true"}
         Domains
 


### PR DESCRIPTION
...ot effect all icons within h1. e.g. application/show

Remove old style .gear-numbers which is no longer used
Change "external link" icon color to grey instead of black
Remove inadvertant dupulication of font-size on .gear-icon
