### PR TITLE
Hide small app type icon in origin and

### DIFF
--- a/console/app/assets/stylesheets/_iconfont.scss
+++ b/console/app/assets/stylesheets/_iconfont.scss
@@ -140,6 +140,9 @@ dl.font-icon-legend {
     width: 15px;
     font-size: $smallFontSize;
     color: $grayMedium;
+    .label-premium {
+      @include usage_rate_indicator()
+    }
   }
   &.font-icon-legend-large {
     dd {

--- a/console/app/assets/stylesheets/_mixins.scss
+++ b/console/app/assets/stylesheets/_mixins.scss
@@ -141,6 +141,10 @@
   font-family: openshift-icon;
 }
 
+@mixin usage_rate_indicator() {
+  font-size: 14px;
+}
+
 @mixin iconfont-adjust($size-offset: 6, $left: 0, $margin-right: 0) {
   font-size: $tileHeadingIconFontSize - $size-offset;
   left: $left;

--- a/console/app/assets/stylesheets/console/_tile.scss
+++ b/console/app/assets/stylesheets/console/_tile.scss
@@ -34,14 +34,18 @@
       display: table-cell;
       vertical-align: middle;
       &:last-child {
-        width: 45px;
+        width: 50px;
         text-align: right;
-        .font-icon {
+        span {
           font-size: 13px;
           cursor: help;
+          margin-right: 5px;
           &:last-child {
-            margin-left: 6px;
+            margin-right: 0;
           }
+        }
+        .label-premium {
+          @include usage_rate_indicator()
         }
       }
     }
@@ -181,6 +185,7 @@
     display: inline-block;
     vertical-align: middle;
     margin-top: 0;
+    line-height: 1.5;
   }
 } 
 

--- a/console/app/helpers/console/layout_helper.rb
+++ b/console/app/helpers/console/layout_helper.rb
@@ -340,4 +340,8 @@ module Console::LayoutHelper
     opts = logo_data_icon_for item
     content_tag :span, "", :class => opts[:class], "data-icon" => opts[:data_icon].html_safe, :title => opts[:title], "aria-hidden" => "true"
   end
+
+  def show_small_app_type_icon?()
+    false
+  end
 end

--- a/console/app/views/application_types/_application_type.html.haml
+++ b/console/app/views/application_types/_application_type.html.haml
@@ -22,7 +22,7 @@
     %p.help-block= link_to type.website, type.website
 
   .tile-meta
-    %dl{:class => 'font-icon-legend'}
+    %dl.font-icon-legend
       - if type.support_type == :openshift
         %dt
           %span.icon-star-empty{"aria-hidden" => "true", :title => "OpenShift maintained"}
@@ -36,7 +36,7 @@
 
       - if type.usage_rates?
         %dt
-          %span.icon-dollar.label-premium{"aria-hidden" => "true", "title" => "Usage rates"}
+          = usage_rate_indicator
         %dd 
           May include additional usage fees at certain levels, see plan for details.
 

--- a/console/app/views/application_types/_tile.html.haml
+++ b/console/app/views/application_types/_tile.html.haml
@@ -7,18 +7,19 @@
       %h3
         = link_to type.display_name, application_type_path(type), :class => 'tile-target'
 
-        - if type.usage_rates?
-          = usage_rate_indicator
-
       = application_type_tags(type.tags - excluded_tags)
 
       - if type.tags.include?(:in_development)
         %p This type is in development and will not be visible in production.
     .tile-table-cell
+      - if type.usage_rates?
+        = usage_rate_indicator
+
       - if type.automatic_updates?
         %span.font-icon{"aria-hidden" => "true", "data-icon" => "\uee50", "title" => "Receives automatic security updates"}
-
-      - if type.cartridge?
-        %span.font-icon{"aria-hidden" => "true", "data-icon" => "\ue021", "title" => "Cartridge"}
-      - elsif type.quickstart?
-        %span.font-icon{"aria-hidden" => "true", "data-icon" => "\ue029", "title" => "QuickStart"}
+      
+      - if show_small_app_type_icon?
+        - if type.cartridge?
+          %span.font-icon{"aria-hidden" => "true", "data-icon" => "\ue021", "title" => "Cartridge"}
+        - elsif type.quickstart?
+          %span.font-icon{"aria-hidden" => "true", "data-icon" => "\ue029", "title" => "QuickStart"}

--- a/console/app/views/application_types/show.html.haml
+++ b/console/app/views/application_types/show.html.haml
@@ -49,7 +49,7 @@
 
 
           .help-block
-            %dl{:class => 'font-icon-legend'}
+            %dl.font-icon-legend
               - if @application_type.support_type == :openshift
                 %dt
                   %span.icon-star-empty{"aria-hidden" => "true", :title => "OpenShift maintained"}
@@ -63,7 +63,7 @@
 
               - if @application_type.usage_rates?
                 %dt
-                  %span.icon-dollar.label-premium{"aria-hidden" => "true", "title" => "Usage rates"}
+                  = usage_rate_indicator
                 %dd 
                   May include additional usage fees at certain levels, see plan for details.
 


### PR DESCRIPTION
Reverting back to use usage_rate_indicator
Added mixin to adjust $ sign size to match related group icon size
Minor haml change
