### PR TITLE
Bug 1049089 - Speed up selinux labeling usage

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -784,6 +784,10 @@ module OpenShift
         @container_plugin.set_rw_permission(paths)
       end
 
+      def chcon(path, label = nil, type=nil, role=nil, user=nil)
+        @container_plugin.chcon(path, label, type, role, user)
+      end
+
       def memory_in_bytes
         @container_plugin.memory_in_bytes(@uuid)
       end

--- a/node/lib/openshift-origin-node/model/application_container_ext/ssh_authorized_keys.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/ssh_authorized_keys.rb
@@ -181,12 +181,6 @@ module OpenShift
                 keys[id] = entry
               end
             end
-
-            # set/reset the SELinux context for the .ssh directory
-            ssh_dir = PathUtils.join(@container.container_dir, "/.ssh")
-            cmd = "restorecon -R #{ssh_dir}"
-            ::OpenShift::Runtime::Utils::oo_spawn(cmd)
-
           end
 
           private
@@ -278,8 +272,9 @@ module OpenShift
                   end
                   file.close
                 end
-                @container.set_ro_permission(authorized_keys_file)
-                ::OpenShift::Runtime::Utils::oo_spawn("restorecon #{authorized_keys_file}")
+                PathUtils.oo_chown(0, @container.gid, authorized_keys_file)
+                @container.chcon(authorized_keys_file,
+                                      ::OpenShift::Runtime::Utils::SELinux.get_mcs_label(@container.uid))
               end
             end
             keys

--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -436,8 +436,6 @@ module OpenShift
       #
       #   v2_cart_model.do_unlock_gear(entries)
       def do_unlock(entries)
-        mcs_label = ::OpenShift::Runtime::Utils::SELinux.get_mcs_label(@container.uid)
-
         entries.each do |entry|
           if entry.end_with?('/')
             entry.chomp!('/')
@@ -471,8 +469,6 @@ module OpenShift
       # Take the given array of file system entries and prepare them for the application developer
       #    v2_cart_model.do_lock_gear(entries)
       def do_lock(entries)
-        mcs_label = ::OpenShift::Runtime::Utils::SELinux.get_mcs_label(@container.uid)
-
         # It is expensive doing one file at a time but...
         # ...it allows reporting on the failed command at the file level
         # ...we don't have to worry about the length of argv
@@ -1535,7 +1531,6 @@ module OpenShift
       # Writes the +stop_lock+ file and changes its ownership to the gear user.
       def create_stop_lock
         unless stop_lock?
-          mcs_label = ::OpenShift::Runtime::Utils::SELinux.get_mcs_label(@container.uid)
           File.new(stop_lock, File::CREAT|File::TRUNC|File::WRONLY, 0644).close()
           @container.set_rw_permission(stop_lock)
         end

--- a/node/lib/openshift-origin-node/utils/selinux.rb
+++ b/node/lib/openshift-origin-node/utils/selinux.rb
@@ -21,6 +21,30 @@ require 'openshift-origin-common/config'
 require 'openshift-origin-common/utils/etc_utils'
 require 'openshift-origin-node/utils/node_logger'
 
+module Selinux
+  class Context_s_t
+    include Comparable
+
+    # Comparison excluding MCS label
+    #
+    # @param other [Context_s_t] context being compared against
+    def <=>(other)
+      test = Selinux.context_user_get(self) <=> Selinux.context_user_get(other)
+      return test unless 0 == test
+
+      test = Selinux.context_role_get(self) <=> Selinux.context_role_get(other)
+      return test unless 0 == test
+
+      Selinux.context_type_get(self) <=> Selinux.context_type_get(other)
+    end
+
+    # Convert context to string
+    def to_s
+      Selinux.context_str(self)
+    end
+  end
+end
+
 module OpenShift
   module Runtime
     module Utils
@@ -122,32 +146,42 @@ module OpenShift
         # the file itself.
         #
         def self.chcon(path, label=nil, type=nil, role=nil, user=nil)
+          expected, actual = path_context(path)
+          Selinux.context_range_set(expected, label) unless label.nil?
+          Selinux.context_type_set(expected, type) unless type.nil?
+          Selinux.context_role_set(expected, role) unless role.nil?
+          Selinux.context_user_set(expected, user) unless user.nil?
+
+          range_eq = Selinux.context_range_get(expected) == Selinux.context_range_get(actual)
+          return if expected == actual && range_eq
+          return if -1 != Selinux.lsetfilecon(path, expected.to_s)
+
+          err = "Could not set the file context #{expected} on #{path}"
+          NodeLogger.logger.error(err)
+          raise Errno::EINVAL.new(err)
+        end
+
+        # Retrieve the default context for an object on the file system
+        #
+        # @param path [String] path of file or directory
+        # @return [Array<Context_s_t, Context_s_t>] The expected context and actual context
+        def self.path_context(path)
           matchpathcon_update
