### PR TITLE
Bug 1063677 - Show apache running info when run "rhc cartridge status" for python app

### DIFF
--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
@@ -102,7 +102,6 @@ function status() {
     if [ $res -eq 0 ]
     then
         client_result "Application is running"
-        client_result "$output"
     else
         client_result "Application is either stopped or inaccessible"
     fi


### PR DESCRIPTION
Fixed by getting rid of the curl output
