### PR TITLE
[DO_NOT_MERGE] card639 changes

### DIFF
--- a/admin-console/test/functional/admin_console/applications_controller_test.rb
+++ b/admin-console/test/functional/admin_console/applications_controller_test.rb
@@ -7,7 +7,7 @@ module AdminConsole
       @login = "user#{@random}"
       @password = 'password'
       @user = CloudUser.new(login: @login)
-      @user.capabilities["private_ssl_certificates"] = true
+      @user.private_ssl_certificates = true
       @user.save
       Lock.create_lock(@user)
       register_user(@login, @password)

--- a/admin-console/test/functional/admin_console/users_controller_test.rb
+++ b/admin-console/test/functional/admin_console/users_controller_test.rb
@@ -7,7 +7,7 @@ module AdminConsole
       @login = "user#{@random}"
       @password = 'password'
       @user = CloudUser.new(login: @login)
-      @user.capabilities["private_ssl_certificates"] = true
+      @user.private_ssl_certificates = true
       @user.save
       Lock.create_lock(@user)
       register_user(@login, @password)

--- a/admin-console/test/support/base.rb
+++ b/admin-console/test/support/base.rb
@@ -9,7 +9,7 @@ class ActiveSupport::TestCase
     login = "user#{random}"
     password = 'password'
     user = CloudUser.new(login: login)
-    user.capabilities["private_ssl_certificates"] = true
+    user.private_ssl_certificates = true
     user.save
     Lock.create_lock(user)
     register_user(login, password)

--- a/broker-util/oo-admin-ctl-user
+++ b/broker-util/oo-admin-ctl-user
@@ -68,341 +68,276 @@ USAGE
 end
 
 class String
-    def to_b()
-        return true if self.to_s.strip =~ /^(true|t|yes|y|1)$/i
-
-        return false
-    end
+  def to_b()
+    return true if self.to_s.strip =~ /^(true|t|yes|y|1)$/i
+    return false
+  end
 end
 
 def set_max_domains(user, maxdomains)
-    caps = user.capabilities
-    if caps["max_domains"] == maxdomains
-        puts "User already has max_domains set to #{user.max_domains}"
-        return
-    end
+  if user.max_domains == maxdomains
+    puts "User already has max_domains set to #{max_domains}"
+    return
+  end
 
-    print "Setting max_domains to #{maxdomains}... "
-    caps["max_domains"] = maxdomains
-    if user.save
-        puts "Done."
-    else
-        puts "An error occurred saving the user."
-        puts "Errors: #{user.errors.messages}"
-        exit 6
-    end
+  print "Setting max_domains to #{maxdomains}... "
+  user.maxdomains = maxdomains
+  if user.save
+    puts "Done."
+  else
+    puts "An error occurred saving the user."
+    puts "Errors: #{user.errors.messages}"
+    exit 6
+  end
 end
 
 def set_max_gears(user, maxgears)
-    caps = user.capabilities
-    if caps["max_gears"] == maxgears
-        puts "User already has max_gears set to #{user.max_gears}"
-        return
-    end
+  if user.maxgears == maxgears
+    puts "User already has max_gears set to #{max_gears}"
+    return
+  end
 
-    print "Setting max_gears to #{maxgears}... "
-    caps["max_gears"] = maxgears
-    if user.save
-        puts "Done."
-    else
-        puts "An error occurred saving the user."
-        puts "Errors: #{user.errors.messages}"
-        exit 6
-    end
+  print "Setting max_gears to #{maxgears}... "
+  user.maxgears = maxgears
+  if user.save
+    puts "Done."
+  else
+    puts "An error occurred saving the user."
+    puts "Errors: #{user.errors.messages}"
+    exit 6
+  end
 end
 
 def set_max_tracked_storage(user, maxtrackedstorage)
-    caps = user.capabilities
-    if caps["max_tracked_addtl_storage_per_gear"] == maxtrackedstorage
-        puts "User already has max_tracked_addtl_storage_per_gear set to #{caps['max_tracked_addtl_storage_per_gear']}"
-        return
-    end
+  if user.max_tracked_additional_storage == maxtrackedstorage
+    puts "User already has max_tracked_additional_storage set to #{maxtrackedstorage}"
+    return
+  end
 
-    print "Setting max_tracked_addtl_storage_per_gear to #{maxtrackedstorage}... "
-    caps["max_tracked_addtl_storage_per_gear"] = maxtrackedstorage
-    if user.save
-        puts "Done."
-    else
-        puts "An error occurred saving the user."
-        puts "Errors: #{user.errors.messages}"
-        exit 6
-    end
+  print "Setting max_tracked_addtl_storage_per_gear to #{maxtrackedstorage}... "
+  user.max_tracked_additional_storage = maxtrackedstorage
+  if user.save
+    puts "Done."
+  else
+    puts "An error occurred saving the user."
+    puts "Errors: #{user.errors.messages}"
+    exit 6
+  end
 end
 
 def set_max_untracked_storage(user, maxuntrackedstorage)
-    caps = user.capabilities
-    if caps["max_untracked_addtl_storage_per_gear"] == maxuntrackedstorage
-        puts "User already has max_untracked_addtl_storage_per_gear set to #{caps['max_untracked_addtl_storage_per_gear']}"
-        return
-    end
+  if user.max_untracked_additional_storage == maxuntrackedstorage
+    puts "User already has max_untracked_additional_storage set to #{maxuntrackedstorage}"
+    return
+  end
 
