### PR TITLE
[origin_ui_155] Improved and detailed debug/info/error messages

### DIFF
--- a/console/app/assets/javascripts/console/form.js.coffee
+++ b/console/app/assets/javascripts/console/form.js.coffee
@@ -77,6 +77,18 @@ $ ->
         else
           false
 
+  $('.alert.with-alert-details a').click (event) ->
+    event.preventDefault() if event?
+    link = $(this)
+    message = link.closest('.alert.with-alert-details')
+    details = message.next('.alert-details')
+    message.toggleClass('detailed')
+    details.toggleClass('hide')
+    if link.text() == 'Show more' 
+      link.text('Show less')
+    else 
+      link.text('Show more')
+
   # application_type/<type>
   $('form#new_application').validate
     ignore: ""

--- a/console/app/assets/stylesheets/_alerts.scss
+++ b/console/app/assets/stylesheets/_alerts.scss
@@ -1,3 +1,5 @@
+@import "compass/css3/border-radius";
+
 // ALERT STYLES
 // ------------
 
@@ -30,6 +32,25 @@
 .alert.alert-error a, .alert.alert-error a:hover, .alert.alert-error a:active,
 .alert.alert-danger a, .alert.alert-danger a:hover, .alert.alert-danger a:active {
   color:$errorText;
+}
+
+// Alert details
+.alert.with-alert-details.detailed {
+  margin-bottom: 0;
+  @include border-bottom-radius(0);
+}
+.alert-details {
+  background-color: $openshiftLightRed;
+  border-left-color: #ae1b2d;
+  border-right: 2px solid $openshiftRed;
+  border-bottom: 2px solid $openshiftRed;
+  @include border-bottom-radius(2px);
+  ul {
+    font-size: 90%;
+    li {
+      padding-top: 6px;
+    }
+  }
 }
 
 // Adjust close link position

--- a/console/app/assets/stylesheets/_variables.scss
+++ b/console/app/assets/stylesheets/_variables.scss
@@ -61,6 +61,7 @@ $gridColumnWidthLarge:    58.5px;
 
 $openshiftRed:                  #CD202C; /* From style guide */
 $openshiftBrightRed:            #EA0011;
+$openshiftLightRed:             rgba(205, 32, 44, 0.08);
 $openshiftDarkRed:              #a1000c; /* action-call dark */
 $openshiftMediumBackgroundGray: #343434; /* From screenshots, for nav */
 $openshiftDarkBackgroundGray:   #333; /* From screenshots, background of sign in link */

--- a/console/app/controllers/aliases_controller.rb
+++ b/console/app/controllers/aliases_controller.rb
@@ -34,14 +34,14 @@ class AliasesController < ConsoleController
     @alias.application = @application
 
     if @alias.save
-      redirect_to @application, :flash => {:success => "Alias '#{@alias.id}' has been created"}
+      redirect_to @application, :flash => flash_messages(@alias.messages).merge({:success => "Alias '#{@alias.id}' has been created"})
     else
       render :new
     end
   rescue ActiveResource::ResetConnectionError => e
     raise unless Rails.env.test? || Rails.env.devenv? || Rails.env.development?
     @alias = @application.find_alias params[:alias][:id]
-    redirect_to @application, :flash => {:success => "Alias '#{@alias.id}' has been created"}
+    redirect_to @application, :flash => flash_messages(@alias.messages).merge({:success => "Alias '#{@alias.id}' has been created"})
   end
 
   def delete
@@ -54,7 +54,7 @@ class AliasesController < ConsoleController
     @alias = @application.find_alias params[:id]
     if @alias.destroy
       message = "Alias '#{params[:id]}' has been removed"
-      redirect_to @application, :flash => {:success => message.to_s}
+      redirect_to @application, :flash => flash_messages(@alias.messages).merge({:success => message.to_s})
     else
       render :delete
     end
@@ -74,7 +74,7 @@ class AliasesController < ConsoleController
     end
 
     if @alias.save
-      redirect_to @application, :flash => {:success => "Alias '#{@alias.id}' has been updated"}
+      redirect_to @application, :flash => flash_messages(@alias.messages).merge({:success => "Alias '#{@alias.id}' has been updated"})
     else
       render :edit
     end

--- a/console/app/controllers/console_controller.rb
+++ b/console/app/controllers/console_controller.rb
@@ -6,6 +6,7 @@ class ConsoleController < Console.config.parent_controller.constantize
   include CostAware
   include Console::CommunityAware
   include Console::LogHelper
+  include Console::ErrorsHelper
 
   layout 'console'
 

--- a/console/app/controllers/restarts_controller.rb
+++ b/console/app/controllers/restarts_controller.rb
@@ -8,8 +8,7 @@ class RestartsController < ConsoleController
     @application = Application.find(params[:application_id], :as => current_user)
 
     if @application.restart!
-      message = @application.messages.first || "The application '#{@application.name}' has been restarted"
-      redirect_to @application, :flash => {:success => message.to_s}
+      redirect_to @application, :flash => flash_messages(@application.messages, {:success => "The application '#{@application.name}' has been restarted"})
     else
       render :show
     end

--- a/console/app/controllers/scaling_controller.rb
+++ b/console/app/controllers/scaling_controller.rb
@@ -27,7 +27,7 @@ class ScalingController < ConsoleController
     @cartridge.scales_from, @cartridge.scales_to = range
 
     if @cartridge.save
