### PR TITLE
Bug 1038129 - Gear is not started after restore when hot_deploy marker is present

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
@@ -802,7 +802,7 @@ module OpenShift
           options[:hot_deploy] = deployment_metadata.hot_deploy
 
           # if it's a new gear via scale-up, force hot_deploy to false
-          options[:hot_deploy] = false if options[:post_install]
+          options[:hot_deploy] = false if options[:post_install] || options[:restore]
 
           parallel_results = with_gear_rotation(options) do |target_gear, local_gear_env, options|
             target_gear_uuid = target_gear.is_a?(String) ? target_gear : target_gear.uuid

--- a/node/lib/openshift-origin-node/model/application_container_ext/snapshots.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/snapshots.rb
@@ -181,6 +181,8 @@ module OpenShift
               return result unless distribute_result[:status] == RESULT_SUCCESS
 
               options[:all] = true
+              options[:restore] = true
+
               activate_result = result[:activate_result] = activate(options)
               return result unless activate_result[:status] == RESULT_SUCCESS
             else


### PR DESCRIPTION
When restoring a snapshot of gear with hot_deploy marker present, the gear is not started after successfull restore.

Fixed that and added cucumber test for that
