### PR TITLE
Use denormalized domain_namespace

### DIFF
--- a/broker/test/integration/application_test.rb
+++ b/broker/test/integration/application_test.rb
@@ -21,7 +21,7 @@ class ApplicationTest < ActiveSupport::TestCase
     app = Application.find_by(canonical_name: app_name.downcase)
 
     assert_equal(app.name, orig_app.name)
-    assert_equal(app.domain.namespace, orig_app.domain.namespace)
+    assert_equal(app.domain_namespace, orig_app.domain_namespace)
 
     app.aliases.push(Alias.new(fqdn: "app.foo.bar"))
 

--- a/controller/app/controllers/emb_cart_controller.rb
+++ b/controller/app/controllers/emb_cart_controller.rb
@@ -57,7 +57,7 @@ class EmbCartController < BaseController
 
     valid_sizes = OpenShift::ApplicationContainerProxy.valid_gear_sizes & @application.domain.allowed_gear_sizes & @application.domain.owner.allowed_gear_sizes
 
-    return render_error(:forbidden, "The owner of the domain #{@application.domain.namespace} has disabled all gear sizes from being created.  You will not be able to add any cartridge in this domain.",
+    return render_error(:forbidden, "The owner of the domain #{@application.domain_namespace} has disabled all gear sizes from being created.  You will not be able to add any cartridge in this domain.",
                         134) if valid_sizes.empty?
 
     return render_error(:unprocessable_entity, "The gear size '#{gear_size}' is not valid for this domain. Allowed sizes: #{valid_sizes.to_sentence}.",

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1333,7 +1333,7 @@ class Application
         tag = conn._id.to_s
 
         pub_inst.gears.each do |gear|
-          input_args = [gear.name, self.domain.namespace, gear.uuid]
+          input_args = [gear.name, self.domain_namespace, gear.uuid]
           unless gear.removed
             job = gear.get_execute_connector_job(pub_inst, conn.from_connector_name, conn.connection_type, input_args)
             RemoteJob.add_parallel_job(handle, tag, gear, job)
@@ -1371,7 +1371,7 @@ class Application
 
           Rails.logger.debug "Output of publisher - '#{pub_out}'"
           sub_inst.gears.each do |gear|
-            input_args = [gear.name, self.domain.namespace, gear.uuid, input_to_subscriber]
+            input_args = [gear.name, self.domain_namespace, gear.uuid, input_to_subscriber]
             unless gear.removed
               job = gear.get_execute_connector_job(sub_inst, conn.to_connector_name, conn.connection_type, input_args, pub_inst.cartridge_name)
               RemoteJob.add_parallel_job(handle, tag, gear, job)
@@ -1399,7 +1399,7 @@ class Application
   def deregister_routing_dns
     dns = OpenShift::DnsService.instance
     begin
-      dns.deregister_application("ha-#{self.name}", self.domain.namespace)
+      dns.deregister_application("ha-#{self.name}", self.domain_namespace)
       dns.publish
     ensure
       dns.close
@@ -1410,7 +1410,7 @@ class Application
     target_hostname = Rails.configuration.openshift[:router_hostname]
     dns = OpenShift::DnsService.instance
     begin
-      dns.register_application("ha-#{self.name}", self.domain.namespace, target_hostname)
+      dns.register_application("ha-#{self.name}", self.domain_namespace, target_hostname)
       dns.publish
     ensure
       dns.close

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -353,6 +353,12 @@ class Application
     super
   end
 
+  ##
+  # Return either the denormalized domain name or nil, since namespace is denormalized
+  def domain_namespace
+    attributes['domain_namespace'] or has_domain? ? domain.canonical_namespace : nil
+  end
+
   def capabilities
     @capabilities ||= domain.owner.capabilities.deep_dup rescue (raise OpenShift::UserException, "The application cannot be changed at this time.  Contact support.")
   end

--- a/controller/app/models/gear.rb
+++ b/controller/app/models/gear.rb
@@ -129,7 +129,7 @@ class Gear
   def register_dns
     dns = OpenShift::DnsService.instance
     begin
-      dns.register_application(self.name, application.domain.namespace, public_hostname)
+      dns.register_application(self.name, application.domain_namespace, public_hostname)
       dns.publish
     ensure
       dns.close
@@ -139,7 +139,7 @@ class Gear
   def deregister_dns
     dns = OpenShift::DnsService.instance
     begin
-      dns.deregister_application(self.name, self.application.domain.namespace)
+      dns.deregister_application(self.name, self.application.domain_namespace)
       dns.publish
     ensure
       dns.close

--- a/controller/app/rest_models/rest_embedded_cartridge15.rb
+++ b/controller/app/rest_models/rest_embedded_cartridge15.rb
@@ -181,7 +181,7 @@ class RestEmbeddedCartridge15 < OpenShift::Model
     self.help_topics = cart.help_topics
 
     if app and !nolinks
-      domain_id = app.domain.namespace
+      domain_id = app.domain_namespace
       app_id = app.name
       if not app_id.nil? and not domain_id.nil?
         self.links = {

--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -335,7 +335,7 @@ module OpenShift
         args['--with-container-name'] = gear.name
         args['--with-quota-blocks'] = quota_blocks if quota_blocks
         args['--with-quota-files'] = quota_files if quota_files
-        args['--with-namespace'] = app.domain.namespace
+        args['--with-namespace'] = app.domain_namespace
         args['--with-uid'] = gear.uid if gear.uid
         args['--with-request-id'] = Thread.current[:user_action_log_uuid]
         args
@@ -1399,7 +1399,7 @@ module OpenShift
         args = Hash.new
         args['--with-container-uuid']=gear.uuid
         args['--with-container-name']=gear.name
-        args['--with-namespace']=app.domain.namespace
+        args['--with-namespace']=app.domain_namespace
         result = execute_direct(@@C_CONTROLLER, 'frontend-backup', args)
         result = parse_result(result)
         result.resultIO.string
@@ -1806,7 +1806,7 @@ module OpenShift
         begin
           dns = OpenShift::DnsService.instance
           public_hostname = destination_container.get_public_hostname
-          dns.modify_application(gear.name, app.domain.namespace, public_hostname)
+          dns.modify_application(gear.name, app.domain_namespace, public_hostname)
           dns.publish
         ensure
           dns.close
@@ -2155,7 +2155,7 @@ module OpenShift
         end
 
         log_debug "DEBUG: Moving system components for app '#{app.name}', gear '#{gear.name}' to #{destination_container.id}"
-        log_debug `eval \`ssh-agent\`; ssh-add #{rsync_keyfile}; ssh -o StrictHostKeyChecking=no -A root@#{source_container.get_ip_address} "rsync -aAX -e 'ssh -o StrictHostKeyChecking=no' --include '.httpd.d/' --include '.httpd.d/#{gear.uuid}_***' --include '#{gear.name}-#{app.domain.namespace}' --include '.last_access/' --include '.last_access/#{gear.uuid}' --exclude '*' /var/lib/openshift/ root@#{destination_container.get_ip_address}:/var/lib/openshift/"; exit_code=$?; ssh-agent -k; exit $exit_code`
+        log_debug `eval \`ssh-agent\`; ssh-add #{rsync_keyfile}; ssh -o StrictHostKeyChecking=no -A root@#{source_container.get_ip_address} "rsync -aAX -e 'ssh -o StrictHostKeyChecking=no' --include '.httpd.d/' --include '.httpd.d/#{gear.uuid}_***' --include '#{gear.name}-#{app.domain_namespace}' --include '.last_access/' --include '.last_access/#{gear.uuid}' --exclude '*' /var/lib/openshift/ root@#{destination_container.get_ip_address}:/var/lib/openshift/"; exit_code=$?; ssh-agent -k; exit $exit_code`
         if $?.exitstatus != 0
           raise OpenShift::NodeException.new("Error moving system components for app '#{app.name}', gear '#{gear.name}' from #{source_container.id} to #{destination_container.id}", 143)
         end
@@ -2890,7 +2890,7 @@ module OpenShift
               @id = e.server_identity
               Rails.logger.debug "DEBUG: Changing server identity of '#{gear.name}' from '#{gear.server_identity}' to '#{@id}'"
               dns_service = OpenShift::DnsService.instance
-              dns_service.modify_application(gear.name, app.domain.namespace, get_public_hostname)
+              dns_service.modify_application(gear.name, app.domain_namespace, get_public_hostname)
               dns_service.publish
               gear.server_identity = @id
               app.save

--- a/plugins/routing/activemq/lib/openshift/activemq_routing_plugin.rb
+++ b/plugins/routing/activemq/lib/openshift/activemq_routing_plugin.rb
@@ -24,7 +24,7 @@ module OpenShift
       msg = {
         :action => :add_ssl,
         :app_name => app.name,
-        :namespace => app.domain.namespace,
+        :namespace => app.domain_namespace,
         :alias => fqdn,
         :ssl => ssl_cert,
         :private_key => pvt_key,
@@ -37,7 +37,7 @@ module OpenShift
       msg = {
         :action => :remove_ssl,
         :app_name => app.name,
-        :namespace => app.domain.namespace,
+        :namespace => app.domain_namespace,
         :alias => fqdn
       }
       send_msg msg.to_yaml
@@ -47,7 +47,7 @@ module OpenShift
       msg = {
         :action => :add_alias,
         :app_name => app.name,
-        :namespace => app.domain.namespace,
+        :namespace => app.domain_namespace,
         :alias => alias_str
       }
       send_msg msg.to_yaml
@@ -57,7 +57,7 @@ module OpenShift
       msg = {
         :action => :remove_alias,
         :app_name => app.name,
-        :namespace => app.domain.namespace,
+        :namespace => app.domain_namespace,
         :alias => alias_str
       }
       send_msg msg.to_yaml
@@ -67,7 +67,7 @@ module OpenShift
       msg = {
         :action => :create_application,
         :app_name => app.name,
-        :namespace => app.domain.namespace,
+        :namespace => app.domain_namespace,
       }
       send_msg msg.to_yaml
     end
@@ -76,7 +76,7 @@ module OpenShift
       msg = {
         :action => :delete_application,
         :app_name => app.name,
-        :namespace => app.domain.namespace,
+        :namespace => app.domain_namespace,
       }
       send_msg msg.to_yaml
     end
@@ -85,7 +85,7 @@ module OpenShift
       msg = {
         :action => :add_gear,
         :app_name => app.name,
-        :namespace => app.domain.namespace,
+        :namespace => app.domain_namespace,
         :public_port_name => endpoint_name,
         :public_address => public_ip,
         :public_port => public_port,
@@ -100,7 +100,7 @@ module OpenShift
       msg = {
         :action => :delete_gear,
         :app_name => app.name,
-        :namespace => app.domain.namespace,
+        :namespace => app.domain_namespace,
         :public_address => public_ip,
         :public_port => public_port
       }


### PR DESCRIPTION
@abhgupta review please.  App has domain_namespace denormalized - we should
use it in preference to domain.namespace to avoid pulling domain except
when we have to.
