### PR TITLE
rubygem-openshift-origin-node should own /var/log/openshift/node/*.log

### DIFF
--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -217,6 +217,8 @@ fi
 %{gem_spec}
 %attr(0750,-,-) /usr/sbin/*
 %attr(0755,-,-) /usr/bin/*
+%attr(0640,-,-) %ghost %{_var}/log/openshift/node/platform.log
+%attr(0640,-,-) %ghost %{_var}/log/openshift/node/platform-trace.log
 /usr/libexec/openshift/lib/quota_attrs.sh
 /usr/libexec/openshift/lib/archive_git_submodules.sh
 %attr(0755,-,-) %{openshift_lib}/cartridge_sdk


### PR DESCRIPTION
openshift-origin-node/utils/logger/split_trace_logger.rb creates the default
files.
