### PR TITLE
Fix obsoletes and provides

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/openshift-origin-cartridge-10gen-mms-agent.spec
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/openshift-origin-cartridge-10gen-mms-agent.spec
@@ -12,10 +12,8 @@ Requires:      openshift-origin-cartridge-mongodb
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
 Requires:      mms-agent
-
-Obsoletes: openshift-origin-cartridge-10gen-mms-agent-0.1
-
-
+Provides:      openshift-origin-cartridge-10gen-mms-agent-0.1 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-10gen-mms-agent-0.1 <= 1.99.9
 BuildArch:     noarch
 
 %description

--- a/cartridges/openshift-origin-cartridge-cron/openshift-origin-cartridge-cron.spec
+++ b/cartridges/openshift-origin-cartridge-cron/openshift-origin-cartridge-cron.spec
@@ -10,9 +10,8 @@ URL:           https://www.openshift.com
 Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
-
-Obsoletes: openshift-origin-cartridge-cron-1.4
-
+Provides:      openshift-origin-cartridge-cron-1.4 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-cron-1.4 <= 1.99.9
 BuildArch:     noarch
 
 %description

--- a/cartridges/openshift-origin-cartridge-diy/openshift-origin-cartridge-diy.spec
+++ b/cartridges/openshift-origin-cartridge-diy/openshift-origin-cartridge-diy.spec
@@ -10,9 +10,8 @@ URL:           https://www.openshift.com
 Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
-
-Obsoletes: openshift-origin-cartridge-diy-0.1
-
+Provides:      openshift-origin-cartridge-diy-0.1 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-diy-0.1 <= 1.99.9
 BuildArch:     noarch
 
 %description

--- a/cartridges/openshift-origin-cartridge-haproxy/openshift-origin-cartridge-haproxy.spec
+++ b/cartridges/openshift-origin-cartridge-haproxy/openshift-origin-cartridge-haproxy.spec
@@ -18,9 +18,8 @@ Requires:      haproxy
 Requires:      socat
 Requires:      %{?scl:%scl_prefix}rubygem-daemons
 Requires:      %{?scl:%scl_prefix}rubygem-rest-client
-
-Obsoletes: openshift-origin-cartridge-haproxy-1.4
-
+Provides:      openshift-origin-cartridge-haproxy-1.4 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-haproxy-1.4 <= 1.99.9
 BuildArch:     noarch
 
 %description

--- a/cartridges/openshift-origin-cartridge-jbossas/openshift-origin-cartridge-jbossas.spec
+++ b/cartridges/openshift-origin-cartridge-jbossas/openshift-origin-cartridge-jbossas.spec
@@ -26,9 +26,9 @@ Requires:      jboss-as
 Requires:      maven
 %endif
 BuildRequires: jpackage-utils
+Provides:      openshift-origin-cartridge-jbossas-7 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-jbossas-7 <= 1.99.9
 BuildArch:     noarch
-
-Obsoletes: openshift-origin-cartridge-jbossas-7
 
 %description
 Provides JBossAS support to OpenShift. (Cartridge Format V2)

--- a/cartridges/openshift-origin-cartridge-jbosseap/openshift-origin-cartridge-jbosseap.spec
+++ b/cartridges/openshift-origin-cartridge-jbosseap/openshift-origin-cartridge-jbosseap.spec
@@ -23,9 +23,9 @@ Requires:      maven3
 Requires:      maven
 %endif
 BuildRequires: jpackage-utils
+Provides:      openshift-origin-cartridge-jbosseap-6.0 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-jbosseap-6.0 <= 1.99.9
 BuildArch:     noarch
-
-Obsoletes: openshift-origin-cartridge-jbosseap-6.0
 
 %description
 Provides JBossEAP support to OpenShift. (Cartridge Format V2)

--- a/cartridges/openshift-origin-cartridge-jbossews/openshift-origin-cartridge-jbossews.spec
+++ b/cartridges/openshift-origin-cartridge-jbossews/openshift-origin-cartridge-jbossews.spec
@@ -23,10 +23,11 @@ Requires:      maven3
 Requires:      maven
 %endif
 BuildRequires: jpackage-utils
