### PR TITLE
Add app, gear UUIDs to openshift_log

### DIFF
--- a/node/lib/openshift-origin-node/model/frontend/http/plugins/frontend_http_base.rb
+++ b/node/lib/openshift-origin-node/model/frontend/http/plugins/frontend_http_base.rb
@@ -70,14 +70,18 @@ module OpenShift
             SERVER_HTTPS_PORT = 443
             SERVER_CONNECT_ADDR = '127.0.0.1'
 
-            attr_reader :container_uuid, :container_name, :namespace
+            attr_reader :container_uuid, :container_name, :namespace, :application_uuid
             attr_accessor :fqdn
 
-            def initialize(container_uuid, fqdn, container_name, namespace)
+            def initialize(container_uuid, fqdn, container_name, namespace, application_uuid=nil)
               @container_uuid = container_uuid
               @fqdn = fqdn
               @container_name = container_name
               @namespace = namespace
+
+              # app uuid is ONLY used by connect() for storing the value in the nodes db.
+              # it may not be populated during other invocations
+              @application_uuid = application_uuid
             end
 
             def unprivileged_unidle

--- a/node/lib/openshift-origin-node/model/frontend_httpd.rb
+++ b/node/lib/openshift-origin-node/model/frontend_httpd.rb
@@ -1,12 +1,12 @@
 #--
 # Copyright 2010 Red Hat, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -178,6 +178,10 @@ module OpenShift
         @container_name = container.name
         @namespace = container.namespace
 
+        # this is ONLY used when invoking "connect" so the app uuid can be stored
+        # in the nodes db, so it can be added to the node openshift_log (access log)
+        @application_uuid = container.application_uuid
+
         if (container.name.to_s == "") or (container.namespace.to_s == "")
           self.class.plugins.each do |pl|
             begin
@@ -201,11 +205,11 @@ module OpenShift
                                                 @container_uuid)
         end
 
-        @plugins = self.class.plugins.map { |pl| pl.new(@container_uuid, @fqdn, @container_name, @namespace) }
+        @plugins = self.class.plugins.map { |pl| pl.new(@container_uuid, @fqdn, @container_name, @namespace, @application_uuid) }
       end
 
       # Public: Change the fqdn for the plugins
-      # 
+      #
       # Useful when multiple fqdns are used for a given gear
       # Returns nil On Success or raises on Failure
       def set_fqdn(new_fqdn)
@@ -566,7 +570,7 @@ module OpenShift
                                                 @container_uuid, @fqdn)
         end
 
