### PR TITLE
Various iptables integration fixes

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -987,6 +987,39 @@ class OODiag
     WANT
   end
 
+  def test_missing_iptables_config
+    skip_test unless @is_node
+    iptables_conf = '/etc/sysconfig/iptables'
+    return if File.exists? iptables_conf
+
+    do_fail <<-BUG
+      #{iptables_conf} is missing.  Rebooting this system will likely lead to a
+      broken firewall.  Ensure that the openshift-iptables-port-proxy service
+      is running and all critical services are currently allowed by the running
+      firewall then run 'service iptables save'.
+    BUG
+  end
+
+  def test_system_config_firewall
+    skip_test unless @is_node
+    conf_file = '/etc/sysconfig/system-config-firewall'
+
+    `grep enabled #{conf_file}`
+     have_system_config_firewall = 0 == $?.to_i
+     if have_system_config_firewall
+       do_warn <<-WARN
+         Using system-config-firewall and lokkit with OpenShift is not recommended.
+         To continue using lokkit people ensure the following custom rules are 
+         installed in #{conf_file}:
+
+         --custom-rules=ipv4:filter:/etc/openshift/system-config-firewall-compat
+         --custom-rules=ipv4:filter:/etc/openshift/iptables.filter.rules
+         --custom-rules=ipv4:nat:/etc/openshift/iptables.nat.rules
+       WARN
+     end
+    
+  end
+
   def test_node_quota_bug
     skip_test unless @is_node && @os_is[:rhel6]
     verbose "testing for quota creation failure bug"

--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -1009,7 +1009,7 @@ class OODiag
      if have_system_config_firewall
        do_warn <<-WARN
          Using system-config-firewall and lokkit with OpenShift is not recommended.
-         To continue using lokkit people ensure the following custom rules are 
+         To continue using lokkit please ensure the following custom rules are 
          installed in #{conf_file}:
 
          --custom-rules=ipv4:filter:/etc/openshift/system-config-firewall-compat

--- a/node/misc/etc/system-config-firewall-compat
+++ b/node/misc/etc/system-config-firewall-compat
@@ -1,0 +1,5 @@
+# WARNING: It is not recommended to use system-config-firewall post OpenShift
+# installation.  This file is intended to save admins from accidentally causing
+# an outage.
+-N rhc-app-comm
+-A INPUT -j rhc-app-comm

--- a/node/misc/sbin/oo-admin-ctl-iptables-port-proxy
+++ b/node/misc/sbin/oo-admin-ctl-iptables-port-proxy
@@ -42,11 +42,11 @@ check_firewall() {
     iptables -L | grep 'rhc-app-comm  all' >/dev/null 2>&1
     RETVAL=$?
     if [ ! $RETVAL -eq 0 ]; then
-        echo "ERROR: rhc-app-comm chain not found.  Check /etc/sysconfig/iptables." 1>&2
+        echo "ERROR: rhc-app-comm INPUT rule not found.  Check /etc/sysconfig/iptables." 1>&2
         if [ $FALLBACK ]; then
             iptables -N rhc-app-comm
-            iptables -A INPUT -j rhc-app-comm
-            echo "WARNING: The chain has been temporarily added."
+            iptables -I INPUT 1 -j rhc-app-comm
+            echo "WARNING: The INPUT rule has been temporarily added."
         else
             exit 1
         fi

--- a/node/misc/sbin/oo-admin-ctl-iptables-port-proxy
+++ b/node/misc/sbin/oo-admin-ctl-iptables-port-proxy
@@ -10,6 +10,8 @@ RULES_FILE="/etc/openshift/iptables.filter.rules"
 NAT_FILE="/etc/openshift/iptables.nat.rules"
 
 start() {
+    check_firewall true
+
     ROUTE_LOCALNET=`sysctl -n net.ipv4.conf.all.route_localnet`
     if [ $ROUTE_LOCALNET -eq "0" ]; then
         echo "WARNING: net.ipv4.conf.all.route_localnet must be enabled." 1>&2
@@ -34,6 +36,23 @@ stop() {
     iptables -t nat -F
 }
 
+check_firewall() {
+    FALLBACK=$1
+
+    iptables -L | grep 'rhc-app-comm  all' >/dev/null 2>&1
+    RETVAL=$?
+    if [ ! $RETVAL -eq 0 ]; then
+        echo "ERROR: rhc-app-comm chain not found.  Check /etc/sysconfig/iptables." 1>&2
+        if [ $FALLBACK ]; then
+            iptables -N rhc-app-comm
+            iptables -A INPUT -j rhc-app-comm
+            echo "WARNING: The chain has been temporarily added."
+        else
+            exit 1
+        fi
+    fi
+}
+
 case "$1" in
     start)
         start
@@ -42,6 +61,8 @@ case "$1" in
         stop
         ;;
     status)
