### PR TITLE
Set the JBOSSAS_PIDFILE to JVM process pid

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/control
@@ -279,10 +279,9 @@ function start() {
   # Check for running app
   if isrunning; then
       echo "Application is already running"
-  else    
+  else
+    export JBOSS_PIDFILE=${JBOSSAS_PID_FILE}
     ${JBOSSAS_BIN_DIR}/standalone.sh > ${OPENSHIFT_TMP_DIR}/${cartridge_type}.log 2>&1 &
-    PROCESS_ID=$!
-    echo "$PROCESS_ID" > ${JBOSSAS_PID_FILE}
 
     if ! ishttpup; then
         echo "Timed out waiting for http listening port"


### PR DESCRIPTION
The JBossAS standalone.sh script use the 'JBOSS_PIDFILE' environment variable to store the PID of the JVM process. However in our control script we set the JBOSSAS_PIDFILE to the standalone.sh script PID, instead of the JVM pid. 

See:
https://github.com/openshift/origin-server/blob/master/cartridges/openshift-origin-cartridge-jbossas/versions/7/bin/standalone.sh#L208
