### PR TITLE
User Guide: s/deptlist.txt/deplist.txt/

### DIFF
--- a/documentation/oo_user_guide.adoc
+++ b/documentation/oo_user_guide.adoc
@@ -305,7 +305,7 @@ OpenShift Origin also supports the ability for a user to schedule jobs to be ran
 The markers directory will allow the user to specify settings such as enabling hot deployments or which version of Java to use.
 
 ==== The libs directory
-The libs directory is a location where the developer can provide any dependencies that are not able to be deployed using the standard dependency resolution system for the selected runtime. In the case of PHP, the standard convention that OpenShift Origin uses is providing _PEAR_ modules in the deptlist.txt file.
+The libs directory is a location where the developer can provide any dependencies that are not able to be deployed using the standard dependency resolution system for the selected runtime. In the case of PHP, the standard convention that OpenShift Origin uses is providing _PEAR_ modules in the deplist.txt file.
 
 ==== The misc directory
 The misc directory is a location provided to the developer to store any application code that they do not want exposed publicly.


### PR DESCRIPTION
Fix a typo in the OpenShift Origin User Guide: PHP uses "deplist.txt," not "deptlist.txt."
