### PR TITLE
Rest API Deployment support for passing the artifact url parameter

### DIFF
--- a/broker/test/system/deployment_test.rb
+++ b/broker/test/system/deployment_test.rb
@@ -141,6 +141,50 @@ class DeploymentTest < ActionDispatch::IntegrationTest
     body = JSON.parse(@response.body)
     assert_equal(3, body["data"].length, "There should only be 3 deployments kept")
 
+    #create binary deployment for tar.gz
+    request_via_redirect(:post, APP_DEPLOYMENT_COLLECTION_URL_FORMAT % [@ns, @app], {:artifact_url=> "http://localhost/deploymentvalidation.tar.gz"}, @headers)
+    assert_response :created
+    assert_response :success
+    body = JSON.parse(@response.body)
+    binary_deployment_id = body["data"]["id"]
+
+    assert_equal(false , body["data"]["hot_deploy"], "hot_deploy is #{body["data"]["hot_deploy"]} where it should be false")
+    assert_equal(false , body["data"]["force_clean_build"], "force_clean_build is #{body["data"]["force_clean_build"]} where it should be false")
+    # query deployment list
+    request_via_redirect(:get, APP_DEPLOYMENT_COLLECTION_URL_FORMAT % [@ns, @app], {}, @headers)
+    assert_response :ok
+    body = JSON.parse(@response.body)
+    assert_equal(3, body["data"].length)
+    missing_id = true
+    body["data"].each { |activation_hash|
+      if activation_hash["id"] == binary_deployment_id
+        missing_id = false
+      end
+    }
+    assert_equal missing_id, false
+
+    #create binary deployment for tgz
+    request_via_redirect(:post, APP_DEPLOYMENT_COLLECTION_URL_FORMAT % [@ns, @app], {:artifact_url=> "http://localhost/deploymentvalidationv2.tgz"}, @headers)
+    assert_response :created
+    assert_response :success
+    body = JSON.parse(@response.body)
+    binary_deployment_id_tgz = body["data"]["id"]
+
+    assert_equal(false , body["data"]["hot_deploy"], "hot_deploy is #{body["data"]["hot_deploy"]} where it should be false")
+    assert_equal(false , body["data"]["force_clean_build"], "force_clean_build is #{body["data"]["force_clean_build"]} where it should be false")
+    # query deployment list
+    request_via_redirect(:get, APP_DEPLOYMENT_COLLECTION_URL_FORMAT % [@ns, @app], {}, @headers)
+    assert_response :ok
+    body = JSON.parse(@response.body)
+    assert_equal(3, body["data"].length)
+    missing_id = true
+    body["data"].each { |activation_hash|
+      if activation_hash["id"] == binary_deployment_id_tgz
+        missing_id = false
+      end
+    }
+    assert_equal missing_id, false
+
   end
 
 end

--- a/controller/app/rest_models/rest_application.rb
+++ b/controller/app/rest_models/rest_application.rb
@@ -234,7 +234,7 @@ class RestApplication < OpenShift::Model
         "LIST_ENVIRONMENT_VARIABLES" => Link.new("List all environment variables", "GET", URI::join(url, "application/#{@id}/environment-variables")),
         "DEPLOY" => Link.new("Deploy the application", "POST", URI::join(url, "application/#{@id}/deployments"), nil,[
           OptionalParam.new("ref", "string", "Git ref (tag, branch, commit id)", nil, "master"),
-          #OptionalParam.new("artifact_url", "string", "URL where the deployment artifact can be downloaded from", nil, "N/A"),
+          OptionalParam.new("artifact_url", "string", "URL where the deployment artifact can be downloaded from"),
           OptionalParam.new("hot_deploy", "boolean", "Indicates whether this is a hot deployment", "true or false", false),
           OptionalParam.new("force_clean_build", "string", "Indicates whether a clean build should be performed", "true or false", false),
         ]),

