### PR TITLE
<httpd carts> bug 1060068: ensure extra httpd conf dirs exist

### DIFF
--- a/cartridges/openshift-origin-cartridge-perl/openshift-origin-cartridge-perl.spec
+++ b/cartridges/openshift-origin-cartridge-perl/openshift-origin-cartridge-perl.spec
@@ -1,4 +1,5 @@
 %global cartridgedir %{_libexecdir}/openshift/cartridges/perl
+%global httpdconfdir /etc/openshift/cart.conf.d/httpd/perl
 
 Name:          openshift-origin-cartridge-perl
 Version: 1.19.1
@@ -51,6 +52,7 @@ Perl cartridge for OpenShift. (Cartridge Format V2)
 %install
 %__mkdir -p %{buildroot}%{cartridgedir}
 %__cp -r * %{buildroot}%{cartridgedir}
+%__mkdir -p %{buildroot}%{httpdconfdir}
 
 %if 0%{?fedora}%{?rhel} <= 6
 rm -rf %{buildroot}%{cartridgedir}/versions/5.16
@@ -69,6 +71,8 @@ rm %{buildroot}%{cartridgedir}/metadata/manifest.yml.*
 %doc %{cartridgedir}/README.md
 %doc %{cartridgedir}/COPYRIGHT
 %doc %{cartridgedir}/LICENSE
+%dir %{httpdconfdir}
+%attr(0755,-,-) %{httpdconfdir}
 
 
 %changelog

--- a/cartridges/openshift-origin-cartridge-php/openshift-origin-cartridge-php.spec
+++ b/cartridges/openshift-origin-cartridge-php/openshift-origin-cartridge-php.spec
@@ -1,5 +1,6 @@
 %global cartridgedir %{_libexecdir}/openshift/cartridges/php
 %global frameworkdir %{_libexecdir}/openshift/cartridges/php
+%global httpdconfdir /etc/openshift/cart.conf.d/httpd/php
 
 Name:          openshift-origin-cartridge-php
 Version: 1.20.1
@@ -82,6 +83,7 @@ PHP cartridge for openshift. (Cartridge Format V2)
 %__mkdir -p %{buildroot}%{cartridgedir}
 %__cp -r * %{buildroot}%{cartridgedir}
 %__mkdir -p %{buildroot}%{cartridgedir}/versions/shared/configuration/etc/conf/
+%__mkdir -p %{buildroot}%{httpdconfdir}
 
 %if 0%{?fedora}%{?rhel} <= 6
 %__mv %{buildroot}%{cartridgedir}/metadata/manifest.yml.rhel6 %{buildroot}%{cartridgedir}/metadata/manifest.yml
@@ -99,6 +101,8 @@ PHP cartridge for openshift. (Cartridge Format V2)
 %attr(0755,-,-) %{cartridgedir}/bin/
 %{cartridgedir}
 %doc %{cartridgedir}/README.md
+%dir %{httpdconfdir}
+%attr(0755,-,-) %{httpdconfdir}
 
 
 %changelog

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/openshift-origin-cartridge-phpmyadmin.spec
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/openshift-origin-cartridge-phpmyadmin.spec
@@ -1,4 +1,5 @@
 %global cartridgedir %{_libexecdir}/openshift/cartridges/phpmyadmin
+%global httpdconfdir /etc/openshift/cart.conf.d/httpd/phpmyadmin
 
 Summary:       phpMyAdmin support for OpenShift
 Name:          openshift-origin-cartridge-phpmyadmin
@@ -28,6 +29,7 @@ Provides phpMyAdmin cartridge support. (Cartridge Format V2)
 %install
 %__mkdir -p %{buildroot}%{cartridgedir}
 %__cp -r * %{buildroot}%{cartridgedir}
+%__mkdir -p %{buildroot}%{httpdconfdir}
 %if 0%{?fedora}%{?rhel} <= 6
 rm -rf %{buildroot}%{cartridgedir}/versions/3.5
 mv %{buildroot}%{cartridgedir}/metadata/manifest.yml.rhel %{buildroot}%{cartridgedir}/metadata/manifest.yml
@@ -49,6 +51,8 @@ ln -sf %{cartridgedir}/versions/shared/phpMyAdmin/config.inc.php %{_sysconfdir}/
 %doc %{cartridgedir}/README.md
 %doc %{cartridgedir}/COPYRIGHT
 %doc %{cartridgedir}/LICENSE
+%dir %{httpdconfdir}
+%attr(0755,-,-) %{httpdconfdir}
 
 %changelog
 * Thu Jan 30 2014 Adam Miller <admiller@redhat.com> 1.18.1-1

--- a/cartridges/openshift-origin-cartridge-python/openshift-origin-cartridge-python.spec
+++ b/cartridges/openshift-origin-cartridge-python/openshift-origin-cartridge-python.spec
@@ -1,4 +1,5 @@
 %global cartridgedir %{_libexecdir}/openshift/cartridges/python
+%global httpdconfdir /etc/openshift/cart.conf.d/httpd/python
 
 Name:          openshift-origin-cartridge-python
 Version: 1.20.1
@@ -83,6 +84,7 @@ Python cartridge for OpenShift. (Cartridge Format V2)
 %install
 %__mkdir -p %{buildroot}%{cartridgedir}
 %__cp -r * %{buildroot}%{cartridgedir}
+%__mkdir -p %{buildroot}%{httpdconfdir}
 
 %__mkdir -p %{buildroot}%{cartridgedir}/env
 
@@ -111,6 +113,8 @@ Python cartridge for OpenShift. (Cartridge Format V2)
 %files
 %dir %{cartridgedir}
 %attr(0755,-,-) %{cartridgedir}/bin/
+%dir %{httpdconfdir}
+%attr(0755,-,-) %{httpdconfdir}
 %if 0%{?fedora}%{?rhel} <= 6
 %attr(0755,-,-) %{cartridgedir}/usr/versions/2.6/bin/
 %attr(0755,-,-) %{cartridgedir}/usr/versions/2.6/bin/*

--- a/cartridges/openshift-origin-cartridge-ruby/openshift-origin-cartridge-ruby.spec
+++ b/cartridges/openshift-origin-cartridge-ruby/openshift-origin-cartridge-ruby.spec
@@ -4,6 +4,7 @@
 %endif
 
 %global cartridgedir %{_libexecdir}/openshift/cartridges/ruby
+%global httpdconfdir /etc/openshift/cart.conf.d/httpd/ruby
 
 Name:          openshift-origin-cartridge-ruby
 Version: 1.20.1
@@ -158,6 +159,7 @@ Ruby cartridge for OpenShift. (Cartridge Format V2)
 %install
 %__mkdir -p %{buildroot}%{cartridgedir}
 %__cp -r * %{buildroot}%{cartridgedir}
+%__mkdir -p %{buildroot}%{httpdconfdir}
 
 %if 0%{?fedora}%{?rhel} <= 6
 %__mv %{buildroot}%{cartridgedir}/versions/1.9-scl %{buildroot}%{cartridgedir}/versions/1.9
@@ -180,6 +182,8 @@ Ruby cartridge for OpenShift. (Cartridge Format V2)
 %doc %{cartridgedir}/README.md
 %doc %{cartridgedir}/COPYRIGHT
 %doc %{cartridgedir}/LICENSE
+%dir %{httpdconfdir}
+%attr(0755,-,-) %{httpdconfdir}
 
 %changelog
 * Thu Jan 30 2014 Adam Miller <admiller@redhat.com> 1.20.1-1


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1060068
httpd cartridges won't see new /etc/openshift/cart.conf.d dirs when restarted
