### PR TITLE
Add ~/.node_modules to dependency_dirs

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/bin/install
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/install
@@ -10,8 +10,6 @@ case "$1" in
     version="$2"
 esac
 
-ln -s ${OPENSHIFT_DEPENDENCIES_DIR}nodejs/node_modules ${OPENSHIFT_HOMEDIR}.node_modules
-
 ## npm link
 link_global_modules $version
 

--- a/cartridges/openshift-origin-cartridge-nodejs/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-nodejs/metadata/managed_files.yml
@@ -18,3 +18,4 @@ setup_rewritten:
 dependency_dirs:
 - ~/.npm
 - node_modules
+- ~/.node_modules: node_modules


### PR DESCRIPTION
Previously the symlink from ~/.node_modules to
app-root/runtime/dependencies/nodejs/node_modules was created in the
install script - move it to managed_files.yml so we don't need to do it
in bash.
