### PR TITLE
Bug 1034110 - Added force-delete action to oo-cartridge

### DIFF
--- a/node-util/bin/oo-cartridge
+++ b/node-util/bin/oo-cartridge
@@ -31,7 +31,7 @@ def usage
             --action add --with-cartridge-name mock-0.1
 
 == List of arguments
-       -a|--action                             One of <add|delete>
+       -a|--action                             One of <add|delete|force-delete>
        -c|--with-container-uuid     gear_uuid  Unique identifier for the gear
        -n|--with-cartridge-name     name       Unique identifier for the cartridge
        -u|--with-template-url                  override default application template
@@ -102,6 +102,8 @@ begin
       output = container.configure(c, template_url)
       output << container.post_configure(c, template_url)
     when 'delete'
+      container.deconfigure(c, true)
+    when 'force-delete'
       container.deconfigure(c)
     else
       usage
@@ -116,15 +118,15 @@ rescue OpenShift::Runtime::Utils::ShellExecutionException => e
     $stderr.puts e.backtrace.join("\n")
   end
 
-  exit -1
+  exit(-1)
 rescue Exception => e
   $stderr.puts "Cartridge #{action} failed"
   $stderr.puts e.message
   $stderr.puts e.backtrace.join("\n") if $OO_CART_DEBUG
-  exit -1
+  exit(-1)
 else
   puts "Cartridge #{action} succeeded"
-  
+
   if ($OO_CART_DEBUG || verbose)
     puts "Output:\n-----------------------------\n#{output}"
   end

--- a/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
@@ -116,8 +116,8 @@ module OpenShift
         #
         # context: root -> gear user -> root
         # @param cart_name   cartridge name
-        def deconfigure(cart_name)
-          @cartridge_model.deconfigure(cart_name)
+        def deconfigure(cart_name, strict_error=false)
+          @cartridge_model.deconfigure(cart_name, strict_error)
         end
 
         # Unsubscribe from a cart

--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -360,13 +360,21 @@ module OpenShift
       # will be deleted.
       #
       # deconfigure('php-5.3')
-      def deconfigure(cartridge_name)
+      #
+      # In case you don't want to continue when the teardown operation fail you
+      # can set the second attribute to 'true'
+      #
+      # deconfigure('mysql-5.1', true)
+      #
+      #
+      def deconfigure(cartridge_name, strict_error=false)
         teardown_output = ''
 
         cartridge = nil
         begin
           cartridge = get_cartridge(cartridge_name)
-        rescue
+        rescue => e
+          raise e if strict_error
           teardown_output << "CLIENT_ERROR: Corrupted cartridge #{cartridge_name} removed. There may be extraneous data left on system.\n"
           logger.warn("Corrupted cartridge #{@container.uuid}/#{cartridge_name} removed. There may be extraneous data left on system.")
 


### PR DESCRIPTION
Added optional parameter for 'deconfigure' to make this action fail when the cartridge does not exists. The old behavior is preserved in the 'force-delete' action.