+Provides:      openshift-origin-cartridge-jbossews-1.0 = 2.0.0
+Provides:      openshift-origin-cartridge-jbossews-2.0 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-jbossews-1.0 <= 1.99.9
+Obsoletes:     openshift-origin-cartridge-jbossews-2.0 <= 1.99.9
 BuildArch:     noarch
-
-Obsoletes: openshift-origin-cartridge-jbossews-1.0
-Obsoletes: openshift-origin-cartridge-jbossews-2.0
 
 %description
 Provides JBossEWS1.0 and JBossEWS2.0 support to OpenShift. (Cartridge Format V2)

--- a/cartridges/openshift-origin-cartridge-jenkins-client/openshift-origin-cartridge-jenkins-client.spec
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/openshift-origin-cartridge-jenkins-client.spec
@@ -22,9 +22,9 @@ Requires:      java-1.7.0-openjdk
 %endif
 Requires:      %{?scl:%scl_prefix}rubygems
 Requires:      %{?scl:%scl_prefix}rubygem-json
+Provides:      openshift-origin-cartridge-jenkins-client-1.4 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-jenkins-client-1.4 <= 1.99.9
 BuildArch:     noarch
-
-Obsoletes: openshift-origin-cartridge-jenkins-client-1.4
 
 %description
 Provides plugin jenkins client support. (Cartridge Format V2)

--- a/cartridges/openshift-origin-cartridge-jenkins/openshift-origin-cartridge-jenkins.spec
+++ b/cartridges/openshift-origin-cartridge-jenkins/openshift-origin-cartridge-jenkins.spec
@@ -14,9 +14,9 @@ Requires:      java >= 1.6
 Requires:      jenkins
 Requires:      jenkins-plugin-openshift
 Requires:      openshift-origin-node-util
+Provides:      openshift-origin-cartridge-jenkins-1.4 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-jenkins-1.4 <= 1.99.9
 BuildArch:     noarch
-
-Obsoletes: openshift-origin-cartridge-jenkins-1.4
 
 %description
 Provides Jenkins cartridge to OpenShift. (Cartridge Format V2)

--- a/cartridges/openshift-origin-cartridge-mongodb/openshift-origin-cartridge-mongodb.spec
+++ b/cartridges/openshift-origin-cartridge-mongodb/openshift-origin-cartridge-mongodb.spec
@@ -14,9 +14,9 @@ Requires:      libmongodb
 Requires:      mongodb
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
+Provides:      openshift-origin-cartridge-mongodb-2.2 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-mongodb-2.2 <= 1.99.9
 BuildArch:     noarch
-
-Obsoletes: openshift-origin-cartridge-mongodb-2.2
 
 %description
 Provides mongodb cartridge support to OpenShift

--- a/cartridges/openshift-origin-cartridge-mysql/openshift-origin-cartridge-mysql.spec
+++ b/cartridges/openshift-origin-cartridge-mysql/openshift-origin-cartridge-mysql.spec
@@ -11,18 +11,16 @@ Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%
 Requires:      mysql-server
 Requires:      mysql-devel
 Requires:      mysql-connector-java
-
 # For RHEL6 install mysql55 from SCL
 %if 0%{?rhel}
 Requires:      mysql55
 Requires:      mysql55-mysql-devel
 %endif
-
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
+Provides:      openshift-origin-cartridge-mysql-5.1 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-mysql-5.1 <= 1.99.9
 BuildArch:     noarch
-
-Obsoletes: openshift-origin-cartridge-mysql-5.1
 
 %description
 Provides mysql cartridge support to OpenShift. (Cartridge Format V2)

--- a/cartridges/openshift-origin-cartridge-nodejs/openshift-origin-cartridge-nodejs.spec
+++ b/cartridges/openshift-origin-cartridge-nodejs/openshift-origin-cartridge-nodejs.spec
@@ -15,26 +15,21 @@ Group:         Development/Languages
 License:       ASL 2.0
 URL:           http://www.openshift.com
 Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
-
 %if 0%{?fedora}%{?rhel} <= 6
 Requires:      %{scl}
 %endif