+        check_firewall
+
         if [ ! -f $RULES_FILE ]; then
             echo "ERROR: $RULES_FILE does not exist." 1>&2
             exit 1
@@ -61,7 +82,10 @@ case "$1" in
 
         NAT_ASSERTED=`grep DNAT $NAT_FILE | wc -l`
         NAT=`iptables -t nat -L | grep DNAT | wc -l`
-        if [ ! $NAT_ASSERTED -eq $NAT ]; then
+        # Bug 1040824 - We can't assume the openshift nat rules are the only ones
+        # running.  For that reason we only alert if there are more OpenShift NAT
+        # rules than what we see actually running.
+        if [ $NAT_ASSERTED -gt $NAT ]; then
             echo "ERROR: A difference has been detected between state of $NAT_FILE and the NAT table." 1>&2
             exit 1
         fi

--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -151,6 +151,8 @@ mv %{buildroot}%{gem_instdir}/misc/services/openshift-tc.service %{buildroot}/et
 mv %{buildroot}%{gem_instdir}/misc/services/openshift-iptables-port-proxy.service %{buildroot}/etc/systemd/system/openshift-iptables-port-proxy.service
 %endif
 
+cp %{buildroot}%{gem_instdir}/misc/etc/system-config-firewall-compat %{buildroot}/etc/openshift/
+
 # Don't install or package what's left in the misc directory
 rm -rf %{buildroot}%{gem_instdir}/misc
 rm -rf %{buildroot}%{gem_instdir}/.yardoc
@@ -227,6 +229,7 @@ fi
 %attr(0755,-,-) %{openshift_lib}/cartridge_sdk/ruby
 %attr(0744,-,-) %{openshift_lib}/cartridge_sdk/ruby/*
 %dir /etc/openshift
+%attr(0644,-,-) %config /etc/openshift/system-config-firewall-compat
 %config(noreplace) /etc/openshift/node.conf
 %attr(0600,-,-) %config(noreplace) /etc/openshift/iptables.filter.rules
 %attr(0600,-,-) %config(noreplace) /etc/openshift/iptables.nat.rules


### PR DESCRIPTION
- oo-diagnostics will warn if /etc/sysconfig/iptables is missing
- oo-diagnostics will advise admins not to use lokkit (and offer helpful advice
  if they must)
- oo-admin-ctl-iptables-port-proxy will ensure the rhc-app-comm chain exist
- oo-admin-ctl-iptables-port-proxy's status method was improved to better handle custom NAT rules

This is to address:

Bug 1032798 - unable to create scaled app because of misconfigured iptables method
Bug 1027122 - Running lokkit tools on node will block openshift-iptables-port-proxy service starting.
Bug 1053639 - Following deployment instructions for OSE2.0 node seems to cause iptables issues with openshift-iptables-port-proxy service start

The latter has been very problematic because manual installs would tell users
to run a sed command.  If commands are copied wrong or out of order it can lead
to a broken setup.  Lokkit commands are much easier to copy/paste from a wiki.
