### PR TITLE
Bug 1023588 - Build cartridge index from cache

### DIFF
--- a/node-util/bin/oo-admin-cartridge
+++ b/node-util/bin/oo-admin-cartridge
@@ -48,7 +48,7 @@ module OpenShift
               end
             end
           when :list
-            return repository.to_s
+            return options.verbose ? repository.inspect : repository.to_s
           when :erase
             begin
               repository.erase(options.name, options.version, options.cartridge_version)

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -33,9 +33,8 @@ module MCollective
           lock.flock(File::LOCK_EX)
 
           @@cartridge_repository = ::OpenShift::Runtime::CartridgeRepository.instance
-          @@cartridge_repository.clear
 
-          Dir.glob(PathUtils.join('/usr/libexec/openshift/cartridges', '*')).each do |path|
+          Dir.glob(PathUtils.join(@@config.get('CARTRIDGE_BASE_PATH'), '*')).each do |path|
             begin
               manifest = @@cartridge_repository.install(path)
               Log.instance.info("Installed cartridge (#{manifest.cartridge_vendor}, #{manifest.name}, #{manifest.version}, #{manifest.cartridge_version}) from #{path}")


### PR DESCRIPTION
- Restore support for cartridges added to node via oo-admin-cartridge
