### PR TITLE
Add default user capability to create HA apps

### DIFF
--- a/broker/conf/broker.conf
+++ b/broker/conf/broker.conf
@@ -12,6 +12,8 @@ DEFAULT_MAX_GEARS="100"
 DEFAULT_GEAR_CAPABILITIES="small"
 # Default gear size for a new gear
 DEFAULT_GEAR_SIZE="small"
+# Default user capability to create Highly Available applications
+DEFAULT_ALLOW_HA="false"
 
 # For replica sets, use ',' delimiter for multiple servers
 # Eg: MONGO_HOST_PORT="<host1:port1>,<host2:port2>..."

--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -83,6 +83,7 @@ Broker::Application.configure do
     :default_gear_size => conf.get("DEFAULT_GEAR_SIZE", "small"),
     :gear_sizes => conf.get("VALID_GEAR_SIZES", "small").split(","),
     :default_gear_capabilities => conf.get("DEFAULT_GEAR_CAPABILITIES", "small").split(","),
+    :default_allow_ha => conf.get('DEFAULT_ALLOW_HA', "false"),
     :community_quickstarts_url => conf.get('COMMUNITY_QUICKSTARTS_URL'),
     :scopes => ['Scope::Session', 'Scope::Read', 'Scope::Domain', 'Scope::Application', 'Scope::Userinfo'],
     :default_scope => 'userinfo',

--- a/broker/config/environments/production.rb
+++ b/broker/config/environments/production.rb
@@ -72,6 +72,7 @@ Broker::Application.configure do
     :default_gear_size => conf.get("DEFAULT_GEAR_SIZE", "small"),
     :gear_sizes => conf.get("VALID_GEAR_SIZES", "small").split(","),
     :default_gear_capabilities => conf.get("DEFAULT_GEAR_CAPABILITIES", "small").split(","),
+    :default_allow_ha => conf.get('DEFAULT_ALLOW_HA', "false"),
     :community_quickstarts_url => conf.get("COMMUNITY_QUICKSTARTS_URL"),
     :scopes => ['Scope::Session', 'Scope::Read', 'Scope::Domain', 'Scope::Application', 'Scope::Userinfo'],
     :default_scope => 'userinfo',

--- a/broker/config/environments/test.rb
+++ b/broker/config/environments/test.rb
@@ -82,6 +82,7 @@ Broker::Application.configure do
     :default_gear_size => conf.get("DEFAULT_GEAR_SIZE", "small"),
     :gear_sizes => conf.get("VALID_GEAR_SIZES", "small").split(","),
     :default_gear_capabilities => conf.get("DEFAULT_GEAR_CAPABILITIES", "small").split(","),
+    :default_allow_ha => conf.get('DEFAULT_ALLOW_HA', "false"),
     :scopes => ['Scope::Session', 'Scope::Read', 'Scope::Domain', 'Scope::Application', 'Scope::Userinfo'],
     :default_scope => 'userinfo',
     :scope_expirations => OpenShift::Controller::Configuration.parse_expiration("session=1.days|2.days", 1.month),

--- a/controller/app/models/cloud_user.rb
+++ b/controller/app/models/cloud_user.rb
@@ -218,7 +218,7 @@ class CloudUser
 
   def default_capabilities
     {
-      "ha" => false,
+      "ha" => Rails.application.config.openshift[:default_allow_ha],
       "subaccounts" => false,
       "gear_sizes" => Rails.application.config.openshift[:default_gear_capabilities],
       "max_domains" => Rails.application.config.openshift[:default_max_domains],


### PR DESCRIPTION
The openshift admin has to manually add the HA capability to users.

```
oo-admin-ctl-user -l $USER --allowha true
```

It should be great to have a DEFAULT_HA configuration parameter to automatize this.
