### PR TITLE
Add optional syslog support to Rails apps

### DIFF
--- a/broker/Gemfile
+++ b/broker/Gemfile
@@ -13,6 +13,7 @@ gem 'mongoid'
 gem 'bson'
 gem 'bson_ext'
 gem 'pry', :require => 'pry' if ENV['PRY']
+gem 'syslog-logger'
 # Fedora 19 splits psych out into its own gem.
 if Gem::Specification.respond_to?(:find_all_by_name) and not Gem::Specification::find_all_by_name('psych').empty?
   gem 'psych'

--- a/broker/Gemfile
+++ b/broker/Gemfile
@@ -13,7 +13,7 @@ gem 'mongoid'
 gem 'bson'
 gem 'bson_ext'
 gem 'pry', :require => 'pry' if ENV['PRY']
-gem 'syslog-logger'
+gem 'syslog-logger', '~> 1.6.8', :require => false
 # Fedora 19 splits psych out into its own gem.
 if Gem::Specification.respond_to?(:find_all_by_name) and not Gem::Specification::find_all_by_name('psych').empty?
   gem 'psych'

--- a/broker/conf/broker.conf
+++ b/broker/conf/broker.conf
@@ -137,3 +137,8 @@ ALLOW_OBSOLETE_CARTRIDGES="false"
 # Aliases of the form word-word.<domain> are rejected to prevent conflicts with app names.
 # Also this still will not create any DNS entry for the alias; that is an external step.
 ALLOW_ALIAS_IN_DOMAIN="false"
+
+# Whether to send OpenShift log messages to syslog or to files.
+# If true, messages that normally end up in the Rails environment-specific log
+# (e.g. production.rb), usage.log, and user_action.log will instead go to syslog.
+# SYSLOG_ENABLED="true"

--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -121,7 +121,5 @@ Broker::Application.configure do
     :http_proxy => conf.get('HTTP_PROXY', '')
   }
 
-  if config.openshift[:syslog_enabled]
-    config.logger = OpenShift::Syslog.logger_for('openshift-broker', 'app')
-  end
+  config.logger = OpenShift::Syslog.logger_for('openshift-broker', 'app') if config.openshift[:syslog_enabled]
 end

--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -100,7 +100,8 @@ Broker::Application.configure do
     :ha_dns_suffix => conf.get('HA_DNS_SUFFIX', ""),
     :valid_ssh_key_types => OpenShift::Controller::Configuration.parse_list(conf.get('VALID_SSH_KEY_TYPES', nil)),
     :allow_obsolete_cartridges => conf.get_bool('ALLOW_OBSOLETE_CARTRIDGES', "false"),
-    :allow_multiple_haproxy_on_node => conf.get_bool('ALLOW_MULTIPLE_HAPROXY_ON_NODE', "true")
+    :allow_multiple_haproxy_on_node => conf.get_bool('ALLOW_MULTIPLE_HAPROXY_ON_NODE', "true"),
+    :syslog_enabled => conf.get_bool('SYSLOG_ENAVLED', 'false')
   }
 
   config.auth = {
@@ -119,4 +120,8 @@ Broker::Application.configure do
     :connection_timeout => conf.get("CART_DOWNLOAD_CONN_TIMEOUT", "2").to_i,
     :http_proxy => conf.get('HTTP_PROXY', '')
   }
+
+  if config.openshift[:syslog_enabled]
+    config.logger = OpenShift::Syslog.logger_for('openshift-broker', 'app')
+  end
 end

--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -101,7 +101,7 @@ Broker::Application.configure do
     :valid_ssh_key_types => OpenShift::Controller::Configuration.parse_list(conf.get('VALID_SSH_KEY_TYPES', nil)),
     :allow_obsolete_cartridges => conf.get_bool('ALLOW_OBSOLETE_CARTRIDGES', "false"),
     :allow_multiple_haproxy_on_node => conf.get_bool('ALLOW_MULTIPLE_HAPROXY_ON_NODE', "true"),
