### PR TITLE
Bug 1005123

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -88,9 +88,6 @@ function pre-repo-archive() {
     echo 'Saving away previously bundled RubyGems'
     mv ${OPENSHIFT_REPO_DIR}.bundle ${OPENSHIFT_RUBY_DIR}/tmp/
     mv ${OPENSHIFT_REPO_DIR}vendor ${OPENSHIFT_RUBY_DIR}/tmp/
-  else
-    # Remove last Gemfile checkum file to force bundler to run.
-    rm -rf ${OPENSHIFT_RUBY_DIR}tmp/.gemfile_md5sum
   fi
 }
 
@@ -119,6 +116,10 @@ function build() {
     # If a Gemfile is committed and it is modified, then bundle install
     #
     if [ -f ${OPENSHIFT_REPO_DIR}/Gemfile ]; then
+      if force_clean_build_enabled_for_latest_deployment; then
+        # Remove last Gemfile checksum file to force bundler to run.
+        rm -f ${OPENSHIFT_RUBY_DIR}tmp/.gemfile_md5sum
+      fi
       if ! gemfile_is_modified; then
         echo "NOTE: Skipping 'bundle install' because Gemfile is not modified."
         return 0

--- a/cartridges/openshift-origin-cartridge-ruby/lib/util
+++ b/cartridges/openshift-origin-cartridge-ruby/lib/util
@@ -69,7 +69,15 @@ function gemfile_is_modified {
     md5sum --status --check "${gemfile_md5_file}"
     is_modified=$?
     popd 1>/dev/null
-    return `[ "$is_modified" == "1" ] && echo 0 || echo 1`
+
+    if [ "$is_modified" == "1" ]; then
+      # make sure we update the checksum!
+      update_gemfile_sum
+
+      return 0
+    fi
+
+    return 1
   fi
 }
 


### PR DESCRIPTION
Move deletion of checksum file for Gemfile.lock from pre-repo-archive to
build because pre-repo-archive isn't invoked when using a builder
cartridge, meaning that force_clean_build wouldn't always be respected.

Update the checksum file if it changes, so future checksum comparisons
will evaluate correctly.
