### PR TITLE
[TO_STAGE] Bug 1032950

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/deployments.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/deployments.rb
@@ -206,6 +206,7 @@ module OpenShift
           target = PathUtils.join('..', deployment_datetime)
           link = PathUtils.join(@container_dir, 'app-deployments', 'by-id', deployment_id)
           FileUtils.ln_s(target, link)
+          PathUtils.oo_lchown(uid, gid, link)
         end
 
         def unlink_deployment_id(deployment_id)

--- a/node/test/unit/build_lifecycle_test.rb
+++ b/node/test/unit/build_lifecycle_test.rb
@@ -849,6 +849,7 @@ class BuildLifecycleTest < OpenShift::NodeTestCase
 
     link = PathUtils.join(@container.container_dir, 'app-deployments', 'by-id', deployment_id)
     FileUtils.expects(:ln_s).with(PathUtils.join('..', deployment_datetime), link)
+    PathUtils.expects(:oo_lchown).with(@container.uid, @container.gid, link)
     metadata = mock()
     @container.expects(:deployment_metadata_for).with(deployment_datetime).returns(metadata)
     metadata.expects(:id=).with(deployment_id)


### PR DESCRIPTION
Change ownership of by-id link to gear uid/gid so future deployments
that don't go through mcollective don't fail because of file
permissions issues.

(cherry picked from commit ae08e4ea393437954385922a1b0af13c2fe11805)
