### PR TITLE
<tests> Update test tags and enable REMOTE_USER auth for tests

### DIFF
--- a/broker/test/functional/admin_stats_db_test.rb
+++ b/broker/test/functional/admin_stats_db_test.rb
@@ -19,6 +19,7 @@ class AdminStatsDbTest < ActionController::TestCase
     register_user(@login, @password)
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
     stubber
     @namespace = "ns#{@random}"

--- a/broker/test/functional/alias_controller_test.rb
+++ b/broker/test/functional/alias_controller_test.rb
@@ -15,6 +15,7 @@ class AliasControllerTest < ActionController::TestCase
     register_user(@login, @password)
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
     stubber
     @namespace = "ns#{@random}"

--- a/broker/test/functional/app_events_controller_test.rb
+++ b/broker/test/functional/app_events_controller_test.rb
@@ -15,6 +15,7 @@ class AppEventsControllerTest < ActionController::TestCase
     register_user(@login, @password)
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
     stubber
     @namespace = "ns#{@random}"

--- a/broker/test/functional/application_controller_test.rb
+++ b/broker/test/functional/application_controller_test.rb
@@ -15,6 +15,7 @@ class ApplicationControllerTest < ActionController::TestCase
     register_user(@login, @password)
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
     stubber
     @namespace = "ns#{@random}"

--- a/broker/test/functional/authorizations_controller_test.rb
+++ b/broker/test/functional/authorizations_controller_test.rb
@@ -18,6 +18,7 @@ class AuthorizationsControllerTest < ActionController::TestCase
     register_user(@login, @password)
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
 
   end

--- a/broker/test/functional/deployments_controller_test.rb
+++ b/broker/test/functional/deployments_controller_test.rb
@@ -15,6 +15,7 @@ class DeploymentsControllerTest < ActionController::TestCase
     register_user(@login, @password)
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
     stubber
     @namespace = "ns#{@random}"

--- a/broker/test/functional/descriptors_controller_test.rb
+++ b/broker/test/functional/descriptors_controller_test.rb
@@ -15,6 +15,7 @@ class DescriptorsControllerTest < ActionController::TestCase
     register_user(@login, @password)
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
     stubber
     @namespace = "ns#{@random}"

--- a/broker/test/functional/dns_resolvable_controller_test.rb
+++ b/broker/test/functional/dns_resolvable_controller_test.rb
@@ -15,6 +15,7 @@ class DnsResolvableControllerTest < ActionController::TestCase
     register_user(@login, @password)
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
     stubber
     @namespace = "ns#{@random}"

--- a/broker/test/functional/domains_controller_test.rb
+++ b/broker/test/functional/domains_controller_test.rb
@@ -15,6 +15,7 @@ class DomainsControllerTest < ActionController::TestCase
     register_user(@login, @password)
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
     stubber
   end

--- a/broker/test/functional/emb_cart_controller_test.rb
+++ b/broker/test/functional/emb_cart_controller_test.rb
@@ -15,6 +15,7 @@ class EmbCartControllerTest < ActionController::TestCase
     register_user(@login, @password)
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
     stubber
     @namespace = "ns#{@random}"

--- a/broker/test/functional/emb_cart_events_controller_test.rb
+++ b/broker/test/functional/emb_cart_events_controller_test.rb
@@ -15,6 +15,7 @@ class EmbCartEventsControllerTest < ActionController::TestCase
     register_user(@login, @password)    
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
     stubber
     @namespace = "ns#{@random}"

--- a/broker/test/functional/gear_groups_controller_test.rb
+++ b/broker/test/functional/gear_groups_controller_test.rb
@@ -18,6 +18,7 @@ class GearGroupsControllerTest < ActionController::TestCase
     register_user(@login, @password)
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
     stubber
     @namespace = "ns#{@random}"

--- a/broker/test/functional/gears_controller_test.rb
+++ b/broker/test/functional/gears_controller_test.rb
@@ -18,6 +18,7 @@ class GearsControllerTest < ActionController::TestCase
     register_user(@login, @password)
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
 
   end

--- a/broker/test/functional/keys_controller_test.rb
+++ b/broker/test/functional/keys_controller_test.rb
@@ -15,6 +15,7 @@ class KeysControllerTest < ActionController::TestCase
     register_user(@login, @password)
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
     stubber
 

