### PR TITLE
[wip] Bug 1034583 - Added -ssl3 option to curl in jenkins-client

### DIFF
--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/install
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/install
@@ -45,7 +45,7 @@ else
         client_result ""
         client_result "Associated with job '${JOB_NAME}' in Jenkins server."
         bldr_url="${JENKINS_DNS_NAME}computer/${OPENSHIFT_APP_NAME}bldr/"
-        status_code=`curl -s -w %{http_code} --output /dev/null --insecure https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@$bldr_url`
+        status_code=`curl -s -ssl3 -w %{http_code} --output /dev/null --insecure https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@$bldr_url`
         if [ "$status_code" == "200" ]
         then
             client_result "In addition we found an existing builder which you might also want"

--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_build
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_build
@@ -6,16 +6,18 @@ require 'json'
 STDOUT.sync = true
 STDERR.sync = true
 
+CURL_CMD = "curl -s -ssl3 --insecure"
+
 @hostname = ENV['JENKINS_URL'].split("/")[-1]
 @job_url = "/job/#{ENV['OPENSHIFT_APP_NAME']}-build"
 
 def job_available?
-  status_code = `curl -s -w %{http_code} --output /dev/null -X POST --insecure https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}#{@job_url}/api/json`
+  status_code = `#{CURL_CMD} -w %{http_code} --output /dev/null -X POST https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}#{@job_url}/api/json`
   return status_code == '200'
 end
 
 def get_jobs_info
-  jobs = `curl -s --insecure https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}#{@job_url}/api/json`
+  jobs = `#{CURL_CMD} https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}#{@job_url}/api/json`
   result = $?
   if result.exitstatus != 0
     puts "ERROR - Couldn't access jobs information"
@@ -25,7 +27,7 @@ def get_jobs_info
 end
 
 def get_job_info(num)
-  jobs = `curl -s --insecure https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}#{@job_url}/#{num}/api/json`
+  jobs = `#{CURL_CMD} https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}#{@job_url}/#{num}/api/json`
   result = $?
   if result.exitstatus != 0
     puts "ERROR - Couldn't access job information"
@@ -41,11 +43,11 @@ end
 
 def is_cancelled
   jobs_info = get_jobs_info
-  queueItem = jobs_info["queueItem"]
+  jobs_info["queueItem"]
 end
 
 def schedule_build
-  status_code = `curl -s -w %{http_code} --output /dev/null -X POST --insecure https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}#{@job_url}/build`
+  status_code = `#{CURL_CMD} -w %{http_code} --output /dev/null -X POST https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}#{@job_url}/build`
   if status_code != '302' && status_code != '200'
     puts "ERROR - Couldn't schedule job"
     exit 292

--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_create_job
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_create_job
@@ -9,6 +9,8 @@ require 'fileutils'
 STDOUT.sync = true
 STDERR.sync = true
 
+CURL_CMD = "curl -s -ssl3 --insecure"
+
 @hostname = ENV['JENKINS_URL'].split("/")[-1].downcase
 @data_dir = ENV['OPENSHIFT_DATA_DIR']
 @job_name = "#{ENV['OPENSHIFT_APP_NAME']}-build"
@@ -34,7 +36,7 @@ def create_job
   FileUtils.rm @job_erb
 
 status_code = `/bin/sed -e "s,UPSTREAM_SSH,#{@uuid}@#{@app_name}-\\${OPENSHIFT_NAMESPACE}.#{@openshift_domain},g" #{job_template_xml} \
-  | curl -s  -X POST -H "Content-Type: application/xml" -H "Expect: " --data-binary @- --insecure https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}/createItem?name=#{@job_name}`
+  | #{CURL_CMD} -X POST -H "Content-Type: application/xml" -H "Expect: " --data-binary @- https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}/createItem?name=#{@job_name}`
 
   puts "create_job status: #{status_code}"
   if not File.exists? File.join(@data_dir, 'jobs', @app_name, 'config.xml')

--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_job_action
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_job_action
@@ -3,12 +3,14 @@
 STDOUT.sync = true
 STDERR.sync = true
 
+CURL_CMD = "curl -s -ssl3 --insecure"
+
 @hostname = ENV['JENKINS_URL'].split("/")[-1].downcase
 @job_url = "/job/#{ENV['OPENSHIFT_APP_NAME']}-build"
 @action = ARGV[0]
 
 def job_action
-  status_code = `curl -s -w %{http_code} --output /dev/null -X POST --insecure https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}#{@job_url}/#{@action}`
+  status_code = `#{CURL_CMD} -w %{http_code} --output /dev/null -X POST https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}#{@job_url}/#{@action}`
 
   if status_code != '302' && status_code != '200' # returns a 302 but checking 200 just to be safe
     exit 1


### PR DESCRIPTION
The problem here is the missing -ssl3 option for curl that cause SSL connection handshake to end prematurely. There is a blog post about this: http://carnivore.it/2011/10/07/error_14077458_ssl_routines_ssl23_get_server_hello_reason_1112

```
   -3/--sslv3
          (SSL) Forces curl to use SSL version 3 when negotiating with a remote SSL server.
```

I don't really understand why this is needed, as we use --insecure as default. I suspect new version of curl or something in the openssl library that must changed recently.
