### PR TITLE
fix php cart PEAR builds

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -73,29 +73,29 @@ function tidy() {
 }
 
 function build() {
-    echo "Building PHP cartridge"
+    # Force clean build (.openshift/markers/force_clean_build)
     if force_clean_build_enabled_for_latest_deployment; then
-      echo "force_clean_build enabled - recreating pear libs" 1>&2
-      mkdir -p "${OPENSHIFT_PHP_DIR}"/phplib/pear/{docs,ext,php,cache,cfg,data,download,temp,tests,www}
+      echo "Force clean build enabled - recreating PEARs"
+      mkdir -p ${OPENSHIFT_PHP_DIR}phplib/pear/{docs,ext,php,cache,cfg,data,download,temp,tests,www}
     fi
 
+    # PEAR
     if [ -f ${OPENSHIFT_REPO_DIR}deplist.txt ]
     then
+        echo "Checking deplist.txt for PEAR dependency.."
         for f in $(cat ${OPENSHIFT_REPO_DIR}deplist.txt)
         do
-            echo "Checking pear: $f"
-            echo
-            if php_context "pear list '$f'" > /dev/null
-            then
-                php_context "pear upgrade '$f'"
-            elif ! ( php_context "php -c ${OPENSHIFT_PHP_DIR}conf -m | grep -i -q \^`basename '$f'`\$" )
-            then
-                php_context "pear install --alldeps '$f'"
+            echo -e "Checking PEAR: $f\n"
+            if ! php_context "pear info '$f' >/dev/null"; then
+              php_context "pear install --alldeps '$f'"
             else
-                echo "Extension already installed in the system: $f"
+              php_context "pear upgrade --alldeps '$f'" || :
             fi
-            # Remove gear-specific absolute paths from the generated PEAR files
-            find ${OPENSHIFT_PHP_DIR}phplib/pear/pear/ -type f ! -name '.*' -exec sed -i "s|${OPENSHIFT_HOMEDIR}|~/|g" {} \;
+            echo
+            # Remove gear-specific absolute paths from the generated PEAR
+            # files except from the hidden dirs/files (cache, registry etc.)
+            find ${OPENSHIFT_PHP_DIR}phplib/pear/pear/ -type f \( ! -regex '.*/\..*' \) \
+              -exec sed -i "s|${OPENSHIFT_HOMEDIR}|~/|g" {} \;
         done
     fi
 }

--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -8,19 +8,28 @@ HTTPD_CFG_DIR=$OPENSHIFT_PHP_DIR/configuration/etc/conf.d
 HTTPD_PASSENV_FILE=$HTTPD_CFG_DIR/passenv.conf
 HTTPD_PID_FILE=$OPENSHIFT_PHP_DIR/run/httpd.pid
 