--- a/broker/test/functional/user_controller_test.rb
+++ b/broker/test/functional/user_controller_test.rb
@@ -15,6 +15,7 @@ class UserControllerTest < ActionController::TestCase
     register_user(@login, @password)
 
     @request.env['HTTP_AUTHORIZATION'] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @request.env['REMOTE_USER'] = @login
     @request.env['HTTP_ACCEPT'] = "application/json"
     stubber
   end

--- a/broker/test/helpers/rest/api.rb
+++ b/broker/test/helpers/rest/api.rb
@@ -104,6 +104,7 @@ def http_call(api, internal_test=false)
       headers = {}
       headers["HTTP_ACCEPT"] = "application/json" + (api.version ? "; version=#{api.version}" : "")
       headers["HTTP_AUTHORIZATION"] = "Basic #{$credentials}"
+      headers["REMOTE_USER"] = $user
       request_via_redirect(method, "/broker/rest" + api.uri, api.request, headers)
       return @response.body.strip
     end

--- a/broker/test/system/alias_test.rb
+++ b/broker/test/system/alias_test.rb
@@ -20,6 +20,7 @@ class AliasTest < ActionDispatch::IntegrationTest
     @headers = {}
     @headers["HTTP_AUTHORIZATION"] = "Basic " + Base64.encode64("#{@login}:#{@password}")
     @headers["HTTP_ACCEPT"] = "application/json"
+    @headers['REMOTE_USER'] = @login
     register_user(@login, @password)
 
     ssl_certificate_data

--- a/broker/test/system/app_cartridge_events_test.rb
+++ b/broker/test/system/app_cartridge_events_test.rb
@@ -21,6 +21,7 @@ class AppCartridgeEventsTest < ActionDispatch::IntegrationTest
     @password = "password"
     @headers = {}
     @headers["HTTP_AUTHORIZATION"] = "Basic " + Base64.encode64("#{@login}:#{@password}")
+    @headers['REMOTE_USER'] = @login
     @headers["HTTP_ACCEPT"] = "application/json"
     register_user(@login, @password)
 

--- a/broker/test/system/app_cartridges_test.rb
+++ b/broker/test/system/app_cartridges_test.rb
@@ -20,6 +20,7 @@ class AppCartridgesTest < ActionDispatch::IntegrationTest
     @headers = {}
     @headers["HTTP_AUTHORIZATION"] = "Basic " + Base64.encode64("#{@login}:#{@password}")
     @headers["HTTP_ACCEPT"] = "application/json"
+    @headers['REMOTE_USER'] = @login
     register_user(@login, @password)
 
     https!

--- a/broker/test/system/app_events_test.rb
+++ b/broker/test/system/app_events_test.rb
@@ -19,6 +19,7 @@ class AppEventsTest < ActionDispatch::IntegrationTest
     @headers = {}
     @headers["HTTP_AUTHORIZATION"] = "Basic " + Base64.encode64("#{@login}:#{@password}")
     @headers["HTTP_ACCEPT"] = "application/json"
+    @headers['REMOTE_USER'] = @login
     register_user(@login, @password)
 
     https!

--- a/broker/test/system/application_test.rb
+++ b/broker/test/system/application_test.rb
@@ -17,6 +17,7 @@ class ApplicationTest < ActionDispatch::IntegrationTest
     @headers = {}
     @headers["HTTP_AUTHORIZATION"] = "Basic " + Base64.encode64("#{@login}:#{@password}")
     @headers["HTTP_ACCEPT"] = "application/json"
+    @headers['REMOTE_USER'] = @login
     register_user(@login, @password)
 
     https!

--- a/broker/test/system/deployment_test.rb
+++ b/broker/test/system/deployment_test.rb
@@ -20,6 +20,7 @@ class DeploymentTest < ActionDispatch::IntegrationTest
     @headers = {}
     @headers["HTTP_AUTHORIZATION"] = "Basic " + Base64.encode64("#{@login}:#{@password}")
     @headers["HTTP_ACCEPT"] = "application/json"
+    @headers['REMOTE_USER'] = @login
     register_user(@login, @password)
 
     https!

