### PR TITLE
Bug 1049044 - Restore setting ssh config settings for gear

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/setup.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/setup.rb
@@ -178,6 +178,8 @@ module OpenShift
           FileUtils.touch(known_hosts)
           FileUtils.touch(ssh_config)
 
+          set_rw_permission_R(ssh_dir)
+
           FileUtils.chmod(0600, [ssh_key, ssh_public_key])
           FileUtils.chmod(0660, [known_hosts, ssh_config])
 


### PR DESCRIPTION
- Setting the file permissions was incorrectly removed
- https://bugzilla.redhat.com/show_bug.cgi?id=1049044#c8
