### PR TITLE
Fix the Apache vhost plugin

### DIFF
--- a/plugins/frontend/README.frontend_httpd_plugins.md
+++ b/plugins/frontend/README.frontend_httpd_plugins.md
@@ -141,7 +141,7 @@ The frontend configuration must be wiped out.
 
 Remove and install frontend plugin packages as necessary.
 
-    rpm -e rubygem-openshift-origin-frontend-apache-mod-rewrite
+    rpm --nodeps -e rubygem-openshift-origin-frontend-apache-mod-rewrite
     yum -y install rubygem-openshift-origin-frontend-apache-vhost
 
 
@@ -155,7 +155,7 @@ Change the value of `OPENSHIFT_FRONTEND_HTTP_PLUGINS` in
 `/etc/openshift/node.conf` and restart mcollective.
 
     vi /etc/openshift/node.conf
-    service mcollective restart
+    service ruby193-mcollective restart
 
 
 Finally, rebuild the working http frontend configuration from the

--- a/plugins/frontend/apache-vhost/httpd/frontend-vhost-http-template.erb
+++ b/plugins/frontend/apache-vhost/httpd/frontend-vhost-http-template.erb
@@ -19,7 +19,7 @@
 
   # Log custom format for OpenShift parsing.
   # Log format is:
-  LogFormat "%h %{V_MATCH_HOST}e %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" openshift
+  LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" openshift
   CustomLog logs/openshift_log openshift
 
   ProxyTimeout 300

--- a/plugins/frontend/apache-vhost/httpd/frontend-vhost-https-template.erb
+++ b/plugins/frontend/apache-vhost/httpd/frontend-vhost-https-template.erb
@@ -32,7 +32,7 @@
 
   # Log custom format for OpenShift parsing.
   # Log format is:
-  LogFormat "%h %{V_MATCH_HOST}e %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" openshift
+  LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" openshift
   CustomLog logs/openshift_log openshift
 
   ProxyTimeout 300

--- a/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
+++ b/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
@@ -419,8 +419,8 @@ module OpenShift
               ::OpenShift::Runtime::Frontend::Http::Plugins::reload_httpd
             end
 
-            def with_lock_and_reload
-              self.class.with_lock_and_reload
+            def with_lock_and_reload(&block)
+              self.class.with_lock_and_reload(&block)
             end
 
           end


### PR DESCRIPTION
Fix bug in the Apache vhost plugin that prevented it from functioning.

Change V_MATCH_HOST to %v in custom access log format so the server name
is included in the log (V_MATCH_HOST is only available when using the
mod rewrite plugin).

Correct a couple of issues in the frontend httpd plugins readme.

Bug 1058849
