### PR TITLE
Changes pertain to app creation page, specifically app name with namespace input fields

### DIFF
--- a/console/app/assets/stylesheets/_forms.scss
+++ b/console/app/assets/stylesheets/_forms.scss
@@ -44,12 +44,14 @@ select,
 textarea {
   @include font-shorthand(); // Set size, weight, line-height here
 }
+
 input,
 button,
 select,
 textarea {
-  font-family: $baseFontFamily;
+  font-family: $inputFontFamily;
 }
+
 
 // Identify controls by their labels
 label {
@@ -107,7 +109,7 @@ input[type="image"],
   background-color: $inputBackground;
   border: 1px solid $inputBorder;
   @include box-shadow(inset 0 1px 1px rgba(0,0,0,.075));
-  height: $baseLineHeight; /* IE needs an explicit height */
+  min-height: $baseLineHeight; /* IE needs min-height */
   line-height: $baseLineHeight; /* IE needs an explicit line-height */
   $transition: border linear .2s, box-shadow linear .2s;
   @include transition($transition);
@@ -785,11 +787,20 @@ textarea[readonly] {
   .control-label { margin-left: 15px; text-align: left; color: #666; }
   .error > .control-label { color: $errorBackground; }
 
-  .help-block { max-width: 500px; -moz-transition: 0.2s; overflow: hidden; text-overflow: ellipsis; font-size: $tinyFontSize;}
+  .help-block, .help-inline { max-width: 500px; -moz-transition: 0.2s; overflow: hidden; text-overflow: ellipsis; font-size: $tinyFontSize;}
 
   h3 .font-icon {margin-left: 10px}
 }
-
+@media (max-width:979px) {
+  .form-important {
+    .controls {
+      margin-left: $horizontalComponentOffset - 40;
+    }
+    .control-label {
+      width: $horizontalComponentOffset - 60; // .controls - 20
+    }
+  }
+}
 @media (max-width: 767px) {
   .form-important {
     .control-label { margin-left: 0; }
@@ -798,6 +809,13 @@ textarea[readonly] {
     .alert { max-width: inherit; }
     .controls > h3 { display: inline-block; margin-top: 0; }
     .form-actions { padding-left: 0; }
+  }
+  .control-group-important {
+    .input-large, .input-xlarge, .input-xxlarge,
+    input[class*="span"], select[class*="span"], textarea[class*="span"], 
+    .uneditable-input {
+      min-height: 38px; // increase heights
+    }
   }
 }
 

--- a/console/app/assets/stylesheets/_mixins.scss
+++ b/console/app/assets/stylesheets/_mixins.scss
@@ -198,7 +198,7 @@
 @mixin input-block-level() {
   display: block;
   width: 100%;
-  min-height: 28px; // Make inputs at least the height of their button counterpart
+  min-height: 30px; // Make inputs at least the height of their button counterpart
   @include box-sizing(border-box); // Makes inputs behave like true block-level elements
 }
 

--- a/console/app/assets/stylesheets/_variables.scss
+++ b/console/app/assets/stylesheets/_variables.scss
@@ -2,6 +2,11 @@ $baseFontFamily:     "Open Sans", "Helvetica Neue", Helvetica, "Liberation Sans"
 $headerFontFamily:   "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 $monoFontFamily:      Menlo, Monaco, "Liberation Mono", Consolas, monospace !default;
 
+// Needed because FF on Mac sets line-height based on font-family, ignoring form field explicit line-height, 
+// causing inputs next to span.input-append and/or span.input-prepend to have different heights when set to Open Sans.
+// Assigning "Lucida Grande" because it most closely resembles "Open Sans" and has wide use on mac, but not on IE and Lunix.
+$inputFontFamily:     "Lucida Grande", "Open Sans", "Lucida Sans Unicode", "Liberation Sans", Arial, sans-serif !default;	
+
 $baseLineHeight:          	20px;
 $baseFontSize:				14px;
 $leadLineHeight:          	$baseLineHeight * 1.5;

--- a/console/app/assets/stylesheets/console/_core.scss
+++ b/console/app/assets/stylesheets/console/_core.scss
@@ -560,9 +560,6 @@ a.cap-link:hover {
   margin-bottom: 15px;
 }
 
-.control-group.error p+p {padding-left: 100px;}
-
-
 .sshkey-name {
   max-width: 80px;
   overflow: hidden;

--- a/console/app/views/applications/_name.html.haml
+++ b/console/app/views/applications/_name.html.haml
@@ -14,7 +14,7 @@
     :autofocus => true,
     :size => nil, 
     :placeholder => 'Application name', 
-    :class => "application_name #{'error' if application.errors.include? :name}"
+    :class => "application_name span3 #{'error' if application.errors.include? :name}"
 
   - if domains.length == 1 and (can_create == false or domains.first.owner?)
     -# Readonly
@@ -40,7 +40,7 @@
     = form.text_field :domain_name, 
       :placeholder => 'Namespace', 
       :size => nil, 
-      :class => "domain_name #{'error' if application.errors.include? :domain_name}"
+      :class => "domain_name span3 #{'error' if application.errors.include? :domain_name}"
     %span.add-on>= ".#{RestApi.application_domain_suffix}"
 
     - show_first = true


### PR DESCRIPTION
- Remove font-family because (a)it's causing a weird height descrepency issue on FF and (b)it's superfluous
- Change explicit height to min-height. It was part of several issues that were causing the input and .add-on's to have different heights at different browser widths.
- Adjust width between label and controls at <979px width, because of horizontal scroll.
- Apply min-height at <767px so .control-group-important elements have consistent heights.
- input-block-level mixin needs slightly taller min-height to account for descrepency on FF at mobile res. I believe this is because of changes to our base font-family, font-size, and line-height.
- Reapply span3 (same as prod) to control both input widths at specific browser widths.
