### PR TITLE
ruby193-mcollective updates

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -1067,7 +1067,7 @@ class OODiag
     # Under certain circumstances they would not have the dominating MCS label
     # (s0-s0:c0.c1023) and not be able to affect gears.
     scl_root = @project_is[:enterprise] ? "/opt/rh/ruby193/root" : ""
-    context = `ps -o label= $(pgrep -f 'ruby[^[:space:]]*[[:space:]]/usr/sbin/mcollectived([[:space:]]|$)')`.chomp.split ":"
+    context = `ps -o label= $(pgrep -f "ruby[^[:space:]]*[[:space:]]#{scl_root}/usr/sbin/mcollectived([[:space:]]|$)")`.chomp.split ":"
     context.shift
     context = context.join ":"
     expected = "system_r:openshift_initrc_t:s0-s0:c0.c1023"

--- a/plugins/msg-node/mcollective/facts/openshift-facts
+++ b/plugins/msg-node/mcollective/facts/openshift-facts
@@ -1,8 +1,9 @@
 #!/bin/bash
-rpm -q ruby193-mcollective &> /dev/null
-if [ $? -eq 0 ]; then
-  YAML="/opt/rh/ruby193/root/etc/mcollective/facts.yaml"
-else
-  YAML="/etc/mcollective/facts.yaml"
+
+PREFIX=""
+
+if [ -f /opt/rh/ruby193/root/usr/libexec/mcollective/update_yaml.rb ]; then
+  PREFIX="/opt/rh/ruby193/root"
 fi
-oo-exec-ruby /usr/libexec/mcollective/update_yaml.rb $YAML &> /dev/null
+
+oo-exec-ruby ${PREFIX}/usr/libexec/mcollective/update_yaml.rb ${PREFIX}/etc/mcollective/facts.yaml &> /tmp/facts.log


### PR DESCRIPTION
Update openshift-facts and oo-diagnostics for a couple of instances that hadn't been updated yet for the ruby193-mcollective change.
