### PR TITLE
node: make sure to own the /var/log/openshift/node directory in rpm

### DIFF
--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -196,10 +196,6 @@ sed -i -e '/NON-RUNTIME BEGIN/,/NON-RUNTIME END/d' %{buildroot}%{brokerdir}/Gemf
 %defattr(0640,apache,apache,0750)
 %attr(0750,-,-) %{_var}/log/openshift/broker
 %attr(0750,-,-) %{_var}/log/openshift/broker/httpd
-%attr(0640,-,-) %ghost %{_var}/log/openshift/broker/production.log
-%attr(0640,-,-) %ghost %{_var}/log/openshift/broker/development.log
-%attr(0640,-,-) %ghost %{_var}/log/openshift/broker/user_action.log
-%attr(0640,-,-) %ghost %{_var}/log/openshift/broker/usage.log
 %attr(0750,-,-) %{brokerdir}/script
 %attr(0750,-,-) %{brokerdir}/tmp
 %attr(0750,-,-) %{brokerdir}/tmp/cache

--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -219,8 +219,6 @@ fi
 %attr(0750,-,-) /usr/sbin/*
 %attr(0755,-,-) /usr/bin/*
 %attr(0750,-,-) %{_var}/log/openshift/node
-%attr(0640,-,-) %ghost %{_var}/log/openshift/node/platform.log
-%attr(0640,-,-) %ghost %{_var}/log/openshift/node/platform-trace.log
 /usr/libexec/openshift/lib/quota_attrs.sh
 /usr/libexec/openshift/lib/archive_git_submodules.sh
 %attr(0755,-,-) %{openshift_lib}/cartridge_sdk

--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -108,6 +108,7 @@ cp -a ./%{gem_dir}/* %{buildroot}%{gem_dir}/
 mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}/usr/sbin
 mkdir -p %{buildroot}%{appdir}/.tc_user_dir
+mkdir -p %{buildroot}%{_var}/log/openshift/node
 
 # Move the gem configs to the standard filesystem location
 mkdir -p %{buildroot}/etc/openshift
@@ -217,6 +218,7 @@ fi
 %{gem_spec}
 %attr(0750,-,-) /usr/sbin/*
 %attr(0755,-,-) /usr/bin/*
+%attr(0750,-,-) %{_var}/log/openshift/node
 %attr(0640,-,-) %ghost %{_var}/log/openshift/node/platform.log
 %attr(0640,-,-) %ghost %{_var}/log/openshift/node/platform-trace.log
 /usr/libexec/openshift/lib/quota_attrs.sh

--- a/openshift-console/openshift-origin-console.spec
+++ b/openshift-console/openshift-origin-console.spec
@@ -199,10 +199,6 @@ fi
 %{openshiftconfigdir}
 %attr(0750,-,-) %{_var}/log/openshift/console
 %attr(0750,-,-) %{_var}/log/openshift/console/httpd
-%attr(0644,-,-) %ghost %{_var}/log/openshift/console/production.log
-%attr(0644,-,-) %ghost %{_var}/log/openshift/console/development.log
-%attr(0644,-,-) %ghost %{_var}/log/openshift/console/httpd/error_log
-%attr(0644,-,-) %ghost %{_var}/log/openshift/console/httpd/access_log
 %attr(0750,-,-) %{consoledir}/script
 %attr(0750,-,-) %{consoledir}/tmp
 %attr(0750,-,-) %{consoledir}/tmp/cache


### PR DESCRIPTION
Make sure that /var/log/openshift/node is owned by the RPM package.

Also, do not %ghost the log files. This will drop all the log files at uninstall or upgrade of the package.

Bug https://bugzilla.redhat.com/show_bug.cgi?id=1033607
