### PR TITLE
Bug 1022439 - Restore missing httpd.pid when restarting PHP cart

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -10,7 +10,7 @@ HTTPD_PID_FILE=$OPENSHIFT_PHP_DIR/run/httpd.pid
 function apache() {
     if [ "$1" != "stop" ]; then
       write_httpd_passenv $HTTPD_PASSENV_FILE
-      oo-erb conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
+      oo-erb ${OPENSHIFT_PHP_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
     fi
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     /usr/sbin/httpd -C "Include $HTTPD_CFG_DIR/*.conf" -f $HTTPD_CFG_FILE -k $1
@@ -26,7 +26,7 @@ function apache() {
 
 function restart() {
     write_httpd_passenv $HTTPD_PASSENV_FILE
-    oo-erb conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
+    oo-erb ${OPENSHIFT_PHP_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
     ensure_httpd_restart_succeed "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     /usr/sbin/httpd -C "Include $HTTPD_CFG_DIR/*.conf" -f $HTTPD_CFG_FILE -k restart
     return $?

--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -27,6 +27,7 @@ function apache() {
 function restart() {
     write_httpd_passenv $HTTPD_PASSENV_FILE
     oo-erb ${OPENSHIFT_PHP_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
+    ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     ensure_httpd_restart_succeed "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     /usr/sbin/httpd -C "Include $HTTPD_CFG_DIR/*.conf" -f $HTTPD_CFG_FILE -k restart
     return $?

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
@@ -25,7 +25,7 @@ function start_apache() {
 
 function start() {
     echo "Starting PYTHON cart"
-    oo-erb conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
+    oo-erb ${OPENSHIFT_PYTHON_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
     if [ -f "$OPENSHIFT_REPO_DIR/app.py" ]
     then
         start_app
@@ -77,7 +77,7 @@ function restart() {
         start
     else
         stop_app
-        oo-erb conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
+        oo-erb ${OPENSHIFT_PYTHON_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
         write_httpd_passenv $HTTPD_PASSENV_FILE
         ensure_httpd_restart_succeed "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
         /usr/sbin/httpd -C "Include $OPENSHIFT_PYTHON_DIR/etc/conf.d/*.conf" -f $HTTPD_CFG_FILE -k restart

--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -12,7 +12,7 @@ HTTPD_PID_FILE=$OPENSHIFT_RUBY_DIR/run/httpd.pid
 function start() {
     echo "Starting Ruby cartridge"
     write_httpd_passenv $HTTPD_PASSENV_FILE
-    oo-erb conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
+    oo-erb ${OPENSHIFT_RUBY_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     ruby_context "/usr/sbin/httpd -C 'Include $OPENSHIFT_RUBY_DIR/etc/conf.d/*.conf' -f $HTTPD_CFG_FILE -k start"
 }
@@ -30,7 +30,7 @@ function stop() {
 function restart() {
     echo "${1}ing Ruby cart"
     write_httpd_passenv $HTTPD_PASSENV_FILE
-    oo-erb conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
+    oo-erb ${OPENSHIFT_RUBY_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
     touch $OPENSHIFT_REPO_DIR/tmp/restart.txt
     ensure_httpd_restart_succeed "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     ruby_context "/usr/sbin/httpd -C 'Include $OPENSHIFT_RUBY_DIR/etc/conf.d/*.conf' -f $HTTPD_CFG_FILE -k restart"


### PR DESCRIPTION
Fix the case when `httpd.pid` file is removed or missing and user want to restart the cartridge and fix the case when you call `php/bin/control restart` and the path to `performance.conf.erb.hidden` is wrong.