--- a/controller/app/rest_models/rest_application10.rb
+++ b/controller/app/rest_models/rest_application10.rb
@@ -220,7 +220,7 @@ class RestApplication10 < OpenShift::Model
         "LIST_ENVIRONMENT_VARIABLES" => Link.new("List all environment variables", "GET", URI::join(url, "domains/#{@domain_id}/applications/#{@name}/environment-variables")),
         "DEPLOY" => Link.new("Deploy the application", "POST", URI::join(url, "domains/#{@domain_id}/applications/#{@name}/deployments"), nil,[
           OptionalParam.new("ref", "string", "Git ref (tag, branch, commit id)", nil, "master"),
-          #OptionalParam.new("artifact_url", "string", "URL where the deployment artifact can be downloaded from", nil, "N/A"),
+          OptionalParam.new("artifact_url", "string", "URL where the deployment artifact can be downloaded from"),
           OptionalParam.new("hot_deploy", "boolean", "Indicates whether this is a hot deployment", "true or false", false),
           OptionalParam.new("force_clean_build", "string", "Indicates whether a clean build should be performed", "true or false", false),
         ]),

--- a/controller/app/rest_models/rest_application13.rb
+++ b/controller/app/rest_models/rest_application13.rb
@@ -145,7 +145,7 @@ class RestApplication13 < OpenShift::Model
         "LIST_ENVIRONMENT_VARIABLES" => Link.new("List all environment variables", "GET", URI::join(url, "domain/#{@domain_id}/application/#{@name}/environment-variables")),
         "DEPLOY" => Link.new("Deploy the application", "POST", URI::join(url, "domain/#{@domain_id}/application/#{@name}/deployments"), nil,[
           OptionalParam.new("ref", "string", "Git ref (tag, branch, commit id)", nil, "master"),
-          #OptionalParam.new("artifact_url", "string", "URL where the deployment artifact can be downloaded from", nil, "N/A"),
+          OptionalParam.new("artifact_url", "string", "URL where the deployment artifact can be downloaded from"),
           OptionalParam.new("hot_deploy", "boolean", "Indicates whether this is a hot deployment", "true or false", false),
           OptionalParam.new("force_clean_build", "string", "Indicates whether a clean build should be performed", "true or false", false),
         ]),

--- a/controller/app/rest_models/rest_application15.rb
+++ b/controller/app/rest_models/rest_application15.rb
@@ -232,7 +232,7 @@ class RestApplication15 < OpenShift::Model
         "LIST_ENVIRONMENT_VARIABLES" => Link.new("List all environment variables", "GET", URI::join(url, "domain/#{@domain_id}/application/#{@name}/environment-variables")),
         "DEPLOY" => Link.new("Deploy the application", "POST", URI::join(url, "domain/#{@domain_id}/application/#{@name}/deployments"), nil,[
           OptionalParam.new("ref", "string", "Git ref (tag, branch, commit id)", nil, "master"),
-          #OptionalParam.new("artifact_url", "string", "URL where the deployment artifact can be downloaded from", nil, "N/A"),
+          OptionalParam.new("artifact_url", "string", "URL where the deployment artifact can be downloaded from"),
           OptionalParam.new("hot_deploy", "boolean", "Indicates whether this is a hot deployment", "true or false", false),
           OptionalParam.new("force_clean_build", "string", "Indicates whether a clean build should be performed", "true or false", false),
         ]),

--- a/node/lib/openshift-origin-node/model/application_container_ext/deployments.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/deployments.rb
@@ -349,10 +349,13 @@ module OpenShift
         end
 
         def determine_extract_command(options)
-          use_stdin = !!options[:stdin]
-          filename  = options[:file]
+          use_artifact_url  = !!options[:artifact_url]
+          use_stdin         = !!options[:stdin]
+          filename          = options[:file]
 
-          if use_stdin
+          if use_artifact_url
+            "/usr/bin/curl #{options[:artifact_url]} | /bin/tar -xz"
+          elsif use_stdin
             "/bin/tar -xz"
           elsif filename =~ /\.tar\.gz$/i or filename =~ /\.tar$/i
             "/bin/tar xf #{filename}"

