### PR TITLE
Remove calls to FileUtils.cd

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/setup.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/setup.rb
@@ -114,14 +114,10 @@ module OpenShift
 
           add_env_var("REPO_DIR", PathUtils.join(gearappdir, "runtime", "repo") + "/", true) do |v|
             FileUtils.mkdir_p(v, :verbose => @debug)
-            FileUtils.cd gearappdir do |d|
-              FileUtils.ln_s("runtime/repo", "repo", :verbose => @debug)
-              FileUtils.ln_s("runtime/dependencies", "dependencies", :verbose => @debug)
-              FileUtils.ln_s("runtime/build-dependencies", "build-dependencies", :verbose => @debug)
-            end
-            FileUtils.cd PathUtils.join(gearappdir, "runtime") do |d|
-              FileUtils.ln_s("../data", "data", :verbose => @debug)
-            end
+            FileUtils.ln_s("runtime/repo", PathUtils.join(gearappdir, "repo"), :verbose => @debug)
+            FileUtils.ln_s("runtime/dependencies", PathUtils.join(gearappdir, "dependencies"), :verbose => @debug)
+            FileUtils.ln_s("runtime/build-dependencies", PathUtils.join(gearappdir, "build-dependencies"), :verbose => @debug)
+            FileUtils.ln_s("../data", PathUtils.join(gearappdir, "runtime", "data"), :verbose => @debug)
           end
 
           add_env_var("TMP_DIR", "/tmp/", true)

--- a/node/lib/openshift-origin-node/model/application_container_ext/snapshots.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/snapshots.rb
@@ -245,9 +245,7 @@ module OpenShift
                                    timeout: @hourglass.remaining,
                                    expected_exitstatus: 0)
 
-            FileUtils.cd PathUtils.join(@container_dir, 'app-root', 'runtime') do
-            FileUtils.ln_s('../data', 'data')
-          end
+          FileUtils.ln_s('../data', PathUtils.join(@container_dir, 'app-root', 'runtime', 'data'))
         end
 
         def handle_scalable_restore(gear_groups, gear_env)


### PR DESCRIPTION
Remove calls to FileUtils.cd and replace relative paths with absolute
ones - fixes a race condition when multiple threads are trying to
create gears at the same time.