-
 Requires:      %{?scl:%scl_prefix}npm
 Requires:      %{?scl:%scl_prefix}nodejs-pg
 Requires:      %{?scl:%scl_prefix}nodejs-options
 Requires:      %{?scl:%scl_prefix}nodejs-supervisor
 Requires:      %{?scl:%scl_prefix}nodejs-async
-
 Requires:      %{?scl:%scl_prefix}nodejs-express
 Requires:      %{?scl:%scl_prefix}nodejs-connect
 Requires:      %{?scl:%scl_prefix}nodejs-mongodb
 Requires:      %{?scl:%scl_prefix}nodejs-mysql
 Requires:      %{?scl:%scl_prefix}nodejs-node-static
-
 Requires:      nodejs
 Requires:      nodejs-async
 Requires:      nodejs-connect
@@ -45,9 +40,8 @@ Requires:      nodejs-node-static
 Requires:      nodejs-pg
 Requires:      nodejs-supervisor
 Requires:      nodejs-options
-
-Obsoletes: openshift-origin-cartridge-nodejs-0.6
-
+Provides:      openshift-origin-cartridge-nodejs-0.6 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-nodejs-0.6 <= 1.99.9
 BuildArch:     noarch
 
 %description

--- a/cartridges/openshift-origin-cartridge-perl/openshift-origin-cartridge-perl.spec
+++ b/cartridges/openshift-origin-cartridge-perl/openshift-origin-cartridge-perl.spec
@@ -14,10 +14,9 @@ Requires:      openshift-origin-node-util
 Requires:      mod_perl
 Requires:      perl-App-cpanminus
 Requires:      perl-IO-Socket-SSL
-
-Obsoletes: openshift-origin-cartridge-perl-5.10
-
-BuildArch: noarch
+Provides:      openshift-origin-cartridge-perl-5.10 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-perl-5.10 <= 1.99.9
+BuildArch:     noarch
 
 %description
 Perl cartridge for OpenShift. (Cartridge Format V2)

--- a/cartridges/openshift-origin-cartridge-php/openshift-origin-cartridge-php.spec
+++ b/cartridges/openshift-origin-cartridge-php/openshift-origin-cartridge-php.spec
@@ -14,6 +14,9 @@ Requires:      rubygem(openshift-origin-node)
 %if 0%{?fedora}%{?rhel} <= 6
 Requires:      php >= 5.3.2
 Requires:      php < 5.4
+Requires:      php54
+Requires:      php54-php
+Requires:      php54-php-pear
 %endif
 %if 0%{?fedora} >= 19
 Requires:      php >= 5.5
@@ -21,17 +24,10 @@ Requires:      php < 5.6
 %endif
 Requires:      php
 Requires:      php-pear
-
-#  RHEL-6 PHP 5.4 SCL
-%if 0%{?fedora}%{?rhel} <= 6
-Requires:      php54
-Requires:      php54-php
-Requires:      php54-php-pear
-%endif
-
+Provides:      openshift-origin-cartridge-php-5.3 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-php-5.3 <= 1.99.9
 BuildArch:     noarch
 
-Obsoletes: openshift-origin-cartridge-php-5.3
 
 %description
 PHP cartridge for openshift. (Cartridge Format V2)

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/openshift-origin-cartridge-phpmyadmin.spec
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/openshift-origin-cartridge-phpmyadmin.spec
@@ -12,9 +12,9 @@ Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
 Requires:      phpMyAdmin < 5.0
+Provides:      openshift-origin-cartridge-phpmyadmin-3.4 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-phpmyadmin-3.4 <= 1.99.9
 BuildArch:     noarch
-
-Obsoletes: openshift-origin-cartridge-phpmyadmin-3.4
 
 %description
 Provides phpMyAdmin cartridge support. (Cartridge Format V2)

--- a/cartridges/openshift-origin-cartridge-postgresql/openshift-origin-cartridge-postgresql.spec
+++ b/cartridges/openshift-origin-cartridge-postgresql/openshift-origin-cartridge-postgresql.spec
@@ -60,9 +60,9 @@ Requires:      %{?scl_ruby:%scl_prefix_ruby}rubygem-pg
 Requires:      rhdb-utils
 Requires:      uuid-pgsql
 Requires:      proj-nad
