### PR TITLE
Bug 1017536 - Duplication warning messages when creating scalable app with empty git repo

### DIFF
--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -332,7 +332,7 @@ module OpenShift
 
         ::OpenShift::Runtime::Utils::Cgroups.new(@container.uuid).boost do
           if empty_repository?
-            output << "CLIENT_MESSAGE: An empty Git repository has been created for your application.  Use 'git push' to add your code."
+            output << "CLIENT_MESSAGE: An empty Git repository has been created for your application.  Use 'git push' to add your code." if cartridge.name == primary_cartridge.name
           else
             output << start_cartridge('start', cartridge, user_initiated: true)
           end


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1017536 
When creating new scalable app with empty git repo, will return message that empty git repo has been created twice.

Fixed so the message will be displayed only for primary cartridge.
