### PR TITLE
Bug 1021472: Mark php 0.0.7 upgrade incompatible

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml.rhel
@@ -12,7 +12,6 @@ Vendor: php.net
 Cartridge-Version: 0.0.7
 Compatible-Versions:
 - 0.0.5
-- 0.0.6
 Cartridge-Vendor: redhat
 Categories:
 - service


### PR DESCRIPTION
Ensure the performance.conf file is properly managed during upgrades by
marking the 0.0.7 version incompatible with prior versions.
