### PR TITLE
Bug 1063764: Unsubscribe connections was not being called

### DIFF
--- a/controller/app/models/gear.rb
+++ b/controller/app/models/gear.rb
@@ -176,7 +176,7 @@ class Gear
       application.process_commands(result_io, component._id, self)
     end
     raise OpenShift::NodeException.new("Unable to add component #{component.cartridge_name}::#{component.component_name}", result_io.exitcode, result_io) if result_io.exitcode != 0
-    if component.is_sparse?
+    if component.is_sparse? and !self.sparse_carts.include?(component._id)
       self.sparse_carts << component._id
       self.save!
     end

--- a/controller/app/pending_ops_models/unsubscribe_connections_op.rb
+++ b/controller/app/pending_ops_models/unsubscribe_connections_op.rb
@@ -10,7 +10,8 @@ class UnsubscribeConnectionsOp < PendingAppOp
         sub_inst = nil
         sub_ginst = nil
         begin
-          pub_inst = application.find_component_instance_for(ComponentSpec.demongoize(from))
+          # the publishing (from) component instance is no longer in the app, since it has been deleted already
+          pub_cart_name = ComponentSpec.demongoize(from).cartridge_name
           sub_inst = application.find_component_instance_for(ComponentSpec.demongoize(to))
           sub_ginst = application.group_instances.find(sub_inst.group_instance_id)
         rescue Mongoid::Errors::DocumentNotFound
@@ -21,7 +22,7 @@ class UnsubscribeConnectionsOp < PendingAppOp
 
         sub_inst.gears.each do |gear|
           unless gear.removed
-            job = gear.get_unsubscribe_job(sub_inst, pub_inst.cartridge_name)
+            job = gear.get_unsubscribe_job(sub_inst, pub_cart_name)
             RemoteJob.add_parallel_job(handle, tag, gear, job)
           end
         end


### PR DESCRIPTION
Also removed an unnecessary DeleteGroupInstanceOp call. The gear delete op takes care of deleting the group instance.
