### PR TITLE
Exclude metadata.json from deployment checksum

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
@@ -534,6 +534,10 @@ module OpenShift
           link_deployment_id(deployment_datetime, deployment_id)
 
           begin
+            sync_runtime_repo_dir_to_deployment(deployment_datetime)
+            sync_runtime_dependencies_dir_to_deployment(deployment_datetime)
+            sync_runtime_build_dependencies_dir_to_deployment(deployment_datetime)
+
             deployment_metadata = deployment_metadata_for(deployment_datetime)
             deployment_metadata.id = deployment_id
             deployment_metadata.checksum = calculate_deployment_checksum(deployment_id)
@@ -545,10 +549,6 @@ module OpenShift
             out = "Deployment id is #{deployment_id}"
             buffer << out
             options[:out].puts(out) if options[:out]
-
-            sync_runtime_repo_dir_to_deployment(deployment_datetime)
-            sync_runtime_dependencies_dir_to_deployment(deployment_datetime)
-            sync_runtime_build_dependencies_dir_to_deployment(deployment_datetime)
           rescue IOError => e
             out = "Error preparing deployment #{deployment_id}; "
             buffer << out

--- a/node/lib/openshift-origin-node/model/application_container_ext/deployments.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/deployments.rb
@@ -128,8 +128,9 @@ module OpenShift
         def calculate_deployment_checksum(deployment_id)
           deployment_dir = PathUtils.join(@container_dir, 'app-deployments', 'by-id', deployment_id)
 
-          # TODO use a better algorithm
-          out, err, rc = run_in_container_context("tar c . | tar xO | sha1sum | cut -f 1 -d ' '",
+          command = "tar -c --exclude metadata.json . | tar -xO | sha1sum | cut -f 1 -d ' '"
+
+          out, err, rc = run_in_container_context(command,
                                                   chdir: deployment_dir,
                                                   expected_exitstatus: 0)
 

--- a/node/test/unit/build_lifecycle_test.rb
+++ b/node/test/unit/build_lifecycle_test.rb
@@ -702,15 +702,15 @@ class BuildLifecycleTest < OpenShift::NodeTestCase
     @container.stubs(:calculate_deployment_checksum).with(deployment_id).returns(checksum)
     @container.expects(:link_deployment_id).with(deployment_datetime, deployment_id)
 
+    @container.expects(:sync_runtime_repo_dir_to_deployment).with(deployment_datetime)
+    @container.expects(:sync_runtime_dependencies_dir_to_deployment).with(deployment_datetime)
+    @container.expects(:sync_runtime_build_dependencies_dir_to_deployment).with(deployment_datetime)
+
     metadata = mock()
     @container.expects(:deployment_metadata_for).with(deployment_datetime).returns(metadata)
     metadata.expects(:id=).with(deployment_id)
     metadata.expects(:checksum=).with(checksum)
     metadata.expects(:save)
-
-    @container.expects(:sync_runtime_repo_dir_to_deployment).with(deployment_datetime)
-    @container.expects(:sync_runtime_dependencies_dir_to_deployment).with(deployment_datetime)
-    @container.expects(:sync_runtime_build_dependencies_dir_to_deployment).with(deployment_datetime)
 
     prepare_options = {deployment_datetime: deployment_datetime}
     output = @container.prepare(prepare_options)
@@ -731,6 +731,11 @@ class BuildLifecycleTest < OpenShift::NodeTestCase
     deployment_id = 'abcd1234'
     @container.expects(:calculate_deployment_id).with(deployment_datetime).returns(deployment_id)
     @container.expects(:link_deployment_id).with(deployment_datetime, deployment_id)
+
+    @container.expects(:sync_runtime_repo_dir_to_deployment).with(deployment_datetime)
+    @container.expects(:sync_runtime_dependencies_dir_to_deployment).with(deployment_datetime)
+    @container.expects(:sync_runtime_build_dependencies_dir_to_deployment).with(deployment_datetime)
+
     metadata = mock()
     @container.expects(:deployment_metadata_for).with(deployment_datetime).returns(metadata)
     metadata.expects(:id=).with(deployment_id).raises(IOError.new('msg'))


### PR DESCRIPTION
Also sync from runtime to deployment directories prior to doing
checksum calculation.

Bug 1021578