-          mode = File.lstat(path).mode & 07777
-          old_context = Selinux.lgetfilecon(path)
-          context = Selinux.matchpathcon(path, mode)
-          if context == -1
-            if old_context == -1
+          mode     = File.lstat(path).mode & 07777
+          actual   = Selinux.lgetfilecon(path)
+          expected = Selinux.matchpathcon(path, mode)
+
+          if -1 == expected
+            if -1 == actual
               err = "Could not read or determine the file context for #{path}"
               NodeLogger.logger.error(err)
               raise Errno::EINVAL.new(err)
             else
-              context = old_context
+              expected = actual
             end
           end
-          context = Selinux.context_new(context[1])
-          Selinux.context_range_set(context, label) unless label.nil?
-          Selinux.context_type_set(context, type)   unless type.nil?
-          Selinux.context_role_set(context, role)   unless role.nil?
-          Selinux.context_user_set(context, user)   unless user.nil?
-          context = Selinux.context_str(context)
-          if context != old_context[1]
-            if Selinux.lsetfilecon(path, context) == -1
-              err = "Could not set the file context #{context} on #{path}"
-              NodeLogger.logger.error(err)
-              raise Errno::EINVAL.new(err)
-            end
-          end
+
+          return Selinux.context_new(expected[1]), Selinux.context_new(actual[1])
         end
 
         #
@@ -217,23 +251,26 @@ module OpenShift
 
         private
 
+        @@matchpathcon_files_mtimes = Hash.new
+        @@mutex = Mutex.new
+
         #
         # Private: Update the file context database cache
         #
-        @@matchpathcon_files_mtimes = Hash.new
         def self.matchpathcon_update
-          new_files_mtimes = Hash.new
-          Dir.glob(Selinux.selinux_file_context_path + '*').each do |f|
-            new_files_mtimes[f] = File.stat(f).mtime
-          end
-
-          if new_files_mtimes != @@matchpathcon_files_mtimes
-            if not @@matchpathcon_files_mtimes.empty?
-              Selinux.matchpathcon_fini
+          @@mutex.synchronize do
+            new_files_mtimes = Hash.new
+            Dir.glob(Selinux.selinux_file_context_path + '*').each do |f|
+              new_files_mtimes[f] = File.stat(f).mtime
             end
-            NodeLogger.logger.debug("The file context database is being reloaded.")
-            Selinux.matchpathcon_init(nil)
-            @@matchpathcon_files_mtimes = new_files_mtimes
+
+            if new_files_mtimes != @@matchpathcon_files_mtimes
+              Selinux.matchpathcon_fini unless @@matchpathcon_files_mtimes.empty?
+
+              NodeLogger.logger.debug('The file context database is being reloaded.')
+              Selinux.matchpathcon_init(nil)
+              @@matchpathcon_files_mtimes = new_files_mtimes
+            end
           end
         end
 

--- a/plugins/container/libvirt/lib/openshift/runtime/containerization/libvirt_container.rb
+++ b/plugins/container/libvirt/lib/openshift/runtime/containerization/libvirt_container.rb
@@ -439,6 +439,10 @@ Dir(after)    #{@container.uuid}/#{@container.uid} => #{list_home_dir(@container
           OpenShift::Runtime::Utils::SELinux.set_mcs_label(@mcs_label, paths)
         end
 
+        def chcon(path, label = nil, type=nil, role=nil, user=nil)
+          ::OpenShift::Runtime::Utils::SELinux.chcon(path, label, type, role, user)
+        end
+
         # retrieve the default maximum memory limit
         def memory_in_bytes(uuid)
           OpenShift::Runtime::Utils::Cgroups.new(uuid).templates[:default]['memory.limit_in_bytes'].to_i

--- a/plugins/container/selinux/lib/openshift/runtime/containerization/selinux_container.rb
+++ b/plugins/container/selinux/lib/openshift/runtime/containerization/selinux_container.rb
@@ -66,7 +66,7 @@ module OpenShift
                   ) unless rc == 0
 
             set_ro_permission(@container.container_dir)
-            FileUtils.chmod 0o0750, @container.container_dir
+            FileUtils.chmod 0750, @container.container_dir
           end
 
           enable_cgroups
@@ -367,6 +367,10 @@ Dir(after)    #{@container.uuid}/#{@container.uid} => #{list_home_dir(@container
         def set_rw_permission(paths)
           PathUtils.oo_chown(@container.uid, @container.gid, paths)
           ::OpenShift::Runtime::Utils::SELinux.set_mcs_label(mcs_label, paths)
+        end
+
+        def chcon(path, label = nil, type=nil, role=nil, user=nil)
+          ::OpenShift::Runtime::Utils::SELinux.chcon(path, label, type, role, user)
         end
 
         # retrieve the default maximum memory limit


### PR DESCRIPTION
- Stop resetting selinux context n-times on same code path
- Stop creating selinux labels when they are not needed
- Expose chcon rather than shelling out to restorecon(1)

Conflicts:
    node/lib/openshift-origin-node/model/v2_cart_model.rb
