### PR TITLE
Various deploy fixes

### DIFF
--- a/cartridges/openshift-origin-cartridge-jenkins-client/metadata/jenkins_shell_command
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/metadata/jenkins_shell_command
@@ -4,14 +4,8 @@ alias rsync="rsync --delete-after -az -e '$GIT_SSH'"
 
 upstream_ssh="UPSTREAM_SSH"
 
-# Create a new deployment dir
-# NOTE: the deployment dir's repo dir will remain empty and
-# ~/app-root/runtime/repo will be used instead
-local_deployment_dir=`gear create-deployment-dir`
-
-# Set up symlinks
-ln -nsf $OPENSHIFT_HOMEDIR/app-deployments/$local_deployment_dir/build-dependencies $OPENSHIFT_HOMEDIR/app-root/runtime/build-dependencies
-ln -nsf $OPENSHIFT_HOMEDIR/app-deployments/$local_deployment_dir/dependencies $OPENSHIFT_HOMEDIR/app-root/runtime/dependencies
+# remove previous metadata, if any
+rm -f $OPENSHIFT_HOMEDIR/app-deployments/current/metadata.json
 
 if ! marker_present "force_clean_build"; then
   # don't fail if these rsyncs fail
@@ -34,10 +28,10 @@ $GIT_SSH $upstream_ssh "gear stop --conditional --exclude-web-proxy --git-ref $G
 deployment_dir=`$GIT_SSH $upstream_ssh 'gear create-deployment-dir'`
 
 # Push content back to application
-rsync $OPENSHIFT_HOMEDIR/app-deployments/$local_deployment_dir/metadata.json $upstream_ssh:app-deployments/$deployment_dir/metadata.json
-rsync $WORKSPACE/ $upstream_ssh:app-deployments/$deployment_dir/repo/
-rsync $OPENSHIFT_BUILD_DEPENDENCIES_DIR $upstream_ssh:app-deployments/$deployment_dir/build-dependencies/
-rsync $OPENSHIFT_DEPENDENCIES_DIR $upstream_ssh:app-deployments/$deployment_dir/dependencies/
+rsync $OPENSHIFT_HOMEDIR/app-deployments/current/metadata.json $upstream_ssh:app-deployments/$deployment_dir/metadata.json
+rsync $WORKSPACE/ $upstream_ssh:app-root/runtime/repo/
+rsync $OPENSHIFT_BUILD_DEPENDENCIES_DIR $upstream_ssh:app-root/runtime/build-dependencies/
+rsync $OPENSHIFT_DEPENDENCIES_DIR $upstream_ssh:app-root/runtime/dependencies/
 
 # Configure / start app
 $GIT_SSH $upstream_ssh "gear remotedeploy --deployment-datetime $deployment_dir"

