### PR TITLE
Enable syslog configurability for frontend access logging

### DIFF
--- a/plugins/frontend/apache-mod-rewrite/httpd/openshift_route.include
+++ b/plugins/frontend/apache-mod-rewrite/httpd/openshift_route.include
@@ -203,4 +203,13 @@ ProxyPassReverse ${V_MATCH_PATH} http://${V_ROUTE} interpolate
 # Log custom format for OpenShift parsing.
 # Log format is:
 LogFormat "%h %{V_MATCH_HOST}e %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X %{V_ROUTE}e%{V_PATH}e" openshift
-CustomLog logs/openshift_log openshift env=V_PATH
+
+#
+# If the `OpenShiftFrontendSyslogEnabled` option is defined, pipe output to syslog rather than a file.
+#
+<IfDefine OpenShiftFrontendSyslogEnabled>
+  CustomLog "|logger -t openshift-node-frontend" openshift env=V_PATH
+</IfDefine>
+<IfDefine !OpenShiftFrontendSyslogEnabled>
+  CustomLog logs/openshift_log openshift env=V_PATH
+</IfDefine>

--- a/plugins/frontend/apache-vhost/httpd/frontend-vhost-http-template.erb
+++ b/plugins/frontend/apache-vhost/httpd/frontend-vhost-http-template.erb
@@ -20,7 +20,16 @@
   # Log custom format for OpenShift parsing.
   # Log format is:
   LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" openshift
-  CustomLog logs/openshift_log openshift
+
+  #
+  # If the `OpenShiftFrontendSyslogEnabled` option is defined, pipe output to syslog rather than a file.
+  #
+  <IfDefine OpenShiftFrontendSyslogEnabled>
+    CustomLog "|logger -t openshift-node-frontend" openshift
+  </IfDefine>
+  <IfDefine !OpenShiftFrontendSyslogEnabled>
+    CustomLog logs/openshift_log openshift
+  </IfDefine>
 
   ProxyTimeout 300
 

--- a/plugins/frontend/apache-vhost/httpd/frontend-vhost-https-template.erb
+++ b/plugins/frontend/apache-vhost/httpd/frontend-vhost-https-template.erb
@@ -33,7 +33,16 @@
   # Log custom format for OpenShift parsing.
   # Log format is:
   LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" openshift
-  CustomLog logs/openshift_log openshift
+
+  #
+  # If the `OpenShiftFrontendSyslogEnabled` option is defined, pipe output to syslog rather than a file.
+  #
+  <IfDefine OpenShiftFrontendSyslogEnabled>
+    CustomLog "|logger -t openshift-node-frontend" openshift
+  </IfDefine>
+  <IfDefine !OpenShiftFrontendSyslogEnabled>
+    CustomLog logs/openshift_log openshift
+  </IfDefine>
 
   ProxyTimeout 300
 


### PR DESCRIPTION
Adding the `OpenShiftFrontendSyslogEnabled` configuration option to
httpd will enable gear access logging to syslog rather than a file.
