### PR TITLE
Bug 1025451: Include cartridge vendor in sdk cart ident function

### DIFF
--- a/node/misc/usr/lib/cartridge_sdk/bash/sdk
+++ b/node/misc/usr/lib/cartridge_sdk/bash/sdk
@@ -337,7 +337,7 @@ function ensure_httpd_restart_succeed() {
 
 # report the primary cartridge name for this gear
 function primary_cartridge_name() {
-  awk -F: '{printf "%s-%s", $2, $3}' $OPENSHIFT_PRIMARY_CARTRIDGE_DIR/env/OPENSHIFT_*_IDENT
+  awk -F: '{printf "%s-%s-%s", $1, $2, $3}' $OPENSHIFT_PRIMARY_CARTRIDGE_DIR/env/OPENSHIFT_*_IDENT
 }
 
 # Returns 0 if the named marker $1 exists, otherwise 1.


### PR DESCRIPTION
Include the cartridge vendor when constructing a cartridge name/identifier from
the `primary_cartridge_name` function. This disambiguates cartridges provided by
other vendors (e.g. for builder cartridges such as Jenkins which will use the
identifier to construct new gears).
