### PR TITLE
Add application metadata and validators

### DIFF
--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -103,6 +103,7 @@ class Application
   field :analytics, type: Hash, default: {}
   field :secret_token, type: String
   field :config, type: Hash, default: {'auto_deploy' => true, 'deployment_branch' => 'master', 'keep_deployments' => 1, 'deployment_type' => 'git'}
+  field :meta, type: Hash
   embeds_many :component_instances, class_name: ComponentInstance.name
   embeds_many :group_instances, class_name: GroupInstance.name
   embeds_many :app_ssh_keys, class_name: ApplicationSshKey.name
@@ -112,6 +113,7 @@ class Application
   has_members through: :domain, default_role: :admin
 
   validates :config, presence: true, application_config: true
+  validates :meta, application_metadata: true
 
   index({'group_instances.gears.uuid' => 1}, {:unique => true, :sparse => true})
   index({'pending_op_groups.created_at' => 1})

--- a/controller/app/validators/application_metadata_validator.rb
+++ b/controller/app/validators/application_metadata_validator.rb
@@ -1,0 +1,19 @@
+class ApplicationMetadataValidator < ActiveModel::Validator
+  def validate(record)
+    meta = record.meta
+    if meta.present?
+      meta.each_pair do |k,v|
+        record.errors.add(:meta, "Key #{k} is not a string") unless k.is_a? String
+        if v
+          if v.is_a? Array
+            record.errors.add(:meta, "The array of values provided for '#{k}' must be strings or numbers") if v.any?{ |o| not (o.is_a?(String) or o.is_a?(Numeric)) }
+          else
+            record.errors.add(:meta, "Value for '#{k}' must be a string, number, or list of strings and numbers") unless v.is_a?(String) or v.is_a?(Numeric)
+          end
+        end
+      end
+      size = BSON.serialize(meta).length
+      record.errors.add(:meta, "Application metadata may not be larger than 10KB - currently #{(size/1024).ceil}KB") if size > 10*1024
+    end
+  end
+end


### PR DESCRIPTION
Allow plugin code to store data on the application.  Currently limited to
10KB, string keys, and values that are strings, numbers, or lists of strings
and numbers.

@ncdc, @danmcp review
