### PR TITLE
BuildRequire systemd for mock/koji F19+ builds

### DIFF
--- a/openshift-console/openshift-origin-console.spec
+++ b/openshift-console/openshift-origin-console.spec
@@ -71,6 +71,7 @@ BuildRequires: %{?scl:%scl_prefix}rubygem-jquery-rails
 BuildRequires: %{?scl:%scl_prefix}rubygem-uglifier
 
 %if 0%{?fedora} >= 19
+BuildRequires: systemd
 BuildRequires: ruby(release)
 %else
 BuildRequires: %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}


### PR DESCRIPTION
The systemd package provides the %{_unitdir} macro which is required for the %files section of the spec