-      redirect_to application_scaling_path, :flash => {:success => "Updated scale settings for cartridge '#{@cartridge.display_name}'"}
+      redirect_to application_scaling_path, :flash => flash_messages(@cartridge.messages).merge({:success => "Updated scale settings for cartridge '#{@cartridge.display_name}'"})
     else
       render :show
     end

--- a/console/app/controllers/storage_controller.rb
+++ b/console/app/controllers/storage_controller.rb
@@ -11,7 +11,7 @@ class StorageController < ConsoleController
     @cartridge.additional_gear_storage = Integer(params[:cartridge][:additional_gear_storage])
 
     if @cartridge.save
-      redirect_to application_storage_path(@application), :flash => {:success => "Updated storage for cartridge '#{@cartridge.display_name}'"}
+      redirect_to application_storage_path(@application), :flash => flash_messages(@cartridge.messages).merge({:success => "Updated storage for cartridge '#{@cartridge.display_name}'"})
     else
       flash.now[:error] = @cartridge.errors.messages.values.flatten
       render :show

--- a/console/app/helpers/console/errors_helper.rb
+++ b/console/app/helpers/console/errors_helper.rb
@@ -1,0 +1,20 @@
+module Console::ErrorsHelper
+
+  def flash_messages(messages, default=nil)
+    if messages.present?
+      flashes = {}
+      messages.each do |message|
+        text = (message[:text] || message.text).byteslice(0, 4 * 1024)
+        if !defined?(message.severity) || !message.severity || message.severity == 'info'
+          flashes[:success] = text
+        else
+          flashes[message.severity.to_sym] = text
+        end
+      end
+      flashes
+    else
+      default
+    end
+  end
+
+end

--- a/console/app/views/cartridge_types/show.html.haml
+++ b/console/app/views/cartridge_types/show.html.haml
@@ -10,15 +10,19 @@
 - else
   %h1 Add Cartridge to #{link_to @application.name, application_path(@application)}
 
-= render :partial => @cartridge_type, :locals => {:hide_link => true, :extra_info => true, :application => @application}
-
-= render :partial => 'cartridge_types/cartridge_type_notifications', :locals => { :type => @cartridge_type }
-
 = semantic_form_for @cartridge, :url => application_cartridges_path(@application), :html => {:class => 'form form-important'} do |f|
   = f.hidden_field :name, :value => @cartridge_type.name
   = f.hidden_field :url, :value => @cartridge_type.url
 
   = f.semantic_errors
+
+  - if @cartridge_type.custom?
+    .alert.alert-info
+      This cartridge will be downloaded into your application.  The cart will have access to all of your application data - be sure this is what you really want to do!
+      = link_to "Learn more", downloadable_cartridges_help_url
+
+  = render :partial => @cartridge_type, :locals => {:hide_link => true, :extra_info => true, :application => @application}
+  = render :partial => 'cartridge_types/cartridge_type_notifications', :locals => { :type => @cartridge_type }
 
   = f.inputs :class => 'inputs form-horizontal add-cartridge' do
     = control_group(false) do
@@ -37,11 +41,6 @@
       - else
         = @cartridge_type.display_name
     cartridge to your application?
-
-  - if @cartridge_type.custom?
-    .alert.alert-info
-      This cartridge will be downloaded into your application.  The cart will have access to all of your application data - be sure this is what you really want to do!
-      = link_to "Learn more", downloadable_cartridges_help_url
 
   = f.buttons do
     = link_to "Back", @wizard ? application_cartridge_types_path(@application) : application_path(@application), :class => 'btn'

--- a/console/app/views/restarts/_form.html.haml
+++ b/console/app/views/restarts/_form.html.haml
@@ -1,4 +1,6 @@
 = semantic_form_for @application, :url => application_restart_path(@application), :method => 'put', :html => {:class => 'form'} do |f|
+  = f.semantic_errors
+
   %p
     Depending on the size of your application it may take up to several minutes to restart.
   %p
@@ -6,7 +8,6 @@
     %strong
       '#{@application.name}'?
 
-  = f.semantic_errors
   = f.buttons do
     = link_to 'Cancel', application_path(@application), :class => 'btn cancel'
     = f.commit_button 'Restart'

--- a/controller/lib/openshift/controller/api_responses.rb
+++ b/controller/lib/openshift/controller/api_responses.rb
@@ -124,7 +124,10 @@ module OpenShift
 
           when OpenShift::UserException
             status = ex.response_code || :unprocessable_entity
-            internal_error = false
+            error_code, node_message, messages = extract_node_messages(ex, error_code, message, field)
+            message = node_message || "Unable to complete the requested operation. \nReference ID: #{request.uuid}"           
+            messages.push(Message.new(:error, message, error_code, field))
+            return render_error(status, message, error_code, field, nil, messages, false)
 
           when OpenShift::AccessDeniedException
             status = :forbidden


### PR DESCRIPTION
Card: https://trello.com/c/nbc4FTwh/155-5-display-detailed-debug-info-messages-from-rest-api-calls-in-a-more-link-next-to-error-pages-whenever-an-error-comes-up

Many improvements to error messages in the web console.

In the broker:

Replaces the :error message returned by the broker with a user friendly message with Reference ID and also moves the original :error thrown by the node to a :debug message. This will also make sure the broker includes :warning messages (for example app over quota) even when this kind of error happens.

So for example, take an app over quota where you try to add a cartridge. This patch will turn the current response

http://pastebin.com/ap7JB1pv

into something like 

http://pastebin.com/k5A1LXAA
