### PR TITLE
Update haproxy_ctld.rb

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/haproxy_ctld.rb
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/haproxy_ctld.rb
@@ -175,7 +175,7 @@ class Haproxy
 
         @last_scale_up_time=Time.now
         # remove_count_threshold defines how long @session_gear_pct must be
-        # below @remove_gear_pct.
+        # below @gear_remove_pct.
         @remove_count_threshold = 20
         @remove_count = 0
         self.populate_status_urls


### PR DESCRIPTION
Corrected a simple spelling mistake in comments. Var name @remove_gear_pct should be @gear_remove_pct.
