### PR TITLE
Don't use app_dns == gear_dns with update_cluster

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
@@ -1144,7 +1144,7 @@ module OpenShift
         # - if the current "master" gear, copies all app-deployments to all new gears (if any)
         # - if the current "master" gear, activates the current deployment on all new gears (if any)
         # - calls the web proxy cartridge's 'update-cluster' control method
-        def update_cluster(proxies, cluster, rollback = false)
+        def update_cluster(proxies, cluster, rollback, sync_new_gears)
           # currently there's no easy way to only target web proxy gears from the broker
           # via mcollective, so this is a temporary workaround
           return unless proxy_cart = @cartridge_model.web_proxy
@@ -1210,10 +1210,8 @@ module OpenShift
             logger.info "Retrieving updated gear registry #{uuid} entries"
             updated_entries = gear_registry.entries
 
-            # only rsync and activate if we're the currently elected proxy
-            # TODO the way we determine this needs to change so gears other than
-            # the initial proxy gear can be elected
-            if gear_env['OPENSHIFT_APP_DNS'] == gear_env['OPENSHIFT_GEAR_DNS']
+            # the broker will inform us if we are supposed to sync and activate new gears
+            if sync_new_gears == true
               old_web_gears = old_registry[:web]
               new_web_gears = updated_entries[:web].values.select do |entry|
                 entry.uuid != self.uuid and not old_web_gears.keys.include?(entry.uuid)

--- a/node/test/unit/application_container_test.rb
+++ b/node/test/unit/application_container_test.rb
@@ -406,7 +406,7 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
     @container.expects(:activate).never
     @container.cartridge_model.expects(:do_control).never
 
-    @container.update_cluster("", "")
+    @container.update_cluster("", "", false, false)
   end
 
   def test_update_cluster_rollback
@@ -424,14 +424,14 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
     @container.expects(:generate_update_cluster_control_args).with(nil).returns(args)
 
     @container.cartridge_model.expects(:do_control).with('update-cluster', web_proxy, args: args)
-    @container.update_cluster("", "", true)
+    @container.update_cluster("", "", true, false)
   end
 
   def test_update_cluster_add_gears
     web_proxy = mock()
     @container.cartridge_model.expects(:web_proxy).returns(web_proxy)
 
-    gear_env = {'OPENSHIFT_APP_DNS' => 'foo-bar.example.com', 'OPENSHIFT_GEAR_DNS' => 'foo-bar.example.com'}
+    gear_env = {'OPENSHIFT_APP_DNS' => 'foo-bar.example.com', 'OPENSHIFT_GEAR_DNS' => '123-bar.example.com'}
     ::OpenShift::Runtime::Utils::Environ::expects(:for_gear).with(@container.container_dir).returns(gear_env)
 
     gear_registry = mock()
@@ -561,7 +561,7 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
       "#{uuid},#{dns_entries[index]},bar,node1.example.com,#{ports[index]}"
     end.join(' ')
 
-    @container.update_cluster(proxy_arg, cluster_arg)
+    @container.update_cluster(proxy_arg, cluster_arg, false, true)
   end
 
   def test_with_gear_rotation_no_proxy_no_all

--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -275,7 +275,7 @@ module OpenShift
               begin
                 district = District.find_by({"server_identities.name" => @id})
                 district_uuid = district.uuid
-              rescue Mongoid::Errors::DocumentNotFound 
+              rescue Mongoid::Errors::DocumentNotFound
                 district_uuid = 'NONE'
               end
             else
@@ -312,7 +312,7 @@ module OpenShift
               begin
                 district = District.find_by({"server_identities.name" => @id})
                 district_uuid = district.uuid
-              rescue Mongoid::Errors::DocumentNotFound 
+              rescue Mongoid::Errors::DocumentNotFound
                 district_uuid = 'NONE'
               end
             else
@@ -382,7 +382,7 @@ module OpenShift
         result = nil
         (1..10).each do |i|
           args = build_base_gear_args(gear, quota_blocks, quota_files)
