### PR TITLE
Bug 1021462 - Pushing user variables failing if haproxy not installed

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/environment.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/environment.rb
@@ -319,11 +319,12 @@ module OpenShift
           begin
             gears.each do |gear|
               logger.debug("Updating #{gear} from #{source}")
+              ssh_command ="ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=#{@container_dir}/.openshift_ssh/known_hosts -F #{@container_dir}/.openshift_ssh/config -i #{@container_dir}/.openshift_ssh/id_rsa"
               threads[gear] = Thread.new(gear) do |fqdn|
                 gear_dns = fqdn
                 retries  = 2
                 begin
-                  command = "/usr/bin/rsync -rp0 --delete -e 'ssh -o StrictHostKeyChecking=no' #{source}/ #{fqdn}:#{target}"
+                  command = "/usr/bin/rsync -rp0 --delete -e '#{ssh_command}' #{source}/ #{fqdn}:#{target}"
                   env = OpenShift::Runtime::Utils::Environ.for_gear(@container_dir)
                   ::OpenShift::Runtime::Utils::oo_spawn(command, expected_exitstatus: 0, uid: @uid, env: env)
                 rescue Exception => e


### PR DESCRIPTION
- Use same ssh settings as haproxy/bin/ssh
