### PR TITLE
Bug 1067031 - Do not include old versions of carts in latest carts just ...

### DIFF
--- a/node/lib/openshift-origin-node/model/cartridge_repository.rb
+++ b/node/lib/openshift-origin-node/model/cartridge_repository.rb
@@ -371,6 +371,19 @@ module OpenShift
       end
 
       #
+      # Determine the latest cartridge version present for a cart
+      #
+      def latest_cartridge_version(cart_name)
+        versions = []
+        @index[cart_name].each_value do |cart_version_to_cart|
+          versions += cart_version_to_cart.keys.delete_if { |v| v == '_' }
+          versions.uniq!
+        end
+
+        Manifest.sort_versions(versions).last
+      end
+
+      #
       # Determine whether the given cartridge version is the latest for (cartridge_name, version)
       #
       def latest_cartridge_version?(cartridge_name, version, cartridge_version)
@@ -412,10 +425,13 @@ module OpenShift
       def latest_versions
         cartridges = []
 
-        @index.each_key do |cart_name|
-          @index[cart_name].keys.sort.reverse.each do |software_version|
-            latest = @index[cart_name][software_version]['_']
-            cartridges << latest unless latest.instance_of?(Hash)
+        @index.each do |cart_name, software_versions|
+          lcv = latest_cartridge_version(cart_name)
+          software_versions.keys.sort.reverse.each do |software_version|
+            unless software_versions[software_version][lcv].instance_of?(Hash)
+              latest = software_versions[software_version]['_']
+              cartridges << latest unless latest.instance_of?(Hash)
+            end
           end
         end
 

--- a/node/test/unit/cartridge_repository_test.rb
+++ b/node/test/unit/cartridge_repository_test.rb
@@ -129,7 +129,7 @@ class CartridgeRepositoryTest < OpenShift::NodeTestCase
 
     e = cr.select('crtest', '0.1')
     assert_equal '0.0.1', e.cartridge_version
-    
+
     cr.expects(:installed_in_base_path?).with('crtest', '0.1', '0.0.1').returns(false)
     cr.erase('crtest', '0.1', '0.0.1')
 
@@ -195,6 +195,8 @@ class CartridgeRepositoryTest < OpenShift::NodeTestCase
     assert cr.latest_cartridge_version?('crtest', '0.2', '0.0.2')
     assert !cr.latest_cartridge_version?('crtest', '0.2', '0.0.1')
     assert !cr.latest_cartridge_version?('crtest', '0.1', '0.0.3')
+
+    assert_equal '0.0.2', cr.latest_cartridge_version('crtest')
   end
 
   def test_latest_versions
@@ -205,7 +207,7 @@ class CartridgeRepositoryTest < OpenShift::NodeTestCase
 
     cr = OpenShift::Runtime::CartridgeRepository.instance
     cr.load
-    
+
     e = cr.select('crtest', '0.1')
     refute_nil e
     assert_equal '0.1', e.version
@@ -220,7 +222,7 @@ class CartridgeRepositoryTest < OpenShift::NodeTestCase
     assert_equal '0.2', e.version
     assert_equal '0.0.3', e.cartridge_version
     assert e.manifest['Group-Overrides'][0]['components'].include?('crtest-0.2')
-    
+
     e  = cr.select('crtest', '0.3')
     refute_nil e
     assert_equal '0.3', e.version
@@ -240,6 +242,8 @@ class CartridgeRepositoryTest < OpenShift::NodeTestCase
       assert_equal 'crtest', cart.name
       assert_equal 'crtest', cart.manifest['Name']
     end
+
+    assert_equal 2, latest.length
 
     latest.delete_if do |cart|
       cart.cartridge_version == lookup[cart.version]


### PR DESCRIPTION
...because they have a unique software version