-    print "Setting max_untracked_addtl_storage_per_gear to #{maxuntrackedstorage}... "
-    caps["max_untracked_addtl_storage_per_gear"] = maxuntrackedstorage
-    if user.save
-        puts "Done."
-    else
-        puts "An error occurred saving the user."
-        puts "Errors: #{user.errors.messages}"
-        exit 6
-    end
+  print "Setting max_untracked_addtl_storage_per_gear to #{maxuntrackedstorage}... "
+  user.max_untracked_additional_storage = maxuntrackedstorage
+  if user.save
+    puts "Done."
+  else
+    puts "An error occurred saving the user."
+    puts "Errors: #{user.errors.messages}"
+    exit 6
+  end
 end
 
 def set_consumed_gears(user, consumedgears)
-    old_value = user.consumed_gears
-    if user.consumed_gears == consumedgears
-        puts "User already has consumed_gears set to #{user.consumed_gears}"
-        return
-    end
+  old_value = user.consumed_gears
+  if user.consumed_gears == consumedgears
+    puts "User already has consumed_gears set to #{user.consumed_gears}"
+    return
+  end
 
-    print "Setting consumed_gears to #{consumedgears}... "
-    result = CloudUser.where(login: user.login, consumed_gears: old_value).find_and_modify({ "$set" => { "consumed_gears" => consumedgears } } )
-    if result.nil?
-      puts "User's consumed_gear count changed between read and write, try again."
-      return
-    end
-    puts "Done."
+  print "Setting consumed_gears to #{consumedgears}... "
+  result = CloudUser.where(login: user.login, consumed_gears: old_value).find_and_modify({ "$set" => { "consumed_gears" => consumedgears } } )
+  if result.nil?
+    puts "User's consumed_gear count changed between read and write, try again."
+    return
+  end
+  puts "Done."
 end
 
 def allow_sub_accounts(user, allow)
-    # user.capabilities_will_change!
-    caps = user.capabilities
-    if caps['subaccounts'] == allow
-        puts "User already has allowsubaccounts set to #{allow}"
-        return
-    end
+  if user.subaccounts == allow
+    puts "User already has allowsubaccounts set to #{allow}"
+    return
+  end
 
-    print "Setting subaccounts capability to #{allow} for user #{user.login}... "
-    caps['subaccounts'] = allow
-    if user.save
-        puts "Done."
-    else
-        puts "An error occurred modifying the user capabilities."
-        puts "Errors: #{user.errors.messages}"
-        exit 6
-    end
+  print "Setting subaccounts capability to #{allow} for user #{user.login}... "
+  user.subaccounts = allow
+  if user.save
+    puts "Done."
+  else
+    puts "An error occurred modifying the user capabilities."
+    puts "Errors: #{user.errors.messages}"
+    exit 6
+  end
 end
 
 def allow_private_ssl_certificates(user, allow)
-    # user.capabilities_will_change!
-    caps = user.capabilities
-    if caps['private_ssl_certificates'] == allow
-        puts "User already has allow private_ssl_certificates set to #{allow}"
-        return
-    end
+  if user.private_ssl_certificates == allow
+    puts "User already has allow private_ssl_certificates set to #{allow}"
+    return
+  end
 
-    print "Setting private_ssl_certificates capability to #{allow} for user #{user.login}... "
-    caps['private_ssl_certificates'] = allow
-    if user.save
-        puts "Done."
-    else
-        puts "An error occurred modifying the user capabilities."
-        puts "Errors: #{user.errors.messages}"
-        exit 6
-    end
+  print "Setting private_ssl_certificates capability to #{allow} for user #{user.login}... "
+  user.private_ssl_certificates = allow
+  if user.save
+    puts "Done."
+  else
+    puts "An error occurred modifying the user capabilities."
+    puts "Errors: #{user.errors.messages}"
+    exit 6
+  end
 end
 
 def allow_plan_upgrade(user, allow)
-    caps = user.capabilities
-    if caps['plan_upgrade_enabled'] == allow
-        puts "User already has plan_upgrade_enabled set to #{allow}"
-        return
-    end
+  if user.plan_upgrade_enabled == allow
+    puts "User already has plan_upgrade_enabled set to #{allow}"
+    return
+  end
 
-    print "Setting plan_upgraded_enabled capability to #{allow} for user #{user.login}... "
-    caps['plan_upgrade_enabled'] = allow
-    if user.save
-        puts "Done."
-    else
-        puts "An error occurred modifying the user capabilities."
-        puts "Errors: #{user.errors.messages}"
-        exit 6
-    end
+  print "Setting plan_upgraded_enabled capability to #{allow} for user #{user.login}... "
+  user.plan_upgrade_enabled = allow
+  if user.save
+    puts "Done."
+  else
+    puts "An error occurred modifying the user capabilities."
+    puts "Errors: #{user.errors.messages}"
+    exit 6
+  end
 end
 
 def add_sub_account(user, subaccount_login)
-    caps = user.capabilities
-    unless caps['subaccounts']
-        puts "User #{user.login} does not have the capability to manage sub accounts"
-        return
-    end
+  unless user.subaccounts
+    puts "User #{user.login} does not have the capability to manage sub accounts"
+    return
+  end
 
-    begin
-        child_user = CloudUser::find_by_identity(subaccount_login)
-    rescue Mongoid::Errors::DocumentNotFound
-        child_user = nil
-    end
+  begin
+    child_user = CloudUser::find_by_identity(subaccount_login)
+  rescue Mongoid::Errors::DocumentNotFound
+    child_user = nil
+  end
     