--- a/broker/test/system/domain_test.rb
+++ b/broker/test/system/domain_test.rb
@@ -14,6 +14,7 @@ class DomainTest < ActionDispatch::IntegrationTest
     @headers = {}
     @headers["HTTP_AUTHORIZATION"] = "Basic " + Base64.encode64("#{@login}:#{@password}")
     @headers["HTTP_ACCEPT"] = "application/json"
+    @headers['REMOTE_USER'] = @login
     register_user(@login, @password)
 
     https!
@@ -156,6 +157,7 @@ class DomainTest < ActionDispatch::IntegrationTest
     @new_headers = {}
     @new_headers["HTTP_AUTHORIZATION"] = "Basic " + Base64.encode64("new#{@login}:password")
     @new_headers["HTTP_ACCEPT"] = "application/json"
+    @new_headers['REMOTE_USER'] = "new#{@login}"
     register_user("new#{@login}","password")
     request_via_redirect(:put, DOMAIN_COLLECTION_URL + "/#{ns}", {:name => new_ns}, @new_headers)
     assert_response :not_found
@@ -218,6 +220,7 @@ class DomainTest < ActionDispatch::IntegrationTest
     @new_headers = {}
     @new_headers["HTTP_AUTHORIZATION"] = "Basic " + Base64.encode64("new#{@login}:password")
     @new_headers["HTTP_ACCEPT"] = "application/json"
+    @new_headers['REMOTE_USER'] = "new#{@login}"
     register_user("new#{@login}","password")
     request_via_redirect(:delete, DOMAIN_COLLECTION_URL + "/#{ns}", {}, @new_headers)
     assert_response :not_found

--- a/broker/test/test_helper.rb
+++ b/broker/test/test_helper.rb
@@ -32,8 +32,12 @@ end
 
 def register_user(login=nil, password=nil)
   if ENV['REGISTER_USER']
-    accnt = UserAccount.new(user: login, password: password)
-    accnt.save
+    if File.exists?("/etc/openshift/plugins.d/openshift-origin-auth-remote-user.conf")
+      `/usr/bin/htpasswd -b /etc/openshift/htpasswd #{login} #{password} > /dev/null 2>&1`
+    else
+      accnt = UserAccount.new(user: login, password: password)
+      accnt.save
+    end
   end
 end
 

--- a/broker/test/unit/application_test.rb
+++ b/broker/test/unit/application_test.rb
@@ -218,6 +218,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest #ActiveSupport::TestCas
     headers = {}
     headers["HTTP_ACCEPT"] = "application/json"
     headers["HTTP_AUTHORIZATION"] = "Basic #{credentials}"
+    headers["REMOTE_USER"] = $user
     request_via_redirect(:get, "/broker/rest/user", {}, headers)
     assert_equal @response.status, 200
   end
@@ -228,6 +229,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest #ActiveSupport::TestCas
     headers = {}
     headers["HTTP_ACCEPT"] = "application/json"
     headers["HTTP_AUTHORIZATION"] = "Basic #{credentials}"
+    headers["REMOTE_USER"] = $user
     request_via_redirect(method, "/broker/rest" + uri, params, headers)
     @response
   end

--- a/controller/test/cucumber/cartridge-lifecycle-nodejs.feature
+++ b/controller/test/cucumber/cartridge-lifecycle-nodejs.feature
@@ -1,7 +1,6 @@
 @runtime_extended3
 @cartridge_nodejs
 @runtime_extended
-@not-enterprise
 @not-fedora-19
 Feature: Cartridge Lifecycle NodeJS Verification Tests
   Scenario Outline: Application Creation
@@ -27,10 +26,15 @@ Feature: Cartridge Lifecycle NodeJS Verification Tests
     Then the application should not be accessible
 
     @rhel-only
-    Scenarios: RHEL scenarios
+    Scenarios: RHEL SCL scenarios
+      |  cart_name  |
+      | nodejs-0.10 |
+
+    @rhel-only 
+    @not-enterprise
+    Scenarios: RHEL non-SCL scenarios
       |  cart_name  |
       | nodejs-0.6  |
-      | nodejs-0.10 |
 
     @fedora-19-only
     Scenarios: Fedora 19 scenarios

