### PR TITLE
Bug 1064157 - new filepaths in oo-diagnostics

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -1025,8 +1025,8 @@ class OODiag
          installed in #{conf_file}:
 
          --custom-rules=ipv4:filter:/etc/openshift/system-config-firewall-compat
-         --custom-rules=ipv4:filter:/etc/openshift/iptables.filter.rules
-         --custom-rules=ipv4:nat:/etc/openshift/iptables.nat.rules
+         --custom-rules=ipv4:filter:/var/lib/openshift/.httpd.d/iptables.filter.rules
+         --custom-rules=ipv4:nat:/var/lib/openshift/.httpd.d/iptables.nat.rules
        WARN
      end
     


### PR DESCRIPTION
iptables.*.rules has moved to /var/lib/openshift/.httpd.d .
This commit updates oo-diagnostics with new filepaths.
    modified:   common/bin/oo-diagnostics
