### PR TITLE
Make the Python cartridge work with CentOS.

### DIFF
--- a/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-community/lib/utils
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-community/lib/utils
@@ -119,12 +119,10 @@ function get_distro_name_and_release() {
    version=$(uname -r)
    if [ "$distro" = "linux" ]; then
       if [ -f "/etc/redhat-release" ]; then
-         if grep "Red Hat" /etc/redhat-release > /dev/null 2>&1; then
-            distro="rhel"
+         if grep "Fedora" /etc/redhat-release > /dev/null 2>&1; then
+            distro="fedora"
          else
-            if grep "Fedora" /etc/redhat-release > /dev/null 2>&1; then
-               distro="fedora"
-            fi
+            distro="rhel"
          fi
          version=$(lsb_release -r | awk '{print $2}')
      fi


### PR DESCRIPTION
Without this code change, any Python app creation will fail on CentOS 6.x.

In the past, I have used configuration management to make my /etc/redhat-release file contain `CentOS release 6.4 (Final, not Red Hat)`.