-    if not child_user.nil?
-        if child_user.parent_user_id == user._id
-            puts "Error: Subaccount for '#{subaccount_login}' already exists under #{user.login}"
-        elsif not child_user.parent_user_id.nil?
-            parent_user = CloudUser.with(consistency: :eventual).find_by(_id: child_user.parent_user_id)
-            puts "Error: Subaccount for '#{subaccount_login}' already exists under #{parent_user.login}"
-        else
-            puts "Error: User '#{subaccount_login}' already exists"
-        end
-        exit 5
-    end
-    
-    print "Adding subaccount for #{subaccount_login} under #{user.login}... "
-    child_user = CloudUser.new(login: subaccount_login, parent_user_id: user._id)
-    if child_user.save
-        puts "Done."
+  if not child_user.nil?
+    if child_user.parent_user_id == user._id
+      puts "Error: Subaccount for '#{subaccount_login}' already exists under #{user.login}"
+    elsif not child_user.parent_user_id.nil?
+      parent_user = CloudUser.with(consistency: :eventual).find_by(_id: child_user.parent_user_id)
+      puts "Error: Subaccount for '#{subaccount_login}' already exists under #{parent_user.login}"
     else
-        puts "An error occurred adding the sub account #{subaccount_login}."
-        puts "Errors: #{child_user.errors.messages}"
-        exit 6
+      puts "Error: User '#{subaccount_login}' already exists"
     end
-    Lock.create_lock(child_user)
+    exit 5
+  end
+    
+  print "Adding subaccount for #{subaccount_login} under #{user.login}... "
+  child_user = CloudUser.new(login: subaccount_login, parent_user_id: user._id)
+  if child_user.save
+    puts "Done."
+  else
+    puts "An error occurred adding the sub account #{subaccount_login}."
+    puts "Errors: #{child_user.errors.messages}"
+    exit 6
+  end
+  Lock.create_lock(child_user)
 end
 
 def remove_sub_account(user, subaccount_login)
-    caps = user.capabilities
-    unless caps['subaccounts']
-        puts "User #{user.login} does not have the capability to manage sub accounts"
-        return
-    end
+  unless user.subaccounts
+    puts "User #{user.login} does not have the capability to manage sub accounts"
+    return
+  end
 
-	  begin
-        child_user = CloudUser::find_by_identity(subaccount_login)
-    rescue Mongoid::Errors::DocumentNotFound
-        puts "Error: Sub Account User '#{subaccount_login}' not found"
-        exit 5
-    end
+  begin
+    child_user = CloudUser::find_by_identity(subaccount_login)
+  rescue Mongoid::Errors::DocumentNotFound
+    puts "Error: Sub Account User '#{subaccount_login}' not found"
+    exit 5
+  end
     
-    if child_user.parent_user_id.nil? || (child_user.parent_user_id != user._id)
-        puts "Error: User '#{subaccount_login}' is not a sub account of #{user.login}"
-        exit 5
-    end
+  if child_user.parent_user_id.nil? || (child_user.parent_user_id != user._id)
+    puts "Error: User '#{subaccount_login}' is not a sub account of #{user.login}"
+    exit 5
+  end
     
-    print "Removing subaccount for #{child_user.login} under #{user.login}... "
-    begin
-      child_user.force_delete
-    rescue Exception => e
-      puts "An error occurred removing the sub account for #{subaccount_login} : #{e.message}"
-      exit 6
-    end
-    puts "Done."
+  print "Removing subaccount for #{child_user.login} under #{user.login}... "
+  begin
+    child_user.force_delete
+  rescue Exception => e
+    puts "An error occurred removing the sub account for #{subaccount_login} : #{e.message}"
+    exit 6
+  end
+  puts "Done."
 end
 
 def add_gear_size(user, gear_size)
-    print "Adding gear size #{gear_size} for user #{user.login}... "
+  print "Adding gear size #{gear_size} for user #{user.login}... "
 
-    begin
-      if Rails.configuration.respond_to?('billing')
-        billing_config = Rails.configuration.billing
-        allowed_gears = []
-        billing_config[:plans].each do |plan_id, plan_info|
-          allowed_gears += plan_info[:capabilities]['gear_sizes']
-        end
-        allowed_gears.uniq!
-        unless allowed_gears.include?(gear_size)
-          if (user.plan_id != billing_config[:default_plan].to_s) or user.usage_account_id.present?
-            puts "Error: User is not allowed to use gear size #{gear_size}."
-            exit 5
-          end
-        end
-      end
-      user.add_gear_size(gear_size)
-    rescue Exception=>e
-      puts e.message
-      exit 1
-    end
-    if !user.save
-        puts "An error occurred adding the gear size #{gear_size} to user #{user.login}."
-        puts "Errors: #{user.errors.messages}"
-        exit 6
-    end
-    puts "Done."
-
-    print "Adding gear size #{gear_size} for domains of user #{user.login}... "
-    user.domains.each do |d|
-      if (user.allowed_gear_sizes - d.allowed_gear_sizes) == [gear_size]
-        d.allowed_gear_sizes = user.allowed_gear_sizes
-        if !d.save
-          puts "An error occurred adding the gear size #{gear_size} to domain #{d.namespace} for user #{user.login}."
-          puts "Errors: #{d.errors.messages}"
-          exit 7
-        end
-      end
-    end
-    puts "Done."
+  begin
+    user.add_gear_size(gear_size)
+  rescue Exception=>e
+    puts e.message
+    exit 1
+  end
+  puts "Done."
 end
 
 def remove_gear_size(user, gear_size)
-    print "Removing gear size #{gear_size} for user #{user.login}... "
+  print "Removing gear size #{gear_size} for user #{user.login}... "
 
-    begin
-      user.remove_gear_size(gear_size)
-    rescue Exception => e
-      puts e.message
-      exit 6
-    end
-    if !user.save
-        puts "An error occurred removing the gear size #{gear_size} from user #{user.login}."
-        puts "Errors: #{user.errors.messages}"
-        exit 6
-    end
-    puts "Done."
-
-    print "Removing gear size #{gear_size} for domains of user #{user.login}... "
-    user.domains.each do |d|
-      d.allowed_gear_sizes = (user.allowed_gear_sizes & d.allowed_gear_sizes)
-      if !d.save
-        puts "An error occurred removing the gear size #{gear_size} from domain #{d.namespace} for user #{user.login}."
-        puts "Errors: #{d.errors.messages}"
-        exit 7
-      end
-    end
-    puts "Done."
+  begin
+    user.remove_gear_size(gear_size)
+  rescue Exception => e
+    puts e.message
+    exit 6
+  end
+  puts "Done."
 end
 
 def inherit_on_subaccounts(user, allow, capability, cap_name)
