### PR TITLE
Bug 1065243: fixing invalid mongo query attribute

### DIFF
--- a/broker-util/oo-admin-repair
+++ b/broker-util/oo-admin-repair
@@ -569,7 +569,7 @@ def repair_removed_nodes(available_servers, unresponsive_servers, auto_confirm)
             district.servers.each do |si|
               next if si.name != server
               deactivated = true unless si.active
-              res = District.where(:_id => district._id, :servers.name => server).update({"$set" => {"servers.$.unresponsive" => true}})
+              res = District.where(:_id => district._id, "servers.name" => server).update({"$set" => {"servers.$.unresponsive" => true}})
               raise OpenShift::OOException.new("Could not set unresponsive to true for #{si.name}") if res.nil? or !res["updatedExisting"]
               break
             end


### PR DESCRIPTION
:servers.name is invalid. It should be within quotes with or without a leading colon (:) to convert it into the symbol.