--- a/controller/test/cucumber/cartridge-lifecycle-php.feature
+++ b/controller/test/cucumber/cartridge-lifecycle-php.feature
@@ -1,6 +1,5 @@
 @runtime_extended2
 @runtime
-@not-enterprise
 Feature: Cartridge Lifecycle PHP Verification Tests
   Scenario Outline: Application Creation
   #Given a new <cart_name> application, verify its availability

--- a/controller/test/cucumber/cartridge-lifecycle-ruby.feature
+++ b/controller/test/cucumber/cartridge-lifecycle-ruby.feature
@@ -1,6 +1,5 @@
 @runtime
 @runtime_extended1
-@not-enterprise
 Feature: Cartridge Lifecycle Ruby Verification Tests
   Scenario Outline: Application Creation
   #Given a new <cart_name> application, verify its availability

--- a/controller/test/cucumber/runtime-cartridge-jbossas.feature
+++ b/controller/test/cucumber/runtime-cartridge-jbossas.feature
@@ -1,6 +1,7 @@
 @runtime_extended1
 @jboss
 @jbossas
+@not-enterprise
 Feature: V2 SDK JBossAS Cartridge
 
   Scenario: Add cartridge

--- a/controller/test/cucumber/runtime-cartridge-nodejs.feature
+++ b/controller/test/cucumber/runtime-cartridge-nodejs.feature
@@ -1,6 +1,5 @@
 @runtime_extended3
 @cartridge_nodejs
-@not-enterprise
 Feature: V2 SDK Node.js Cartridge
 
   Scenario Outline: Add cartridge
@@ -14,9 +13,14 @@ Feature: V2 SDK Node.js Cartridge
     Then the application git repo will not exist
 
     @rhel-only
-    Scenarios: RHEL
+    Scenarios: RHEL SCL
       | nodejs_version |
       |  0.10          |
+
+    @rhel-only
+    @not-enterprise
+    Scenarios: RHEL non-SCL
+      | nodejs_version |
       |  0.6           |
 
     @fedora-only
@@ -30,9 +34,14 @@ Feature: V2 SDK Node.js Cartridge
     Then the application git repo will not exist
 
     @rhel-only
-    Scenarios: RHEL
+    Scenarios: RHEL SCL
       | nodejs_version |
       |  0.10          |
+
+    @rhel-only
+    @not-enterprise
+    Scenarios: RHEL non-SCL
+      | nodejs_version |
       |  0.6           |
       
     @fedora-only

--- a/controller/test/cucumber/runtime-cartridge-switchyard.feature
+++ b/controller/test/cucumber/runtime-cartridge-switchyard.feature
@@ -2,6 +2,7 @@
 @runtime_extended3
 @rhel-only
 @jboss
+@not-enterprise
 Feature: SwitchYard Application Sub-Cartridge
   Scenario: Create Delete one EAP application with embedded SwitchYard
     Given a new jbosseap-6 type application

--- a/node/test/support/functional_api.rb
+++ b/node/test/support/functional_api.rb
@@ -31,6 +31,7 @@ class FunctionalApi
 
   def initialize
     @login = "user#{random_string}"
+    register_user(@login,"password")
     @namespace = "ns#{random_string}"
     @url_base = "https://#{@login}:password@localhost/broker/rest"
     @tmp_dir = "/var/tmp-tests/#{Time.now.to_i}"
@@ -45,6 +46,14 @@ class FunctionalApi
       print "Unknown auth plugin. Not registering user #{$user}/#{$password}."
       print "Modify #{__FILE__}#initialize if user registration is required."
       cmd = nil
+    end
+  end
+
+  def register_user(login=nil, password=nil)
+    if ENV['REGISTER_USER']
+      if File.exists?("/etc/openshift/plugins.d/openshift-origin-auth-remote-user.conf")
+        `/usr/bin/htpasswd -b /etc/openshift/htpasswd #{login} #{password}`
+      end
     end
   end
 


### PR DESCRIPTION
- update broker tests to set REMOTE_USER header
- update tests that don't already create user when REGISTER_USER env
  variable is set, and ensure that users are registered when using remote user basic auth.
- update cucumber test tags
