### PR TITLE
Update server.js template to instanciate with new syntax

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/usr/template/server.js
+++ b/cartridges/openshift-origin-cartridge-nodejs/usr/template/server.js
@@ -113,7 +113,7 @@ var SampleApp = function() {
      */
     self.initializeServer = function() {
         self.createRoutes();
-        self.app = express.createServer();
+        self.app = express();
 
         //  Add handlers for the app (from the routes).
         for (var r in self.routes) {


### PR DESCRIPTION
This removes the following warning on express server startup

```
Warning: express.createServer() is deprecated, express
applications no longer inherit from http.Server,
please use:

  var express = require("express");
  var app = express();
```