-    :syslog_enabled => conf.get_bool('SYSLOG_ENAVLED', 'false')
+    :syslog_enabled => conf.get_bool('SYSLOG_ENABLED', 'false')
   }
 
   config.auth = {

--- a/broker/config/environments/production.rb
+++ b/broker/config/environments/production.rb
@@ -110,7 +110,5 @@ Broker::Application.configure do
     :http_proxy => conf.get('HTTP_PROXY', '')
   }
 
-  if config.openshift[:syslog_enabled]
-    config.logger = OpenShift::Syslog.logger_for('openshift-broker', 'app')
-  end
+  config.logger = OpenShift::Syslog.logger_for('openshift-broker', 'app') if config.openshift[:syslog_enabled]
 end

--- a/broker/config/environments/production.rb
+++ b/broker/config/environments/production.rb
@@ -89,7 +89,8 @@ Broker::Application.configure do
     :ha_dns_suffix => conf.get('HA_DNS_SUFFIX', ""),
     :valid_ssh_key_types => OpenShift::Controller::Configuration.parse_list(conf.get('VALID_SSH_KEY_TYPES', nil)),
     :allow_obsolete_cartridges => conf.get_bool('ALLOW_OBSOLETE_CARTRIDGES', "false"),
-    :allow_multiple_haproxy_on_node => conf.get_bool('ALLOW_MULTIPLE_HAPROXY_ON_NODE', "false")
+    :allow_multiple_haproxy_on_node => conf.get_bool('ALLOW_MULTIPLE_HAPROXY_ON_NODE', "false"),
+    :syslog_enabled => conf.get_bool('SYSLOG_ENABLED', 'false')
   }
 
   config.auth = {
@@ -108,4 +109,8 @@ Broker::Application.configure do
     :connection_timeout => conf.get("CART_DOWNLOAD_CONN_TIMEOUT", "2").to_i,
     :http_proxy => conf.get('HTTP_PROXY', '')
   }
+
+  if config.openshift[:syslog_enabled]
+    config.logger = OpenShift::Syslog.logger_for('openshift-broker', 'app')
+  end
 end

--- a/broker/config/environments/test.rb
+++ b/broker/config/environments/test.rb
@@ -98,7 +98,8 @@ Broker::Application.configure do
     :ha_dns_suffix => conf.get('HA_DNS_SUFFIX', ""),
     :valid_ssh_key_types => OpenShift::Controller::Configuration.parse_list(conf.get('VALID_SSH_KEY_TYPES', nil)),
     :allow_obsolete_cartridges => conf.get_bool('ALLOW_OBSOLETE_CARTRIDGES', "false"),
-    :allow_multiple_haproxy_on_node => conf.get_bool('ALLOW_MULTIPLE_HAPROXY_ON_NODE', "true")
+    :allow_multiple_haproxy_on_node => conf.get_bool('ALLOW_MULTIPLE_HAPROXY_ON_NODE', "true"),
+    :syslog_enabled => conf.get_bool('SYSLOG_ENABLED', 'false')
   }
 
   config.auth = {
@@ -115,5 +116,9 @@ Broker::Application.configure do
     :max_cart_size => conf.get("MAX_CART_SIZE", "20480").to_i,
     :max_download_time => conf.get("MAX_DOWNLOAD_TIME", "10").to_i
   }
+
+  if config.openshift[:syslog_enabled]
+    config.logger = OpenShift::Syslog.logger_for('openshift-broker', 'app')
+  end
 
 end

--- a/broker/config/environments/test.rb
+++ b/broker/config/environments/test.rb
@@ -117,8 +117,6 @@ Broker::Application.configure do
     :max_download_time => conf.get("MAX_DOWNLOAD_TIME", "10").to_i
   }
 
-  if config.openshift[:syslog_enabled]
-    config.logger = OpenShift::Syslog.logger_for('openshift-broker', 'app')
-  end
+  config.logger = OpenShift::Syslog.logger_for('openshift-broker', 'app') if config.openshift[:syslog_enabled]
 
 end

--- a/broker/config/initializers/extended_logger.rb
+++ b/broker/config/initializers/extended_logger.rb
@@ -6,28 +6,32 @@ end
 
 module OpenShift
   class Formatter
