### PR TITLE
Fix MySQL 5.1 failed to start issue + more verbose error reporting.

### DIFF
--- a/cartridges/openshift-origin-cartridge-mysql/bin/control
+++ b/cartridges/openshift-origin-cartridge-mysql/bin/control
@@ -4,6 +4,7 @@ source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_MYSQL_DIR}/lib/mysql_context"
 
 export STOPTIMEOUT=10
+export OPENSHIFT_MYSQL_VERSION=$(mysql_version)
 
 # Run mysql commands
 function run_sql {

--- a/cartridges/openshift-origin-cartridge-mysql/bin/control
+++ b/cartridges/openshift-origin-cartridge-mysql/bin/control
@@ -31,9 +31,10 @@ function is_running {
 # Start mysqld and block until it comes up.
 function start {
   if ! is_running; then
-    echo "Starting MySQL cartridge"
+    echo "Starting MySQL ${OPENSHIFT_MYSQL_VERSION} cartridge"
+    rm -f $OPENSHIFT_MYSQL_DB_LOG_DIR/*.log
     oo-erb conf/my.cnf.erb.hidden > conf/my.cnf
-    mysql_context "/usr/bin/mysqld_safe --defaults-file=$OPENSHIFT_MYSQL_DIR/conf/my.cnf" > /dev/null 2>&1 &
+    mysql_context "/usr/bin/mysqld_safe --defaults-file=$OPENSHIFT_MYSQL_DIR/conf/my.cnf > $OPENSHIFT_MYSQL_DB_LOG_DIR/mysql_start.log 2>&1" &
     wait_for_mysqld_availability
   else
     echo "MySQL already running" 1>&2
@@ -55,8 +56,12 @@ function wait_for_mysqld_availability {
     sleep 1
   done
 
-  echo "Details from MySQL error log:"
-  tail -n 200 $OPENSHIFT_MYSQL_DB_LOG_DIR/mysql_error.log
+  # Send error logs to console, otherwise the logs file will be erased
+  # when MySQL server fail to start.
+  #
+  echo "MySQL server failed to start:"
+  [ -f ${OPENSHIFT_MYSQL_DB_LOG_DIR}/mysql_start.log ] && cat $OPENSHIFT_MYSQL_DB_LOG_DIR/mysql_start.log
+  [ -f ${OPENSHIFT_MYSQL_DB_LOG_DIR}/mysql_error.log ] && cat $OPENSHIFT_MYSQL_DB_LOG_DIR/mysql_error.log
   exit 1
 }
 
@@ -65,7 +70,7 @@ function stop {
     pidfile=$OPENSHIFT_MYSQL_DIR/pid/mysql.pid
 
     if [ -f $pidfile ]; then
-      echo "Stopping MySQL cartridge"
+      echo "Stopping MySQL ${OPENSHIFT_MYSQL_VERSION} cartridge"
       pid=$( /bin/cat $pidfile )
       /bin/kill $pid
       ret=$?

--- a/cartridges/openshift-origin-cartridge-mysql/bin/install
+++ b/cartridges/openshift-origin-cartridge-mysql/bin/install
@@ -8,13 +8,6 @@ case "$1" in
     version="$2"
 esac
 
-# Add OPENSHIFT_MYSQL_VERSION variable to help mysql_context
-# choose the right version. Also need to be exported for install.
-#
-env_dir="${OPENSHIFT_MYSQL_DIR}/env"
-set_env_var 'OPENSHIFT_MYSQL_VERSION' $version $env_dir
-export OPENSHIFT_MYSQL_VERSION=$version
-
 # Generate username, password, and db name and create env variables
 echo 'Generating username and password'
 
@@ -33,7 +26,7 @@ mysql_data_dir="${OPENSHIFT_MYSQL_DIR}/data"
 mysql_context "/usr/bin/mysql_install_db --datadir=${mysql_data_dir} --user=${USER}" || error 'Failed to create mysqldb', 119
 
 client_result ""
-client_result "MySQL ${OPENSHIFT_MYSQL_VERSION} database added.  Please make note of these credentials:"
+client_result "MySQL ${version} database added.  Please make note of these credentials:"
 client_result ""
 client_result "       Root User: $username"
 client_result "   Root Password: $password"

--- a/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb
+++ b/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb
@@ -10,7 +10,7 @@
 # ft_max_word_len -> OPENSHIFT_MYSQL_FT_MAX_WORD_LEN
 
 [mysqld]
-datadir=<%= ENV['OPENSHIFT_MYSQL_DIR'] %>/data/
+datadir=<%= ENV['OPENSHIFT_MYSQL_DIR'] %>data/
 socket=<%= ENV['OPENSHIFT_MYSQL_DB_SOCKET'] %>
 bind-address=<%= ENV['OPENSHIFT_MYSQL_DB_HOST'] %>
 # Disabling symbolic-links is recommended to prevent assorted security risks
@@ -45,8 +45,8 @@ innodb_flush_log_at_trx_commit = 1
 innodb_lock_wait_timeout = 50
 
 [mysqld_safe]
-log-error=<%= ENV['OPENSHIFT_MYSQL_DB_LOG_DIR'] %>/mysql_error.log
-pid-file=<%= ENV['OPENSHIFT_MYSQL_DIR'] %>/pid/mysql.pid
+log-error=<%= ENV['OPENSHIFT_MYSQL_DB_LOG_DIR'] %>mysql_error.log
+pid-file=<%= ENV['OPENSHIFT_MYSQL_DIR'] %>pid/mysql.pid
 
 [mysqldump]
 quick

--- a/cartridges/openshift-origin-cartridge-mysql/lib/mysql_context.fedora
+++ b/cartridges/openshift-origin-cartridge-mysql/lib/mysql_context.fedora
@@ -17,8 +17,12 @@ function update_configuration {
     esac
 }
 
+function mysql_version {
+  echo ${OPENSHIFT_MYSQL_IDENT} | cut -d':' -f3
+}
+
 function mysql_context {
-  case $OPENSHIFT_MYSQL_VERSION in
+  case $(mysql_version) in
     5.5) eval $1 ;;
   esac
 }

--- a/cartridges/openshift-origin-cartridge-mysql/lib/mysql_context.rhel
+++ b/cartridges/openshift-origin-cartridge-mysql/lib/mysql_context.rhel
@@ -30,8 +30,12 @@ function update_configuration {
     esac
 }
 
+function mysql_version {
+  echo ${OPENSHIFT_MYSQL_IDENT} | cut -d':' -f3
+}
+
 function mysql_context {
-  case $OPENSHIFT_MYSQL_VERSION in
+  case $(mysql_version) in
     5.1) eval $1 ;;
     5.5) /usr/bin/scl enable mysql55 "/opt/rh/mysql55/root/$1" ;;
   esac


### PR DESCRIPTION
This patch add more verbose output to console in case the MySQL server fail to start. This might help to debug various issues, like corrupted database, wrong database version and so.

This should fix these BZ:
- https://bugzilla.redhat.com/show_bug.cgi?id=1045342
- https://bugzilla.redhat.com/show_bug.cgi?id=1051651
