### PR TITLE
Card origin_runtime_21 - Enable BUNDLE_WITHOUT env variable for Ruby

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -115,11 +115,19 @@ function build() {
             return 0
           fi
         fi
-        echo "Bundling RubyGems based on Gemfile/Gemfile.lock to repo/vendor/bundle with 'bundle install --deployment'"
         pushd ${OPENSHIFT_REPO_DIR} 1> /dev/null
           SAVED_GIT_DIR=$GIT_DIR
           unset GIT_DIR
-          ruby_context "bundle install --deployment"
+          # You can tell bundler to skip installing certain gem group by using
+          # $ rhc env set BUNDLE_WITHOUT="group1 group2 ..."
+          #
+          if [ -z "${BUNDLE_WITHOUT}" ]; then
+            echo "Bundling RubyGems based on Gemfile/Gemfile.lock to repo/vendor/bundle with 'bundle install --deployment'"
+            ruby_context "bundle install --deployment"
+          else
+            echo "Bundling RubyGems based on Gemfile/Gemfile.lock to repo/vendor/bundle with 'bundle install --deployment --without \"${BUNDLE_WITHOUT}\"'"
+            ruby_context "bundle install --deployment --without '${BUNDLE_WITHOUT}'"
+          fi
           export GIT_DIR=$SAVED_GIT_DIR
         popd 1> /dev/null
     fi

--- a/documentation/oo_cartridge_guide.adoc
+++ b/documentation/oo_cartridge_guide.adoc
@@ -1049,6 +1049,7 @@ The `ruby` cartridge provides several environment variables to reference for eas
 
 OPENSHIFT_RUBY_LOGDIR:: Log files go here.
 OPENSHIFT_RUBY_VERSION:: The Ruby language version. The valid values are `1.8` and `1.9`.
+BUNDLE_WITHOUT: Prevents Bundler from installing certain groups specified in the Gemfile.
 
 === Using RAILS_ENV=development
 


### PR DESCRIPTION
This PR will allow Ruby cartridge users to set `BUNDLE_WITHOUT` environment variable via using `rhc env set` to specify a Gemfile groups they don't want to install during application deployment.

For instance, if to prevent installing 'xapian' in Redmine when users have 'dmsf' plugin installed as a GIT submodule, all you need to do is:

`rhc env set BUNDLE_WITHOUT="xapian"`

and then do a `git push` as usuall.

I tested using BUNDLE_WITHOUT just as an env variable but for some reason, this variables is not picked up by build() function, so I added it explicitely using `--without` option. 

`BUNDLE_WITHOUT` is a standard bundler variable defined in (bundle-config)[http://bundler.io/v1.3/man/bundle-config.1.html] man page:

```
The canonical form of this configuration is "without". To convert the canonical form
to the environment variable form, capitalize it, and prepend BUNDLE_.
The environment variable form of "without" is  BUNDLE_WITHOUT.
```
