### PR TITLE
Bug 1019219 - PassEnv warning messages are shown when deploy app

### DIFF
--- a/node/misc/usr/lib/cartridge_sdk/bash/sdk
+++ b/node/misc/usr/lib/cartridge_sdk/bash/sdk
@@ -396,10 +396,6 @@ function update_httpd_passenv {
   ( sed <$1 -e '/^PassEnv /d'
     for key in $(env |cut -d= -f1)
     do
-      # Exclude these three variables as Apache unset them
-      [[ $key == 'SHELL' ]] && continue
-      [[ $key == 'USER' ]] && continue
-      [[ $key == 'LOGNAME' ]] && continue
       if [[ $key =~ ^[A-Z].* ]]
       then
         echo PassEnv $key
@@ -421,6 +417,10 @@ function update_httpd_passenv {
 function write_httpd_passenv {
   ( for key in $(env |cut -d= -f1)
     do
+      # Exclude these three variables as Apache unset them
+      [[ $key == 'SHELL' ]] && continue
+      [[ $key == 'USER' ]] && continue
+      [[ $key == 'LOGNAME' ]] && continue
       if [[ $key =~ ^[A-Z].* ]]
       then
         echo PassEnv $key


### PR DESCRIPTION
Fixed by moving the SHELL, USER, LOGNAME variables exclusion to the right function, which is used on start/restart of the cartridges.
