### PR TITLE
Fix output from decode_connections

### DIFF
--- a/plugins/frontend/apache-mod-rewrite/lib/openshift/runtime/frontend/http/plugins/apache-mod-rewrite.rb
+++ b/plugins/frontend/apache-mod-rewrite/lib/openshift/runtime/frontend/http/plugins/apache-mod-rewrite.rb
@@ -126,7 +126,7 @@ module OpenShift
                 entry[2][$~[1].downcase] = 1
               elsif connection =~ /^(REDIRECT|FILE|TOHTTPS|SSL_TO_GEAR):(.*)$/
                 entry[2][$~[1].downcase] = 1
-                entry[1] = $~[2]
+                entry[1] = $~[2].split("|").first
               else
                 entry[1] = connection.split("|").first
               end


### PR DESCRIPTION
Strip off "|$app_uuid|$gear_uuid" from the end of all types of
connections (including TOHTTPS etc), not just from connections without
modifiers.
