### PR TITLE
Some rest-domains.feature tests rely on DEFAULT_MAX_DOMAINS = 1

### DIFF
--- a/controller/test/cucumber/rest-domains.feature
+++ b/controller/test/cucumber/rest-domains.feature
@@ -278,8 +278,13 @@ Feature: domains
     When I send a POST request to "/domains" with the following:"name=api<random>"
     Then the response should be "201"
     And the response should be a "domain" with attributes "name=api<random>"
-    When I send a POST request to "/domains" with the following:"name=apix<random>"
+    When the user has MAX_DOMAINS set to 1
+    And I send a POST request to "/domains" with the following:"name=apix<random>"
     Then the response should be "409"
+    When the user has MAX_DOMAINS set to 2
+    And I send a POST request to "/domains" with the following:"name=apix<random>"
+    Then the response should be "201"
+    And the response should be a "domain" with attributes "name=apix<random>"
     
     Scenarios:
      | format | 
@@ -291,8 +296,13 @@ Feature: domains
     And I accept "<format>"
     When I send a POST request to "/domains" with the following:"name=api<random>"
     Then the response should be "201"
-    When I send a POST request to "/domains" with the following:"name=api<random>"
+    When the user has MAX_DOMAINS set to 1
+    And I send a POST request to "/domains" with the following:"name=api<random>"
     Then the response should be "409"
+    And the error message should have "severity=error&exit_code=103"
+    When the user has MAX_DOMAINS set to 2
+    And I send a POST request to "/domains" with the following:"name=api<random>"
+    Then the response should be "422"
     And the error message should have "severity=error&exit_code=103"
     
     Scenarios:

--- a/controller/test/cucumber/step_definitions/api_steps.rb
+++ b/controller/test/cucumber/step_definitions/api_steps.rb
@@ -165,6 +165,10 @@ Given /^a quickstart UUID$/ do
   @uuid = quickstarts[0]['quickstart']['id']
 end
 
+When /^the user has MAX_DOMAINS set to (\d*)$/ do |max_domains|
+  set_max_domains(@username,max_domains)
+end
+
 When /^I send a GET request to "([^\"]*)"$/ do |path|
   path = sub_random(path)
   url = @base_url + path.to_s

--- a/controller/test/cucumber/support/user_helper.rb
+++ b/controller/test/cucumber/support/user_helper.rb
@@ -32,5 +32,10 @@ module UserHelper
     run command
   end
 
+  def set_max_domains(login, max_domains)
+    command = "/usr/sbin/oo-admin-ctl-user -l #{login} --setmaxdomains #{max_domains}"
+    run command
+  end
+
 end
 World(UserHelper)


### PR DESCRIPTION
Update the user's max domain value instead of relying on the broker.conf
default value.
