### PR TITLE
Bug 1045224 - install iptables rules in new dir

### DIFF
--- a/node/misc/bin/oo-iptables-port-proxy
+++ b/node/misc/bin/oo-iptables-port-proxy
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
 source /etc/openshift/node.conf
-nat_rules_file=/etc/openshift/iptables.nat.rules
-filter_rules_file=/etc/openshift/iptables.filter.rules
+nat_rules_file=/var/lib/openshift/.httpd.d/iptables.nat.rules
+filter_rules_file=/var/lib/openshift/.httpd.d/iptables.filter.rules
 lock_file=/var/lock/oo-iptables-port-proxy.rules.lock
 
 function help() {

--- a/node/misc/sbin/oo-admin-ctl-iptables-port-proxy
+++ b/node/misc/sbin/oo-admin-ctl-iptables-port-proxy
@@ -6,8 +6,8 @@
 # Description: Script to apply the openshift port proxy iptables rules.
 ### END INIT INFO
 
-RULES_FILE="/etc/openshift/iptables.filter.rules"
-NAT_FILE="/etc/openshift/iptables.nat.rules"
+RULES_FILE="/var/lib/openshift/.httpd.d/iptables.filter.rules"
+NAT_FILE="/var/lib/openshift/.httpd.d/iptables.nat.rules"
 
 start() {
     check_firewall true

--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -109,10 +109,12 @@ mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}/usr/sbin
 mkdir -p %{buildroot}%{appdir}/.tc_user_dir
 mkdir -p %{buildroot}%{_var}/log/openshift/node
+mkdir -p %{buildroot}%{_var}/lib/openshift/.httpd.d
 
 # Move the gem configs to the standard filesystem location
 mkdir -p %{buildroot}/etc/openshift
 rm -rf %{buildroot}%{gem_instdir}/conf/plugins.d/README
+mv %{buildroot}%{gem_instdir}/conf/iptables.*.rules %{buildroot}%{_var}/lib/openshift/.httpd.d
 mv %{buildroot}%{gem_instdir}/conf/* %{buildroot}/etc/openshift
 
 #move pam limit binaries to proper location
@@ -223,16 +225,17 @@ fi
 %attr(0750,-,-) %{_var}/log/openshift/node
 /usr/libexec/openshift/lib/quota_attrs.sh
 /usr/libexec/openshift/lib/archive_git_submodules.sh
-%attr(0755,-,-) %{openshift_lib}/cartridge_sdk
-%attr(0755,-,-) %{openshift_lib}/cartridge_sdk/bash
+%dir %attr(0755,-,-) %{openshift_lib}/cartridge_sdk
+%dir %attr(0755,-,-) %{openshift_lib}/cartridge_sdk/bash
 %attr(0744,-,-) %{openshift_lib}/cartridge_sdk/bash/*
-%attr(0755,-,-) %{openshift_lib}/cartridge_sdk/ruby
+%dir %attr(0755,-,-) %{openshift_lib}/cartridge_sdk/ruby
 %attr(0744,-,-) %{openshift_lib}/cartridge_sdk/ruby/*
 %dir /etc/openshift
 %attr(0644,-,-) %config /etc/openshift/system-config-firewall-compat
 %config(noreplace) /etc/openshift/node.conf
-%attr(0600,-,-) %config(noreplace) /etc/openshift/iptables.filter.rules
-%attr(0600,-,-) %config(noreplace) /etc/openshift/iptables.nat.rules
+%dir %{_var}/lib/openshift/.httpd.d
+%attr(0600,-,-) %config(noreplace) %{_var}/lib/openshift/.httpd.d/iptables.filter.rules
+%attr(0600,-,-) %config(noreplace) %{_var}/lib/openshift/.httpd.d/iptables.nat.rules
 %config(noreplace) /etc/openshift/env/*
 %attr(0640,-,-) %config(noreplace) /etc/openshift/resource_limits.conf
 %dir %attr(0755,-,-) %{appdir}


### PR DESCRIPTION
install iptables.*.rules in /var/lib/openshift/.httpd.d instead of
/etc/openshift.

solve 'files listed twice' warning during rpmbuild for
rubygem-openshift-origin-node

```
modified:   node/rubygem-openshift-origin-node.spec
```
