### PR TITLE
Bug 1022982

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/control
@@ -260,10 +260,11 @@ function build() {
 function deploy() {
   echo "Deploying JBoss"
 
-  if [ "$(ls ${OPENSHIFT_REPO_DIR}/deployments)" ]; then
+  # if repo/deployments has any files in it, sync them to $JBOSSAS_DEPLOYMENTS_DIR
+  # and delete any files in $JBOSSAS_DEPLOYMENTS_DIR that don't exist in
+  # repo/deployments
+  if [ "$(ls ${OPENSHIFT_REPO_DIR}/deployments 2>/dev/null)" ]; then
     rsync -r --delete --exclude ".*" ${OPENSHIFT_REPO_DIR}/deployments/ $JBOSSAS_DEPLOYMENTS_DIR
-  else
-    rm -rf ${JBOSSAS_DEPLOYMENTS_DIR}/*
   fi
 }
 

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/control
@@ -262,11 +262,11 @@ function build() {
 function deploy() {
   echo "Deploying $cartridge_type cartridge"
 
-  if [ "$(ls ${OPENSHIFT_REPO_DIR}/deployments)" ]; then
+  # if repo/deployments has any files in it, sync them to $JBOSSEAP_DEPLOYMENTS_DIR
+  # and delete any files in $JBOSSEAP_DEPLOYMENTS_DIR that don't exist in
+  # repo/deployments
+  if [ "$(ls ${OPENSHIFT_REPO_DIR}/deployments 2>/dev/null)" ]; then
     rsync -r --delete --exclude ".*" ${OPENSHIFT_REPO_DIR}/deployments/ $JBOSSEAP_DEPLOYMENTS_DIR
-  else
-    rm -rf ${OPENSHIFT_JBOSSEAP_DIR}/standalone/deployments/*
-    rm -rf ${JBOSSEAP_DEPLOYMENTS_DIR}/*
   fi
 }
 

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/deploy
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/deploy
@@ -12,8 +12,9 @@ if [ -d $tmp ]; then
   done
 fi
 
-if [ -d ${OPENSHIFT_REPO_DIR}/webapps ]; then
+# if repo/webapps has any files in it, sync them to $OPENSHIFT_JBOSSEWS_DIR/webapps
+# and delete any files in $OPENSHIFT_JBOSSEWS_DIR/webapps that don't exist in
+# repo/webapps
+if [ "$(ls ${OPENSHIFT_REPO_DIR}/webapps 2>/dev/null)" ]; then
   rsync -r --delete ${OPENSHIFT_REPO_DIR}/webapps/ ${OPENSHIFT_JBOSSEWS_DIR}/webapps/
-else
-  rm -rf ${OPENSHIFT_JBOSSEWS_DIR}/webapps/*
 fi


### PR DESCRIPTION
Only rsync from repo to JBoss cartridge webapps/deployments directory
if the repo directory has files in it.

Don't delete content from the cartridge dir unnecessarily.
