### PR TITLE
allow custom ha prefix and suffix

### DIFF
--- a/broker/conf/broker.conf
+++ b/broker/conf/broker.conf
@@ -117,6 +117,11 @@ SSL_ENDPOINT="allow"
 ALLOW_HA_APPLICATIONS="false"
 ROUTER_HOSTNAME="www.example.com"
 
+# Prefix/Suffix used for Highly Available application URL
+# http://${HA_DNS_PREFIX}${APP_NAME}-${DOMAIN_NAME}${HA_DNS_SUFFIX}.${CLOUD_DOMAIN}
+HA_DNS_PREFIX="ha-"
+HA_DNS_SUFFIX=""
+
 #Whether to allow obsolete cartridges to be instantiated for a new application or added to an existing application
 ALLOW_OBSOLETE_CARTRIDGES="false"
 

--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -92,6 +92,8 @@ Broker::Application.configure do
     :max_members_per_resource => conf.get('MAX_MEMBERS_PER_RESOURCE', '100').to_i,
     :allow_ha_applications => conf.get_bool('ALLOW_HA_APPLICATIONS', "false"),
     :router_hostname => conf.get('ROUTER_HOSTNAME', "www.example.com"),
+    :ha_dns_prefix => conf.get('HA_DNS_PREFIX', "ha-"),
+    :ha_dns_suffix => conf.get('HA_DNS_SUFFIX', ""),
     :valid_ssh_key_types => OpenShift::Controller::Configuration.parse_list(conf.get('VALID_SSH_KEY_TYPES', nil)),
     :allow_obsolete_cartridges => conf.get_bool('ALLOW_OBSOLETE_CARTRIDGES', "false")
   }

--- a/broker/config/environments/production.rb
+++ b/broker/config/environments/production.rb
@@ -81,6 +81,8 @@ Broker::Application.configure do
     :max_members_per_resource => conf.get('MAX_MEMBERS_PER_RESOURCE', '100').to_i,
     :allow_ha_applications => conf.get_bool('ALLOW_HA_APPLICATIONS', "false"),
     :router_hostname => conf.get('ROUTER_HOSTNAME', "www.example.com"),
+    :ha_dns_prefix => conf.get('HA_DNS_PREFIX', "ha-"),
+    :ha_dns_suffix => conf.get('HA_DNS_SUFFIX', ""),
     :valid_ssh_key_types => OpenShift::Controller::Configuration.parse_list(conf.get('VALID_SSH_KEY_TYPES', nil)),
     :allow_obsolete_cartridges => conf.get_bool('ALLOW_OBSOLETE_CARTRIDGES', "false")
   }

--- a/broker/config/environments/test.rb
+++ b/broker/config/environments/test.rb
@@ -90,6 +90,8 @@ Broker::Application.configure do
     :max_members_per_resource => conf.get('MAX_MEMBERS_PER_RESOURCE', '100').to_i,
     :allow_ha_applications => conf.get_bool('ALLOW_HA_APPLICATIONS', "false"),
     :router_hostname => conf.get('ROUTER_HOSTNAME', "www.example.com"),
+    :ha_dns_prefix => conf.get('HA_DNS_PREFIX', "ha-"),
+    :ha_dns_suffix => conf.get('HA_DNS_SUFFIX', ""),
     :valid_ssh_key_types => OpenShift::Controller::Configuration.parse_list(conf.get('VALID_SSH_KEY_TYPES', nil)),
     :allow_obsolete_cartridges => conf.get_bool('ALLOW_OBSOLETE_CARTRIDGES', "false")
   }

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1397,9 +1397,11 @@ class Application
   end
 
   def deregister_routing_dns
+    ha_dns_prefix = Rails.configuration.openshift[:ha_dns_prefix]
+    ha_dns_suffix = Rails.configuration.openshift[:ha_dns_suffix]
     dns = OpenShift::DnsService.instance
     begin
-      dns.deregister_application("ha-#{self.name}", self.domain_namespace)
+      dns.deregister_application("#{ha_dns_prefix}#{self.name}", "#{self.domain.namespace}#{ha_dns_suffix}")
       dns.publish
     ensure
       dns.close
@@ -1407,10 +1409,12 @@ class Application
   end
 
   def register_routing_dns
+    ha_dns_prefix = Rails.configuration.openshift[:ha_dns_prefix]
+    ha_dns_suffix = Rails.configuration.openshift[:ha_dns_suffix]
     target_hostname = Rails.configuration.openshift[:router_hostname]
     dns = OpenShift::DnsService.instance
     begin
-      dns.register_application("ha-#{self.name}", self.domain_namespace, target_hostname)
+      dns.register_application("#{ha_dns_prefix}#{self.name}", "#{self.domain.namespace}#{ha_dns_suffix}", target_hostname)
       dns.publish
     ensure
       dns.close


### PR DESCRIPTION
Curently, ha applications have a DNS entry pointing to ROUTER_HOSTNAME (in broker.conf).

This pull pequest make it possible to change the default 'ha-appname-namespace.example.com'.

Custom prefix or suffix could be used instead, for example 'appname-namespace.ha.example.com'