-    caps = user.capabilities
-    caps['inherit_on_subaccounts'] ||= []
- 
-    if caps['inherit_on_subaccounts'].include?(capability) == allow
-        puts "User already has #{cap_name} inheritance set to #{allow}"
-        return
-    end
+  if user.inherit_on_subaccounts.include?(capability) == allow
+    puts "User already has #{cap_name} inheritance set to #{allow}"
+    return
+  end
 
-    # user.capabilities_will_change!
-    print "Setting #{cap_name} inheritance to #{allow} for user #{user.login}... "
-    if allow
-      caps['inherit_on_subaccounts'].push(capability)
-    else
-      caps['inherit_on_subaccounts'].delete(capability)
-    end
+  print "Setting #{cap_name} inheritance to #{allow} for user #{user.login}... "
+  if allow
+    user.add_capability_inherit_on_subaccounts(capability)
+  else
+    user.remove_capability_inherit_on_subaccounts(capability)
+  end
     
-    if user.save
-        puts "Done."
-    else
-        puts "An error occurred modifying the user capabilities."
-        puts "Errors: #{user.errors.messages}"
-        exit 6
-    end
+  if user.save
+    puts "Done."
+  else
+    puts "An error occurred modifying the user capabilities."
+    puts "Errors: #{user.errors.messages}"
+    exit 6
+  end
 end
 
 def allow_ha(user, allow)
-    unless Rails.configuration.openshift[:allow_ha_applications]
-      puts "Error: Platform does not allow HA applications"
-      exit 5
-    end
-    caps = user.capabilities
-    if caps['ha'] == allow
-        puts "User already has HA set to #{allow}"
-        return
-    end
+  unless Rails.configuration.openshift[:allow_ha_applications]
+    puts "Error: Platform does not allow HA applications"
+    exit 5
+  end
+  if user.ha == allow
+    puts "User already has HA set to #{allow}"
+    return
+  end
 
