### PR TITLE
Keep proxy gears disabled appropriately

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/bin/control
+++ b/cartridges/openshift-origin-cartridge-haproxy/bin/control
@@ -246,18 +246,25 @@ function enable-server() {
         echo "Enabling server $gear"
         if [ "${gear}" == "${OPENSHIFT_GEAR_UUID}" ]; then
             gearid="local-gear"
-            info=($(app_web_to_proxy_ratio_and_colocated_gears))
-            ratio=${info[0]}
-            if [ "$ratio" -ge 3 ]; then
-                echo "Not enabling local gear since web/proxy ratio is $ratio"
-                return 0
-            fi
         elif [ "${gear}" == "${OPENSHIFT_APP_UUID}" ]; then
             domain=$(get-app-domain)
             gearid="gear-${OPENSHIFT_APP_NAME}-${domain}"
         else
             domain=$(get-app-domain)
             gearid="gear-${gear}-${domain}"
+        fi
+        info=($(app_web_to_proxy_ratio_and_colocated_gears))
+        ratio=${info[0]}
+        unset info[0]
+        if [ "$ratio" -ge 3 ]; then
+            declare -A map
+            for uuid in ${info[@]}; do
+                map["$uuid"]=1
+            done
+            if [[ ${map["$gear"]} ]]; then
+                echo "Not enabling proxy gear since web/proxy ratio is $ratio"
+                return 0
+            fi
         fi
         set +e
         echo "enable server express/$gearid" | socat stdio $OPENSHIFT_HAPROXY_DIR/run/stats > /dev/null

--- a/node/test/support/functional_api.rb
+++ b/node/test/support/functional_api.rb
@@ -316,7 +316,7 @@ EOFZ
     response = JSON.parse(response)
 
     logger.info("Got Response(#{response})")
-    
+
     logger.info("Done Deploy Binary Artifact Using REST API")
 
   end
@@ -329,5 +329,44 @@ EOFZ
 
   def cloud_domain
     ::OpenShift::Config.new.get('CLOUD_DOMAIN')
+  end
+
+  def assert_gear_status_in_proxy(proxy, target_gear, status)
+    proxy_status_csv = `curl "http://#{proxy.dns}/haproxy-status/;csv" 2>/dev/null`
+
+    if proxy.uuid == target_gear.uuid
+      name = 'local-gear'
+    else
+      gear_name = target_gear.dns.split('-')[0]
+      name = "gear-#{gear_name}-#{target_gear.namespace}"
+    end
+
+    passed = false
+    proxy_status_csv.split("\n").each do |line|
+      if line =~ /#{name}/
+        assert_match /#{status}/, line
+        passed = true
+        break
+      end
+    end
+
+    flunk("Target gear #{name} did not have expected status #{status}") unless passed
+  end
+
+  def restart_cartridge(app_name, cartridge)
+    logger.info("Restarting #{cartridge} in #{app_name}")
+
+    begin
+      response = RestClient::Request.execute(method: :post,
+                                             url: "#{@url_base}/domains/#{@namespace}/applications/#{app_name}/cartridges/#{cartridge}/events",
+                                             payload: JSON.dump(event: 'restart'),
+                                             headers: {content_type: :json, accept: :json},
+                                             timeout: 180)
+    rescue RestClient::Exception => e
+      raise "Exception restarting: #{e.response}"
+    end
+
+    response = JSON.parse(response)
+    assert_equal 'ok', response['status']
   end
 end


### PR DESCRIPTION
Modify enable-server to keep all proxy gears disabled if the ratio of
web to proxy gears is > 2 (previously this only applied to the
local-gear)
