### PR TITLE
fix_bz_1033144

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossews/bin/build
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/build
@@ -49,7 +49,9 @@ if [ -z "$MAVEN_OPTS" ]; then
   export MAVEN_OPTS="$OPENSHIFT_MAVEN_XMX"
 fi
 
+if [ -z "$MAVEN_ARGS" ]; then
 export MAVEN_ARGS="clean package -Popenshift -DskipTests"
+fi
 
 if [ -n "$OPENSHIFT_MAVEN_MIRROR" ]; then
     echo "Using Maven mirror $OPENSHIFT_MAVEN_MIRROR"


### PR DESCRIPTION
Allow users override $MAVEN_ARGS values in JBoss EWS cartridge, similar to JBoss EAP catridge
