### PR TITLE
Console fine tuning and add tables partial missing from origin

### DIFF
--- a/console/app/assets/stylesheets/_buttons.scss
+++ b/console/app/assets/stylesheets/_buttons.scss
@@ -78,6 +78,11 @@ input[type="submit"].btn {
   margin-right: 12px;
 }
 
+.table {
+  + .btn-toolbar {
+    margin-top: -10px;
+  }
+}
 
 // Button Sizes
 // --------------------------------------------------

--- a/console/app/assets/stylesheets/_forms.scss
+++ b/console/app/assets/stylesheets/_forms.scss
@@ -786,7 +786,6 @@ textarea[readonly] {
   .error > .control-label { color: $errorBackground; }
 
   .help-block { max-width: 500px; -moz-transition: 0.2s; overflow: hidden; text-overflow: ellipsis; font-size: $tinyFontSize;}
-  .alert { max-width: 500px; }
 
   h3 .font-icon {margin-left: 10px}
 }

--- a/console/app/assets/stylesheets/console/_application.scss
+++ b/console/app/assets/stylesheets/console/_application.scss
@@ -115,6 +115,7 @@
 #app-cartridges {
   .cartridge-block {
     position: relative;
+    min-height: 58px;
     &.cartridge-embedded {
       border-top: 1px dashed $consolePanelBorderColor;
     }

--- a/console/app/assets/stylesheets/console/_mixins.scss
+++ b/console/app/assets/stylesheets/console/_mixins.scss
@@ -2,6 +2,8 @@
 }
 
 @mixin brand {
+  position: relative;
+  top: 10px;
 }
 
 @mixin brand_hover {

--- a/console/app/assets/stylesheets/origin.css.scss
+++ b/console/app/assets/stylesheets/origin.css.scss
@@ -37,6 +37,7 @@ Color palette
 @import "console/tile";
 @import "console/application";
 @import "console/popovers";
+@import "console/tables";
 
 @import "console/core";
 

--- a/console/app/views/applications/show.html.haml
+++ b/console/app/views/applications/show.html.haml
@@ -79,7 +79,6 @@
                 - if primary
                   %h3.flow
                     .flow-block{:title => cartridge.name}
-                      %span.font-icon{"aria-hidden" => "true", "data-icon" => "\ue021"}
                       = cartridge.display_name
 
                     .flow-block.right>

--- a/console/app/views/settings/show.html.haml
+++ b/console/app/views/settings/show.html.haml
@@ -13,15 +13,15 @@
 
   - if @keys.present?
     .span12
-      %section
+      %section.row-content
         = render :partial => 'keys', :locals => {:keys => @keys}
 
   .span12
 
     - if @domains.present?
-      %section
+      %section.row-content
         = render :partial => 'domains', :locals => {:domains => @domains, :capabilities => @capabilities}
 
-    %section
+    %section.row-content
       = render :partial => 'authorizations', :locals => {:authorizations => @authorizations}
 


### PR DESCRIPTION
Reduce space btw table and .btn-toolbar
Remove alert max-width because it's not needed.
Make .cartridge-block have a min-height so they are consistent by defaul
Mixin rules target origin logo to position vertically
@import new _tables partial since common no longer references the vendor default
Remove cartridge icon from app details. Looks better and embedded don't have specific icon so it was looking off.
Apply .row-content class to <sections> which apply default margin bottoms