-    if Rails.env.development? or ENV['COLOR_LOGS']
+    if (Rails.env.development? or ENV['COLOR_LOGS']) and not Rails.configuration.openshift[:syslog_enabled]
       SEVERITY_TO_COLOR_MAP   = {'DEBUG'=>'0;37', 'INFO'=>'32', 'WARN'=>'33', 'ERROR'=>'31', 'FATAL'=>'31', 'UNKNOWN'=>'37'}
-  
+
       def call(severity, time, progname, msg)
         formatted_severity = sprintf("%-5s","#{severity}")
-  
+
         formatted_time = time.strftime("%Y-%m-%d %H:%M:%S.") << time.usec.to_s[0..2].rjust(3)
         color = SEVERITY_TO_COLOR_MAP[severity]
-  
+
         "\033[0;37m#{formatted_time}\033[0m [\033[#{color}m#{formatted_severity}\033[0m] #{msg.strip} (pid:#{$$})\n"
       end
-  
+
     else
-  
+
       def call(severity, time, progname, msg)
         formatted_severity = sprintf("%-5s","#{severity}")
-  
-        formatted_time = time.strftime("%Y-%m-%d %H:%M:%S.") << time.usec.to_s[0..2].rjust(3)
-  
-        "#{formatted_time} [#{formatted_severity}] #{msg.strip} (pid:#{$$})\n"
+
+        if Rails.configuration.openshift[:syslog_enabled]
+          "[#{formatted_severity}] src=app #{msg.strip}\n"
+        else
+          formatted_time = time.strftime("%Y-%m-%d %H:%M:%S.") << time.usec.to_s[0..2].rjust(3)
+
+          "#{formatted_time} [#{formatted_severity}] #{msg.strip} (pid:#{$$})\n"
+        end
       end
-  
+
     end
   end
 end

--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -97,6 +97,7 @@ Requires:      %{?scl:%scl_prefix}rubygem-tilt
 Requires:      %{?scl:%scl_prefix}rubygem-treetop
 Requires:      %{?scl:%scl_prefix}rubygem-tzinfo
 Requires:      %{?scl:%scl_prefix}rubygem-xml-simple
+Requires:      %{?scl:%scl_prefix}rubygem-syslog-logger
 
 %if %{with_systemd}
 Requires:      systemd-units

--- a/console/Gemfile
+++ b/console/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 gem 'pry', :require => 'pry' if ENV['PRY']
 gem 'perftools.rb', :require => 'perftools' if ENV['PERFTOOLS']
+gem 'syslog-logger', '~> 1.6.8', :require => false
 
 # NON-RUNTIME BEGIN
 

--- a/console/conf/console.conf.example
+++ b/console/conf/console.conf.example
@@ -122,3 +122,10 @@ CONSOLE_SECURITY=basic
 #
 # REMOTE_USER_COPY_HEADERS=X-Remote-User,Cookies
 
+
+#
+# Should log messages be sent to syslog instead of a log file
+#
+# Optional
+#
+# SYSLOG_ENABLED=true

--- a/console/config/initializers/extended_logger.rb
+++ b/console/config/initializers/extended_logger.rb
@@ -6,28 +6,32 @@ end
 
 module OpenShift
   class Formatter
-    if Rails.env.development? or ENV['COLOR_LOGS']
+    if (Rails.env.development? or ENV['COLOR_LOGS']) and not Console.config.syslog_enabled
       SEVERITY_TO_COLOR_MAP   = {'DEBUG'=>'0;37', 'INFO'=>'32', 'WARN'=>'33', 'ERROR'=>'31', 'FATAL'=>'31', 'UNKNOWN'=>'37'}
-  
+
       def call(severity, time, progname, msg)
         formatted_severity = sprintf("%-5s","#{severity}")
-  
+
         formatted_time = time.strftime("%Y-%m-%d %H:%M:%S.") << time.usec.to_s[0..2].rjust(3)
         color = SEVERITY_TO_COLOR_MAP[severity]
-  
+
         "\033[0;37m#{formatted_time}\033[0m [\033[#{color}m#{formatted_severity}\033[0m] #{msg.strip} (pid:#{$$})\n"
       end
