### PR TITLE
node-proxy: Stop on remove, restart in upgrade

### DIFF
--- a/node-proxy/openshift-origin-node-proxy.spec
+++ b/node-proxy/openshift-origin-node-proxy.spec
@@ -104,15 +104,19 @@ fi
 %post
 %if %{with_systemd}
 /bin/systemctl --system daemon-reload
+/bin/systemctl try-restart openshift-node-web-proxy.service
 %else
 /sbin/chkconfig --add openshift-node-web-proxy || :
+/sbin/service openshift-node-web-proxy condrestart || :
 %endif
 
 %preun
 if [ "$1" -eq "0" ]; then
 %if %{with_systemd}
    /bin/systemctl --no-reload disable openshift-node-web-proxy.service
+   /bin/systemctl stop openshift-node-web-proxy.service
 %else
+   /sbin/service openshift-node-web-proxy stop || :
    /sbin/chkconfig --del openshift-node-web-proxy || :
 %endif
 fi


### PR DESCRIPTION
Change the openshift-origin-node-proxy package to stop the openshift-node-web-proxy service that it includes when the package is removed.

Change openshift-origin-node-proxy to condrestart (restart if already running) openshift-node-web-proxy when the package is upgraded.

This commit fixes bug 1060274.
