### PR TITLE
Bug 1028960 - Prefer perl modules installed on system over CPAN install

### DIFF
--- a/cartridges/openshift-origin-cartridge-perl/bin/build
+++ b/cartridges/openshift-origin-cartridge-perl/bin/build
@@ -32,6 +32,16 @@ then
        continue;
     fi
 
+    # First try to use the Perl module installed on the system. If it fails
+    # install it using CPAN.
+    #
+    if perl -e "use $f;" 2> /dev/null; then
+      echo "***   Skipping module $f install from CPAN (found in system)."
+      echo "***   Please add $f to deplist.txt to install it from CPAN."
+      continue;
+    fi
+
+
     DISABLE_TEST="-n"
     if [ -f "${OPENSHIFT_REPO_DIR}.openshift/markers/enable_cpan_tests" ]
     then


### PR DESCRIPTION
The only problem I can see with this is the existing cartridges that use specific versions of CPAN modules already.
With this patch, the built modules will not longer be used, but instead the system modules will take the priority.

Users can always place the CPAN modules to dependency.txt to override this behavior.
