### PR TITLE
Use app config instead of env vars

### DIFF
--- a/node/test/support/deployment_tester.rb
+++ b/node/test/support/deployment_tester.rb
@@ -53,7 +53,7 @@ class OpenShift::Runtime::DeploymentTester
     if keep_deployments
       # keep up to #{keep} deployments
       logger.info "Setting OPENSHIFT_KEEP_DEPLOYMENTS to #{keep_deployments} for #{@namespace}"
-      @api.add_env_vars(app_name, [{name: 'OPENSHIFT_KEEP_DEPLOYMENTS', value: "#{keep_deployments}"}])
+      @api.configure_application(app_name, keep_deployments: keep_deployments)
 
       gear_env = OpenShift::Runtime::Utils::Environ.for_gear(app_container.container_dir)
 

--- a/node/test/support/functional_api.rb
+++ b/node/test/support/functional_api.rb
@@ -91,6 +91,12 @@ class FunctionalApi
     app_id
   end
 
+  def configure_application(app_name, options)
+    logger.info("Configuring application #{app_name} with config options #{options}")
+    response = RestClient.put("#{@url_base}/domain/#{@namespace}/application/#{app_name}", options, accept: :json)
+    assert_operator 300, :>, response.code, "Invalid response received: #{response}"
+  end
+
   def clone_repo(app_id)
     Dir.chdir(@tmp_dir) do
       response = RestClient.get("#{@url_base}/applications/#{app_id}", accept: :json)


### PR DESCRIPTION
Switch to using app configuration instead of user env vars for
OPENSHIFT_KEEP_DEPLOYMENTS because we're now laying down
~/.env/OPENSHIFT_KEEP_DEPLOYMENTS for all gears when they're created.
