### PR TITLE
<comprehensive deployment guide> Fix unterminated code block

### DIFF
--- a/documentation/oo_deployment_guide_comprehensive.adoc
+++ b/documentation/oo_deployment_guide_comprehensive.adoc
@@ -2181,6 +2181,7 @@ cat << EOF > /etc/httpd/conf.d/cartridge_files.conf
     Require all granted
 </Directory>
 EOF
+----
 
 ===== apache-mod-rewrite Plugin
 


### PR DESCRIPTION
Section 9.7.2 ("Install front-end plugins") contained a code block
that wasn't closed properly. This broke formatting for most of the
document that followed.