-        call_plugins(:add_ssl_cert, 
+        call_plugins(:add_ssl_cert,
                      ssl_cert_clean.map { |c| c.to_pem}.join,
                      priv_key_clean.to_pem,
                      server_alias_clean)

--- a/node/test/unit/frontend_httpd_test.rb
+++ b/node/test/unit/frontend_httpd_test.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env oo-ruby
 #--
 # Copyright 2013 Red Hat, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,11 +24,13 @@ class FrontendHttpServerModelTest < OpenShift::NodeTestCase
 
   def setup
     @container_uuid = '0123456789abcdef'
+    @application_uuid = '0123456789abcdef'
     @container_name = 'frontendtest'
     @namespace = 'frontendtest'
 
     @container = mock('OpenShift::Runtime::ApplicationContainer')
     @container.stubs(:uuid).returns(@container_uuid)
+    @container.stubs(:application_uuid).returns(@application_uuid)
     @container.stubs(:name).returns(@container_name)
     @container.stubs(:namespace).returns(@namespace)
     OpenShift::Runtime::ApplicationContainer.stubs(:from_uuid).with(@container_uuid).returns(@container)
@@ -72,7 +74,7 @@ class FrontendHttpServerModelTest < OpenShift::NodeTestCase
 
   def test_clean_server_name
     frontend = OpenShift::Runtime::FrontendHttpServer.new(@container)
-    
+
     assert_equal "#{@test_alias}", frontend.clean_server_name("#{@test_alias}")
     assert_equal "#{@test_alias}", frontend.clean_server_name("#{@test_alias}".upcase)
     assert_raise OpenShift::Runtime::FrontendHttpServerNameException do

--- a/plugins/frontend/apache-mod-rewrite/httpd/openshift_route.include
+++ b/plugins/frontend/apache-mod-rewrite/httpd/openshift_route.include
@@ -99,10 +99,6 @@ RewriteCond ${openshift-nodes:%{ENV:V_MATCH_NODE_LOOKUP}} ^(.+)$ [OR]
 RewriteCond ${openshift-nodes:%{ENV:V_MATCH_NODE_DEFAULT}} ^(.+)$
 RewriteRule ^(.*)$ - [E=V_ROUTE:%1,E=V_MATCH_PATH:/,E=V_PATH:%{ENV:V_TMP_PATH},NS]
 
-# Extract app uuid and gear uuid
-RewriteCond %{ENV:V_ROUTE} ^([^|]+)\|([^|]+)\|(.+)$
-RewriteRule ^(.*)$ - [E=V_ROUTE:%1,E=APP_UUID:%2,E=GEAR_UUID:%3,NS]
-
 
 # One path element (/a)
 RewriteRule ^(/[^/]+)(.*)$ - [E=V_TMP_MATCH_PATH:$1,E=V_TMP_PATH:$2,E=V_TMP_LVL:1,NS]
@@ -142,6 +138,10 @@ RewriteCond ${openshift-nodes:%{ENV:V_MATCH_NODE_LOOKUP}} ^(.+)$ [OR]
 RewriteCond ${openshift-nodes:%{ENV:V_MATCH_NODE_DEFAULT}} ^(.+)$
 RewriteRule ^(.*)$ - [E=V_ROUTE:%1,E=V_MATCH_PATH:%{ENV:V_TMP_MATCH_PATH},E=V_PATH:%{ENV:V_TMP_PATH},NS]
 
+
+# Extract app uuid and gear uuid
+RewriteCond %{ENV:V_ROUTE} ^([^|]+)\|([^|]+)\|(.+)$
+RewriteRule ^(.*)$ - [E=V_ROUTE:%1,E=APP_UUID:%2,E=GEAR_UUID:%3,NS]
 
 
 # Route based on the populated variables,

--- a/plugins/frontend/apache-mod-rewrite/httpd/openshift_route.include
+++ b/plugins/frontend/apache-mod-rewrite/httpd/openshift_route.include
@@ -17,10 +17,10 @@ RewriteLogLevel 0
 
 # Maps
 RewriteMap    lowercase int:tolower
-RewriteMap      openshift-nodes   dbm=db:/var/lib/openshift/.httpd.d/nodes.db
-RewriteMap      openshift-aliases dbm=db:/var/lib/openshift/.httpd.d/aliases.db
-RewriteMap      openshift-idler   dbm=db:/var/lib/openshift/.httpd.d/idler.db
-RewriteMap      openshift-sts     dbm=db:/var/lib/openshift/.httpd.d/sts.db
+RewriteMap      openshift-nodes    dbm=db:/var/lib/openshift/.httpd.d/nodes.db
+RewriteMap      openshift-aliases  dbm=db:/var/lib/openshift/.httpd.d/aliases.db
+RewriteMap      openshift-idler    dbm=db:/var/lib/openshift/.httpd.d/idler.db
+RewriteMap      openshift-sts      dbm=db:/var/lib/openshift/.httpd.d/sts.db
 
 # Set X-Request-Start header to allow checking request life cycle.
 RequestHeader set X-Request-Start "%t"
@@ -80,11 +80,11 @@ Header set Strict-Transport-Security "max-age=%{STSHEADER}e" env=STSHEADER
 # unrolled in source and we only do three deep.
 #
 # Example table entries
-# www.example.com             => 127.0.250.1:8181
-# www.example.com/foo         => 127.0.250.1:8181/bar
-# www.example.com/health      => NOPROXY
-# www.example.com/bar         => REDIRECT:/baz
-# www.example.com/a/b/c       => GONE
+# www.example.com             => 127.0.250.1:8181|<app uuid>|<gear uuid>
+# www.example.com/foo         => 127.0.250.1:8181/bar|<app uuid>|<gear uuid>
+# www.example.com/health      => NOPROXY|<app uuid>|<gear uuid>
+# www.example.com/bar         => REDIRECT:/baz|<app uuid>|<gear uuid>
+# www.example.com/a/b/c       => GONE|<app uuid>|<gear uuid>
 
 
 # Just match the host
@@ -98,6 +98,10 @@ RewriteCond %{ENV:V_TMP_LVL} =0
 RewriteCond ${openshift-nodes:%{ENV:V_MATCH_NODE_LOOKUP}} ^(.+)$ [OR]
 RewriteCond ${openshift-nodes:%{ENV:V_MATCH_NODE_DEFAULT}} ^(.+)$
 RewriteRule ^(.*)$ - [E=V_ROUTE:%1,E=V_MATCH_PATH:/,E=V_PATH:%{ENV:V_TMP_PATH},NS]
+
+# Extract app uuid and gear uuid
+RewriteCond %{ENV:V_ROUTE} ^([^|]+)\|([^|]+)\|(.+)$
+RewriteRule ^(.*)$ - [E=V_ROUTE:%1,E=APP_UUID:%2,E=GEAR_UUID:%3,NS]
 
 
 # One path element (/a)
@@ -202,7 +206,12 @@ ProxyPassReverse ${V_MATCH_PATH} http://${V_ROUTE} interpolate
 #
 # Log custom format for OpenShift parsing.
 # Log format is:
-LogFormat "%h %{V_MATCH_HOST}e %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X %{V_ROUTE}e%{V_PATH}e" openshift
+<IfDefine OpenShiftAnnotateFrontendAccessLog>
+  LogFormat "%h %{V_MATCH_HOST}e %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X %{V_ROUTE}e%{V_PATH}e %{APP_UUID}e %{GEAR_UUID}e" openshift
+</IfDefine>
+<IfDefine !OpenShiftAnnotateFrontendAccessLog>
+  LogFormat "%h %{V_MATCH_HOST}e %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X %{V_ROUTE}e%{V_PATH}e" openshift
+</IfDefine>
 
 #
 # If the `OpenShiftFrontendSyslogEnabled` option is defined, pipe output to syslog rather than a file.

--- a/plugins/frontend/apache-mod-rewrite/test/functional/apache_mod_rewrite_test.rb
+++ b/plugins/frontend/apache-mod-rewrite/test/functional/apache_mod_rewrite_test.rb
@@ -1,12 +1,12 @@
 #--
 # Copyright 2010 Red Hat, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -67,12 +67,13 @@ module OpenShift
         "#{@fqdn}/ssl_to_gear" => "SSL_TO_GEAR:/dest"
       }
 