--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -444,54 +444,14 @@ command :'binary-deploy' do |c|
           raise UsageException.new("OPENSHIFT_DEPLOYMENT_TYPE is 'git' - binary deployments are disabled.")
       end
 
-      puts "Beginning binary deployment"
-
-      options = { stdin: $stdin }
-
-      puts "Stopping gear"
-      @container.stop_gear(user_initiated: true,
-                          exclude_web_proxy: true,
-                          out: $stdout,
-                          err: $stderr)
-
-      puts "Creating new deployment directory"
-      deployment_datetime = @container.create_deployment_dir
-      options[:deployment_datetime] = deployment_datetime
-
-      puts "Preparing deployment"
-      @container.prepare(options)
-
-      puts "Distributing deployment"
-      result = @container.distribute(options)
-      distribute_status = result[:status]
-      puts "Distribution status: #{distribute_status}"
-
-      if distribute_status != RESULT_SUCCESS
-        puts "Distribution failed for the following gears:"
-        failures = result[:gear_results].values.select { |r| r[:status] != RESULT_SUCCESS }
-        puts failures.map { |f| "#{f[:gear_uuid]} (#{f[:errors][0]})" }.join("\n")
-      end
-
-      options[:all]                = true
-      options[:report_deployments] = true
-      puts "Activating deployment"
-      result = @container.activate(options)
-      activate_status = result[:status]
-      puts "Activation status: #{activate_status}"
-
-      if activate_status != RESULT_SUCCESS
-        puts "Activation failed for the following gears:"
-        failures = result[:gear_results].values.select { |r| r[:status] != RESULT_SUCCESS }
-        puts failures.map { |f| "#{f[:gear_uuid]} (#{f[:errors][0]})" }.join("\n")
-      end
-
-      if distribute_status == RESULT_SUCCESS and activate_status == RESULT_SUCCESS
-        deployment_status = 'success'
+      options = { out: $stdout, err: $stderr }
+      if args.count > 0
+        options[:file] = args[0]
       else
-        deployment_status = 'failure'
+        options[:stdin] = $stdin
       end
 
-      puts "Deployment status: #{deployment_status}"
+      result = @container.deploy_binary_artifact(options)
     end
   end
 end
@@ -683,3 +643,4 @@ command :'rotate-in' do |c|
     $stdout.puts(JSON.dump(result)) if options.as_json
   end
 end
+

--- a/node/test/functional/platform_binary_deploy_test.rb
+++ b/node/test/functional/platform_binary_deploy_test.rb
@@ -23,6 +23,7 @@ require 'restclient/request'
 class PlatformBinaryDeployTest < OpenShift::NodeBareTestCase
   DEFAULT_TITLE     = "Welcome to OpenShift"
   CHANGED_TITLE     = "Test1"
+  VERSION_TWO_TITLE = "Test2"
 
   def setup
     @framework_cartridge = ENV['CART_TO_TEST'] || 'mock-0.1'
@@ -40,6 +41,18 @@ class PlatformBinaryDeployTest < OpenShift::NodeBareTestCase
 
   def test_binary_deploy
     binary_deploy_test([ @framework_cartridge ])
+  end
+  
+  def test_rest_api_binary_deployment_to_scaled_app
+    options = {}
+    options[:scaling] = true
+    use_the_rest_api_binary_deploy_app_test([ @framework_cartridge ], options)
+  end
+
+  def test_rest_api_binary_deployment_to_nonscaled_app
+    options = {}
+    options[:scaling] = false
+    use_the_rest_api_binary_deploy_app_test([ @framework_cartridge ], options)
   end
 
   def binary_deploy_test(cartridges, options = {})
@@ -66,4 +79,65 @@ class PlatformBinaryDeployTest < OpenShift::NodeBareTestCase
 
     @api.assert_http_title_for_app(app_name2, @namespace, CHANGED_TITLE)
   end