-function apache() {
-    if [ "$1" != "stop" ]; then
-      write_httpd_passenv $HTTPD_PASSENV_FILE
-      oo-erb ${OPENSHIFT_PHP_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
-    fi
+function start() {
+    echo "Starting PHP ${OPENSHIFT_PHP_VERSION} cartridge (Apache+mod_php)"
+    write_httpd_passenv $HTTPD_PASSENV_FILE
+    oo-erb ${OPENSHIFT_PHP_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
-    php_context "/usr/sbin/httpd -C 'Include $HTTPD_CFG_DIR/*.conf' -f $HTTPD_CFG_FILE -k $1"
-    ret=$?
-    [ "$ret" == "0" -a "$1" == "start" ] && wait_for_pid_file $HTTPD_PID_FILE
-    return $ret
+    php_context "/usr/sbin/httpd -C 'Include $HTTPD_CFG_DIR/*.conf' -f $HTTPD_CFG_FILE -k start" \
+      && wait_for_pid_file $HTTPD_PID_FILE
+    return $?
+}
+
+function reload() {
+    echo "Reloading PHP ${OPENSHIFT_PHP_VERSION} cartridge (Apache+mod_php)"
+    write_httpd_passenv $HTTPD_PASSENV_FILE
+    oo-erb ${OPENSHIFT_PHP_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
+    ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
+    php_context "/usr/sbin/httpd -C 'Include $HTTPD_CFG_DIR/*.conf' -f $HTTPD_CFG_FILE -k graceful" \
+      && wait_for_pid_file $HTTPD_PID_FILE
+    return $?
 }
 
 function restart() {
+    echo "Restarting PHP ${OPENSHIFT_PHP_VERSION} cartridge (Apache+mod_php)"
     write_httpd_passenv $HTTPD_PASSENV_FILE
     oo-erb ${OPENSHIFT_PHP_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
@@ -30,18 +39,19 @@ function restart() {
 }
 
 function stop() {
+    echo "Stopping PHP ${OPENSHIFT_PHP_VERSION} cartridge (Apache+mod_php)"
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     if [ -f "$HTTPD_PID_FILE" ]; then
       # If we still have a PID file, then ensure_valid_httpd_process's call to
       # killall_httpds didn't happen.
       httpd_pid=`cat "$HTTPD_PID_FILE" 2> /dev/null`
-      php_context "/usr/sbin/httpd -C 'Include $HTTPD_CFG_DIR/*.conf' -f $HTTPD_CFG_FILE -k stop"
-      wait_for_stop $httpd_pid
+      php_context "/usr/sbin/httpd -C 'Include $HTTPD_CFG_DIR/*.conf' -f $HTTPD_CFG_FILE -k stop" \
+        && wait_for_stop $httpd_pid
     fi
 }
 
 function configtest() {
-    client_message "Testing Apache *.conf files"
+    echo "Testing Apache *.conf files"
     php_context "/usr/sbin/httpd -C 'Include $HTTPD_CFG_DIR/*.conf' -f $HTTPD_CFG_FILE -t"
     return $?
 }
@@ -51,20 +61,15 @@ function status() {
    then
       client_result "Application is running"
       client_result $output
-      return 0
    else
       client_result "Application is either stopped or inaccessible"
-      # FIXME: We should return 1 once we can handle non-zero return statuses
-      #        (This should be possible after we remove the v1 logic completely)
-      return 0
    fi
 }
 
 function tidy() {
-    client_message "Emptying log dir: $OPENSHIFT_PHP_LOG_DIR"
+    echo "Emptying log dir: $OPENSHIFT_PHP_LOG_DIR"
     shopt -s dotglob
-    rm -rf $OPENSHIFT_PHP_LOG_DIR/*
-    return 0
+    rm -rf $OPENSHIFT_PHP_LOG_DIR/* || :
 }
 
 function build() {
@@ -93,19 +98,17 @@ function build() {
             find ${OPENSHIFT_PHP_DIR}phplib/pear/pear/ -type f ! -name '.*' -exec sed -i "s|${OPENSHIFT_HOMEDIR}|~/|g" {} \;
         done
     fi
-    return 0
 }
 
 case "$1" in
-  start)           echo "Starting PHP cartridge";   apache start ;;
-  stop)            echo "Stopping PHP cartridge";   stop ;;
-  restart)         echo "Restarting PHP cartridge"; restart ;;
-  reload|graceful) echo "Reloading PHP cartridge";  apache graceful ;;
+  start)           start ;;
+  stop)            stop ;;
+  restart)         restart ;;
+  reload|graceful) reload ;;
   status)          status ;;
   configtest)      configtest ;;
   tidy)            tidy ;;
   build)           build ;;
-  deploy)          exit 0 ;; # Nothing to deploy on template PHP cartridge
   *)               exit 0
 esac
 

--- a/cartridges/openshift-origin-cartridge-php/versions/shared/configuration/etc/conf.d/openshift.conf.erb
+++ b/cartridges/openshift-origin-cartridge-php/versions/shared/configuration/etc/conf.d/openshift.conf.erb
@@ -1,16 +1,14 @@
 ServerRoot "<%= ENV['OPENSHIFT_PHP_DIR'] %>"
-DocumentRoot "<%= "#{ENV['OPENSHIFT_REPO_DIR']}/php" %>"
+DocumentRoot "<%= "#{ENV['OPENSHIFT_REPO_DIR']}php" %>"
 Listen <%= "#{ENV['OPENSHIFT_PHP_IP']}:#{ENV['OPENSHIFT_PHP_PORT']}" %>
 User  <%= ENV['OPENSHIFT_GEAR_UUID'] %>
 Group <%= ENV['OPENSHIFT_GEAR_UUID'] %>
-ErrorLog "<%= "|/usr/sbin/rotatelogs #{ENV['OPENSHIFT_PHP_DIR']}/logs/error_log-%Y%m%d-%H%M%S-%Z 86400" %>"
-CustomLog "<%= "|/usr/sbin/rotatelogs #{ENV['OPENSHIFT_PHP_DIR']}/logs/access_log-%Y%m%d-%H%M%S-%Z 86400" %>" combined
+ErrorLog "<%= "|/usr/sbin/rotatelogs #{ENV['OPENSHIFT_PHP_DIR']}logs/error_log-%Y%m%d-%H%M%S-%Z 86400" %>"
+CustomLog "<%= "|/usr/sbin/rotatelogs #{ENV['OPENSHIFT_PHP_DIR']}logs/access_log-%Y%m%d-%H%M%S-%Z 86400" %>" combined
 <IfVersion >= 2.4>
-DefaultRuntimeDir "<%= "#{ENV['OPENSHIFT_PHP_DIR']}/run"%>"
+DefaultRuntimeDir "<%= "#{ENV['OPENSHIFT_PHP_DIR']}run"%>"
 </IfVersion>
-php_value include_path "<%= ".:#{ENV['OPENSHIFT_REPO_DIR']}/libs/:#{ENV['OPENSHIFT_PHP_DIR']}/phplib/pear/pear/php/:/usr/share/pear/"%>"
 
-<Directory "<%= "#{ENV['OPENSHIFT_REPO_DIR']}/php" %>">
+<Directory "<%= "#{ENV['OPENSHIFT_REPO_DIR']}php" %>">
   AllowOverride All
 </Directory>
-

--- a/cartridges/openshift-origin-cartridge-php/versions/shared/configuration/etc/php.ini.erb
+++ b/cartridges/openshift-origin-cartridge-php/versions/shared/configuration/etc/php.ini.erb
@@ -782,10 +782,7 @@ default_mimetype = "text/html"
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; UNIX: "/path1:/path2"
-;include_path = ".:/php/includes"
-;
-; Windows: "\path1;\path2"
-;include_path = ".;c:\php\includes"
+include_path = "<%= ".:#{ENV['OPENSHIFT_REPO_DIR']}libs/:#{ENV['OPENSHIFT_PHP_DIR']}phplib/pear/pear/php/:/usr/share/pear/"%>"
 ;
 ; PHP's default setting for include_path is ".;/path/to/php/pear"
 ; http://www.php.net/manual/en/ini.core.php#ini.include-path
@@ -872,7 +869,7 @@ file_uploads = On
 ; specified).
 ; http://www.php.net/manual/en/ini.core.php#ini.upload-tmp-dir
 
-upload_tmp_dir = "<%= "#{ENV['OPENSHIFT_PHP_DIR']}/tmp/" %>"
+upload_tmp_dir = "<%= "#{ENV['OPENSHIFT_PHP_DIR']}tmp/" %>"
 
 ; Maximum allowed size for uploaded files.
 ; http://www.php.net/manual/en/ini.core.php#ini.upload-max-filesize
@@ -1268,7 +1265,7 @@ session.save_handler = files
 ; where MODE is the octal representation of the mode. Note that this
 ; does not overwrite the process's umask.
 ; http://www.php.net/manual/en/session.configuration.php#ini.session.save-path
-session.save_path = "<%= "#{ENV['OPENSHIFT_PHP_DIR']}/sessions/" %>"
+session.save_path = "<%= "#{ENV['OPENSHIFT_PHP_DIR']}sessions/" %>"
 
 ; Whether to use cookies.
 ; http://www.php.net/manual/en/session.configuration.php#ini.session.use-cookies


### PR DESCRIPTION
1. php control script cleanup
2. fix php cart PEAR builds
   
   > ```
   > - ignore checking for php extensions, as they're not PEARs
   > - do not fail on upgrading PEAR to the same specific version
   > - upgrade each PEAR with all dependencies
   > - prevent malforming PEAR cache&registry files
   > 
   > Bug 1047473 - Fail to install missing dependencies to PHP-5.4 app via
   > deplist.txt - https://bugzilla.redhat.com/show_bug.cgi?id=1047473
   > 
   > Bug 1045338 - Failed to create drupal quickstart with php-5.4 cartridge
   > in INT - https://bugzilla.redhat.com/show_bug.cgi?id=1045338
   > 
   > Bug 1046048 - Mail PEAR causes errors during deploy, no email
   > capabilities - https://bugzilla.redhat.com/show_bug.cgi?id=1046048
   > 
   > Bug 977036 - PHP gear creating throwing PEAR warnings to platform
   > logs - https://bugzilla.redhat.com/show_bug.cgi?id=977036
   > ```
3.  fix php-cli include_path; config cleanup    
   
   > ```
   > - Fix include_path when php is invoked from command line
   > - Remove double-slashes from Apache/PHP configuration files
   > ```
