### PR TITLE
Tolerate custom cartridges in the broker in the console

### DIFF
--- a/console/app/assets/stylesheets/_forms.scss
+++ b/console/app/assets/stylesheets/_forms.scss
@@ -719,6 +719,9 @@ legend + .control-group {
     &:first-child {
       *padding-left: $horizontalComponentOffset;
     }
+    .inline:first-child {
+      padding-top: 5px;
+    }
   }
   // Remove bottom margin on block level help text since that's accounted for on .control-group
   .help-block {

--- a/console/app/assets/stylesheets/console/_base.scss
+++ b/console/app/assets/stylesheets/console/_base.scss
@@ -39,12 +39,8 @@ dl {
     margin-bottom: $baseLineHeight / 3;
   }
   dd {
-    margin: 0 0 $baseLineHeight + 7 $baseLineHeight; 
+    margin: 0 0 $baseLineHeight + 7 $baseLineHeight;
     font-size: $baseFontSize;
-    a {
-      color: inherit;
-      font-style: italic;
-    }
   }
 }
 

--- a/console/app/assets/stylesheets/console/_tile.scss
+++ b/console/app/assets/stylesheets/console/_tile.scss
@@ -97,14 +97,14 @@
       margin-bottom: $baseLineHeight / 2;
     }
   }
