### PR TITLE
Bug 1022889 - AVC message is seen when mcolletive facts update cron job ...

### DIFF
--- a/plugins/msg-node/mcollective/facts/openshift-facts
+++ b/plugins/msg-node/mcollective/facts/openshift-facts
@@ -6,4 +6,4 @@ if [ -f /opt/rh/ruby193/root/usr/libexec/mcollective/update_yaml.rb ]; then
   PREFIX="/opt/rh/ruby193/root"
 fi
 
-oo-exec-ruby ${PREFIX}/usr/libexec/mcollective/update_yaml.rb ${PREFIX}/etc/mcollective/facts.yaml &> /tmp/facts.log
+oo-exec-ruby ${PREFIX}/usr/libexec/mcollective/update_yaml.rb ${PREFIX}/etc/mcollective/facts.yaml &> /dev/null


### PR DESCRIPTION
...is running.

Looking back at the history showed that the switch to writing to /tmp/facts.log
was actually a mistake.  I'm reverting that change which will address this bug.
