### PR TITLE
<jenkins_create_job> Remove always-failing test, capture jenkins createItem HTTP response

### DIFF
--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_create_job
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_create_job
@@ -34,13 +34,9 @@ def create_job
   FileUtils.rm @job_erb
 
 status_code = `/bin/sed -e "s,UPSTREAM_SSH,#{@uuid}@#{@app_name}-\\${OPENSHIFT_NAMESPACE}.#{@openshift_domain},g" #{job_template_xml} \
-  | curl -s  -X POST -H "Content-Type: application/xml" -H "Expect: " --data-binary @- --insecure https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}/createItem?name=#{@job_name}`
+  | curl -s -w %{http_code} -X POST -H "Content-Type: application/xml" -H "Expect: " --data-binary @- --insecure https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}/createItem?name=#{@job_name}`
 
   puts "create_job status: #{status_code}"
-  if not File.exists? File.join(@data_dir, 'jobs', @app_name, 'config.xml')
-    puts  'build config does not exist'
-    exit 1
-  end
 
   if status_code != '200'
     exit 1


### PR DESCRIPTION
This script was checking for the jenkins client config in
`data/jobs/app_name/config.xml`, but that file never gets
created. Removed that check, and also fixed the `curl` invocation so
that the HTTP response code is properly captured once more.
