### PR TITLE
Bug 1035176 - openshift-iptables-port-proxy start causes duplicate rules

### DIFF
--- a/node/misc/sbin/oo-admin-ctl-iptables-port-proxy
+++ b/node/misc/sbin/oo-admin-ctl-iptables-port-proxy
@@ -18,11 +18,11 @@ start() {
     fi
 
     if [ -f $RULES_FILE ]; then
-      { echo "*filter"; cat $RULES_FILE; echo "COMMIT"; } | iptables-restore -n
+      { echo -e "*filter\n-F rhc-app-comm"; cat $RULES_FILE; echo "COMMIT"; } | iptables-restore -n
     fi
 
     if [ -f $NAT_FILE ]; then
-      { echo "*nat"; cat $NAT_FILE; echo "COMMIT"; } | iptables-restore -n
+      { echo "*nat"; cat $NAT_FILE; echo "COMMIT"; } | iptables-restore --table=nat
     fi
 }
 


### PR DESCRIPTION
Updated oo-admin-ctl-iptables-port-proxy start to flush rules prior to
applying them.
