### PR TITLE
Add --no-ri and --no-rdoc to default gem install options

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/install
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/install
@@ -16,10 +16,15 @@ for dir in template; do
 done
 
 mkdir $OPENSHIFT_RUBY_DIR/tmp
-
 mkdir $OPENSHIFT_HOMEDIR/.passenger
 
 echo "$version" > $OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_VERSION
+
+# Skip installing documentation for gems.
+# This will speed up the gem install/bundle install process
+#
+echo "gem: --no-document --no-ri --no-rdoc" > $OPENSHIFT_HOMEDIR/.gemrc
+
 update-configuration $version
 
 # Create additional directories required by RUBY and httpd


### PR DESCRIPTION
This should improve the 'bundle install' speed. The documentation files are usually
not required and generating rdoc/ri from a large ruby gem (nokogiri/etc) might be
time expensive and it takes some inodes as well.