+      @nodes_expected.values.each { |v| v << "|#{@application_uuid}|#{@container_uuid}" }
 
       @aliases=["foo.example.com", "bar.example.com"]
       @ssl_certs=[["SSL_CERT", "SSL_KEY", "bar.example.com"]]
 
       @plugin_class = ::OpenShift::Runtime::Frontend::Http::Plugins::ApacheModRewrite
-      @plugin = @plugin_class.new(@container_uuid, @fqdn, @container_name, @namespace)
+      @plugin = @plugin_class.new(@container_uuid, @fqdn, @container_name, @namespace, @application_uuid)
 
       exercise_plugin_is_available
     end

--- a/plugins/frontend/apache-vhost/httpd/frontend-vhost-http-template.erb
+++ b/plugins/frontend/apache-vhost/httpd/frontend-vhost-http-template.erb
@@ -19,7 +19,12 @@
 
   # Log custom format for OpenShift parsing.
   # Log format is:
-  LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" openshift
+  <IfDefine OpenShiftAnnotateFrontendAccessLog>
+    LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X <%= app_uuid %> <%= gear_uuid %>" openshift
+  </IfDefine>
+  <IfDefine !OpenShiftAnnotateFrontendAccessLog>
+    LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" openshift
+  </IfDefine>
 
   #
   # If the `OpenShiftFrontendSyslogEnabled` option is defined, pipe output to syslog rather than a file.

--- a/plugins/frontend/apache-vhost/httpd/frontend-vhost-https-template.erb
+++ b/plugins/frontend/apache-vhost/httpd/frontend-vhost-https-template.erb
@@ -32,7 +32,12 @@
 
   # Log custom format for OpenShift parsing.
   # Log format is:
-  LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" openshift
+  <IfDefine OpenShiftAnnotateFrontendAccessLog>
+    LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X <%= app_uuid %> <%= gear_uuid %>" openshift
+  </IfDefine>
+  <IfDefine !OpenShiftAnnotateFrontendAccessLog>
+    LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" openshift
+  </IfDefine>
 
   #
   # If the `OpenShiftFrontendSyslogEnabled` option is defined, pipe output to syslog rather than a file.

--- a/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
+++ b/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
@@ -41,11 +41,11 @@ module OpenShift
 
             attr_reader :basedir, :token, :app_path
 
-            def initialize(container_uuid, fqdn, container_name, namespace)
+            def initialize(container_uuid, fqdn, container_name, namespace, application_uuid=nil)
               @config = ::OpenShift::Config.new
               @basedir = @config.get("OPENSHIFT_HTTP_CONF_DIR")
 
-              super(container_uuid, fqdn, container_name, namespace)
+              super(container_uuid, fqdn, container_name, namespace, application_uuid)
 
               @token = "#{@container_uuid}_#{@namespace}_#{@container_name}"
               @app_path = File.join(@basedir, token)
@@ -127,6 +127,9 @@ module OpenShift
                   File.open(conf_path, File::RDWR | File::CREAT | File::TRUNC, 0644) do |f|
                     server_name = @fqdn
                     include_path = @app_path
+                    app_uuid = @application_uuid
+                    gear_uuid = @container_uuid
+                    app_namespace = @namespace
                     ssl_certificate_file = '/etc/pki/tls/certs/localhost.crt'
                     ssl_key_file = '/etc/pki/tls/private/localhost.key'
                     f.write(ERB.new(File.read(@template_http)).result(binding))
@@ -375,6 +378,9 @@ module OpenShift
                 File.open(ssl_conf_path(server_alias), File::RDWR | File::CREAT | File::TRUNC, 0644) do |f|
                   server_name = server_alias
                   include_path = @app_path
+                  app_uuid = @application_uuid
+                  gear_uuid = @container_uuid
+                  app_namespace = @namespace
                   f.write(ERB.new(File.read(@template_http)).result(binding))
                   f.write("\n")
                   f.write(ERB.new(File.read(@template_https)).result(binding))

--- a/plugins/frontend/apachedb/test/functional/geardb_plugin_test.rb
+++ b/plugins/frontend/apachedb/test/functional/geardb_plugin_test.rb
@@ -1,12 +1,12 @@
 #--
 # Copyright 2010 Red Hat, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
Add support for including the app and gear UUIDs in the node access log
(openshift_log). This is optional and disabled by default.
