### PR TITLE
Fall back to current deployment dir for remotedeploy

### DIFF
--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -380,7 +380,7 @@ command :remotedeploy do |c|
       result = @container.remote_deploy(out: $stdout,
                                         err: $stderr,
                                         hot_deploy: hot_deploy_enabled,
-                                        deployment_datetime: options.deployment_datetime,
+                                        deployment_datetime: options.deployment_datetime || @container.current_deployment_datetime,
                                         report_deployments: true,
                                         all: true)
 


### PR DESCRIPTION
Fall back to using ApplicationContainer#current_deployment_datetime in
'gear remotedeploy' if it's not specified. This should allow Jenkins
jobs created prior to the deployment enhancements to continue
functioning, albeit not 100% functional as far as deployment metadata
goes.
