### PR TITLE
Bug 1045661 - After configuring mysql timezone and restarting cart. the configuration is lost

### DIFF
--- a/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb
+++ b/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb
@@ -31,6 +31,8 @@ lower_case_table_names = <%= ENV['OPENSHIFT_MYSQL_LOWER_CASE_TABLE_NAMES'] ? ENV
 <%= ENV['OPENSHIFT_MYSQL_DEFAULT_STORAGE_ENGINE'] ? "default-storage-engine = #{ENV['OPENSHIFT_MYSQL_DEFAULT_STORAGE_ENGINE']}" : '' %>
 myisam_sort_buffer_size = 2M
 
+<%= ENV['OPENSHIFT_MYSQL_TIMEZONE'] ? "default-time-zone = '#{ENV['OPENSHIFT_MYSQL_TIMEZONE']}'" : '' %>
+
 #INNODB
 # You can set .._buffer_pool_size up to 50 - 80 %
 # of RAM but beware of setting memory usage too high

--- a/documentation/oo_cartridge_guide.adoc
+++ b/documentation/oo_cartridge_guide.adoc
@@ -654,7 +654,12 @@ OPENSHIFT_MYSQLDB_DB_HOST:: The MySQL IP address
 OPENSHIFT_MYSQLDB_DB_PORT:: The MySQL port
 OPENSHIFT_MYSQLDB_DB_LOG_DIR:: The path to the MySQL log directory
 OPENSHIFT_MYSQL_VERSION: The version of the MySQL server
-
+OPENSHIFT_MYSQL_TIMEZONE: The MySQL server timezone
+OPENSHIFT_MYSQL_LOWER_CASE_TABLE_NAMES: Sets how the table names are stored and compared
+OPENSHIFT_MYSQL_DEFAULT_STORAGE_ENGINE: The default storage engine (table type)
+OPENSHIFT_MYSQL_MAX_CONNECTIONS: The maximum permitted number of simultaneous client connections
+OPENSHIFT_MYSQL_FT_MIN_WORD_LEN: The minimum length of the word to be included in a FULLTEXT index.
+OPENSHIFT_MYSQL_FT_MAX_WORD_LEN: The maximum length of the word to be included in a FULLTEXT index.
 
 [[nodejs]]
 == NodeJS


### PR DESCRIPTION
Solved by adding new env variable OPENSHIFT_MYSQL_TIMEZONE, which will preserve the timezone value after the cartridge.
Also added the new env variable to the oo-cartridge-guide with other variables which are availeble to the users, but are missing in the guide.
