### PR TITLE
Bug 1053471 Parse a string to multiple env vars of an array of hashes

### DIFF
--- a/controller/app/controllers/applications_controller.rb
+++ b/controller/app/controllers/applications_controller.rb
@@ -80,7 +80,7 @@ class ApplicationsController < BaseController
     end
 
     user_env_vars = params[:environment_variables].presence
-    Application.validate_user_env_variables(user_env_vars, true)
+    user_env_vars = Application.validate_user_env_variables(user_env_vars, true)
 
     init_git_url = params[:initial_git_url].presence
     if init_git_url

--- a/controller/app/controllers/emb_cart_controller.rb
+++ b/controller/app/controllers/emb_cart_controller.rb
@@ -33,7 +33,7 @@ class EmbCartController < BaseController
     gear_size = params[:gear_size] rescue nil
 
     user_env_vars = params[:environment_variables].presence
-    Application.validate_user_env_variables(user_env_vars, true)
+    user_env_vars = Application.validate_user_env_variables(user_env_vars, true)
 
     cart_urls = []
     cmap = {}

--- a/controller/app/controllers/environment_variables_controller.rb
+++ b/controller/app/controllers/environment_variables_controller.rb
@@ -47,7 +47,7 @@ class EnvironmentVariablesController < BaseController
       rest_env_var = get_rest_environment_variable(env_var)
       return render_success(:created, "environment-variable", rest_env_var, "Added environment variable '#{name}' to application #{@application.name}", result)
     else
-      Application.validate_user_env_variables(user_env_vars)
+      user_env_vars = Application.validate_user_env_variables(user_env_vars)
       result = @application.patch_user_env_variables(user_env_vars)
       set_vars, unset_vars = Application.sanitize_user_env_variables(user_env_vars)
       rest_env_vars = set_vars.map {|ev| get_rest_environment_variable(ev)}

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -2843,6 +2843,11 @@ class Application
 
   def self.validate_user_env_variables(user_env_vars, no_delete=false)
     if user_env_vars.present?
+      begin
+        user_env_vars = YAML.load(user_env_vars)
+      rescue Exception => e
+        raise OpenShift::UserException.new("Invalid param format: expected YAML", 186, "environment_variables")
+      end
       if !user_env_vars.is_a?(Array) or !user_env_vars[0].is_a?(Hash)
         raise OpenShift::UserException.new("Invalid environment variables: expected array of hashes", 186, "environment_variables")
       end
@@ -2861,6 +2866,8 @@ class Application
         set_vars, unset_vars = sanitize_user_env_variables(user_env_vars)
         raise OpenShift::UserException.new("Environment variable deletion not allowed for this operation", 193, "environment_variables") unless unset_vars.empty?
       end
+
+      return user_env_vars
     end
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1053471

When setting multiple env vars with SET_UNSET_ENVIRONMENT_VARIABLES API, and in the runtime of
adding cartridges(ADD_CARTRIDGE) or creating apps(ADD_APPLICATION), user_env_vars is passed as
a raw string, and thus, the variable cannot be recoganized as an array of hashes. The fixes
include:
1. parse user_env_vars and return the parsed data (Application.validate_user_env_variables)
2. modify the methods invoking Application.validate_user_env_variables (
   EnvironmentVariablesController, ApplicationsController, EmbCartController)
