### PR TITLE
Improve performance for tools which iterate over ApplicationContainers

### DIFF
--- a/node-util/bin/oo-admin-ctl-gears
+++ b/node-util/bin/oo-admin-ctl-gears
@@ -170,7 +170,7 @@ module OpenShift
               gear_set << gear
             end
           else
-            gear_set = ApplicationContainer.all
+            gear_set = ApplicationContainer.all(nil, false)
           end
           gear_set.each do |gear|
             begin

--- a/node-util/bin/oo-restorecon
+++ b/node-util/bin/oo-restorecon
@@ -45,7 +45,7 @@ def restore_con(dir, label, verbose = False)
 end
 
 if options[:all]
-    OpenShift::Runtime::ApplicationContainer.all.each do |container|
+    OpenShift::Runtime::ApplicationContainer.all(nil, false).each do |container|
         mcs_label = OpenShift::Runtime::Utils::SELinux.get_mcs_label(container.uid)
         restore_con(container.container_dir, mcs_label, options[:verbose])
     end

--- a/node/lib/openshift-origin-node/model/node.rb
+++ b/node/lib/openshift-origin-node/model/node.rb
@@ -325,8 +325,8 @@ module OpenShift
         res['gears_started_count'] = 0
         res['gears_deploying_count'] = 0
         res['gears_unknown_count'] = 0
-        OpenShift::Runtime::ApplicationContainer.all.each do |app|
-          res['git_repos_count'] += 1 if ApplicationRepository.new(app).exists?
+        OpenShift::Runtime::ApplicationContainer.all(nil, false).each do |app|
+          # res['git_repos_count'] += 1 if ApplicationRepository.new(app).exists?
           res['gears_total_count'] += 1
 
           case app.state.value

--- a/node/misc/bin/oo-cgroup-disable
+++ b/node/misc/bin/oo-cgroup-disable
@@ -78,8 +78,8 @@ end
 
 begin
   if all_containers
-    OpenShift::Runtime::ApplicationContainer.all.each do |c|
-      OpenShift::Runtime::Utils::Cgroups.new(c.uuid).delete
+    OpenShift::Runtime::ApplicationContainer.all_uuids.each do |uuid|
+      OpenShift::Runtime::Utils::Cgroups.new(uuid).delete
     end
   else
     OpenShift::Runtime::Utils::Cgroups.new(container_uuid.to_s).delete

--- a/node/misc/bin/oo-cgroup-enable
+++ b/node/misc/bin/oo-cgroup-enable
@@ -79,8 +79,8 @@ end
 
 begin
   if all_containers
-    OpenShift::Runtime::ApplicationContainer.all.each do |c|
-      OpenShift::Runtime::Utils::Cgroups.new(c.uuid).create
+    OpenShift::Runtime::ApplicationContainer.all_uuids.each do |uuid|
+      OpenShift::Runtime::Utils::Cgroups.new(uuid).create
     end
   else
     OpenShift::Runtime::Utils::Cgroups.new(container_uuid.to_s).create

--- a/node/misc/bin/oo-cgroup-reclassify
+++ b/node/misc/bin/oo-cgroup-reclassify
@@ -80,8 +80,8 @@ end
 begin
   errors = {}
   if all_containers
-    OpenShift::Runtime::ApplicationContainer.all.each do |c|
-      errs = OpenShift::Runtime::Utils::Cgroups.new(c.uuid).classify_processes
+    OpenShift::Runtime::ApplicationContainer.all_uuids.each do |uuid|
+      errs = OpenShift::Runtime::Utils::Cgroups.new(uuid).classify_processes
       errors.merge!(errs)
     end
   else

--- a/node/misc/bin/oo-cgroup-template
+++ b/node/misc/bin/oo-cgroup-template
@@ -97,7 +97,7 @@ begin
     puts OpenShift::Runtime::Utils::Cgroups.show_templates.join("\n")
   else
     if all_containers
-      containers = OpenShift::Runtime::ApplicationContainer.all.map { |c| c.uuid }
+      containers = OpenShift::Runtime::ApplicationContainer.all_uuids
     else
       containers = [container_uuid.to_s]
     end