-  
+
     else
-  
+
       def call(severity, time, progname, msg)
         formatted_severity = sprintf("%-5s","#{severity}")
-  
-        formatted_time = time.strftime("%Y-%m-%d %H:%M:%S.") << time.usec.to_s[0..2].rjust(3)
-  
-        "#{formatted_time} [#{formatted_severity}] #{msg.strip} (pid:#{$$})\n"
+
+        if Console.config.syslog_enabled
+          "[#{formatted_severity}] src=app #{msg.strip}\n"
+        else
+          formatted_time = time.strftime("%Y-%m-%d %H:%M:%S.") << time.usec.to_s[0..2].rjust(3)
+
+          "#{formatted_time} [#{formatted_severity}] #{msg.strip} (pid:#{$$})\n"
+        end
       end
-  
+
     end
   end
 end
@@ -35,14 +39,14 @@ end
 Rails.logger.formatter = OpenShift::Formatter.new
 
 if Rails.env.development? and not ENV['ASSET_LOGS']
-  Rails::Rack::Logger.class_eval do 
+  Rails::Rack::Logger.class_eval do
     def call_with_quiet_assets(env)
       previous_level = Rails.logger.level
-      Rails.logger.level = Logger::ERROR if env['PATH_INFO'].index("/assets/") == 0 
+      Rails.logger.level = Logger::ERROR if env['PATH_INFO'].index("/assets/") == 0
       call_without_quiet_assets(env).tap do
         Rails.logger.level = previous_level
-      end 
-    end 
-    alias_method_chain :call, :quiet_assets 
-  end 
+      end
+    end
+    alias_method_chain :call, :quiet_assets
+  end
 end

--- a/console/lib/console/configuration.rb
+++ b/console/lib/console/configuration.rb
@@ -38,6 +38,7 @@ module Console
     config_accessor :community_url
     config_accessor :cache_store
     config_accessor :prohibited_email_domains
+    config_accessor :syslog_enabled
 
     #
     # A class that represents the capabilities object
@@ -146,6 +147,11 @@ module Console
 
         self.prohibited_email_domains = config[:PROHIBITED_EMAIL_DOMAINS].split(',').map { |email| email.strip } rescue []
 
+        if self.syslog_enabled = config[:SYSLOG_ENABLED]
+          require 'syslog-logger'
+          Rails.configuration.logger = Logger::Syslog.new('openshift-console')
+        end
+
         if cache_store = config[:CACHE_STORE]
           Rails.configuration.send(:cache_store=, eval("[#{cache_store}]"))
         end
@@ -160,7 +166,7 @@ module Console
 
         if asset_host = config[:ASSET_HOST]
           Rails.configuration.action_controller.asset_host = asset_host
-        end        
+        end
 
         case config[:CONSOLE_SECURITY]
         when 'basic'

--- a/console/openshift-origin-console.gemspec
+++ b/console/openshift-origin-console.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'haml',                    '>= 3.1.7', '< 4.1'
   s.add_dependency 'rdiscount',               '> 1.6.3'
   s.add_dependency 'sass-twitter-bootstrap',  '~> 2.0.1'
-  s.add_dependency 'syslog-logger',           '~> 1.6.8'
 end

--- a/console/openshift-origin-console.gemspec
+++ b/console/openshift-origin-console.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'haml',                    '>= 3.1.7', '< 4.1'
   s.add_dependency 'rdiscount',               '> 1.6.3'
   s.add_dependency 'sass-twitter-bootstrap',  '~> 2.0.1'
+  s.add_dependency 'syslog-logger',           '~> 1.6.8'
 end

--- a/console/rubygem-openshift-origin-console.spec
+++ b/console/rubygem-openshift-origin-console.spec
@@ -35,6 +35,7 @@ Requires:      %{?scl:%scl_prefix}rubygems
 Requires:      %{?scl:%scl_prefix}rubygem(sass-rails)
 Requires:      %{?scl:%scl_prefix}rubygem(sass-twitter-bootstrap)
 Requires:      %{?scl:%scl_prefix}rubygem(uglifier)
