### PR TITLE
Handle custom cartridge metadata

### DIFF
--- a/console/app/models/cartridge.rb
+++ b/console/app/models/cartridge.rb
@@ -28,7 +28,7 @@ class Cartridge < RestApi::Base
   has_one    :help_topics, :class_name => as_indifferent_hash
   has_one    :links, :class_name => as_indifferent_hash
 
-  delegate :tags, :priority, :database?, :web_framework?, :builder?, :jenkins_client?, :haproxy_balancer?, :to => :cartridge_type, :allow_nil => false
+  delegate :display_name, :tags, :priority, :database?, :web_framework?, :builder?, :jenkins_client?, :haproxy_balancer?, :to => :cartridge_type, :allow_nil => false
 
   def custom?
     url.present?
@@ -59,10 +59,6 @@ class Cartridge < RestApi::Base
 
   def type
     @attributes[:type]
-  end
-
-  def display_name
-    @attributes[:display_name] || cartridge_type.display_name
   end
 
   def type=(type)
@@ -162,7 +158,7 @@ class Cartridge < RestApi::Base
   end
 
   def cartridge_type
-    @cartridge_type ||= (CartridgeType.cached.find(name) rescue CartridgeType.new(:name => name))
+    @cartridge_type ||= (CartridgeType.cached.find(name) rescue CartridgeType.new(@attributes.slice('name', 'display_name', 'website', 'version', 'type', 'tags', 'license', 'license_url')))
   end
 end
 

--- a/console/app/views/building/new.html.haml
+++ b/console/app/views/building/new.html.haml
@@ -1,6 +1,6 @@
 - content_for :page_title, 'Enable Jenkins Builds'
 
-%h1 Enable Jenkins Builds
+%h1 Enable Jenkins Builds for #{link_to @application.name, application_path(@application)}
 = flashes
 
 %section

--- a/console/app/views/building/show.html.haml
+++ b/console/app/views/building/show.html.haml
@@ -1,6 +1,7 @@
 - content_for :page_title, 'Building your Application'
 
 %h1 Building your Application
+= flashes
 
 %section
   %p OpenShift is configured to build this application with #{link_to 'Jenkins', jenkins_help_url } when you make changes through Git. You can track the progress of builds through the following Jenkins job:

--- a/console/app/views/scaling/delete.html.haml
+++ b/console/app/views/scaling/delete.html.haml
@@ -1,6 +1,6 @@
 - content_for :page_title, 'Disable Scaling'
 
-%h1 Disable Scaling
+%h1 Disable Scaling for #{link_to @application.name, application_path(@application)}
 
 %section
   %p

--- a/console/app/views/scaling/new.html.haml
+++ b/console/app/views/scaling/new.html.haml
@@ -1,16 +1,16 @@
 - content_for :page_title, 'Not Scalable'
 
-%h1 Not Scalable
+%h1 #{link_to @application.name, application_path(@application)} is not scalable
 = flashes
 
 %section
   %p
-    This application is not currently scalable. For the time being 
-    applications must be set to scale when they are created. To make a 
-    new application scalable you will need to pass the command line 
+    This application is not currently scalable. For the time being
+    applications must be set to scale when they are created. To make a
+    new application scalable you will need to pass the command line
     option <code>--scale</code>:
-    
-  %pre.cli 
+
+  %pre.cli
     rhc create-app --scale -a &lt;your application&gt; ...
 
   %p
@@ -20,7 +20,7 @@
     For more information about scaling your applications see
     #{link_to 'our scaling guide in the Developer Center', scaling_help_url}.
 
-  %p 
-    We hope to add the ability to enable scaling on existing applications in the 
-    future - you can provide feedback about this and other features in 
+  %p
+    We hope to add the ability to enable scaling on existing applications in the
+    future - you can provide feedback about this and other features in
     OpenShift via our #{link_to 'feature request page', suggest_features_url}.

--- a/console/app/views/scaling/show.html.haml
+++ b/console/app/views/scaling/show.html.haml
@@ -1,7 +1,8 @@
 - content_for :page_style, 'highlight'
 - content_for :page_title, 'Scale your Application'
 
-%h1 Scale your Application
+%h1 Scale #{link_to @application.name, application_path(@application)}
+= flashes
 
 %section#scaling-gear-groups
   - @cartridges.each do |cartridge|

--- a/console/app/views/storage/show.html.haml
+++ b/console/app/views/storage/show.html.haml
@@ -1,6 +1,7 @@
 - content_for :page_title, 'Change Gear Storage'
 
-%h1 Change Gear Storage
+%h1 Change Gear Storage for #{link_to @application.name, application_path(@application)}
+= flashes
 
 %section#storage-gear-groups
   %section
@@ -18,9 +19,8 @@
       You can check your usage with the RHC command line:
 
       %pre.cli
-        = preserve do
-          :escaped
-            $ rhc show-app #{@application.name} --gears quota
+        :escaped
+          $ rhc show-app #{@application.name} --gears quota
 
   -# This will only render if we have this partial, like in Online or if an admin wants to provide information
   = render('increase_storage') unless @can_modify_storage


### PR DESCRIPTION
Custom web frameworks weren't going in the first slot Storage page should have
references back to app name

@jwforres review