-  &.application_type, &.embedded {
+  &.application_type, &.cartridge_type {
     .tile-table-cell {
       &:first-child {
         width:55px;
       }
     }
   }
-  &.embedded {
+  &.cartridge_type {
     .tile-table-cell {
       &:first-child {
         width:50px;
@@ -121,7 +121,7 @@
       font-size: $smallFontSize;
     }
   }
-  &.embedded {
+  &.cartridge_type {
     padding: 10px 20px 15px 20px;
   }
   > p {

--- a/console/app/helpers/console/layout_helper.rb
+++ b/console/app/helpers/console/layout_helper.rb
@@ -71,7 +71,7 @@ module Console::LayoutHelper
     classes << 'control-group-important' if opts[:important]
     data = if opts[:errors] || args.first == true
         classes << 'error'
-        {:server_error => true}    
+        {:server_error => true}
       end
     content_tag(:div, capture_haml{ yield }.html_safe, :class => classes.join(' '), :data => data)
   end

--- a/console/app/models/application_type.rb
+++ b/console/app/models/application_type.rb
@@ -114,7 +114,7 @@ class ApplicationType
   end
 
   def automatic_updates?
-    cartridge? && !tags.include?(:community)
+    automatic_updates.nil? ? (cartridge && !tags.include?(:community)) : automatic_updates
   end
 
   def cartridge?; source == :cartridge; end
@@ -211,6 +211,8 @@ class ApplicationType
   end
 
   protected
+    attr_accessor :automatic_updates
+
     def self.find_single(id, *arguments)
       case (match = /^([^!]+)!(.+)/.match(id) || [])[1]
       when 'quickstart'; from_quickstart(Quickstart.cached.find match[2])
@@ -258,6 +260,8 @@ class ApplicationType
       [:display_name, :tags, :description, :website, :version, :license, :license_url, :help_topics, :priority, :scalable, :usage_rates].each do |m|
         attrs[m] = type.send(m)
       end
+      attrs[:provider] = type.support_type
+      attrs[:automatic_updates] = type.automatic_updates?
       attrs[:cartridges] = [type.name]
 
       new(attrs, type.persisted?)
@@ -267,7 +271,7 @@ class ApplicationType
       [:display_name, :tags, :description, :website, :initial_git_url, :cartridges_spec, :priority, :scalable, :may_not_scale, :learn_more_url, :provider].each do |m|
         attrs[m] = type.send(m)
       end
-
+      attrs[:automatic_updates] = false
       new(attrs, type.persisted?)
     end
 

--- a/console/app/models/cartridge_type.rb
+++ b/console/app/models/cartridge_type.rb
@@ -62,7 +62,7 @@ class CartridgeType < RestApi::Base
   end
 
   def to_param
-    url || name
+    name || url
   end
 
   def url_suggested_name
@@ -81,6 +81,23 @@ class CartridgeType < RestApi::Base
     name.presence || url
   rescue
     url
+  end
+
+  def support_type
+    @support_type ||=
+      if vendor = @attributes[:vendor].presence
+        vendor == 'redhat' ? :openshift : :community
+      else
+        :community
+      end
+  end
+
+  def automatic_updates?
+    v = @attributes[:automatic_updates]
+    if v.nil?
+      v = !(tags.include?('no_updates') || custom?)
+    end
+    v
   end
 
   # Legacy, use #tags

--- a/console/app/views/cartridge_types/_cartridge_type.html.haml
+++ b/console/app/views/cartridge_types/_cartridge_type.html.haml
@@ -3,7 +3,7 @@
 - extra_info = extra_info if defined? extra_info
 - hide_link = hide_link if defined? hide_link
 
-- classes = "tile #{cartridge_type.tags.join(' ')}"
+- classes = "tile cartridge_type #{cartridge_type.tags.join(' ')}"
 - classes += " inactive" if inactive
 - classes += " tile-click" unless inactive or hide_link
 = div_for cartridge_type, :class => classes do
@@ -20,56 +20,73 @@
           = cartridge_type.display_name
         - else
           = link_to cartridge_type.display_name, application_cartridge_type_path(application, cartridge_type), :class => 'tile-target'
-        
+
         - if cartridge_type.usage_rates?
           = usage_rate_indicator
-
-  - if cartridge_type.custom?
-    %p
-      This cartridge will be downloaded into your application.  The cart will have access to all of your application data - be sure this is what you really want to do!
-
-    %p.text-warning Downloaded cartridges do not receive updates automatically
-
-  - if extra_info
-    %ul.unstyled.meta
-
-      -if cartridge_type.custom?
-        %li.url
-          %label URL:
-          %span= cartridge_type.url
-
-      -# if cartridge_type.license
-        %li.license
-          %label License:
-          - if cartridge_type.respond_to? :license_url
-            = link_to cartridge_type.license, cartridge_type.license_url
-          - else
-            %span= cartridge_type.license
-
-      - if cartridge_type.website
-        %li.website
-          %label Website:
-          = link_to cartridge_type.website, cartridge_type.website
-
-      - if cartridge_type.version
-        %li.version
-          %label Version:
-          %span= cartridge_type.version
 
   - if not (inactive and reason == :installed) and cartridge_type.description.present?
     = show_description cartridge_type.description
 
+  - if extra_info
+
+    .tile-meta
+      %dl.font-icon-legend
+        -if cartridge_type.custom?
+          %dt
+          %dd
+            URL:
+            = cartridge_type.url
+
+        -# if cartridge_type.license
+          %dt
+          %dd
+            License:
+            - if cartridge_type.respond_to? :license_url
+              = link_to cartridge_type.license, cartridge_type.license_url
+            - else
+              = cartridge_type.license
+
+        - if cartridge_type.website.present?
+          %dt
+          %dd
+            Website:
+            = link_to cartridge_type.website, cartridge_type.website
+
+        -# if cartridge_type.version.present?
+          %dt
+          %dd
+            Version:
+            = cartridge_type.version
+
+        - if cartridge_type.support_type == :openshift
+          %dt
+            %span.icon-star-empty{"aria-hidden" => "true", :title => "OpenShift maintained"}
+          %dd{:title => 'Updated and maintained by the OpenShift team'} OpenShift maintained
+
+        - if cartridge_type.automatic_updates?
+          %dt
+            %span.icon-shield{"aria-hidden" => "true", "title" => "Security updates"}
+          %dd
+            Receives automatic security updates
+        - elsif cartridge_type.custom?
+          %dt
+          %dd.text-warning Downloaded cartridges do not receive updates automatically
+
+        - if cartridge_type.usage_rates?
+          %dt
+            = usage_rate_indicator
+          %dd
+            May include additional usage fees at certain levels, see plan for details.
+
+    -if cartridge_type.provides
+      %div
+        %h4 What you get:
+        %ul
+          - cartridge_type.provides.each do |provided|
+            %li= provided
+
   - if cartridge_type.learn_more_url
     = link_to "Learn more", cartridge_type.learn_more_url
-  - elsif cartridge_type.custom?
-    = link_to "Learn more", downloadable_cartridges_help_url
-
-  - if extra_info and cartridge_type.provides
-    %div
-      %h4 What you get:
-      %ul
-        - cartridge_type.provides.each do |provided|
-          %li= provided
 
   - if reason
     - case reason

--- a/console/app/views/cartridge_types/index.html.haml
+++ b/console/app/views/cartridge_types/index.html.haml
@@ -21,7 +21,7 @@
         %form.form-inline{:method => :get, :action => application_cartridge_type_path(@application, 'custom')}
           %p You may also add your own cartridges by providing a link to a #{link_to 'downloadable cartridge', downloadable_cartridges_help_url}.  OpenShift will download and install the cart into your application.  Remember that downloaded cartridges will not automatically receive updates.
 
-          %input{:type => :text, :name => :url, :placeholder => 'URL to a cartridge definition'}
+          %input.span6{:type => :text, :name => :url, :placeholder => 'URL to a cartridge definition'}
           %input.btn{:type => :submit, :value => 'Next', :title => 'Download a cartridge into this app'}
 
   - unless @installed.empty? and @requires.empty? and @conflicts.empty? and @blocked.empty?

--- a/console/app/views/cartridge_types/show.html.haml
+++ b/console/app/views/cartridge_types/show.html.haml
@@ -21,17 +21,13 @@
   = f.semantic_errors
 
   = f.inputs :class => 'inputs form-horizontal add-cartridge' do
-    = control_group(false, :important => true) do  
-      %h3.control-label Gear Size
-      .controls
+    = control_group(false) do
+      .control-label Using Gear Size
+      .controls.cartridge_gear_size
         - if @gear_sizes.length > 1
           = f.select :gear_size, @gear_sizes.map{ |size| [size.to_s.titleize, size]}, {}
         - else
-          %h3.cartridge_gear_size= @gear_sizes.first.to_s.titleize
-          -#%span.icon-question-sign{'aria-hidden'=>"true"}
-          -#.popover-cartridge-gear-sizes.hide
-          -#  .left
-          -#    %h2 Gear resources
+          .inline= @gear_sizes.first.to_s.titleize
 
   %p
     Do you want to add the
@@ -41,6 +37,11 @@
       - else
         = @cartridge_type.display_name
     cartridge to your application?
+
+  - if @cartridge_type.custom?
+    .alert.alert-info
+      This cartridge will be downloaded into your application.  The cart will have access to all of your application data - be sure this is what you really want to do!
+      = link_to "Learn more", downloadable_cartridges_help_url
 
   = f.buttons do
     = link_to "Back", @wizard ? application_cartridge_types_path(@application) : application_path(@application), :class => 'btn'

--- a/console/test/functional/cartridge_types_controller_test.rb
+++ b/console/test/functional/cartridge_types_controller_test.rb
@@ -80,8 +80,8 @@ class CartridgeTypesControllerTest < ActionController::TestCase
     assert assigns(:application)
 
     assert_select 'h3', 'bar'
-    assert_select 'p', /This cartridge will be downloaded/
-    assert_select 'span', 'https://foo.com#bar'
+    assert_select '.alert', /This cartridge will be downloaded/
+    assert_select 'dd', %r(https://foo.com#bar)
     assert_select '.text-warning', /Downloaded cartridges do not receive updates automatically/
     assert_select 'a[href=https://foo.com#bar]', 'bar'
     assert_select ".indicator-gear-increase", "+0"
@@ -97,8 +97,8 @@ class CartridgeTypesControllerTest < ActionController::TestCase
     assert assigns(:application)
 
     assert_select 'h3', 'bar'
-    assert_select 'p', /This cartridge will be downloaded/
-    assert_select 'span', 'http://foo.com#bar'
+    assert_select '.alert', /This cartridge will be downloaded/
+    assert_select 'dd', %r(http://foo.com#bar)
     assert_select '.text-warning', /Downloaded cartridges do not receive updates automatically/
     assert_select 'a[href=http://foo.com#bar]', 'bar'
     assert_select ".indicator-gear-increase", "+0"
@@ -114,10 +114,10 @@ class CartridgeTypesControllerTest < ActionController::TestCase
     assert assigns(:application)
 
     assert_select 'h3', 'bar'
-    assert_select 'p', /This cartridge will be downloaded/
-    assert_select 'span', 'https://foo.com#bar'
-    assert_select '.text-warning', /Downloaded cartridges do not receive updates automatically/
+    assert_select '.alert', /This cartridge will be downloaded/
+    assert_select 'dd', %r(https://foo.com#bar)
     assert_select 'a[href=https://foo.com#bar]', 'bar'
+    assert_select '.text-warning', /Downloaded cartridges do not receive updates automatically/
     assert_select ".indicator-gear-increase", /\+0\-1\b/
   end
 


### PR DESCRIPTION
React more appropriately to a custom cart showing up in the app types list and
the cart types list.  Other small view / behavior tweaks.

@liggitt review please
