### PR TITLE
Bug 1049402 - Spree quickstart can connect to mysql and ends with timeout

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -133,10 +133,12 @@ function deploy() {
   pushd ${OPENSHIFT_REPO_DIR} > /dev/null
   if [ -f Gemfile ]
   then
-    if [ -f Rakefile ] && bundle exec "rake -T" | grep "assets:precompile" >/dev/null
-    then
-      echo "Precompiling with 'bundle exec rake assets:precompile'"
-      ruby_context "bundle exec rake assets:precompile"
+    if [ ! -f ${OPENSHIFT_REPO_DIR}.openshift/markers/disable_asset_compilation ];then
+      if [ -f Rakefile ] && bundle exec "rake -T" | grep "assets:precompile" >/dev/null
+      then
+        echo "Precompiling with 'bundle exec rake assets:precompile'"
+        ruby_context "bundle exec rake assets:precompile"
+      fi
     fi
   fi
   popd > /dev/null

--- a/documentation/oo_cartridge_guide.adoc
+++ b/documentation/oo_cartridge_guide.adoc
@@ -1091,3 +1091,7 @@ Adding marker files to `.openshift/markers` will have the following effects:
 |hot_deploy
 |Will prevent shutdown and startup of the application during builds. The Passenger `restart.txt` file will be used to reload the application.
 |===
+
+|disable_asset_compilation
+|Will prevent assets to be compiled upon application deployment. This marker should be used when deploying application with assets which are already compiled.
+|===


### PR DESCRIPTION
Part 1 of the bugfix.
Adding option to skip the asset compilation during the application deployment.

Use-Case: When user deploys rails application with large amount of assets, which he already precompiled and pushed into his repository. This way he minimizes the change to get timeout because of the large of asset compilation.
