### PR TITLE
Various Ruby cartridge improvements

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -88,6 +88,9 @@ function pre-repo-archive() {
     echo 'Saving away previously bundled RubyGems'
     mv ${OPENSHIFT_REPO_DIR}.bundle ${OPENSHIFT_RUBY_DIR}/tmp/
     mv ${OPENSHIFT_REPO_DIR}vendor ${OPENSHIFT_RUBY_DIR}/tmp/
+  else
+    # Remove last Gemfile checkum file to force bundler to run.
+    rm -rf ${OPENSHIFT_RUBY_DIR}tmp/.gemfile_md5sum
   fi
 }
 
@@ -97,7 +100,8 @@ function build() {
 
     if [ -d ${OPENSHIFT_RUBY_DIR}tmp/.bundle ]
     then
-      echo 'Restoring previously bundled RubyGems (note: you can commit .openshift/markers/force_clean_build at the root of your repo to force a clean bundle)'
+      echo 'Restoring previously bundled RubyGems'
+      echo 'NOTE: You can commit .openshift/markers/force_clean_build to force a clean bundle'
       mv $OPENSHIFT_RUBY_DIR/tmp/.bundle ${OPENSHIFT_REPO_DIR}
       if [ -d ${OPENSHIFT_REPO_DIR}vendor ]
       then
@@ -113,11 +117,11 @@ function build() {
     if [ -f ${OPENSHIFT_REPO_DIR}/Gemfile ]
     then
         if ! gemfile_is_modified; then
-          echo "Skipping 'bundle install' because Gemfile is not modified."
+          echo "NOTE: Skipping 'bundle install' because Gemfile is not modified."
           return 0
         fi
         if ruby_in_development_mode; then
-          echo "Skipping 'bundle install' because running in development mode."
+          echo "NOTE: Skipping 'bundle install' because running in development mode."
           return 0
         fi
         pushd ${OPENSHIFT_REPO_DIR} 1> /dev/null
@@ -129,7 +133,7 @@ function build() {
           echo "Bundling RubyGems based on Gemfile/Gemfile.lock to repo/vendor/bundle..."
           if [ -z "${BUNDLE_WITHOUT}" ]; then
             echo "bundle install --deployment"
-            echo "Note: You can prevent installing certain Gemfile group using: rhc env set BUNDLE_WITHOUT=groupname"
+            echo "NOTE: You can prevent installing certain Gemfile group using: rhc env set BUNDLE_WITHOUT=groupname"
             ruby_context "bundle install --deployment"
           else
             echo "bundle install --deployment --without '${BUNDLE_WITHOUT}'"
@@ -142,7 +146,7 @@ function build() {
 
 function deploy() {
   if ruby_in_development_mode; then
-    echo "The 'rake assets:precompile' is disabled when Ruby is in development mode."
+    echo "NOTE: The 'rake assets:precompile' is disabled when Ruby is in development mode."
     return 0
   fi
   pushd ${OPENSHIFT_REPO_DIR} > /dev/null
@@ -153,7 +157,7 @@ function deploy() {
       then
         echo "Precompiling rails assets with 'bundle exec rake assets:precompile'"
         ruby_context "bundle exec rake assets:precompile"
-        echo "Note: You can disable assets precompilation using: rhc env set RAILS_ENV=development"
+        echo "NOTE: You can disable assets precompilation using: rhc env set RAILS_ENV=development"
       fi
     fi
   fi
@@ -162,8 +166,12 @@ function deploy() {
 
 function post-deploy() {
   if hot_deploy_enabled_for_latest_deployment; then
-    echo "Hot deploy marker is present. Touching Passenger restart.txt to trigger redeployment."
-    touch ${OPENSHIFT_REPO_DIR}tmp/restart.txt
+    if [ -d "${OPENSHIFT_REPO_DIR}tmp" ]; then
+      echo "Hot deploy marker is present. Touching Passenger restart.txt to trigger redeployment."
+      touch ${OPENSHIFT_REPO_DIR}tmp/restart.txt
+    else
+      echo "WARNING: Hot deploy marker is present, but the 'tmp/' directory does not exists."
+    fi
   fi
 }
 

--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -28,9 +28,9 @@ function start() {
     echo "Starting Ruby cartridge"
     mkdir -p ${OPENSHIFT_REPO_DIR}public
     write_httpd_passenv $HTTPD_PASSENV_FILE
-    oo-erb ${OPENSHIFT_RUBY_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
-    ruby_context "RAILS_ENV=${RAILS_ENV:-production} /usr/sbin/httpd $HTTPD_CMD_CONF -k start"
+    update_passenger_performance
+    httpd_with_env start
     [ "$?" == "0" ] && wait_for_pid_file $HTTPD_PID_FILE
 }
 
@@ -45,7 +45,7 @@ function stop() {
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     if [ -f "$HTTPD_PID_FILE" ]; then
         httpd_pid=`cat "$HTTPD_PID_FILE" 2> /dev/null`
-        ruby_context "/usr/sbin/httpd $HTTPD_CMD_CONF -k stop"
+        httpd_with_env stop
         wait_for_stop $httpd_pid
     fi
 }
@@ -57,7 +57,7 @@ function restart() {
     oo-erb ${OPENSHIFT_RUBY_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
     [ -d ${OPENSHIFT_REPO_DIR}/tmp ] && touch ${OPENSHIFT_REPO_DIR}/tmp/restart.txt
     ensure_httpd_restart_succeed "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
-    ruby_context "RAILS_ENV=${RAILS_ENV:-production} /usr/sbin/httpd $HTTPD_CMD_CONF -k restart"
+    httpd_with_env restart
 }
 
 function status() {
@@ -95,13 +95,7 @@ function build() {
     echo "Building Ruby cartridge"
     update-configuration $OPENSHIFT_RUBY_VERSION
 
-    USED_BUNDLER=false
-    if [ -d $OPENSHIFT_RUBY_DIR/tmp/.bundle ]
-    then
-      USED_BUNDLER=true
-    fi
-
-    if $USED_BUNDLER
+    if [ -d ${OPENSHIFT_RUBY_DIR}tmp/.bundle ]
     then
       echo 'Restoring previously bundled RubyGems (note: you can commit .openshift/markers/force_clean_build at the root of your repo to force a clean bundle)'
       mv $OPENSHIFT_RUBY_DIR/tmp/.bundle ${OPENSHIFT_REPO_DIR}
@@ -114,14 +108,17 @@ function build() {
       rm -rf $OPENSHIFT_RUBY_DIR/tmp/.bundle $OPENSHIFT_RUBY_DIR/tmp/vendor
     fi
 
-    # If a Gemfile is committed then bundle install
+    # If a Gemfile is committed and it is modified, then bundle install
+    #
     if [ -f ${OPENSHIFT_REPO_DIR}/Gemfile ]
     then
+        if ! gemfile_is_modified; then
+          echo "Skipping 'bundle install' because Gemfile is not modified."
+          return 0
+        fi
         if ruby_in_development_mode; then
-          if ! gemfile_is_modified; then
-            echo "Skipping 'bundle install' because in development mode and Gemfile is not modified..."
-            return 0
-          fi
+          echo "Skipping 'bundle install' because running in development mode."
+          return 0
         fi
         pushd ${OPENSHIFT_REPO_DIR} 1> /dev/null
           SAVED_GIT_DIR=$GIT_DIR
@@ -129,11 +126,13 @@ function build() {
           # You can tell bundler to skip installing certain gem group by using
           # $ rhc env set BUNDLE_WITHOUT="group1 group2 ..."
           #
+          echo "Bundling RubyGems based on Gemfile/Gemfile.lock to repo/vendor/bundle..."
           if [ -z "${BUNDLE_WITHOUT}" ]; then
-            echo "Bundling RubyGems based on Gemfile/Gemfile.lock to repo/vendor/bundle with 'bundle install --deployment'"
+            echo "bundle install --deployment"
+            echo "Note: You can prevent installing certain Gemfile group using: rhc env set BUNDLE_WITHOUT=groupname"
             ruby_context "bundle install --deployment"
           else
-            echo "Bundling RubyGems based on Gemfile/Gemfile.lock to repo/vendor/bundle with 'bundle install --deployment --without \"${BUNDLE_WITHOUT}\"'"
+            echo "bundle install --deployment --without '${BUNDLE_WITHOUT}'"
             ruby_context "bundle install --deployment --without '${BUNDLE_WITHOUT}'"
           fi
           export GIT_DIR=$SAVED_GIT_DIR
@@ -149,11 +148,12 @@ function deploy() {
   pushd ${OPENSHIFT_REPO_DIR} > /dev/null
   if [ -f Gemfile ]
   then
-    if [ ! -f ${OPENSHIFT_REPO_DIR}.openshift/markers/disable_asset_compilation ];then
-      if [ -f Rakefile ] && bundle exec "rake -T" | grep "assets:precompile" >/dev/null
+    if [ ! -f ${OPENSHIFT_REPO_DIR}.openshift/markers/disable_asset_compilation ]; then
+      if [ -f Rakefile ] && grep " rails " Gemfile.lock >/dev/null && bundle exec "rake -T" | grep "assets:precompile" >/dev/null
       then
-        echo "Precompiling with 'bundle exec rake assets:precompile'"
+        echo "Precompiling rails assets with 'bundle exec rake assets:precompile'"
         ruby_context "bundle exec rake assets:precompile"
+        echo "Note: You can disable assets precompilation using: rhc env set RAILS_ENV=development"
       fi
     fi
   fi

--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -98,13 +98,17 @@ function build() {
     echo "Building Ruby cartridge"
     update-configuration $OPENSHIFT_RUBY_VERSION
 
-    if [ -d ${OPENSHIFT_RUBY_DIR}tmp/.bundle ]
-    then
+    if [ -d ${OPENSHIFT_RUBY_DIR}tmp/.bundle ]; then
       echo 'Restoring previously bundled RubyGems'
       echo 'NOTE: You can commit .openshift/markers/force_clean_build to force a clean bundle'
+
+      if [ -d ${OPENSHIFT_REPO_DIR}.bundle ]; then
+        echo 'ERROR: You need to remove the ".bundle" directory from your GIT repository.'
+        exit 1;
+      fi
       mv $OPENSHIFT_RUBY_DIR/tmp/.bundle ${OPENSHIFT_REPO_DIR}
-      if [ -d ${OPENSHIFT_REPO_DIR}vendor ]
-      then
+
+      if [ -d ${OPENSHIFT_REPO_DIR}vendor ]; then
         mv $OPENSHIFT_RUBY_DIR/tmp/vendor/bundle ${OPENSHIFT_REPO_DIR}vendor/
       else
         mv $OPENSHIFT_RUBY_DIR/tmp/vendor ${OPENSHIFT_REPO_DIR}
@@ -114,33 +118,33 @@ function build() {
 
     # If a Gemfile is committed and it is modified, then bundle install
     #
-    if [ -f ${OPENSHIFT_REPO_DIR}/Gemfile ]
-    then
-        if ! gemfile_is_modified; then
-          echo "NOTE: Skipping 'bundle install' because Gemfile is not modified."
-          return 0
+    if [ -f ${OPENSHIFT_REPO_DIR}/Gemfile ]; then
+      if ! gemfile_is_modified; then
+        echo "NOTE: Skipping 'bundle install' because Gemfile is not modified."
+        return 0
+      fi
+      if ruby_in_development_mode; then
+        echo "NOTE: Skipping 'bundle install' because running in development mode."
+        return 0
+      fi
+      pushd ${OPENSHIFT_REPO_DIR} 1> /dev/null
+      SAVED_GIT_DIR=$GIT_DIR
+      unset GIT_DIR
+      # You can tell bundler to skip installing certain gem group by using
+      # $ rhc env set BUNDLE_WITHOUT="group1 group2 ..."
+      #
+      if [ -z "${BUNDLE_WITHOUT}" ]; then
+        echo "bundle install --deployment --path ./app-root/repo/vendor/bundle"
+        if groups_in_gemfile ${OPENSHIFT_REPO_DIR}/Gemfile; then
+          echo "NOTE: You can prevent installing certain Gemfile group using: rhc env set BUNDLE_WITHOUT=groupname"
         fi
-        if ruby_in_development_mode; then
-          echo "NOTE: Skipping 'bundle install' because running in development mode."
-          return 0
-        fi
-        pushd ${OPENSHIFT_REPO_DIR} 1> /dev/null
-          SAVED_GIT_DIR=$GIT_DIR
-          unset GIT_DIR
-          # You can tell bundler to skip installing certain gem group by using
-          # $ rhc env set BUNDLE_WITHOUT="group1 group2 ..."
-          #
-          echo "Bundling RubyGems based on Gemfile/Gemfile.lock to repo/vendor/bundle..."
-          if [ -z "${BUNDLE_WITHOUT}" ]; then
-            echo "bundle install --deployment"
-            echo "NOTE: You can prevent installing certain Gemfile group using: rhc env set BUNDLE_WITHOUT=groupname"
-            ruby_context "bundle install --deployment"
-          else
-            echo "bundle install --deployment --without '${BUNDLE_WITHOUT}'"
-            ruby_context "bundle install --deployment --without '${BUNDLE_WITHOUT}'"
-          fi
-          export GIT_DIR=$SAVED_GIT_DIR
-        popd 1> /dev/null
+        ruby_context "bundle install --deployment"
+      else
+        echo "bundle install --deployment --without '${BUNDLE_WITHOUT}' --path ./app-root/repo/vendor/bundle"
+        ruby_context "bundle install --deployment --without '${BUNDLE_WITHOUT}'"
+      fi
+      export GIT_DIR=$SAVED_GIT_DIR
+      popd 1> /dev/null
     fi
 }
 

--- a/cartridges/openshift-origin-cartridge-ruby/lib/util
+++ b/cartridges/openshift-origin-cartridge-ruby/lib/util
@@ -14,15 +14,9 @@ function ruby_in_development_mode {
 # speed up deployment.
 #
 function update_gemfile_sum {
-
   local gemfile_md5_file="${OPENSHIFT_RUBY_DIR}tmp/.gemfile_md5sum"
-
   pushd $OPENSHIFT_REPO_DIR 1>/dev/null
-  if [ -f Gemfile.lock ]; then
-    md5sum Gemfile Gemfile.lock > "${gemfile_md5_file}"
-  else
-    md5sum Gemfile > "${gemfile_md5_file}"
-  fi
+  [ -f Gemfile.lock ] && md5sum Gemfile.lock > "${gemfile_md5_file}"
   popd 1>/dev/null
 }
 
@@ -57,8 +51,7 @@ function gemfile_is_modified {
 
   local gemfile_md5_file="${OPENSHIFT_RUBY_DIR}tmp/.gemfile_md5sum"
 
-  [ ! -f "${OPENSHIFT_REPO_DIR}Gemfile" ] && return 1
-  [ ! -f "${OPENSHIFT_REPO_DIR}Gemfile.lock" ] && return 1
+  [ ! -f "${OPENSHIFT_REPO_DIR}Gemfile.lock" ] && return 0
 
   if [ ! -f "${gemfile_md5_file}" ]; then
     update_gemfile_sum
@@ -114,8 +107,7 @@ function update_passenger_performance {
 }
 
 function httpd_with_env {
-  ruby_context "RAILS_ENV=${RAILS_ENV:-production} /usr/sbin/httpd -C 'Include \
-  $OPENSHIFT_RUBY_DIR/etc/conf.d/*.conf' -f $HTTPD_CFG_FILE -k $1"
+  ruby_context "RAILS_ENV=${RAILS_ENV:-production} /usr/sbin/httpd $HTTPD_CMD_CONF -k $1"
 }
 
 function parse_args {

--- a/cartridges/openshift-origin-cartridge-ruby/lib/util
+++ b/cartridges/openshift-origin-cartridge-ruby/lib/util
@@ -28,6 +28,14 @@ function update_rails_env {
   fi
 }
 
+function groups_in_gemfile {
+  if grep -q "^group " "$1"; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 # Apache is in development mode when the RAILS_ENV is set to the development.
 #
 function httpd_in_development_mode {

--- a/cartridges/openshift-origin-cartridge-ruby/lib/util
+++ b/cartridges/openshift-origin-cartridge-ruby/lib/util
@@ -62,20 +62,13 @@ function gemfile_is_modified {
 
   if [ ! -f "${gemfile_md5_file}" ]; then
     update_gemfile_sum
-    return 1
+    return 0
   else
     pushd $OPENSHIFT_REPO_DIR 1>/dev/null
     md5sum --status --check "${gemfile_md5_file}"
-    success=$?
+    is_modified=$?
     popd 1>/dev/null
-
-    # md5sum returns '1' when the Gemfile(.lock) was modified
-    #
-    if [ "$success" == "1" ]; then
-      return 0
-    else
-      return 1
-    fi
+    return `[ "$is_modified" == "1" ] && echo 0 || echo 1`
   fi
 }
 
@@ -114,6 +107,15 @@ function update-configuration {
         echo -n "${GEM_HOME}/bin" > $OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_PATH_ELEMENT
         ;;
     esac
+}
+
+function update_passenger_performance {
+  oo-erb ${OPENSHIFT_RUBY_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
+}
+
+function httpd_with_env {
+  ruby_context "RAILS_ENV=${RAILS_ENV:-production} /usr/sbin/httpd -C 'Include \
+  $OPENSHIFT_RUBY_DIR/etc/conf.d/*.conf' -f $HTTPD_CFG_FILE -k $1"
 }
 
 function parse_args {


### PR DESCRIPTION
- Refactored httpd start in control script
- Fixed wrong return code from gemfile_is_modified() to handle first git push
- Prevent running bundle install --deployment when there was no modification to a Gemfile/Gemfile.lock in git push.
- Prevent running `bundle exec rake -T` to check if there is a 'assets:precompile' if there is no `rails` in Gemfile (speed up deployment of non-Rails applications)
