### PR TITLE
Binary deployment improvements

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
@@ -430,7 +430,7 @@ module OpenShift
             options[:out].puts message if options[:out]
             buffer << message
 
-            clean_dependencies
+            clean_runtime_dirs(dependencies: true, build_dependencies: true)
 
             # create the dependency directories for each cartridge
             @cartridge_model.each_cartridge do |cartridge|
@@ -516,7 +516,7 @@ module OpenShift
           if options[:stdin] || options[:file]
             options[:destination] = PathUtils.join(@container_dir, 'app-root', 'runtime')
 
-            clean_dependencies
+            clean_runtime_dirs(dependencies: true, build_dependencies: true, repo: true)
 
             extract_deployment_archive(env, options)
           end

--- a/node/lib/openshift-origin-node/model/application_container_ext/deployments.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/deployments.rb
@@ -80,8 +80,23 @@ module OpenShift
 
         end
 
-        def clean_dependencies
-          out, err, rc = run_in_container_context("shopt -s dotglob; /bin/rm -rf app-root/runtime/dependencies/* app-root/runtime/build-dependencies/*",
+        # Removes all files from app-root/runtime/<dirs>
+        #
+        # options for dirs to delete (all default to false):
+        #  :dependencies
+        #  :build_dependencies
+        #  :repo
+        def clean_runtime_dirs(options)
+          dirs = []
+          %w(dependencies build_dependencies repo).each do |dir|
+            dirs << dir if options[dir.to_sym] == true
+          end
+
+          return if dirs.empty?
+
+          dirs.map! { |dir| "app-root/runtime/#{dir.gsub(/_/, '-')}/*" }
+
+          out, err, rc = run_in_container_context("shopt -s dotglob; rm -rf #{dirs.join(' ')}",
                                                     chdir: @container_dir,
                                                     expected_exitstatus: 0)
         end

--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -422,10 +422,20 @@ command :'binary-deploy' do |c|
 
     options = { stdin: $stdin }
 
+    puts "Stopping gear"
+    @container.stop_gear(user_initiated: true,
+                         exclude_web_proxy: true,
+                         out: $stdout,
+                         err: $stderr)
+
+    puts "Creating new deployment directory"
     deployment_datetime = @container.create_deployment_dir
     options[:deployment_datetime] = deployment_datetime
 
+    puts "Preparing deployment"
     @container.prepare(options)
+
+    puts "Distributing deployment"
     result = @container.distribute(options)
     distribute_status = result[:status]
     puts "Distribution status: #{distribute_status}"
@@ -438,6 +448,7 @@ command :'binary-deploy' do |c|
 
     options[:all]                = true
     options[:report_deployments] = true
+    puts "Activating deployment"
     result = @container.activate(options)
     activate_status = result[:status]
     puts "Activation status: #{activate_status}"
@@ -448,7 +459,13 @@ command :'binary-deploy' do |c|
       puts failures.map { |f| "#{f[:gear_uuid]} (#{f[:errors][0]})" }.join("\n")
     end
 
-    puts 'Deployment completed'
+    if distribute_status == RESULT_SUCCESS and activate_status == RESULT_SUCCESS
+      deployment_status = 'success'
+    else
+      deployment_status = 'failure'
+    end
+
+    puts "Deployment status: #{deployment_status}"
   end
 end
 

--- a/node/test/unit/build_lifecycle_test.rb
+++ b/node/test/unit/build_lifecycle_test.rb
@@ -248,7 +248,7 @@ class BuildLifecycleTest < OpenShift::NodeTestCase
     metadata.expects(:force_clean_build=).with(true)
     metadata.expects(:save)
 
-    @container.expects(:clean_dependencies)
+    @container.expects(:clean_runtime_dirs).with(dependencies:true, build_dependencies:true)
     cart1 = mock()
     cart2 = mock()
     @cartridge_model.expects(:each_cartridge).multiple_yields(cart1, cart2)
@@ -756,7 +756,7 @@ class BuildLifecycleTest < OpenShift::NodeTestCase
     gear_env = {a:1}
     OpenShift::Runtime::Utils::Environ.expects(:for_gear).with(@container.container_dir).returns(gear_env)
 
-    @container.expects(:clean_dependencies)
+    @container.expects(:clean_runtime_dirs).with(dependencies:true, build_dependencies:true, repo:true)
     @container.expects(:extract_deployment_archive).with(gear_env, prepare_options)
     @cartridge_model.expects(:do_action_hook).with('prepare',
                                                    gear_env,

--- a/node/test/unit/deployments_test.rb
+++ b/node/test/unit/deployments_test.rb
@@ -452,4 +452,72 @@ EOF
     err = assert_raises(RuntimeError) { @container.extract_deployment_archive(gear_env, file: file_path, destination: destination) }
     assert_equal "Specified file '#{file_path}' does not exist.", err.message
   end
+
+  def test_clean_runtime_dirs_empty_options
+    @container.expects(:run_in_container_context).never
+    @container.clean_runtime_dirs({})
+  end
+
+  def test_clean_runtime_dirs_unexpected_dir
+    @container.expects(:run_in_container_context).never
+    @container.clean_runtime_dirs(foo: 1)
+  end
+
+  def test_clean_runtime_dirs_dependencies_true
+    command = "shopt -s dotglob; rm -rf app-root/runtime/dependencies/*"
+
+    @container.expects(:run_in_container_context)
+              .with(command, chdir: @container.container_dir, expected_exitstatus: 0)
+
+    @container.clean_runtime_dirs(dependencies: true)
+  end
+
+  def test_clean_runtime_dirs_dependencies_not_true
+    @container.expects(:run_in_container_context).never
+    @container.clean_runtime_dirs(dependencies: false)
+    @container.clean_runtime_dirs(dependencies: 1)
+    @container.clean_runtime_dirs(dependencies: 'abc')
+  end
+
+  def test_clean_runtime_dirs_build_dependencies_true
+    command = "shopt -s dotglob; rm -rf app-root/runtime/build-dependencies/*"
+
+    @container.expects(:run_in_container_context)
+              .with(command, chdir: @container.container_dir, expected_exitstatus: 0)
+
+    @container.clean_runtime_dirs(build_dependencies: true)
+  end
+
+  def test_clean_runtime_dirs_build_dependencies_not_true
+    @container.expects(:run_in_container_context).never
+    @container.clean_runtime_dirs(build_dependencies: false)
+    @container.clean_runtime_dirs(build_dependencies: 1)
+    @container.clean_runtime_dirs(build_dependencies: 'abc')
+  end
+
+  def test_clean_runtime_dirs_repo_true
+    command = "shopt -s dotglob; rm -rf app-root/runtime/repo/*"
+
+    @container.expects(:run_in_container_context)
+              .with(command, chdir: @container.container_dir, expected_exitstatus: 0)
+
+    @container.clean_runtime_dirs(repo: true)
+  end
+
+  def test_clean_runtime_dirs_repo_not_true
+    @container.expects(:run_in_container_context).never
+    @container.clean_runtime_dirs(repo: false)
+    @container.clean_runtime_dirs(repo: 1)
+    @container.clean_runtime_dirs(repo: 'abc')
+  end
+
+  def test_clean_runtime_dirs_all_dirs
+    command = "shopt -s dotglob; rm -rf app-root/runtime/dependencies/* app-root/runtime/build-dependencies/* app-root/runtime/repo/*"
+
+    @container.expects(:run_in_container_context)
+              .with(command, chdir: @container.container_dir, expected_exitstatus: 0)
+
+    @container.clean_runtime_dirs(repo: true, build_dependencies: true, dependencies: true)
+
+  end
 end


### PR DESCRIPTION
Stop gear at beginning of binary deployment because the prepare step
extracts into the runtime dirs, which will affect the running app.

Add cleaning of repo dir in addition to the dependencies dirs prior to
extracting a binary artifact into the runtime dir.
