### PR TITLE
<oo-diagnostics> bug 1046202 test_broker_httpd_error_log

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -746,13 +746,17 @@ class OODiag
     #
     # info about mcollective client log error
     out = `grep 'Could not start logger: Errno::EACCES' #{tmpfile}`
-    do_warn <<-FIXLOG unless out.empty?
-      broker error_log: this problem indicates mcollective client logging is failing:
-        #{out}
-      Please fix this issue with the following commands:
-        # chown apache:root /var/log/#{@scl_prefix}-mcollective-client.log
-        # service openshift-broker restart
-    FIXLOG
+    if ! out.empty?
+      logfile = "/var/log/mcollective-client.log"
+      out.match /Errno::EACCES[^\/]+(\/\S+.log)/ and logfile = $1
+      do_warn <<-FIXLOG
+        broker error_log: this problem indicates mcollective client logging is failing:
+          #{out}
+        Please fix this issue with the following commands:
+          # chown apache:root #{logfile}
+          # service openshift-broker restart
+      FIXLOG
+    end
     #
     # done with the tmp file
     system "rm #{tmpfile}"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1046202
just get the log file from the error message instead of trying to
construct it.
