### PR TITLE
Fix bug 1031563 - highlight error messages generated by formtastic

### DIFF
--- a/console/app/assets/stylesheets/_mixins.scss
+++ b/console/app/assets/stylesheets/_mixins.scss
@@ -172,6 +172,7 @@
 @mixin formFieldState($textColor, $borderColor, $backgroundColor, $className) {
   // Set the text color
   > label,
+  ul.help-block,
   .help-inline {
     color: $textColor;
   }


### PR DESCRIPTION
Add back highlighting for ul.help-block elements