+Requires:      %{?scl:%scl_prefix}rubygem(syslog-logger)
 
 %if 0%{?fedora}%{?rhel} <= 6
 BuildRequires: %{?scl:%scl_prefix}build
@@ -55,6 +56,7 @@ BuildRequires: %{?scl:%scl_prefix}rubygem(sass-twitter-bootstrap)
 BuildRequires: %{?scl:%scl_prefix}rubygem(sprockets)
 BuildRequires: %{?scl:%scl_prefix}rubygem(therubyracer)
 BuildRequires: %{?scl:%scl_prefix}rubygem(uglifier)
+BuildRequires: %{?scl:%scl_prefix}rubygem(syslog-logger)
 
 
 BuildRequires: %{?scl:%scl_prefix}rubygems-devel

--- a/controller/config/initializers/usage_audit_log.rb
+++ b/controller/config/initializers/usage_audit_log.rb
@@ -1,9 +1,15 @@
 if Rails.configuration.usage_tracking[:audit_log_enabled]
-  if file = Rails.configuration.usage_tracking[:audit_log_filepath]
+  logger = nil
+
+  if Rails.configuration.openshift[:syslog_enabled]
+    logger = OpenShift::Syslog.logger_for('openshift-broker', 'usage')
+  elsif file = Rails.configuration.usage_tracking[:audit_log_filepath]
     logger = Logger.new(file)
+
     logger.formatter = proc do |severity, datetime, progname, msg|
       "#{datetime}:: #{msg}\n"
     end
-    OpenShift::UsageAuditLog.logger = logger
   end
+
+  OpenShift::UsageAuditLog.logger = logger if logger
 end

--- a/controller/config/initializers/user_action_log.rb
+++ b/controller/config/initializers/user_action_log.rb
@@ -1,5 +1,7 @@
 if Rails.configuration.user_action_logging[:logging_enabled]
-  if file = Rails.configuration.user_action_logging[:log_filepath]
+  if Rails.configuration.openshift[:syslog_enabled]
+    OpenShift::UserActionLog.logger = OpenShift::Syslog.logger_for('openshift-broker', 'useraction')
+  elsif file = Rails.configuration.user_action_logging[:log_filepath]
     OpenShift::UserActionLog.logger = Logger.new(file)
   end
 end

--- a/controller/lib/openshift-origin-controller.rb
+++ b/controller/lib/openshift-origin-controller.rb
@@ -26,6 +26,7 @@ module OpenShift
   autoload :DataStore,                 'openshift/data_store'
   autoload :DistributedLock,           'openshift/distributed_lock'
   autoload :RoutingService,            'openshift/routing_service'
+  autoload :Syslog,                    'openshift/syslog'
 
   autoload :UserActionLog,             'openshift/user_action_log'
   autoload :UsageAuditLog,             'openshift/usage_audit_log'

--- a/controller/lib/openshift/syslog.rb
+++ b/controller/lib/openshift/syslog.rb
@@ -1,0 +1,12 @@
+module OpenShift
+  class Syslog
+    def self.logger_for(program_name, message_source)
+      require 'syslog-logger'
+      Logger::Syslog.new(program_name).tap do |logger|
+        logger.formatter = proc do |severity, datetime, progname, msg|
+          "#{severity} src=#{message_source} #{msg.strip}\n"
+        end
+      end
+    end
+  end
+end

--- a/openshift-console/Gemfile
+++ b/openshift-console/Gemfile
@@ -10,6 +10,7 @@ gem 'openshift-origin-console', :require => 'console', :path => ENV['CONSOLE_PAT
 gem 'rake', '> 0.9.2'
 gem 'pry', :require => 'pry' if ENV['PRY']
 gem 'perftools.rb', :require => 'perftools' if ENV['PERFTOOLS']
+gem 'syslog-logger', '~> 1.6.8', :require => false
 
 # NON-RUNTIME BEGIN
 


### PR DESCRIPTION
Add ability to send the broker log, usage log, user action log, and
console log to syslog (optional, disabled by default).
