### PR TITLE
cron/cron_runjobs.sh Fix user-defined environment variables path

### DIFF
--- a/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
+++ b/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
@@ -15,7 +15,7 @@ function load_env {
     fi
 }
 
-for f in ~/.env/* ~/.env/.uservars/* ~/*/env/*
+for f in ~/.env/* ~/.env/user_vars/* ~/*/env/*
 do
     load_env $f
 done


### PR DESCRIPTION
"rhc set-env" creates files in ~/.env/user_vars, but cron still looked for files in ~/.env/.uservars
