### PR TITLE
Safer writing of gear registry to disk

### DIFF
--- a/node/lib/openshift-origin-node/model/gear_registry.rb
+++ b/node/lib/openshift-origin-node/model/gear_registry.rb
@@ -134,6 +134,7 @@ module OpenShift
             file.write(JSON.dump(self))
             file.fsync
           end
+          @container.set_ro_permission(@registry_file)
         end
       end
 

--- a/node/lib/openshift-origin-node/model/gear_registry.rb
+++ b/node/lib/openshift-origin-node/model/gear_registry.rb
@@ -140,11 +140,13 @@ module OpenShift
 
       def backup
         FileUtils.copy(@registry_file, @backup_file)
+        @container.set_ro_permission(@backup_file)
       end
 
       def restore_from_backup
         raise 'Backup file does not exist' unless File.exist?(@backup_file)
         FileUtils.copy(@backup_file, @registry_file)
+        @container.set_ro_permission(@registry_file)
         load
       end
 

--- a/node/lib/openshift-origin-node/model/gear_registry.rb
+++ b/node/lib/openshift-origin-node/model/gear_registry.rb
@@ -18,6 +18,7 @@ require 'json'
 require 'openshift-origin-node/utils/node_logger'
 require 'active_support/hash_with_indifferent_access'
 require 'active_support/core_ext/hash'
+require 'active_support/core_ext/file/atomic'
 
 module OpenShift
   module Runtime
@@ -129,7 +130,10 @@ module OpenShift
       # Writes the gear registry to disk
       def save
         with_lock do
-          File.open(@registry_file, "w") { |f| f.write JSON.dump(self) }
+          File.atomic_write(@registry_file) do |file|
+            file.write(JSON.dump(self))
+            file.fsync
+          end
         end
       end
 

--- a/node/test/unit/gear_registry_test.rb
+++ b/node/test/unit/gear_registry_test.rb
@@ -203,6 +203,8 @@ EOF
     registry.add({type: :proxy}.merge(options_for_entry("3")))
     registry.add({type: :proxy}.merge(options_for_entry("4")))
 
+    @container.expects(:set_ro_permission).with(@registry_file)
+
     registry.save
     from_file = JSON.load(File.new(@registry_file))
     from_string = JSON.parse(@sample_json)


### PR DESCRIPTION
Use atomic_write and fsync when writing the gear registry to disk.
