### PR TITLE
Bug 1024022 - cartridge allows two starts of supervisor

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/bin/control
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/control
@@ -103,6 +103,11 @@ NODE_EOF
 function start() {
     echo "Starting NodeJS cartridge"
 
+    if is_supervisor_running; then
+        echo "Application is already running"
+        return 0
+    fi
+
     envf="$OPENSHIFT_NODEJS_DIR/configuration/node.env"
     logf="$OPENSHIFT_NODEJS_LOG_DIR/node.log"
 


### PR DESCRIPTION
- Follow other cartridges and starting a started cartridge is a NO-OP
