### PR TITLE
Bug 1014793 - Added 'wait_for_pid' function to Bash SDK

### DIFF
--- a/cartridges/openshift-origin-cartridge-perl/bin/control
+++ b/cartridges/openshift-origin-cartridge-perl/bin/control
@@ -15,6 +15,7 @@ function start() {
   write_httpd_passenv $HTTPD_PASSENV_FILE
   ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
   /usr/sbin/httpd -C "Include $OPENSHIFT_PERL_DIR/etc/conf.d/*.conf" -f $HTTPD_CFG_FILE -k start
+  [ "$?" == "0" ] && wait_for_pid_file $HTTPD_PID_FILE
 }
 
 function stop() {

--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -15,12 +15,7 @@ function apache() {
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     /usr/sbin/httpd -C "Include $HTTPD_CFG_DIR/*.conf" -f $HTTPD_CFG_FILE -k $1
     ret=$?
-    if [ "$1" == "start" ] ; then
-      for i in {1..5} ; do
-        test -f "$HTTPD_PID_FILE" && break;
-        sleep 1;
-      done
-    fi
+    [ "$ret" == "0" -a "$1" == "start" ] && wait_for_pid_file $HTTPD_PID_FILE
     return $ret
 }
 

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
@@ -21,6 +21,7 @@ function start_apache() {
     write_httpd_passenv $HTTPD_PASSENV_FILE
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     /usr/sbin/httpd -C "Include $OPENSHIFT_PYTHON_DIR/etc/conf.d/*.conf" -f $HTTPD_CFG_FILE -k start
+    [ "$?" == "0" ] && wait_for_pid_file $HTTPD_PID_FILE
 }
 
 function start() {

--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -15,6 +15,7 @@ function start() {
     oo-erb ${OPENSHIFT_RUBY_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     ruby_context "/usr/sbin/httpd -C 'Include $OPENSHIFT_RUBY_DIR/etc/conf.d/*.conf' -f $HTTPD_CFG_FILE -k start"
+    [ "$?" == "0" ] && wait_for_pid_file $HTTPD_PID_FILE
 }
 
 function stop() {

--- a/node/misc/usr/lib/cartridge_sdk/bash/sdk
+++ b/node/misc/usr/lib/cartridge_sdk/bash/sdk
@@ -201,6 +201,14 @@ function all_gears {
   oo-gear-registry all
 }
 
+function wait_for_pid_file {
+  [ -f "$1" ] && return 0
+  for i in {1..20}; do
+    sleep .5
+    [ -f "$1" ] && break;
+  done
+}
+
 # wait up to 30 seconds for given process to stop
 # Argument(s):
 #  - process id to wait on


### PR DESCRIPTION
This function is used to wait 10 seconds for PID file to be written by Apache process. All Apache based cartridges were
updated to use this function.
