### PR TITLE
Bug fixes 1064107, 1028919

### DIFF
--- a/controller/app/models/admin/stats/maker.rb
+++ b/controller/app/models/admin/stats/maker.rb
@@ -202,7 +202,7 @@ class Admin::Stats::Maker
           'name' => node['name'],
           'active' => node['active']
       }
-    end
+    end if district['servers']
     return cloned
   end
 


### PR DESCRIPTION
Bug 1028919 - Avoid spurious calls to mcollective rpc interface in case of parallel op execution

Bug 1064107 - Minor fix in district_nodes_clone(), maker.rb
