### PR TITLE
The RHEL nightly build uses /opt/rh/ruby193/root/etc/mcollective/ instea...

### DIFF
--- a/documentation/oo_deployment_guide_comprehensive.adoc
+++ b/documentation/oo_deployment_guide_comprehensive.adoc
@@ -997,7 +997,7 @@ EOF
 
 .RHEL
 ----
-cat <<EOF > /etc/mcollective/client.cfg
+cat <<EOF > /opt/rh/ruby193/root/etc/mcollective/client.cfg
 topicprefix = /topic/
 main_collective = mcollective
 collectives = mcollective
@@ -2002,7 +2002,7 @@ EOF
 
 .RHEL
 ----
-cat <<EOF >/etc/mcollective/server.cfg
+cat <<EOF >/opt/rh/ruby193/root/etc/mcollective/server.cfg
 topicprefix = /topic/
 main_collective = mcollective
 collectives = mcollective
@@ -2026,7 +2026,7 @@ plugin.activemq.pool.1.password = marionette
 
 # Facts
 factsource = yaml
-plugin.yaml = /etc/mcollective/facts.yaml
+plugin.yaml = /opt/rh/ruby193/root/etc/mcollective/facts.yaml
 EOF
 ----
 


### PR DESCRIPTION
...d of /etc/mcollective/

This issue kept me back for a few days - rhel stable repo which doesn't use the scl packages will look for /etc/mcollective/{client,server}.cfg where as the nightly now uses /opt/rh/ruby193/root/etc/mcollective/{client,server}.cfg