+Provides:      openshift-origin-cartridge-postgresql-8.4 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-postgresql-8.4 <= 1.99.9
 BuildArch:     noarch
-
-Obsoletes: openshift-origin-cartridge-postgresql-8.4
 
 %description
 Provides PostgreSQL cartridge support to OpenShift. (Cartridge Format V2)

--- a/cartridges/openshift-origin-cartridge-python/openshift-origin-cartridge-python.spec
+++ b/cartridges/openshift-origin-cartridge-python/openshift-origin-cartridge-python.spec
@@ -27,11 +27,12 @@ Requires:      python < 2.8
 Requires:      mod_wsgi >= 3.4
 Requires:      mod_wsgi < 3.5
 %endif
-
-Obsoletes: openshift-origin-cartridge-community-python-2.7
-Obsoletes: openshift-origin-cartridge-community-python-3.3
-Obsoletes: openshift-origin-cartridge-python-2.6
-
+Provides:      openshift-origin-cartridge-community-python-2.7 = 2.0.0
+Provides:      openshift-origin-cartridge-community-python-3.3 = 2.0.0
+Provides:      openshift-origin-cartridge-python-2.6 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-community-python-2.7 <= 1.99.9
+Obsoletes:     openshift-origin-cartridge-community-python-3.3 <= 1.99.9
+Obsoletes:     openshift-origin-cartridge-python-2.6 <= 1.99.9
 BuildArch:     noarch
 
 %description

--- a/cartridges/openshift-origin-cartridge-ruby/openshift-origin-cartridge-ruby.spec
+++ b/cartridges/openshift-origin-cartridge-ruby/openshift-origin-cartridge-ruby.spec
@@ -16,7 +16,6 @@ URL:           https://www.openshift.com
 Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 Requires:      openshift-origin-node-util
 Requires:      rubygem(openshift-origin-node)
-
 # For the ruby 1.8 cartridge
 %if 0%{?rhel}
 Requires:      mod_passenger
@@ -30,7 +29,6 @@ Requires:      rubygem-thread-dump
 Requires:      %{?scl:%scl_prefix}rubygem-fastthread
 Requires:      %{?scl:%scl_prefix}runtime
 %endif
-
 Requires:      %{?scl:%scl_prefix}js
 Requires:      %{?scl:%scl_prefix}libyaml
 Requires:      %{?scl:%scl_prefix}mod_passenger
@@ -42,10 +40,10 @@ Requires:      %{?scl:%scl_prefix}rubygem-passenger-devel
 Requires:      %{?scl:%scl_prefix}rubygem-passenger-native
 Requires:      %{?scl:%scl_prefix}rubygem-passenger-native-libs
 Requires:      %{?scl:%scl_prefix}rubygems
-
-Obsoletes: openshift-origin-cartridge-ruby-1.8
-Obsoletes: openshift-origin-cartridge-ruby-1.9-scl
-
+Provides:      openshift-origin-cartridge-ruby-1.8 = 2.0.0
+Provides:      openshift-origin-cartridge-ruby-1.9-scl = 2.0.0
+Obsoletes:     openshift-origin-cartridge-ruby-1.8 <= 1.99.9
+Obsoletes:     openshift-origin-cartridge-ruby-1.9-scl <= 1.99.9
 BuildArch:     noarch
 
 %description

--- a/cartridges/openshift-origin-cartridge-switchyard/openshift-origin-cartridge-switchyard.spec
+++ b/cartridges/openshift-origin-cartridge-switchyard/openshift-origin-cartridge-switchyard.spec
@@ -11,9 +11,9 @@ Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%
 Requires:      switchyard-as7-modules
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
+Provides:      openshift-origin-cartridge-switchyard-0.6 = 2.0.0
+Obsoletes:     openshift-origin-cartridge-switchyard-0.6 <= 1.99.9
 BuildArch:     noarch
-
-Obsoletes: openshift-origin-cartridge-switchyard-0.6
 
 %description
 Provides switchyard cartridge support to OpenShift


### PR DESCRIPTION
The Obsoletes and Provides were not to Fedora standards.
This cleans them up so we don't have to make changes when packaging these cartridges for Fedora.
