### PR TITLE
Bug 1025179 - Defend against code that calls execute_parallel with nil args

### DIFF
--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -3492,9 +3492,7 @@ module OpenShift
           start_time = Time.new
           begin
             mc_args = handle.clone
-            custom_options = handle.delete :args
-            Rails.logger.debug("DEBUG: Parallel execute with options #{custom_options.inspect} (Request ID: #{Thread.current[:user_action_log_uuid]})")
-            options = MCollectiveApplicationContainerProxy.rpc_options.merge(custom_options)
+            options = MCollectiveApplicationContainerProxy.rpc_options.merge(handle.delete(:args) || {})
             rpc_client = MCollectiveApplicationContainerProxy.get_rpc_client('openshift', options)
             identities = handle.keys
             rpc_client.custom_request('execute_parallel', mc_args, identities, {'identity' => identities}).each { |mcoll_reply|


### PR DESCRIPTION
Some code paths are calling into remote_job.rb without calling
create_parallel_job first.  Defend against that.

@danmcp review
