### PR TITLE
Bug 1003531: An warning message should be thrown out instead of error me...

### DIFF
--- a/cartridges/openshift-origin-cartridge-postgresql/bin/control
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/control
@@ -141,12 +141,15 @@ function post_restore {
     fi
 
     # Rename old database
-    {
-      echo "
-      ALTER DATABASE \"${old_db}\" RENAME TO \"${new_db}\";
-      " | postgresql_context "psql -U postgres -d postgres"
-    } || error "Failed to rename database" 187
-
+    if [ ${old_db} != ${new_db} ] 
+    then
+      {
+        echo "
+        ALTER DATABASE \"${old_db}\" RENAME TO \"${new_db}\";
+        " | postgresql_context "psql -U postgres -d postgres"
+      } || error "Failed to rename database" 187
+    fi
+	
     {
       # We want to change the default old user in case the app has its own users
       # We also need to check the UID because v1 creates tables owned by the user


### PR DESCRIPTION
...ssage when restore a app with postgresql-8.4 (and postgresl-9.2) cartridge

[test]
