### PR TITLE
the nodejs rpm macros are in nodejs-devel for fedora, need to require it when not building SCL

### DIFF
--- a/node-proxy/openshift-origin-node-proxy.spec
+++ b/node-proxy/openshift-origin-node-proxy.spec
@@ -30,6 +30,8 @@ BuildRequires: systemd-units
 %if 0%{?fedora}%{?rhel} <= 6
 BuildRequires: nodejs010-build
 BuildRequires: scl-utils-build
+%else
+BuildRequires: nodejs-devel
 %endif
 
 BuildArch:     noarch


### PR DESCRIPTION
I have no idea how Origin builds for this have been passing.
