### PR TITLE
Bug 1024299 - Fix symlink python3.3 in virtenv

### DIFF
--- a/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-community/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-community/bin/upgrade
@@ -1,0 +1,8 @@
+#!/bin/bash -eu
+
+source $OPENSHIFT_CARTRIDGE_SDK_BASH
+
+TARGET=$OPENSHIFT_HOMEDIR/app-root/runtime/dependencies/python/virtenv/venv/bin/python3.3
+SOURCE=$OPENSHIFT_PYTHON_DIR/opt/bin/python3.3
+
+exec ln -sf $SOURCE $TARGET


### PR DESCRIPTION
- Relative symlink no longer works after dependency directories added
