### PR TITLE
Bug 1017536 - Duplication warning messages when creating scalable app with empty git repo

### DIFF
--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -334,9 +334,7 @@ module OpenShift
         cartridge              = get_cartridge(name)
 
         ::OpenShift::Runtime::Utils::Cgroups.new(@container.uuid).boost do
-          if empty_repository?
-            output << "CLIENT_MESSAGE: An empty Git repository has been created for your application.  Use 'git push' to add your code."
-          else
+          unless empty_repository?
             output << start_cartridge('start', cartridge, user_initiated: true)
           end
           output << cartridge_action(cartridge, 'post_install', software_version)


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1017536 
When creating new scalable app with empty git repo, will return message that empty git repo has been created twice.

This is just a part of the fix. Second part is in this PR -> https://github.com/openshift/rhc/pull/499
