### PR TITLE
This directive throws a deprecation warning in apache 2.4

### DIFF
--- a/cartridges/openshift-origin-cartridge-perl/versions/shared/etc/conf/httpd.conf
+++ b/cartridges/openshift-origin-cartridge-perl/versions/shared/etc/conf/httpd.conf
@@ -109,7 +109,9 @@ AccessFileName .htaccess
   </Files>
 </IfVersion>
 TypesConfig /etc/mime.types
+<IfVersion < 2.4>
 DefaultType text/plain
+</IfVersion>
 <IfModule mod_mime_magic.c>
     MIMEMagicFile etc/magic
 </IfModule>

--- a/cartridges/openshift-origin-cartridge-perl/versions/shared/etc/conf/httpd_nolog.conf
+++ b/cartridges/openshift-origin-cartridge-perl/versions/shared/etc/conf/httpd_nolog.conf
@@ -109,7 +109,9 @@ AccessFileName .htaccess
   </Files>
 </IfVersion>
 TypesConfig /etc/mime.types
+<IfVersion < 2.4>
 DefaultType text/plain
+</IfVersion>
 <IfModule mod_mime_magic.c>
     MIMEMagicFile etc/magic
 </IfModule>

--- a/cartridges/openshift-origin-cartridge-php/versions/shared/configuration/etc/conf/httpd.conf
+++ b/cartridges/openshift-origin-cartridge-php/versions/shared/configuration/etc/conf/httpd.conf
@@ -107,7 +107,9 @@ AccessFileName .htaccess
   </Files>
 </IfVersion>
 TypesConfig /etc/mime.types
+<IfVersion < 2.4>
 DefaultType text/plain
+</IfVersion>
 <IfModule mod_mime_magic.c>
     MIMEMagicFile conf/magic
 </IfModule>

--- a/cartridges/openshift-origin-cartridge-php/versions/shared/configuration/etc/conf/httpd_nolog.conf
+++ b/cartridges/openshift-origin-cartridge-php/versions/shared/configuration/etc/conf/httpd_nolog.conf
@@ -109,7 +109,9 @@ AccessFileName .htaccess
   </Files>
 </IfVersion>
 TypesConfig /etc/mime.types
+<IfVersion < 2.4>
 DefaultType text/plain
+</IfVersion>
 <IfModule mod_mime_magic.c>
     MIMEMagicFile conf/magic
 </IfModule>

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/versions/shared/conf/httpd.conf.erb
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/versions/shared/conf/httpd.conf.erb
@@ -109,7 +109,9 @@ AccessFileName .htaccess
   </Files>
 </IfVersion>
 TypesConfig /etc/mime.types
+<IfVersion < 2.4>
 DefaultType text/plain
+</IfVersion>
 <IfModule mod_mime_magic.c>
     MIMEMagicFile conf/magic
 </IfModule>

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/versions/shared/conf/httpd_nolog.conf.erb
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/versions/shared/conf/httpd_nolog.conf.erb
@@ -109,7 +109,9 @@ AccessFileName .htaccess
   </Files>
 </IfVersion>
 TypesConfig /etc/mime.types
+<IfVersion < 2.4>
 DefaultType text/plain
+</IfVersion>
 <IfModule mod_mime_magic.c>
     MIMEMagicFile conf/magic
 </IfModule>

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/etc/conf/httpd.conf
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/etc/conf/httpd.conf
@@ -109,7 +109,9 @@ AccessFileName .htaccess
   </Files>
 </IfVersion>
 TypesConfig /etc/mime.types
+<IfVersion < 2.4>
 DefaultType text/plain
+</IfVersion>
 <IfModule mod_mime_magic.c>
     MIMEMagicFile etc/magic
 </IfModule>

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/etc/conf/httpd_nolog.conf
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/etc/conf/httpd_nolog.conf
@@ -109,7 +109,9 @@ AccessFileName .htaccess
   </Files>
 </IfVersion>
 TypesConfig /etc/mime.types
+<IfVersion < 2.4>
 DefaultType text/plain
+</IfVersion>
 <IfModule mod_mime_magic.c>
     MIMEMagicFile etc/magic
 </IfModule>

--- a/cartridges/openshift-origin-cartridge-ruby/versions/shared/etc/conf/httpd.conf
+++ b/cartridges/openshift-origin-cartridge-ruby/versions/shared/etc/conf/httpd.conf
@@ -109,7 +109,9 @@ AccessFileName .htaccess
   </Files>
 </IfVersion>
 TypesConfig /etc/mime.types
+<IfVersion < 2.4>
 DefaultType text/plain
+</IfVersion>
 <IfModule mod_mime_magic.c>
     MIMEMagicFile etc/magic
 </IfModule>

--- a/cartridges/openshift-origin-cartridge-ruby/versions/shared/etc/conf/httpd_nolog.conf
+++ b/cartridges/openshift-origin-cartridge-ruby/versions/shared/etc/conf/httpd_nolog.conf
@@ -109,7 +109,9 @@ AccessFileName .htaccess
   </Files>
 </IfVersion>
 TypesConfig /etc/mime.types
+<IfVersion < 2.4>
 DefaultType text/plain
+</IfVersion>
 <IfModule mod_mime_magic.c>
     MIMEMagicFile etc/magic
 </IfModule>


### PR DESCRIPTION
DefaultType no longer in user in httpd 2.4 -> http://httpd.apache.org/docs/current/mod/core.html#defaulttype
