### PR TITLE
make rhcsh idle time out a configurable parameter in node.conf 

### DIFF
--- a/node/misc/bin/rhcsh
+++ b/node/misc/bin/rhcsh
@@ -49,6 +49,7 @@ if [ -n "$OPENSHIFT_UMASK" ]; then
     umask $OPENSHIFT_UMASK
 fi
 
+OPENSHIFT_RHCSH_IDLE_TIMEOUT=300
 source /etc/openshift/node.conf
 
 function welcome {
@@ -274,7 +275,7 @@ function tail_all {
 }
 
 export PS1="[$OPENSHIFT_GEAR_DNS \W]\> "
-export TMOUT=300
+export TMOUT=$OPENSHIFT_RHCSH_IDLE_TIMEOUT
 export SHELL=/bin/bash
 welcome
 


### PR DESCRIPTION
This is the same patch in pull request #4363 but for the origin-release-3 branch