--- a/cartridges/openshift-origin-cartridge-nodejs/bin/control
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/control
@@ -213,31 +213,9 @@ function build() {
 
     if force_clean_build_enabled_for_latest_deployment; then
       echo "Force-clean builds are enabled. Recreating npm modules" 1>&2
-      # These are directories we want to remove modules from
-      clean_dirs=(
-        "${OPENSHIFT_NODEJS_DIR}/node_modules"
-        "${OPENSHIFT_HOMEDIR}/.npm"
-        "${OPENSHIFT_REPO_DIR}/node_modules"
-      )
+      #TODO see if we need to clean out $OPENSHIFT_REPO_DIR/node_modules
 
-      for dir in "${clean_dirs[@]}"
-      do
-        if [ -d "${dir}" ]
-        then
-          pushd "${dir}" > /dev/null
-          # Only remove non-hidden directories that are not symlinks.
-          #   This lets us remove all installed modules except:
-          #     - Globally installed modules
-          #     - The regex prevents us from deleting hidden top level directories, including .bin
-          find . -maxdepth 1 -regex '^\.\/[^\.].*' -type d -exec rm -rf {} \;
-          # Clear out any missing symlinks from .bin (in case we removed the module)
-          if [ -d ".bin" ]
-          then
-            find .bin -type l -! -exec test -e {} \; -exec rm {} \;
-          fi
-          popd > /dev/null
-        fi
-      done
+      link_global_modules $OPENSHIFT_NODEJS_VERSION
     fi
 
     #  Newer versions of Node set tmp to $HOME/tmp, which is not available

--- a/cartridges/openshift-origin-cartridge-nodejs/bin/install
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/install
@@ -13,11 +13,7 @@ esac
 ln -s ${OPENSHIFT_DEPENDENCIES_DIR}nodejs/node_modules ${OPENSHIFT_HOMEDIR}.node_modules
 
 ## npm link
-pushd $OPENSHIFT_NODEJS_DIR > /dev/null
-  npmgl=$OPENSHIFT_NODEJS_DIR/versions/$version/configuration/npm_global_module_list
-  module_list=$(perl -ne 'print if /^\s*[^#\s]/' "$npmgl" | tr '\n' ' ')
-  npm link $module_list >/dev/null 2>&1
-popd > /dev/null
+link_global_modules $version
 
 # npm keeps per-user config in ~/.npmrc and cache in ~/.npm/  and
 # node-gyp (add-on build tool) uses ~/.node-gyp

--- a/cartridges/openshift-origin-cartridge-nodejs/lib/util
+++ b/cartridges/openshift-origin-cartridge-nodejs/lib/util
@@ -72,4 +72,13 @@ function parse_args {
   done
 }
 
+function link_global_modules {
+  version=$1
+  pushd $OPENSHIFT_NODEJS_DIR > /dev/null
+    npmgl=$OPENSHIFT_NODEJS_DIR/versions/$version/configuration/npm_global_module_list
+    module_list=$(perl -ne 'print if /^\s*[^#\s]/' "$npmgl" | tr '\n' ' ')
+    npm link $module_list >/dev/null 2>&1
+  popd > /dev/null
+}
+
 # vim: ft=sh

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-community/metadata/jenkins_shell_command.erb
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-community/metadata/jenkins_shell_command.erb
@@ -4,14 +4,8 @@ alias rsync="rsync --exclude-from='${OPENSHIFT_PYTHON_DIR}/metadata/rsync.exclud
 
 upstream_ssh="<%= ENV['OPENSHIFT_GEAR_UUID'] %>@<%= ENV['OPENSHIFT_APP_NAME'] %>-${OPENSHIFT_NAMESPACE}.<%= ENV['OPENSHIFT_CLOUD_DOMAIN'] %>"
 
-# Create a new deployment dir
-# NOTE: the deployment dir's repo dir will remain empty and
-# ~/app-root/runtime/repo will be used instead
-local_deployment_dir=`gear create-deployment-dir`
-
-# Set up symlinks
-ln -nsf $OPENSHIFT_HOMEDIR/app-deployments/$local_deployment_dir/build-dependencies $OPENSHIFT_HOMEDIR/app-root/runtime/build-dependencies
-ln -nsf $OPENSHIFT_HOMEDIR/app-deployments/$local_deployment_dir/dependencies $OPENSHIFT_HOMEDIR/app-root/runtime/dependencies
+# remove previous metadata, if any
+rm -f $OPENSHIFT_HOMEDIR/app-deployments/current/metadata.json
 
 if ! marker_present "force_clean_build"; then
   # don't fail if these rsyncs fail
@@ -35,10 +29,10 @@ $GIT_SSH $upstream_ssh "gear stop --conditional --exclude-web-proxy --git-ref $G
 deployment_dir=`$GIT_SSH $upstream_ssh 'gear create-deployment-dir'`
 
 # Push content back to application
-rsync $OPENSHIFT_HOMEDIR/app-deployments/$local_deployment_dir/metadata.json $upstream_ssh:app-deployments/$deployment_dir/metadata.json
-rsync $WORKSPACE/ $upstream_ssh:app-deployments/$deployment_dir/repo/
-rsync $OPENSHIFT_BUILD_DEPENDENCIES_DIR $upstream_ssh:app-deployments/$deployment_dir/build-dependencies/
-rsync $OPENSHIFT_DEPENDENCIES_DIR $upstream_ssh:app-deployments/$deployment_dir/dependencies/
+rsync $OPENSHIFT_HOMEDIR/app-deployments/current/metadata.json $upstream_ssh:app-deployments/$deployment_dir/metadata.json
+rsync $WORKSPACE/ $upstream_ssh:app-root/runtime/repo/
+rsync $OPENSHIFT_BUILD_DEPENDENCIES_DIR $upstream_ssh:app-root/runtime/build-dependencies/
+rsync $OPENSHIFT_DEPENDENCIES_DIR $upstream_ssh:app-root/runtime/dependencies/
 
 # Configure / start app
 $GIT_SSH $upstream_ssh "gear remotedeploy --deployment-datetime $deployment_dir"

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/metadata/jenkins_shell_command.erb
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/metadata/jenkins_shell_command.erb
@@ -4,14 +4,8 @@ alias rsync="rsync --delete-after -azO -e '$GIT_SSH'"
 
 upstream_ssh="<%= ENV['OPENSHIFT_GEAR_UUID'] %>@<%= ENV['OPENSHIFT_APP_NAME'] %>-${OPENSHIFT_NAMESPACE}.<%= ENV['OPENSHIFT_CLOUD_DOMAIN'] %>"
 
-# Create a new deployment dir
-# NOTE: the deployment dir's repo dir will remain empty and
-# ~/app-root/runtime/repo will be used instead
-local_deployment_dir=`gear create-deployment-dir`
-
-# Set up symlinks
-ln -nsf $OPENSHIFT_HOMEDIR/app-deployments/$local_deployment_dir/build-dependencies $OPENSHIFT_HOMEDIR/app-root/runtime/build-dependencies
-ln -nsf $OPENSHIFT_HOMEDIR/app-deployments/$local_deployment_dir/dependencies $OPENSHIFT_HOMEDIR/app-root/runtime/dependencies
+# remove previous metadata, if any
+rm -f $OPENSHIFT_HOMEDIR/app-deployments/current/metadata.json
 
 if ! marker_present "force_clean_build"; then
   # don't fail if these rsyncs fail
@@ -35,10 +29,10 @@ $GIT_SSH $upstream_ssh "gear stop --conditional --exclude-web-proxy --git-ref $G
 deployment_dir=`$GIT_SSH $upstream_ssh 'gear create-deployment-dir'`
 
 # Push content back to application
-rsync $OPENSHIFT_HOMEDIR/app-deployments/$local_deployment_dir/metadata.json $upstream_ssh:app-deployments/$deployment_dir/metadata.json
-rsync $WORKSPACE/ $upstream_ssh:app-deployments/$deployment_dir/repo/
-rsync $OPENSHIFT_BUILD_DEPENDENCIES_DIR $upstream_ssh:app-deployments/$deployment_dir/build-dependencies/
-rsync $OPENSHIFT_DEPENDENCIES_DIR $upstream_ssh:app-deployments/$deployment_dir/dependencies/
+rsync $OPENSHIFT_HOMEDIR/app-deployments/current/metadata.json $upstream_ssh:app-deployments/$deployment_dir/metadata.json
+rsync $WORKSPACE/ $upstream_ssh:app-root/runtime/repo/
+rsync $OPENSHIFT_BUILD_DEPENDENCIES_DIR $upstream_ssh:app-root/runtime/build-dependencies/
+rsync $OPENSHIFT_DEPENDENCIES_DIR $upstream_ssh:app-root/runtime/dependencies/
 
 # Configure / start app
 $GIT_SSH $upstream_ssh "gear remotedeploy --deployment-datetime $deployment_dir"

--- a/node/lib/openshift-origin-node/model/application_container_ext/setup.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/setup.rb
@@ -114,6 +114,11 @@ module OpenShift
 
           add_env_var("REPO_DIR", PathUtils.join(gearappdir, "runtime", "repo") + "/", true) do |v|
             FileUtils.mkdir_p(v, :verbose => @debug)
+            FileUtils.cd gearappdir do |d|
+              FileUtils.ln_s("runtime/repo", "repo", :verbose => @debug)
+              FileUtils.ln_s("runtime/dependencies", "dependencies", :verbose => @debug)
+              FileUtils.ln_s("runtime/build-dependencies", "build-dependencies", :verbose => @debug)
+            end
             FileUtils.cd PathUtils.join(gearappdir, "runtime") do |d|
               FileUtils.ln_s("../data", "data", :verbose => @debug)
             end

--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -537,10 +537,11 @@ module OpenShift
 
       # Creates cartridge dependency directories listed in managed_files.yml.
       #
-      # The directories are created  in ~/app-deployments/#{deployment_datetime}/dependencies.
+      # The directories are created in ~/app-root/runtime/dependencies and/or
+      # ~/app-root/runtime/build-dependencies.
       #
       # This method also creates symlinks from the cartridge directory to the appropriate
-      # symlink in ~/app-root/runtime/dependencies. For example:
+      # symlink in ~/app-root/runtime/{dependencies,build-dependencies}. For example:
       #
       # ~/php/phplib -> ~/app-root/runtime/dependencies/php/phplib
       def create_dependency_directories(cartridge)
@@ -558,15 +559,15 @@ module OpenShift
               # e.g. phplib
               link = target = entry
             else
-              # e.g. jbossas/deployments
+              # e.g. jbossas/standalone/deployments
               link = entry.keys[0]
 
-              # e.g. jbossas/standalone/deployments
+              # e.g. jbossas/deployments
               target = entry.values[0]
             end
 
-            # create the target dir inside the deps dir
-            dependencies_dir = PathUtils.join(@container.container_dir, 'app-deployments', @container.latest_deployment_datetime, dependencies_dir_name)
+            # create the target dir inside the runtime dir
+            dependencies_dir = PathUtils.join(@container.container_dir, 'app-root', 'runtime', dependencies_dir_name)
 
             FileUtils.mkdir_p(PathUtils.join(dependencies_dir, target))
 
@@ -691,7 +692,7 @@ module OpenShift
         end
 
         if repo.exist?
-          repo.archive(PathUtils.join(@container.container_dir, 'app-deployments', @container.latest_deployment_datetime, "repo"), 'master')
+          repo.archive(PathUtils.join(@container.container_dir, 'app-root', 'runtime', 'repo'), 'master')
         end
         ""
       end

--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -104,6 +104,7 @@ command :prereceive do |c|
   c.syntax = "#{name} prereceive"
 
   c.description = "Run the git prereceive steps"
+  c.option "--first-time", "Proceed even if the git ref to deploy isn't found. Used by post_configure"
   c.action do |args, options|
     do_command(c, options) do
       if ENV['OPENSHIFT_DEPLOYMENT_TYPE'] == 'binary'
@@ -133,10 +134,9 @@ command :prereceive do |c|
       end
 
       # only call pre_receive if
-      # - this is the first build ever, i.e. app-root/runtime/repo doesn't exist, OR
-      # - auto deployments are enabled
-      repo_dir = PathUtils.join(@container.container_dir, 'app-root', 'runtime', 'repo')
-      if !File.exist?(repo_dir) or (found_deployment_ref and ENV['OPENSHIFT_AUTO_DEPLOY'] != 'false')
+      # - this is the first build ever (--first-time) or
+      # - auto deployments are enabled and the appropriate git ref was pushed
+      if options.first_time or (found_deployment_ref and ENV['OPENSHIFT_AUTO_DEPLOY'] != 'false')
         @container.pre_receive(out: $stdout, err: $stderr, hot_deploy: hot_deploy)
       end
     end
@@ -147,6 +147,7 @@ command :postreceive do |c|
   c.syntax = "#{name} postreceive"
 
   c.description = "Run the git postreceive steps"
+  c.option "--first-time", "Proceed even if the git ref to deploy isn't found. Used by post_configure"
   c.action do |args, options|
     do_command(c, options) do
       if ENV['OPENSHIFT_DEPLOYMENT_TYPE'] == 'binary'
@@ -169,10 +170,9 @@ command :postreceive do |c|
       end
 
       # only call post_receive if
-      # - this is the first build ever, i.e. app-root/runtime/repo doesn't exist, OR
-      # - auto deployments are enabled
-      repo_dir = PathUtils.join(@container.container_dir, 'app-root', 'runtime', 'repo')
-      if !File.exist?(repo_dir) or (found_deployment_ref and ENV['OPENSHIFT_AUTO_DEPLOY'] != 'false')
+      # - this is the first build ever, i.e. --first-time or
+      # - auto deployments are enabled and the appropriate git ref was pushed
+      if options.first_time or (found_deployment_ref and ENV['OPENSHIFT_AUTO_DEPLOY'] != 'false')
         result = @container.post_receive(out: $stdout,
                                          err: $stderr,
                                          hot_deploy: @repo.file_exists?(HOT_DEPLOY_MARKER, ref_to_deploy),
@@ -245,8 +245,7 @@ command :prepare do |c|
   c.action do |args, options|
     # TODO make sure there is a file arg
     do_command(c, options) do
-      # pass force_clean_build:true so we don't move/copy dependencies from any prior deployment
-      deployment_datetime = @container.create_deployment_dir(force_clean_build: true)
+      deployment_datetime = @container.create_deployment_dir
       @container.prepare(out: $stdout, err: $stderr, deployment_datetime: deployment_datetime, file: args[0])
     end
   end
@@ -310,9 +309,9 @@ end
 
 command :'create-deployment-dir' do |c|
   c.syntax = "#{name} create_deployment_dir"
-  c.description = "Create a deployment directory and force a clean build. Should only be used by CI builders"
+  c.description = "Create a deployment directory. Should only be used by CI builders"
   c.action do |args, options|
-    puts @container.create_deployment_dir(force_clean_build: true)
+    puts @container.create_deployment_dir
   end
 end
 
@@ -358,7 +357,13 @@ command :deploy do |c|
         raise "Git ref #{ref_to_deploy} is invalid"
       end
 
-      @container.deploy(hot_deploy: hot_deploy_enabled, force_clean_build: force_clean_build_enabled, ref: ref_to_deploy, out: $stdout, err: $stderr, report_deployments: true)
+      @container.deploy(hot_deploy: hot_deploy_enabled,
+                        force_clean_build: force_clean_build_enabled,
+                        ref: ref_to_deploy,
+                        out: $stdout,
+                        err: $stderr,
+                        report_deployments: true,
+                        all: true)
     end
   end
 end
@@ -377,7 +382,7 @@ command :'binary-deploy' do |c|
 
     options = { stdin: $stdin }
 
-    deployment_datetime = @container.create_deployment_dir(force_clean_build: true)
+    deployment_datetime = @container.create_deployment_dir
     options[:deployment_datetime] = deployment_datetime
 
     @container.prepare(options)

--- a/node/test/support/functional_api.rb
+++ b/node/test/support/functional_api.rb
@@ -18,6 +18,7 @@ class FunctionalApi
     'jbossews-2.0' => 'src/main/webapp/index.html',
     'mock-0.1'     => 'index.html',
     'nodejs-0.6'   => 'index.html',
+    'nodejs-0.10'   => 'index.html',
     'perl-5.10'    => 'perl/index.pl',
     'php-5.3'      => 'php/index.php',
     'python-2.6'   => 'wsgi/application',


### PR DESCRIPTION
Certain containers (e.g. Tomcat) cache the path to the deployment
directory, and we want to replace the current deployment directory with
a new one when we activate a new deployment.

Replace app-root/runtime/{repo, dependencies, build-dependencies}
symlinks with actual directories. Sync content from the deployment
directory into these directories on activation.

Modify create_dependency_directories to create the directories in
app-root/runtime instead of in the deployment directory.

No need to create cartridge dependency directories any more when
creating a new deployment directory.

Recreate the cartridge dependency directories when building with
force_clean_build enabled.

Clean dependencies if preparing a binary deployment.

Don't use FileUtils.cd when creating the by-id link.

Bug 1020660 - fix jbossews hot deploy
Bug 1021399 - fix nodejs 0.10 hot deploy
Bug 1021411 - fix nodejs 0.6 hot deploy
Bug 1021414 - fix nodejs 0.6/0.10 force clean build
Bug 1019723 - rhc deploy should activate all gears
Bug 1018387 - Drupal quickstart should no longer be broken
Bug 1021798 - fix Python 3.3 with Jenkins
Bug 1018654 - fix Jenkins hot deploy
