### PR TITLE
[WIP] Bug 984867 - Hardcode port 80 for PassengerPreStartUrl

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/versions/shared/etc/conf.d/openshift.conf.erb
+++ b/cartridges/openshift-origin-cartridge-ruby/versions/shared/etc/conf.d/openshift.conf.erb
@@ -19,8 +19,15 @@ ErrorLog "|/usr/sbin/rotatelogs <%= ENV['OPENSHIFT_RUBY_DIR'] %>/logs/error_log-
 CustomLog "|/usr/sbin/rotatelogs <%= ENV['OPENSHIFT_RUBY_DIR'] %>/logs/access_log-%Y%m%d-%H%M%S-%Z 86400" combined
 
 PassengerUser <%= ENV['OPENSHIFT_GEAR_UUID'] %>
-PassengerPreStart http://<%= ENV['OPENSHIFT_RUBY_IP'] %>:<%= ENV['OPENSHIFT_RUBY_PORT'] %>/
+
+# This has been hardcoded to port 80 due to BZ#984867
+#
+# Passenger will do a HEAD request against 127.0.0.1:PORT where the
+# port 8080 is closed in production.
+#
+PassengerPreStart http://<%= ENV['OPENSHIFT_APP_DNS'] %>:80/
 PassengerSpawnIPAddress <%= ENV['OPENSHIFT_RUBY_IP'] %>
+
 PassengerUseGlobalQueue off
 
 # These must be passed on this place to make sure we set the right Rails/Rack


### PR DESCRIPTION
Due to a change in Passenger code, Passenger is now routing all PreStart requests via 127.0.0.1:

```
        def connect
                TCPSocket.new('127.0.0.1', request_port)
        end
```

The 'request_port' is extracted from PassengerPreStartUrl and the HTTP HEAD request is then sent with Host header set to host extracted from URL.

In PROD, where we don't have any HTTP listening on 127.0.0.1:8080, users get this error:

```
[Thu Jan 09 08:32:25 2014] [notice] Apache/2.2.22 (Unix) Phusion_Passenger/3.0.21 configured -- resuming normal operations
/opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/helper-scripts/prespawn:105:in `initialize': Connection refused - connect(2) (Errno::ECONNREFUSED)
    from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/helper-scripts/prespawn:105:in `new'
```

However in DEVENV, where we have httpd configured to listen on 127.0.0.1:8080, the request succeded. This patch will hardcode port 80, so the request will succeed in PROD, however we might see the error above on devenv. 
