### PR TITLE
Gear groups should timeout aggressively when fetching state

### DIFF
--- a/console/app/controllers/applications_controller.rb
+++ b/console/app/controllers/applications_controller.rb
@@ -204,7 +204,7 @@ class ApplicationsController < ConsoleController
     app_id = params[:id].to_s
 
     async{ @application = Application.find(app_id, :as => current_user, :params => {:include => :cartridges}) }
-    async{ @gear_groups_with_state = GearGroup.all(:as => current_user, :params => {:application_id => app_id}) }
+    async{ @gear_groups_with_state = GearGroup.all(:as => current_user, :params => {:application_id => app_id, :timeout => 3}) }
     async{ sshkey_uploaded? }
 
     join!(30)

--- a/controller/app/controllers/gear_groups_controller.rb
+++ b/controller/app/controllers/gear_groups_controller.rb
@@ -6,7 +6,7 @@ class GearGroupsController < BaseController
   GROUP_INSTANCE_ID_COMPATIBILITY_REGEX = /\A[A-Za-z0-9]+\z/
 
   def index
-    gear_states, result_io = @application.get_gear_states()
+    gear_states, result_io = @application.get_gear_states(state_timeout)
     include_endpoints = (params[:include] == "endpoints")
     group_instances = @application.group_instances_with_scale.map{ |group_inst| get_rest_gear_group(group_inst, gear_states, @application, get_url, nolinks, include_endpoints)}
     render_success(:ok, "gear_groups", group_instances, "Showing gear groups for application '#{@application.name}' with domain '#{@application.domain_namespace}'", result_io)
@@ -19,8 +19,14 @@ class GearGroupsController < BaseController
     if gear_group_id !~ GROUP_INSTANCE_ID_COMPATIBILITY_REGEX
       return render_error(:not_found, "Gear group '#{gear_group_id}' not found for application #{@application.name} on domain '#{@application.domain_namespace}'", 101)
     end
-    gear_states, result_io = @application.get_gear_states()
+    gear_states, result_io = @application.get_gear_states(state_timeout)
     group_instance = @application.group_instances.find(gear_group_id)
     render_success(:ok, "gear_group", get_rest_gear_group(group_instance, gear_states, @application, get_url, nolinks, include_endpoints), "Showing gear group #{gear_group_id} for application '#{@application.name}' with domain '#{@application.domain_namespace}'", result_io)
   end
+
+  protected
+    def state_timeout
+      maximum_wait = params[:timeout].to_i
+      maximum_wait == 0 ? nil : [maximum_wait, 120].min
+    end
 end

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -914,8 +914,8 @@ class Application
   ##
   # Retrieves the gear state for all gears within the application.
   # @return [Hash<String, String>] Map of {Gear} ID to state
-  def get_gear_states
-    gear_states, result_io = Gear.get_gear_states(group_instances.map{|g| g.gears}.flatten)
+  def get_gear_states(timeout=nil)
+    gear_states, result_io = Gear.get_gear_states(group_instances.map{|g| g.gears}.flatten, timeout)
     [gear_states, result_io]
   end
 

--- a/controller/app/models/gear.rb
+++ b/controller/app/models/gear.rb
@@ -290,10 +290,10 @@ class Gear
   #
   # == Returns:
   # Hash of Gear._id => state representing the state of each gear
-  def self.get_gear_states(gears)
+  def self.get_gear_states(gears, timeout=nil)
     gear_states = {}
     tag = ""
-    handle = RemoteJob.create_parallel_job
+    handle = RemoteJob.create_parallel_job(timeout || 10)
     RemoteJob.run_parallel_on_gears(gears, handle) { |exec_handle, gear|
       if gear.get_proxy
         RemoteJob.add_parallel_job(exec_handle, tag, gear, gear.get_proxy.get_show_state_job(gear))

--- a/controller/app/models/remote_job.rb
+++ b/controller/app/models/remote_job.rb
@@ -27,8 +27,8 @@ class RemoteJob < OpenShift::Model
   #
   # == Returns:
   # New parallel job handle. Currently represented by a Hash
-  def self.create_parallel_job
-    return { }
+  def self.create_parallel_job(timeout=nil)
+    {:args => {:timeout => timeout}}
   end
 
   # Calls the provided block to generate RemoteJob entries for each gear and executes those jobs in parallel.

--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -3491,9 +3491,11 @@ module OpenShift
         if handle.present?
           start_time = Time.new
           begin
-            options = MCollectiveApplicationContainerProxy.rpc_options
-            rpc_client = MCollectiveApplicationContainerProxy.get_rpc_client('openshift', options)
             mc_args = handle.clone
+            custom_options = handle.delete :args
+            Rails.logger.debug("DEBUG: Parallel execute with options #{custom_options.inspect} (Request ID: #{Thread.current[:user_action_log_uuid]})")
+            options = MCollectiveApplicationContainerProxy.rpc_options.merge(custom_options)
+            rpc_client = MCollectiveApplicationContainerProxy.get_rpc_client('openshift', options)
             identities = handle.keys
             rpc_client.custom_request('execute_parallel', mc_args, identities, {'identity' => identities}).each { |mcoll_reply|
               if mcoll_reply.results[:statuscode] == 0
@@ -3508,7 +3510,7 @@ module OpenShift
           ensure
             rpc_client.disconnect
           end
-          Rails.logger.debug "DEBUG: MCollective Response Time (execute_parallel): #{Time.new - start_time}s  (Request ID: #{Thread.current[:user_action_log_uuid]})"
+          Rails.logger.debug "DEBUG: MCollective Response Time (execute_parallel): #{((Time.new - start_time)*1000).round}ms  (Request ID: #{Thread.current[:user_action_log_uuid]})"
         end
       end
 

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -193,7 +193,7 @@ module MCollective
             args      = job[:args]
 
             exitcode, output, addtl_params = execute_action(action, args)
-            if args['--with-container-uuid'] && ! quota_reported
+            if args['--with-container-uuid'] && ! quota_reported && ! ['app-state-show'].include?(action)
               report_quota(output, args['--with-container-uuid'])
               quota_reported = true
             end


### PR DESCRIPTION
The gear group state call needs to time out more quickly on absent gears.  Set
default to 10s, and allow clients to request a specific timeout via the API. 
Verified that partial results are returned.  UI will use 3 second timeout, and
show 'unknown' for any that have not returned yet.

Also, exclude quota checking from app-state-show because it is not intended to
be read by clients and because it is a performance critical path

@jwhonce @danmcp review please