-    print "Setting HA capability to #{allow} for user #{user.login}... "
-    caps['ha'] = allow
-    if user.save
-        puts "Done."
-    else
-        puts "An error occurred modifying the user capabilities."
-        puts "Errors: #{user.errors.messages}"
-        exit 6
-    end
+  print "Setting HA capability to #{allow} for user #{user.login}... "
+  user.ha = allow
+  if user.save
+    puts "Done."
+  else
+    puts "An error occurred modifying the user capabilities."
+    puts "Errors: #{user.errors.messages}"
+    exit 6
+  end
 end
 
 opts = GetoptLong.new(
@@ -495,43 +430,43 @@ puts
 puts
 
 begin
-    user = CloudUser.find_by_identity(login)
+  user = CloudUser.find_by_identity(login)
 rescue Mongoid::Errors::DocumentNotFound
-    puts "Error: User '#{login}' not found"
-    exit 5
+  puts "Error: User '#{login}' not found"
+  exit 5
 end
 
 changed_user = false
 subaccount_list = []
 
 unless maxdomains.nil?
-    set_max_domains(user, maxdomains)
-    changed_user = true
+  set_max_domains(user, maxdomains)
+  changed_user = true
 end
 
 unless maxgears.nil?
-    set_max_gears(user, maxgears)
-    changed_user = true
+  set_max_gears(user, maxgears)
+  changed_user = true
 end
 
 unless maxtrackedstorage.nil?
-    set_max_tracked_storage(user,maxtrackedstorage)
-    changed_user = true
+  set_max_tracked_storage(user,maxtrackedstorage)
+  changed_user = true
 end
 
 unless maxuntrackedstorage.nil?
-    set_max_untracked_storage(user,maxuntrackedstorage)
-    changed_user = true
+  set_max_untracked_storage(user,maxuntrackedstorage)
+  changed_user = true
 end
 
 unless consumedgears.nil?
-    set_consumed_gears(user, consumedgears)
-    changed_user = true
+  set_consumed_gears(user, consumedgears)
+  changed_user = true
 end
 
 unless allowsubaccounts.nil?
-    allow_sub_accounts(user, allowsubaccounts)
-    changed_user = true
+  allow_sub_accounts(user, allowsubaccounts)
+  changed_user = true
 end
 
 unless args["--allowplanupgrade"].nil?
@@ -539,50 +474,47 @@ unless args["--allowplanupgrade"].nil?
 end
 
 unless allowprivatesslcertificates.nil?
-    allow_private_ssl_certificates(user, allowprivatesslcertificates)
-    changed_user = true
+  allow_private_ssl_certificates(user, allowprivatesslcertificates)
+  changed_user = true
 end
 
 unless account_to_add.nil?
-    add_sub_account(user, account_to_add)
+  add_sub_account(user, account_to_add)
 end
 
 unless account_to_remove.nil?
-    remove_sub_account(user, account_to_remove)
+  remove_sub_account(user, account_to_remove)
 end
 
 unless gear_size_to_add.nil?
-    add_gear_size(user, gear_size_to_add)
-    changed_user = true
+  add_gear_size(user, gear_size_to_add)
+  changed_user = true
 end
 
 unless gear_size_to_remove.nil?
-    remove_gear_size(user, gear_size_to_remove)
-    changed_user = true
+  remove_gear_size(user, gear_size_to_remove)
+  changed_user = true
 end
 
 unless inheritgearsizes.nil?
-    inherit_on_subaccounts(user, inheritgearsizes, 'gear_sizes', 'gearsizes')
-    changed_user = true
+  inherit_on_subaccounts(user, inheritgearsizes, 'gear_sizes', 'gearsizes')
+  changed_user = true
 end
 
 unless allowha.nil?
-    allow_ha(user, allowha)
-    changed_user = true
+  allow_ha(user, allowha)
+  changed_user = true
 end
 
 if args["--listsubaccounts"]
-    subaccount_list = CloudUser.where(parent_user_id: user._id) 
+  subaccount_list = CloudUser.where(parent_user_id: user._id) 
 end
 
 if changed_user
-    # reload user with new settings
-    user = CloudUser.find_by_identity(login)
-    puts
-    puts
+  # reload user with new settings
+  user = CloudUser.find_by_identity(login)
+  puts
 end
-
-caps = user.capabilities
 
 # print out the user's current settings
 puts "User #{user.login}:"
@@ -590,20 +522,20 @@ puts "                            plan: #{user.plan_id}"
 puts "                consumed domains: #{user.domains.count}"
 puts "                     max domains: #{user.max_domains}"
 puts "                  consumed gears: #{user.consumed_gears}"
-puts "                       max gears: #{caps['max_gears']}"
-puts "    max tracked storage per gear: #{caps['max_tracked_addtl_storage_per_gear'] || 0}"
-puts "  max untracked storage per gear: #{caps['max_untracked_addtl_storage_per_gear'] || 0}"
-puts "            plan upgrade enabled: #{caps['plan_upgrade_enabled']}"
-puts "                      gear sizes: #{caps['gear_sizes'].join(', ')}" if caps.has_key?('gear_sizes')
-puts "            sub accounts allowed: #{caps['subaccounts']}" if caps.has_key?('subaccounts')
-puts "private SSL certificates allowed: #{caps['private_ssl_certificates']}" if caps.has_key?('private_ssl_certificates')
-puts "              inherit gear sizes: #{caps['inherit_on_subaccounts'].include?('gear_sizes')}" if caps.has_key?('inherit_on_subaccounts')
-puts "                      HA allowed: #{caps['ha']}" if caps.has_key?('ha')
+puts "                       max gears: #{user.max_gears}"
+puts "    max tracked storage per gear: #{user.max_tracked_additional_storage}"
+puts "  max untracked storage per gear: #{user.max_untracked_additional_storage}"
+puts "            plan upgrade enabled: #{user.plan_upgrade_enabled}" if user.capabilities.has_key?('plan_upgrade_enabled')
+puts "                      gear sizes: #{user.allowed_gear_sizes.join(', ')}"
+puts "            sub accounts allowed: #{user.subaccounts}"
+puts "private SSL certificates allowed: #{user.private_ssl_certificates}"
+puts "              inherit gear sizes: #{user.inherit_on_subaccounts.include?('gear_sizes')}"
+puts "                      HA allowed: #{user.ha}"
 puts 
 if args["--listsubaccounts"] and (not subaccount_list.nil?) and (not subaccount_list.empty?)
-    puts "Sub Accounts: #{subaccount_list.length}"
-    subaccount_list.each do |subaccount|
-        puts "     #{subaccount.login}"
-    end
-    puts
+  puts "Sub Accounts: #{subaccount_list.length}"
+  subaccount_list.each do |subaccount|
+    puts "     #{subaccount.login}"
+  end
+  puts
 end

--- a/broker/test/functional/alias_controller_test.rb
+++ b/broker/test/functional/alias_controller_test.rb
@@ -9,7 +9,7 @@ class AliasControllerTest < ActionController::TestCase
     @login = "user#{@random}"
     @password = 'password'
     @user = CloudUser.new(login: @login)
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
     Lock.create_lock(@user)
     register_user(@login, @password)
@@ -168,7 +168,7 @@ class AliasControllerTest < ActionController::TestCase
   end
 
   test "no user capability by domain and app name" do
-    @user.capabilities["private_ssl_certificates"] = false
+    @user.private_ssl_certificates = false
     @user.save!
 
     server_alias = "as.#{@random}"
@@ -185,7 +185,7 @@ class AliasControllerTest < ActionController::TestCase
   end
 
   test "no user capability by app id" do
-    @user.capabilities["private_ssl_certificates"] = false
+    @user.private_ssl_certificates = false
     @user.save
     server_alias = "as.#{@random}"
     post :create, {"id" => server_alias, "application_id" => @app.id, 

--- a/broker/test/functional/app_events_controller_test.rb
+++ b/broker/test/functional/app_events_controller_test.rb
@@ -9,7 +9,7 @@ class AppEventsControllerTest < ActionController::TestCase
     @login = "user#{@random}"
     @password = "password"
     @user = CloudUser.new(login: @login)
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
     Lock.create_lock(@user)
     register_user(@login, @password)

--- a/broker/test/functional/application_controller_test.rb
+++ b/broker/test/functional/application_controller_test.rb
@@ -9,7 +9,7 @@ class ApplicationControllerTest < ActionController::TestCase
     @login = "user#{@random}"
     @password = "password"
     @user = CloudUser.new(login: @login)
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
     Lock.create_lock(@user)
     register_user(@login, @password)

--- a/broker/test/functional/authorizations_controller_test.rb
+++ b/broker/test/functional/authorizations_controller_test.rb
@@ -12,7 +12,7 @@ class AuthorizationsControllerTest < ActionController::TestCase
     @login = "user#{@random}"
     @password = "password"
     @user = CloudUser.new(login: @login)
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
     Lock.create_lock(@user)
     register_user(@login, @password)

--- a/broker/test/functional/deployments_controller_test.rb
+++ b/broker/test/functional/deployments_controller_test.rb
@@ -9,7 +9,7 @@ class DeploymentsControllerTest < ActionController::TestCase
     @login = "user#{@random}"
     @password = 'password'
     @user = CloudUser.new(login: @login)
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
     Lock.create_lock(@user)
     register_user(@login, @password)

--- a/broker/test/functional/descriptors_controller_test.rb
+++ b/broker/test/functional/descriptors_controller_test.rb
@@ -9,7 +9,7 @@ class DescriptorsControllerTest < ActionController::TestCase
     @login = "user#{@random}"
     @password = "password"
     @user = CloudUser.new(login: @login)
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
     Lock.create_lock(@user)
     register_user(@login, @password)

--- a/broker/test/functional/dns_resolvable_controller_test.rb
+++ b/broker/test/functional/dns_resolvable_controller_test.rb
@@ -9,7 +9,7 @@ class DnsResolvableControllerTest < ActionController::TestCase
     @login = "user#{@random}"
     @password = "password"
     @user = CloudUser.new(login: @login)
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
     Lock.create_lock(@user)
     register_user(@login, @password)

--- a/broker/test/functional/domains_controller_test.rb
+++ b/broker/test/functional/domains_controller_test.rb
@@ -9,7 +9,7 @@ class DomainsControllerTest < ActionController::TestCase
     @login = "user#{@random}"
     @password = "password"
     @user = CloudUser.new(login: @login)
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
     Lock.create_lock(@user)
     register_user(@login, @password)

--- a/broker/test/functional/emb_cart_controller_test.rb
+++ b/broker/test/functional/emb_cart_controller_test.rb
@@ -9,7 +9,7 @@ class EmbCartControllerTest < ActionController::TestCase
     @login = "user#{@random}"
     @password = "password"
     @user = CloudUser.new(login: @login)
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
     Lock.create_lock(@user)
     register_user(@login, @password)

--- a/broker/test/functional/emb_cart_events_controller_test.rb
+++ b/broker/test/functional/emb_cart_events_controller_test.rb
@@ -9,7 +9,7 @@ class EmbCartEventsControllerTest < ActionController::TestCase
     @login = "user#{@random}"
     @user = CloudUser.new(login: @login)
     @password = "password"
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
     Lock.create_lock(@user)
     register_user(@login, @password)    

--- a/broker/test/functional/gear_groups_controller_test.rb
+++ b/broker/test/functional/gear_groups_controller_test.rb
@@ -12,7 +12,7 @@ class GearGroupsControllerTest < ActionController::TestCase
     @login = "user#{@random}"
     @password = "password"
     @user = CloudUser.new(login: @login)
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
     Lock.create_lock(@user)
     register_user(@login, @password)

--- a/broker/test/functional/gears_controller_test.rb
+++ b/broker/test/functional/gears_controller_test.rb
@@ -12,7 +12,7 @@ class GearsControllerTest < ActionController::TestCase
     @login = "user#{@random}"
     @password = "password"
     @user = CloudUser.new(login: @login)
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
     Lock.create_lock(@user)
     register_user(@login, @password)

--- a/broker/test/functional/keys_controller_test.rb
+++ b/broker/test/functional/keys_controller_test.rb
@@ -9,7 +9,7 @@ class KeysControllerTest < ActionController::TestCase
     @login = "user#{@random}"
     @password = "password"
     @user = CloudUser.new(login: @login)
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
     Lock.create_lock(@user)
     register_user(@login, @password)

--- a/broker/test/functional/user_controller_test.rb
+++ b/broker/test/functional/user_controller_test.rb
@@ -9,7 +9,7 @@ class UserControllerTest < ActionController::TestCase
     @login = "user#{@random}"
     @password = "password"
     @user = CloudUser.new(login: @login)
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
     Lock.create_lock(@user)
     register_user(@login, @password)

--- a/broker/test/integration/sub_user_test.rb
+++ b/broker/test/integration/sub_user_test.rb
@@ -47,7 +47,7 @@ class SubUserTest < ActionDispatch::IntegrationTest
     assert_equal 200, status
 
     u = CloudUser.find_by login: @username
-    u.capabilities["subaccounts"] = true
+    u.subaccounts = true
     u.save
 
     @headers["X-Impersonate-User"] = "subuser#{@random}"
@@ -76,11 +76,11 @@ class SubUserTest < ActionDispatch::IntegrationTest
     assert_equal 200, status
 
     u = CloudUser.find_by login: @username
-    u.capabilities["subaccounts"] = true
+    u.subaccounts = true
     u.save
 
     u = CloudUser.find_by login: "#{@username}x"
-    u.capabilities["subaccounts"] = true
+    u.subaccounts = true
     u.save
 
     @headers["X-Impersonate-User"] = "subuser#{@random}"
@@ -100,7 +100,7 @@ class SubUserTest < ActionDispatch::IntegrationTest
     assert_equal 403, status
 
     u = CloudUser.find_by login: "#{@username}"
-    u.capabilities["subaccounts"] = true
+    u.subaccounts = true
     u.save
 
     @headers2 = {}
@@ -135,36 +135,33 @@ class SubUserTest < ActionDispatch::IntegrationTest
     assert_equal 200, status
 
     u = CloudUser.find_by login: "#{@username}"
-    u.capabilities = {"subaccounts"=>true, "gear_sizes"=>Rails.configuration.openshift[:gear_sizes], "max_domains" => 1, "max_gears"=>3, "inherit_on_subaccounts"=>["gear_sizes"]}
+    u.set_capabilities({"subaccounts"=>true, "gear_sizes"=>Rails.configuration.openshift[:gear_sizes], "max_domains" => 1, "max_gears"=>3, "inherit_on_subaccounts"=>["gear_sizes"]}, true)
     u.save
 
     user = CloudUser.find_by(login: @username)
-    assert_equal Rails.configuration.openshift[:gear_sizes].sort, user.capabilities['gear_sizes'].sort
+    assert_equal Rails.configuration.openshift[:gear_sizes].sort, user.allowed_gear_sizes.sort
 
     @headers["X-Impersonate-User"] = "subuser#{@random}"
     get "broker/rest/domains.json", nil, @headers
     assert_equal 200, status
 
     subuser = CloudUser.find_by(login: "subuser#{@random}")
-    capabilities = subuser.capabilities
-    assert_equal Rails.configuration.openshift[:gear_sizes].sort, capabilities["gear_sizes"].sort
+    assert_equal Rails.configuration.openshift[:gear_sizes].sort, subuser.allowed_gear_sizes.sort
 
     u = CloudUser.find_by login: "#{@username}"
-    u.capabilities = {"subaccounts"=>true, "gear_sizes"=>Rails.configuration.openshift[:default_gear_capabilities], "max_domains" => 1, "max_gears"=>3, "inherit_on_subaccounts"=>["gear_sizes"]}
+    u.set_capabilities({"subaccounts"=>true, "gear_sizes"=>Rails.configuration.openshift[:default_gear_capabilities], "max_domains" => 1, "max_gears"=>3, "inherit_on_subaccounts"=>["gear_sizes"]}, true)
     u.save
 
     subuser = CloudUser.find_by(login: "subuser#{@random}")
-    capabilities = subuser.capabilities
-    assert_equal Rails.configuration.openshift[:default_gear_capabilities].sort, capabilities["gear_sizes"].sort
+    assert_equal Rails.configuration.openshift[:default_gear_capabilities].sort, subuser.allowed_gear_sizes.sort
 
     u = CloudUser.find_by login: "#{@username}"
-    u.capabilities = {"subaccounts"=>true, "gear_sizes"=>Rails.configuration.openshift[:default_gear_capabilities], "max_domains" => 1, "max_gears"=>3, "inherit_on_subaccounts"=>[]}
+    u.set_capabilities({"subaccounts"=>true, "gear_sizes"=>Rails.configuration.openshift[:default_gear_capabilities], "max_domains" => 1, "max_gears"=>3, "inherit_on_subaccounts"=>[]}, true)
     u.save
 
     subuser = CloudUser.find_by(login: "subuser#{@random}")
-    capabilities = subuser.capabilities
-    assert_equal 1, capabilities["gear_sizes"].size
-    assert_equal Rails.configuration.openshift[:default_gear_size], capabilities["gear_sizes"][0]
+    assert_equal 1, subuser.allowed_gear_sizes.size
+    assert_equal Rails.configuration.openshift[:default_gear_size], subuser.allowed_gear_sizes[0]
   end
 
   def teardown

--- a/broker/test/integration_ext/removed_nodes_app_fixup_test.rb
+++ b/broker/test/integration_ext/removed_nodes_app_fixup_test.rb
@@ -9,8 +9,8 @@ class RemovedNodesAppFixupTest < ActionDispatch::IntegrationTest
     @unresponsive_server = "ip-11-10-9-8"
 
     @cu = CloudUser.new(login: @login)
-    @cu.capabilities['max_gears'] = 1000
-    @cu.capabilities['ha'] = true
+    @cu.max_gears = 1000
+    @cu.ha = true
     @cu.save!
     Lock.create_lock(@cu)
 

--- a/broker/test/system/alias_test.rb
+++ b/broker/test/system/alias_test.rb
@@ -75,7 +75,7 @@ class AliasTest < ActionDispatch::IntegrationTest
     @app = "app#{@random}"
     @as = "as#{@random}.foo.com"
 
-    @user.capabilities["private_ssl_certificates"] = true
+    @user.private_ssl_certificates = true
     @user.save
 
     #create domain

--- a/broker/test/unit/application_test.rb
+++ b/broker/test/unit/application_test.rb
@@ -152,7 +152,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest #ActiveSupport::TestCas
     app = Application.create_app(@appname, [PHP_VERSION, MYSQL_VERSION], @domain, nil, true)
     app = Application.find_by(canonical_name: @appname.downcase, domain_id: @domain._id) rescue nil
 
-    @user.capabilities["max_untracked_addtl_storage_per_gear"] = 5
+    @user.max_untracked_additional_storage = 5
     @user.save
     app.reload
     app.owner.reload

--- a/broker/test/unit/cloud_user_test.rb
+++ b/broker/test/unit/cloud_user_test.rb
@@ -106,12 +106,8 @@ class CloudUserTest < ActiveSupport::TestCase
     assert caps2 = c.capabilities
     assert_not_same caps, caps2
 
-    c.capabilities = nil
-    assert_nil c.capabilities
-    assert_nil c.capabilities
-
     a = {}
-    c.capabilities = a
+    c.set_capabilities(a, true)
     assert caps3 = c.capabilities
     assert_not_same caps, caps3
     assert_not_same caps2, caps3
@@ -121,9 +117,9 @@ class CloudUserTest < ActiveSupport::TestCase
 
   test "inherited capabilities" do
     parent = CloudUser.create(login: "#{@login}_parent") do |u|
-      u._capabilities = u.default_capabilities
-      u.capabilities['gear_sizes'] = ['foo', 'bar']
-      u.capabilities['inherit_on_subaccounts'] = ['gear_sizes']
+      u.set_capabilities(u.default_capabilities, true)
+      u.set_capabilities({'gear_sizes' => ['foo', 'bar']})
+      u.set_capabilities({'inherit_on_subaccounts' => ['gear_sizes']})
     end
     c = CloudUser.create(login: @login){ |u| u.parent_user_id = parent._id }
 

--- a/controller/app/models/cloud_user.rb
+++ b/controller/app/models/cloud_user.rb
@@ -224,7 +224,7 @@ class CloudUser
       "subaccounts" => false,
       "gear_sizes" => Rails.application.config.openshift[:default_gear_capabilities],
       "max_domains" => Rails.application.config.openshift[:default_max_domains],
-      "max_gears" => Rails.application.config.openshift[:default_max_gears],
+      "max_gears" => Rails.application.config.openshift[:default_max_gears]
     }
   end
 
@@ -268,13 +268,37 @@ class CloudUser
   #
   alias_method :_capabilities, :capabilities
   def capabilities
-    if caps = _capabilities
-      CapabilityProxy.new(caps, inherited_capabilities)
+    caps = _capabilities
+    CapabilityProxy.new(caps, inherited_capabilities)
+  end
+
+  def set_capabilities(caps, clear_existing_caps=false)
+    if clear_existing_caps
+      _capabilities.clear
+      user_caps = capabilities
+      user_caps.each do |k, v|
+        if v.is_a?(Array)
+          _capabilities[k] = []
+        elsif v.is_a?(Hash)
+          _capabilities[k] = {}
+        elsif v.is_a?(Boolean)
+          _capabilities[k] = false
+        elsif v.is_a?(Integer) or v.is_a?(Float)
+          _capabilities[k] = 0
+        else
+          raise OpenShift::UserException.new("Capability type not found for '#{k} : #{v}'")
+        end
+      end 
     end
+    _capabilities.merge!(caps.deep_dup)
   end
 
   def ha
-    return capabilities["ha"] || false
+    capabilities["ha"] || false
+  end
+
+  def ha=(m)
+    _capabilities["ha"] = m if capabilities["ha"] != m
   end
 
   def max_gears
@@ -282,7 +306,7 @@ class CloudUser
   end
 
   def max_gears=(m)
-    capabilities["max_gears"] = m
+    _capabilities["max_gears"] = m if capabilities["max_gears"] != m
   end
 
   def max_domains
@@ -290,7 +314,33 @@ class CloudUser
   end
 
   def max_domains=(m)
-    capabilities["max_domains"] = m
+    _capabilities["max_domains"] = m if capabilities["max_domains"] != m
+  end
+
+  def subaccounts
+    capabilities["subaccounts"] || false
+  end
+
+  def subaccounts=(m)
+    _capabilities["subaccounts"] = m if capabilities["subaccounts"] != m
+  end
+
+  def inherit_on_subaccounts
+    capabilities["inherit_on_subaccounts"] || []
+  end
+
+  def add_capability_inherit_on_subaccounts(capability)
+    inherit_caps = capabilities["inherit_on_subaccounts"] || []
+    unless inherit_caps.include?(capability)
+      _capabilities["inherit_on_subaccounts"] = inherit_caps + [capability]
+    end
+  end
+
+  def remove_capability_inherit_on_subaccounts(capability)
+    inherit_caps = capabilities["inherit_on_subaccounts"] || []
+    if inherit_caps.include?(capability)
+      _capabilities["inherit_on_subaccounts"] = inherit_caps - [capability]
+    end
   end
 
   def allowed_gear_sizes
@@ -299,20 +349,33 @@ class CloudUser
 
   def add_gear_size(gear_size)
     available_sizes = Rails.configuration.openshift[:gear_sizes]
-    if ! available_sizes.include? gear_size
+    unless available_sizes.include?(gear_size)
       raise Exception.new("Size #{gear_size} is not defined. Defined sizes are: #{available_sizes.join ', '}.")
     end
-    self.capabilities['gear_sizes'] << gear_size if not self.capabilities['gear_sizes'].include? gear_size
+    unless capabilities['gear_sizes'].include?(gear_size)
+      _capabilities['gear_sizes'] = capabilities['gear_sizes'] + [gear_size]
+      self.save!
+    end
+    domains.each do |d|
+      if (allowed_gear_sizes - d.allowed_gear_sizes) == [gear_size]
+        d.allowed_gear_sizes = allowed_gear_sizes
+        d.save!
+      end
+    end
   end
 
   def remove_gear_size(gear_size)
-    caps = self.capabilities
+    caps = capabilities
     unless caps["gear_sizes"].include?(gear_size)
-        puts "User #{self.login} does not have gear size #{gear_size} in its capabilities."
-        return
+      puts "User #{self.login} does not have gear size #{gear_size} in its capabilities."
+      return
     end
-
-    caps["gear_sizes"].delete(gear_size)
+    _capabilities["gear_sizes"] = caps["gear_sizes"] - [gear_size]
+    self.save!
+    domains.each do |d|
+      d.allowed_gear_sizes = (allowed_gear_sizes & d.allowed_gear_sizes)
+      d.save!
+    end
   end
 
   def max_storage
@@ -323,8 +386,24 @@ class CloudUser
     capabilities['max_untracked_addtl_storage_per_gear'] || 0
   end
 
+  def max_untracked_additional_storage=(m)
+    _capabilities["max_untracked_addtl_storage_per_gear"] = m if capabilities["max_untracked_addtl_storage_per_gear"] != m
+  end
+
   def max_tracked_additional_storage
     capabilities['max_tracked_addtl_storage_per_gear'] || 0
+  end
+
+  def max_tracked_additional_storage=(m)
+    _capabilities["max_tracked_addtl_storage_per_gear"] = m if capabilities["max_tracked_addtl_storage_per_gear"] != m
+  end
+
+  def private_ssl_certificates
+    capabilities["private_ssl_certificates"] || false
+  end
+
+  def private_ssl_certificates=(m)
+    _capabilities["private_ssl_certificates"] = m if capabilities["private_ssl_certificates"] != m
   end
 
   # Delete user and all its artifacts like domains, applications associated with the user 


### PR DESCRIPTION
Allow adding large gear size to users irrespective of their plan
Silver plan includes large gear size
If the user is enrolled into a plan, do not store capabilites in cloud user mongo record instead get the capabilities based on their plan. Any explicitly set capabilities will be stored in user record.
Fix test cases
