### PR TITLE
Bug 1062894 - Fail to restore the snapshot of a jbosseap-6 app to the existing one

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/control
@@ -371,11 +371,18 @@ function threaddump() {
     fi
 }
 
+function pre_restore() {
+  # this directory contains cached versions of the built jsps which will continue
+  # to get used because they have newer dates than the restored archive.
+  rm -rf $OPENSHIFT_JBOSSAS_DIR/standalone/tmp/* 
+}
+
 export OPENSHIFT_SECRET_TOKEN=${OPENSHIFT_SECRET_TOKEN:-OPENSHIFT_APP_UUID}
 
 case "$1" in
   build)           build ;;
   deploy)          deploy ;;
+  pre-restore)     pre_restore ;;
   start)           start ;;
   stop)            stop ;;
   restart)         restart ;;

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/control
@@ -367,11 +367,18 @@ function threaddump() {
     fi
 }
 
+function pre_restore() {
+  # this directory contains cached versions of the built jsps which will continue
+  # to get used because they have newer dates than the restored archive.
+  rm -rf $OPENSHIFT_JBOSSEAP_DIR/standalone/tmp/* 
+}
+
 export OPENSHIFT_SECRET_TOKEN=${OPENSHIFT_SECRET_TOKEN:-OPENSHIFT_APP_UUID}
 
 case "$1" in
   build)           build ;;
   deploy)          deploy ;;
+  pre-restore)     pre_restore ;;
   start)           start ;;
   stop)            stop ;;
   restart)         restart ;;


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1062894

Given jbosseap-6 app created, it failed to restore its snapshot to an existing
app.
