### PR TITLE
Bug 974933 - Inconsistent message is shown when rhc threaddump for a scaled up app

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/control
@@ -345,7 +345,7 @@ function threaddump() {
         kill -3 $java_pid
         client_result "Success"
         client_result ""
-        client_result "The thread dump file will be available via: rhc tail $OPENSHIFT_APP_NAME -f ${OPENSHIFT_TMP_DIR}${cartridge_type}.log -o '-n 250'"
+        client_result "The thread dump file will be available via: rhc tail $OPENSHIFT_APP_NAME -g $OPENSHIFT_GEAR_UUID -f ${OPENSHIFT_TMP_DIR}${cartridge_type}.log -o '-n 250'"
     else 
         echo "Failed to locate JBOSS PID File"
     fi


### PR DESCRIPTION
Adding the gear UUID to client output of rhc threaddump in JBossAS. Now when using the command, the output wont appear as duplicite message, but a output message for each gear of the scaled app.