-          
+
           # set the secret token for new gear creations
           # log an error if the application does not have its secret_token set
           if app.secret_token.present?
@@ -390,7 +390,7 @@ module OpenShift
           else
             Rails.logger.error "The application #{app.name} (#{app._id.to_s}) does not have its secret token set"
           end
-          
+
           mcoll_reply = execute_direct(@@C_CONTROLLER, 'app-create', args)
 
           begin
@@ -1709,6 +1709,10 @@ module OpenShift
         if options.has_key?(:rollback)
           args['--rollback'] = options[:rollback]
         else
+          if options[:sync_new_gears] == true
+            args['--sync-new-gears'] = true
+          end
+
           proxy_args = []
           options[:proxy_gears].each do |gear|
             proxy_args << "#{gear.uuid},#{gear.name},#{gear.group_instance.application.domain_namespace},#{gear.public_hostname}"
@@ -1917,12 +1921,12 @@ module OpenShift
 
         # get the application state
         idle, leave_stopped = get_app_status(app)
-        
+
         # get the quota blocks and files from the gear
         gear_quota = get_quota(gear)
         quota_blocks = Integer(gear_quota[3])
         quota_files = Integer(gear_quota[6])
-        
+
         gi = gear.group_instance
         gi.all_component_instances.each do |cinst|
           next if cinst.is_sparse? and (not gear.sparse_carts.include? cinst._id) and (not gear.host_singletons)
@@ -1977,7 +1981,7 @@ module OpenShift
                   reply.append destination_container.stop(gear, cinst)
                 end
               end
-              
+
               app.update_proxy_status(action: :enable, gear_uuid: gear.uuid)
             end
             app.save
@@ -3207,12 +3211,12 @@ module OpenShift
           begin
             # in some cases, the get_fact mcollective call gets stuck and never returns
             # to handle these siturations, we are using the ruby Timeout moddule as a safety net
-            # and setting the timer duration as a reasonable multiple of the mcollective timeout value 
+            # and setting the timer duration as a reasonable multiple of the mcollective timeout value
             failsafe_timeout = Rails.configuration.msg_broker[:fact_timeout] * 3
             Timeout::timeout(failsafe_timeout) do
               client.get_fact(:fact => fact) do |response|
                 next unless Integer(response[:body][:statuscode]) == 0
-    
+
                 # Yield the sender and the value to the block
                 result = rvalue(response)
                 yield response[:senderid], result if result
@@ -3509,7 +3513,7 @@ module OpenShift
       end
 
       private
- 
+
       def mask_user_creds(str)
         str.gsub(/(User: |Password: |username=|password=).*/, '\1[HIDDEN]')
       end

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -997,7 +997,7 @@ module MCollective
 
       def oo_update_cluster(args)
         with_container_from_args(args) do |container|
-          container.update_cluster(args['--proxy-gears'], args['--web-gears'], args['--rollback'])
+          container.update_cluster(args['--proxy-gears'], args['--web-gears'], args['--rollback'], args['--sync-new-gears'])
         end
       end
 
@@ -1174,9 +1174,9 @@ module MCollective
            endpoints = []
            cont.cartridge_model.each_cartridge do |cart|
              cart.public_endpoints.each do |ep|
-               endpoint_create_hash = { "cartridge_name" => cart.name+'-'+cart.version, 
-                          "external_port" => env[ep.public_port_name], 
-                          "internal_address" => env[ep.private_ip_name], 
+               endpoint_create_hash = { "cartridge_name" => cart.name+'-'+cart.version,
+                          "external_port" => env[ep.public_port_name],
+                          "internal_address" => env[ep.private_ip_name],
                           "internal_port" => ep.private_port ,
                           "protocols" => ep.protocols,
                           "type" => []


### PR DESCRIPTION
Previously update_cluster was only syncing content to and activating
new gears if the proxy gear in question was the original one
(OPENSHIFT_APP_DNS == OPENSHIFT_GEAR_DNS). Instead of doing this,
modify the broker to select a proxy and pass a boolean indicating that
proxy should do the syncing and activating.
