### PR TITLE
Fix failure when adding new proxy gear

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
@@ -1240,7 +1240,9 @@ module OpenShift
                 # of in batches
 
                 # since the gears are new, set init to true
-                activate_result = activate(gears: new_web_gears.map(&:uuid), deployment_id: deployment_id, init: true)
+                # also set rotate to false because there's no need to rotate out/in these new gears
+                # (nor will it work if the new gear is also a proxy gear)
+                activate_result = activate(gears: new_web_gears.map(&:uuid), deployment_id: deployment_id, init: true, rotate: false)
                 raise "Activation of new gears failed: #{activate_result[:errors].join("\n")}" unless activate_result[:status] == RESULT_SUCCESS
               end
 

--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -270,7 +270,7 @@ command :activate do |c|
   c.option "--init", "Run post_install for new gears"
   c.option "--as-json", "Render the results as JSON to stdout"
   c.option "--all", "Activate all gears in the application (only applicable if executed from a proxy gear)"
-  c.option "--no-rotation", "Don't rotate gears out/in"
+  c.option "--[no-]rotation", "Rotate gears out/in (defaults to true)"
 
   c.action do |args, options|
     # TODO make sure there is a deployment id arg
@@ -283,10 +283,15 @@ command :activate do |c|
         err = nil
       end
 
+      rotate = true
+      if !options.rotation.nil?
+        rotate = options.rotation
+      end
+
       result = @container.activate(deployment_id: args[0],
                                    init: !!options.init,
                                    all: !!options.all,
-                                   rotate: !!!options.no_rotation,
+                                   rotate: rotate,
                                    report_deployments: true,
                                    out: out,
                                    err: err)

--- a/node/test/unit/application_container_test.rb
+++ b/node/test/unit/application_container_test.rb
@@ -538,7 +538,8 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
 
     @container.expects(:activate).with(gears: [uuid2, uuid3],
                                        deployment_id: deployment_id,
-                                       init: true)
+                                       init: true,
+                                       rotate: false)
                                  .returns(status: 'success')
 
     @container.expects(:run_in_container_context).with("rsync -avz --delete --exclude hooks --rsh=/usr/bin/oo-ssh git/#{@app_name}.git/ #{proxy_entry3.uuid}@#{proxy_entry3.proxy_hostname}:git/#{@app_name}.git/",


### PR DESCRIPTION
Set rotate to false when invoking activate from update_cluster - there
is no need to rotate out/in new gears.

Fix bug in gear script with how rotate was being passed to the
container's activate method.

Bug 1022721