+  
+  def use_the_rest_api_binary_deploy_app_test(cartridges, options = {})
+    scaling = !!options[:scaling]
+
+    app_name                = "app#{@api.random_string}"
+    v1_tgz_file_name        = "#{app_name}v1.tgz"
+    v2_tgz_file_name        = "#{app_name}v2.tgz"
+    deploy_target_app_name  = "deploytargetapp#{@api.random_string}"
+
+    @api.up_gears
+
+    framework = cartridges[0]
+
+    # 1) create a scaled app
+    app_id = @api.create_application(app_name, cartridges, scaling)
+    @api.add_ssh_key(app_id, app_name)
+    @api.assert_http_title_for_app(app_name, @namespace, DEFAULT_TITLE)
+
+    # 2) Clone the app repo
+    @api.clone_repo(app_id)
+
+    # 3) Change the app's title
+    @api.change_title(CHANGED_TITLE, app_name, app_id, framework)
+    @api.assert_http_title_for_app(app_name, @namespace, CHANGED_TITLE)
+
+    # 4) save the snapshot (s1) and copy to the local apache  /var/www/html
+    @api.save_deployment_snapshot_for_app(app_id, v1_tgz_file_name)
+    @api.copy_file_to_apache(v1_tgz_file_name)
+
+    # 5) change the app's title and confirm it
+    @api.change_title(VERSION_TWO_TITLE, app_name, app_id, framework)
+    @api.assert_http_title_for_app(app_name, @namespace, VERSION_TWO_TITLE)
+
+    # 6) take a snapshot of the app
+    @api.save_deployment_snapshot_for_app(app_id, v2_tgz_file_name)
+
+    # 7) copy new snapshot (s2) to the local apache /var/www/html
+    @api.copy_file_to_apache(v2_tgz_file_name)
+
+    # 8) create a new app
+    app_id2 = @api.create_application(deploy_target_app_name, cartridges, scaling)
+
+    # 9) configure the app as a binary deployment type
+    @api.set_deployment_type(deploy_target_app_name, 'binary')
+    @api.add_ssh_key(app_id2, deploy_target_app_name)
+    @api.assert_http_title_for_app(deploy_target_app_name, @namespace, DEFAULT_TITLE)
+
+    # 10) use the rest api to deploy the s2 artifact to the new app
+    @api.deploy_binary_artifact_using_rest_api(deploy_target_app_name, "http://localhost:81/#{v2_tgz_file_name}")
+
+    # 11) confirm the title is correct
+    @api.assert_http_title_for_app(app_name, @namespace, VERSION_TWO_TITLE)
+
+    # 12) use the rest api to deploy the s1 artifact to the new app
+    @api.deploy_binary_artifact_using_rest_api(deploy_target_app_name, "http://localhost:81/#{v1_tgz_file_name}")
+    
+    # 13) confirm the title is correct
+    @api.assert_http_title_for_app(deploy_target_app_name, @namespace, CHANGED_TITLE)
+    
+  end # use_the_rest_api_binary_deploy_to_scaled_app_test
+
 end

--- a/node/test/unit/deployments_test.rb
+++ b/node/test/unit/deployments_test.rb
@@ -402,6 +402,11 @@ EOF
     filename = '/tmp/foo.tar'
     assert_equal "/bin/tar xf #{filename}", @container.determine_extract_command(file: filename)
   end
+  
+  def test_determine_extract_command_tar_artifact_url
+    artifact_url = "http://localhost:81/this_is_an_artifact.tgz"
+    assert_equal "/usr/bin/curl #{artifact_url} | /bin/tar -xz", @container.determine_extract_command(artifact_url: artifact_url)
+  end
 
   def test_determine_extract_command_zip
     filename = '/tmp/foo.zip'

--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -867,6 +867,7 @@ module OpenShift
         args['--with-hot-deploy'] = hot_deploy
         args['--with-force-clean-build'] = force_clean_build
         args['--with-ref'] = ref
+        args['--with-artifact-url'] = artifact_url
 
         result_io = run_cartridge_command(@@C_CONTROLLER, gear, "deploy", args)
         return result_io


### PR DESCRIPTION
This is the branch holding the work to get the artifact url parameter passed through on the binary deployment rest api.
