### PR TITLE
python $OPENSHIFT_PYTHON_REQUIREMENTS_PATH ENV VAR

### DIFF
--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
@@ -141,13 +141,14 @@ function build() {
     echo "Activating virtenv"
     activate-virtenv
 
-    if [ -f ${OPENSHIFT_REPO_DIR}/requirements.txt ]
-    then
-        ( cd $OPENSHIFT_REPO_DIR; pip install -r ${OPENSHIFT_REPO_DIR}/requirements.txt $OPENSHIFT_PYTHON_MIRROR )
+    local requirements_file=${OPENSHIFT_PYTHON_REQUIREMENTS_PATH:-requirements.txt}
+    if [ -f ${OPENSHIFT_REPO_DIR}${requirements_file} ]; then
+        echo "Checking for pip dependency listed in ${requirements_file} file.."
+        ( cd $OPENSHIFT_REPO_DIR; pip install -r ${OPENSHIFT_REPO_DIR}${requirements_file} $OPENSHIFT_PYTHON_MIRROR )
     fi
 
-    if [ -f ${OPENSHIFT_REPO_DIR}/setup.py ]
-    then
+    if [ -f ${OPENSHIFT_REPO_DIR}/setup.py ]; then
+        echo "Running setup.py script.."
         ( cd $OPENSHIFT_REPO_DIR; python ${OPENSHIFT_REPO_DIR}/setup.py develop $OPENSHIFT_PYTHON_MIRROR )
     fi
 


### PR DESCRIPTION
Example of usage:
`rhc env-set OPENSHIFT_PYTHON_REQUIREMENTS_PATH=prod-requirements.txt --app <app>`

origin_cartridge_card_54 - https://trello.com/c/uUwu8EWL

[test] [extended:cartridge]
