### PR TITLE
make rhcsh idle time out a configurable parameter in node.conf (OPENSHIFT_RHCSH_IDLE_TIMEOUT)

### DIFF
--- a/node/misc/bin/rhcsh
+++ b/node/misc/bin/rhcsh
@@ -49,7 +49,7 @@ if [ -n "$OPENSHIFT_UMASK" ]; then
     umask $OPENSHIFT_UMASK
 fi
 
-RHCSH_IDLE_TIMEOUT=300
+OPENSHIFT_RHCSH_IDLE_TIMEOUT=300
 source /etc/openshift/node.conf
 
 function welcome {
@@ -275,7 +275,7 @@ function tail_all {
 }
 
 export PS1="[$OPENSHIFT_GEAR_DNS \W]\> "
-export TMOUT=$RHCSH_IDLE_TIMEOUT
+export TMOUT=$OPENSHIFT_RHCSH_IDLE_TIMEOUT
 export SHELL=/bin/bash
 welcome
 

--- a/node/misc/bin/rhcsh
+++ b/node/misc/bin/rhcsh
@@ -49,6 +49,7 @@ if [ -n "$OPENSHIFT_UMASK" ]; then
     umask $OPENSHIFT_UMASK
 fi
 
+RHCSH_IDLE_TIMEOUT=300
 source /etc/openshift/node.conf
 
 function welcome {
@@ -274,7 +275,7 @@ function tail_all {
 }
 
 export PS1="[$OPENSHIFT_GEAR_DNS \W]\> "
-export TMOUT=300
+export TMOUT=$RHCSH_IDLE_TIMEOUT
 export SHELL=/bin/bash
 welcome
 


### PR DESCRIPTION
We've had users asking for the bash timeout to be raised. This commit makes it a configurable parameter in node.conf.
