### PR TITLE
Bug 1052928 - make the exception clear in case of a conflicting uuid during a move

### DIFF
--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -284,7 +284,7 @@ module OpenShift
           end
           if district_uuid && district_uuid != 'NONE'
             reserved_uid = District::reserve_uid(district_uuid, preferred_uid)
-            raise OpenShift::OOException.new("uid could not be reserved in target district '#{district_uuid}'.  Please ensure the target district has available capacity.") unless reserved_uid
+            raise OpenShift::OOException.new("uid could not be reserved in target district '#{district_uuid}'.  Please ensure the target district has available capacity or does not contain a conflicting uid.") unless reserved_uid
           end
         end
         reserved_uid


### PR DESCRIPTION
Just making the exception more clear. Today when moving an app I was confused about the capacity error when it was in fact a duplicate uuid.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1052928
