### PR TITLE
Bug 1022271

### DIFF
--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -121,6 +121,8 @@ command :prereceive do |c|
       found_deployment_ref = false
       hot_deploy = false
 
+      new_rev = nil
+
       $stdin.each_line do |str|
         arr  = str.split
         refs = arr[2].split('/')
@@ -132,7 +134,6 @@ command :prereceive do |c|
         next unless ref_to_deploy == ref_name
 
         found_deployment_ref = true
-        hot_deploy = @repo.file_exists?(HOT_DEPLOY_MARKER, new_rev)
 
         break
       end
@@ -141,7 +142,23 @@ command :prereceive do |c|
       # - this is the first build ever (--first-time) or
       # - auto deployments are enabled and the appropriate git ref was pushed
       if options.first_time or (found_deployment_ref and ENV['OPENSHIFT_AUTO_DEPLOY'] != 'false')
-        @container.pre_receive(out: $stdout, err: $stderr, hot_deploy: hot_deploy)
+        if options.first_time
+          # if this is an initial build from post_configure, we shouldn't be hot deploying
+          # as that will keep things from starting up properly
+          hot_deploy = false
+        else
+          # otherwise, check the repo for the marker
+          hot_deploy = @repo.file_exists?(HOT_DEPLOY_MARKER, new_rev)
+        end
+
+        force_clean_build = @repo.file_exists?(FORCE_CLEAN_BUILD_MARKER, new_rev)
+
+        @container.pre_receive(out: $stdout,
+                               err: $stderr,
+                               hot_deploy: hot_deploy,
+                               force_clean_build: force_clean_build,
+                               ref: ref_to_deploy,
+                               git_sha1: new_rev)
       end
     end
   end
@@ -176,20 +193,10 @@ command :postreceive do |c|
       # - this is the first build ever, i.e. --first-time or
       # - auto deployments are enabled and the appropriate git ref was pushed
       if options.first_time or (found_deployment_ref and ENV['OPENSHIFT_AUTO_DEPLOY'] != 'false')
-        if options.first_time
-          # if this is an initial build from post_configure, we shouldn't be hot deploying
-          # as that will keep things from starting up properly
-          hot_deploy = false
-        else
-          # otherwise, check the repo for the marker
-          hot_deploy = @repo.file_exists?(HOT_DEPLOY_MARKER, ref_to_deploy)
-        end
 
         result = @container.post_receive(out: $stdout,
                                          err: $stderr,
-                                         hot_deploy: hot_deploy,
                                          ref: ref_to_deploy,
-                                         force_clean_build: @repo.file_exists?(FORCE_CLEAN_BUILD_MARKER, ref_to_deploy),
                                          report_deployments: true,
                                          all: true)
 


### PR DESCRIPTION
Write hot_deploy, force_clean_build, git_ref, git_sha1 to deployment
metadata file as part of prereceive and use metadata file's values
afterwards in postreceive, build, prepare, distribute, activate.
