### PR TITLE
Add depends on bind-utils for oo-diagnostics

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -418,6 +418,18 @@ class OODiag
 
   def prereq_domain_resolves
     skip_test unless @is_broker or @is_node
+
+    `which host`
+    have_host_command = 0 == $?.to_i
+    unless have_host_command
+      do_warn <<-WARN
+         The host command is not available. This command is not required; however, you
+         may install it, by installing the bind-utils package, to enable further
+         diagnostics checking.
+      WARN
+    end
+    skip_test unless have_host_command
+
     verbose "checking that we can resolve our application domain"
 
     domain = @is_broker ? Rails.configuration.openshift[:domain_suffix]

--- a/common/rubygem-openshift-origin-common.spec
+++ b/common/rubygem-openshift-origin-common.spec
@@ -42,6 +42,8 @@ BuildRequires: %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
 %endif
 BuildRequires: %{?scl:%scl_prefix}rubygems
 BuildRequires: %{?scl:%scl_prefix}rubygems-devel
+# For the prereq_domain_resolves check in oo-diagnostics:
+Requires:      bind-utils
 BuildArch:     noarch
 Provides:      rubygem(%{gem_name}) = %version
 


### PR DESCRIPTION
oo-diagnostics uses the host command, which is in the bind-utils package, so make rubygem-openshift-origin-common, which includes the oo-diagnostics command, depend on the bind-utils package.

The above can be a problem on an OpenShift node host, where there may be no other package installed that pulls in the bind-utils package.  On an OpenShift broker host, the rubygem-openshift-origin-dns-nsupdate and openshift-origin-broker-util packages will pull in the bind-utils package.

To be extra safe, add a check in prereq_domain_resolves to warn and skip the test if the host command cannot be found.

This commit fixes bug 1058527.
