### PR TITLE
Bug 1064720 - Group overrides lost during scale

### DIFF
--- a/controller/app/pending_ops_models/scale_op_group.rb
+++ b/controller/app/pending_ops_models/scale_op_group.rb
@@ -13,7 +13,7 @@ class ScaleOpGroup < PendingAppOpGroup
       changes << GroupChange.new(from, to)
     end
 
-    ops, gears_added, gears_removed = app.calculate_ops(changes)
+    ops, gears_added, gears_removed = app.calculate_ops(changes, [], nil, app.group_overrides)
     try_reserve_gears(gears_added, gears_removed, app, ops)
   end
 


### PR DESCRIPTION
Caused the overrides to reset because they weren't being passed to 
calculate_ops.

[merge]
