### PR TITLE
Fixing cartridge documentation typo

### DIFF
--- a/documentation/oo_cartridge_guide.adoc
+++ b/documentation/oo_cartridge_guide.adoc
@@ -1104,7 +1104,6 @@ Adding marker files to `.openshift/markers` will have the following effects:
 
 |hot_deploy
 |Will prevent shutdown and startup of the application during builds. The Passenger `restart.txt` file will be used to reload the application.
-|===
 
 |disable_asset_compilation
 |Will prevent assets to be compiled upon application deployment. This marker should be used when deploying application with assets which are already compiled.


### PR DESCRIPTION
Fixing cartridge documentation typo 

Typo consequence( bottom of the page): 
https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc 