--- a/node/test/unit/node_test.rb
+++ b/node/test/unit/node_test.rb
@@ -73,17 +73,17 @@ class NodeTest < OpenShift::NodeTestCase
 
     buffer = OpenShift::Runtime::Node.get_cartridge_list(true, true, true)
     refute_nil buffer
-    
+
     assert buffer == %Q(CLIENT_RESULT: [\"---\\nName: crtest\\nDisplay-Name: crtest Unit Test\\nVersion: '0.3'\\nVersions:\\n- '0.1'\\n- '0.2'\\n- '0.3'\\nCartridge-Vendor: redhat\\nGroup-Overrides:\\n- components:\\n  - crtest-0.3\\n  - web_proxy\\n\",\"---\\nName: crtest\\nDisplay-Name: crtest Unit Test\\nVersion: '0.2'\\nVersions:\\n- '0.1'\\n- '0.2'\\n- '0.3'\\nCartridge-Vendor: redhat\\nGroup-Overrides:\\n- components:\\n  - crtest-0.2\\n  - web_proxy\\n\",\"---\\nName: crtest\\nDisplay-Name: crtest Unit Test\\nVersion: '0.1'\\nVersions:\\n- '0.1'\\n- '0.2'\\n- '0.3'\\nCartridge-Vendor: redhat\\nGroup-Overrides:\\n- components:\\n  - crtest-0.1\\n  - web_proxy\\n\"])
   end
 
   def test_node_utilization
     scenarios = [
-        {:node_profile => 'small', :quota_blocks => '1048576', :quota_files => '40000', :max_active_gears => '80', 
+        {:node_profile => 'small', :quota_blocks => '1048576', :quota_files => '40000', :max_active_gears => '80',
          :max_active_apps => nil, :no_overcommit_active => false},
-        {:node_profile => 'medium', :quota_blocks => '2097152', :quota_files => '80000', :max_active_gears => nil, 
+        {:node_profile => 'medium', :quota_blocks => '2097152', :quota_files => '80000', :max_active_gears => nil,
          :max_active_apps => '40', :no_overcommit_active => false},
-        {:node_profile => 'large', :quota_blocks => '4194304', :quota_files => '160000', :max_active_gears => '20', 
+        {:node_profile => 'large', :quota_blocks => '4194304', :quota_files => '160000', :max_active_gears => '20',
          :max_active_apps => nil, :no_overcommit_active => true},
     ]
 
@@ -126,7 +126,7 @@ class NodeTest < OpenShift::NodeTestCase
       assert_equal scenario[:node_profile], node_utilization['node_profile']
       assert_equal scenario[:quota_blocks], node_utilization['quota_blocks']
       assert_equal scenario[:quota_files], node_utilization['quota_files']
-      assert_equal scenario[:no_overcommit_active], node_utilization['no_overcommit_active'] 
+      assert_equal scenario[:no_overcommit_active], node_utilization['no_overcommit_active']
       if scenario[:max_active_gears].nil?
         assert_equal scenario[:max_active_apps], node_utilization['max_active_gears']
       else
@@ -136,7 +136,7 @@ class NodeTest < OpenShift::NodeTestCase
       # All apps were created in a started state initially
       assert_equal apps.count, node_utilization['gears_total_count']
       assert_equal apps.count, node_utilization['gears_started_count']
-      assert_equal apps.count, node_utilization['git_repos_count']
+      # assert_equal apps.count, node_utilization['git_repos_count']
       assert_equal apps.count, node_utilization['gears_active_count']
       assert_equal 0, node_utilization['gears_idled_count']
       assert_equal 0, node_utilization['gears_stopped_count']
@@ -157,7 +157,7 @@ class NodeTest < OpenShift::NodeTestCase
       node_utilization = OpenShift::Runtime::Node.node_utilization
       assert_equal apps.count, node_utilization['gears_total_count']
       assert_equal (apps.count-apps.count/4), node_utilization['gears_started_count']
-      assert_equal apps.count, node_utilization['git_repos_count']
+      # assert_equal apps.count, node_utilization['git_repos_count']
       assert_equal (apps.count-apps.count/4), node_utilization['gears_active_count']
       assert_equal apps.count/4, node_utilization['gears_idled_count']
       assert_equal 0, node_utilization['gears_stopped_count']
@@ -178,7 +178,7 @@ class NodeTest < OpenShift::NodeTestCase
       node_utilization = OpenShift::Runtime::Node.node_utilization
       assert_equal apps.count, node_utilization['gears_total_count']
       assert_equal apps.count/2, node_utilization['gears_started_count'] # 1/4 idled, 1/4 stopped
-      assert_equal apps.count, node_utilization['git_repos_count']
+      # assert_equal apps.count, node_utilization['git_repos_count']
       assert_equal apps.count/2, node_utilization['gears_active_count'] # 1/4 idled, 1/4 stopped
       assert_equal apps.count/4, node_utilization['gears_idled_count']
       assert_equal apps.count/4, node_utilization['gears_stopped_count']
@@ -200,7 +200,7 @@ class NodeTest < OpenShift::NodeTestCase
         node_utilization = OpenShift::Runtime::Node.node_utilization
         assert_equal apps.count, node_utilization['gears_total_count']
         assert_equal apps.count/4, node_utilization['gears_started_count'] # 1/4 idled, 1/4 stopped, 1/4 deploying
-        assert_equal apps.count, node_utilization['git_repos_count']
+        # assert_equal apps.count, node_utilization['git_repos_count']
         assert_equal apps.count/2, node_utilization['gears_active_count'] # 1/4 idled, 1/4 stopped, deploying counts as active
         assert_equal apps.count/4, node_utilization['gears_idled_count']
         assert_equal apps.count/4, node_utilization['gears_stopped_count']
@@ -222,7 +222,7 @@ class NodeTest < OpenShift::NodeTestCase
       node_utilization = OpenShift::Runtime::Node.node_utilization
       assert_equal apps.count, node_utilization['gears_total_count']
       assert_equal 0, node_utilization['gears_started_count'] # 1/4 idled, 1/4 stopped, 1/4 deploying, 1/4 unknown
-      assert_equal apps.count, node_utilization['git_repos_count']
+      # assert_equal apps.count, node_utilization['git_repos_count']
       assert_equal apps.count/2, node_utilization['gears_active_count'] # 1/4 idled, 1/4 stopped, deploying and unknown counts as active
       assert_equal apps.count/4, node_utilization['gears_idled_count']
       assert_equal apps.count/4, node_utilization['gears_stopped_count']
@@ -241,7 +241,7 @@ class NodeTest < OpenShift::NodeTestCase
       node_utilization = OpenShift::Runtime::Node.node_utilization
       assert_equal apps.count, node_utilization['gears_total_count']
       assert_equal 0, node_utilization['gears_started_count'] # 1/2 idled, 1/2 stopped
-      assert_equal apps.count, node_utilization['git_repos_count']
+      # assert_equal apps.count, node_utilization['git_repos_count']
       assert_equal 0, node_utilization['gears_active_count'] # 1/2 idled, 1/2 stopped
       assert_equal apps.count/2, node_utilization['gears_idled_count']
       assert_equal apps.count/2, node_utilization['gears_stopped_count']
@@ -262,7 +262,7 @@ class NodeTest < OpenShift::NodeTestCase
       node_utilization = OpenShift::Runtime::Node.node_utilization
       assert_equal apps.count, node_utilization['gears_total_count']
       assert_equal 0, node_utilization['gears_started_count'] # 1/2 idled, 1/2 stopped
-      assert_equal apps.count/2, node_utilization['git_repos_count']
+      # assert_equal apps.count/2, node_utilization['git_repos_count']
       assert_equal 0, node_utilization['gears_active_count'] # 1/2 idled, 1/2 stopped
       assert_equal apps.count/2, node_utilization['gears_idled_count']
       assert_equal apps.count/2, node_utilization['gears_stopped_count']


### PR DESCRIPTION
There are a few things in this commit:
- Introduce ApplicationContainer.all_uuids for cases where a container is not needed
- Call ApplicationContainer.all(nil, false) in scripts where app state is needed but other data is not
- Change ApplicationContainer.from_uuid to use the same environment loading strategy as ApplicationContainer.all
- Remove git_repos_count from node_utilization stats; I don't know what uses that metric, and collecting it means we have to lookup environment variables for all gears, since the repo path is determined by the app name.

Note that even with these changes, I think we'd be much better off having an application state cache on the system (and we have one in OpenShift Online), because reading a state file out of every gear is costly, but these changes should make performance a bit more tolerable.
