### PR TITLE
Bug 1067345 - Make *all commands honor stop_lock

### DIFF
--- a/node-util/sbin/oo-admin-ctl-gears
+++ b/node-util/sbin/oo-admin-ctl-gears
@@ -46,31 +46,35 @@ end
 global_option('-n', '--processes COUNT', Integer, 'Number of processes to use')
 global_option('-w', '--timeout SECONDS', Integer, 'Number of seconds to wait for operation')
 
+HONOR_LOCK  = true
+IGNORE_LOCK = false
+FORCE_STOP  = true
 
 module OpenShift
   module Runtime
     class AdminGearsControl
       include OpenShift::Runtime::Utils
 
-      @@RED    = "\033[31m"
-      @@GREEN  = "\033[32m"
-      @@NORMAL = "\033[0m"
+      RED    = "\033[31m"
+      GREEN  = "\033[32m"
+      NORMAL = "\033[0m"
 
-      def initialize(options, container_uuids=nil)
+
+      def initialize(options, uuids=nil)
         @options                = Hash.new
         @options[:in_processes] = options.processes if options.processes
 
-        @uuids        = container_uuids
+        @uuids          = uuids
 
         # From openshift.ddl#timeout
-        @gear_timeout = options.timeout || 360
-        @forced_options = {force:  true, term_delay: 10}
+        @gear_timeout   = options.timeout || 360
+        @forced_options = {force: FORCE_STOP, term_delay: 10}
 
         output = Array.new
-        if container_uuids.nil?
+        if @uuids.nil?
           output << 'AdminGearsControl: initialized for all gears in parallel'
         else
-          output << "AdminGearsControl: initialized for gear(s) #{container_uuids.join(' ')}"
+          output << "AdminGearsControl: initialized for gear(s) #{uuids.join(', ')}"
         end
         output << "AdminGearsControl: initialized with timeout #{@gear_timeout}s"
 
@@ -89,7 +93,7 @@ module OpenShift
       # @param msg [String] message denoting operation. E.g., 'Starting gear uuid'
       def okay(msg)
         NodeLogger.logger.info("(#{Process.pid}) #{msg}[ OK ]")
-        $stdout.write("#{msg}[ #{@GREEN}OK#{@NORM} ]\n")
+        $stdout.write("#{msg}[ #{GREEN}OK#{NORMAL} ]\n")
       end
 
       # Log success messages
@@ -98,7 +102,7 @@ module OpenShift
       # @param reason [String] reason for failure
       def failed(msg, reason)
         NodeLogger.logger.error("(#{Process.pid}) #{msg}[ Failed ]\n  #{reason}")
-        $stdout.write("#{msg}[ #{@RED}FAILED#{@NORM} ]\n  #{reason}\n")
+        $stdout.write("#{msg}[ #{RED}FAILED#{NORMAL} ]\n  #{reason}\n")
       end
 
       # For a given gear monitor some operation
@@ -147,15 +151,15 @@ module OpenShift
         failures.empty? ? 0 : 254
       end
 
-      def start
-        results = Parallel.map(gears, @options) do |gear|
+      def start(honor_lock = true)
+        results = Parallel.map(gears(honor_lock), @options) do |gear|
           gear_action(gear, "Starting gear #{gear.uuid} ... ") { |g| g.start_gear }
         end
         report_failures(results.select { |h| 0 != h[:exitstatus] })
       end
 
-      def stop(force = false)
-        results = Parallel.map(gears(false), @options) do |gear|
+      def stop(honor_lock = true, force = false)
+        results = Parallel.map(gears(honor_lock), @options) do |gear|
           opt = {user_initiated: false}
           opt.merge(@forced_options) if force
           gear_action(gear, "Stopping gear #{gear.uuid} ... ") { |g| g.stop_gear(opt) }
@@ -163,8 +167,8 @@ module OpenShift
         report_failures(results.select { |h| 0 != h[:exitstatus] })
       end
 
-      def restart
-        results = Parallel.map(gears(false), @options) do |gear|
+      def restart(honor_lock = true)
+        results = Parallel.map(gears(honor_lock), @options) do |gear|
           opt = {user_initiated: false}
           opt.merge(@forced_options)
           [
@@ -176,7 +180,7 @@ module OpenShift
       end
 
       def status
-        Parallel.map(gears(false), @options) do |gear|
+        Parallel.map(gears(IGNORE_LOCK), @options) do |gear|
           output = Array.new
           output << "Checking application #{gear.container_name} (#{gear.uuid}) status:"
           output << '-----------------------------------------------'
@@ -200,54 +204,33 @@ module OpenShift
         0
       end
 
-      def idle
-        results = Parallel.map(gears(false), @options) do |gear|
+      def idlegear
+        results = Parallel.map(gears(IGNORE_LOCK), @options) do |gear|
           msg = "Idling gear #{gear.uuid} ... "
           gear_action(gear, msg) { |g| g.idle_gear }
         end
         report_failures(results.select { |h| 0 != h[:exitstatus] })
       end
 
-      def unidle
-        results = Parallel.map(gears(false), @options) do |gear|
+      def unidlegear
+        results = Parallel.map(gears(IGNORE_LOCK), @options) do |gear|
           msg = "Unidling gear #{gear.uuid} ... "
           gear_action(gear, msg) { |g| g.unidle_gear }
         end
         report_failures(results.select { |h| 0 != h[:exitstatus] })
       end
 
-      def gear_uuids(skip_stopped=true)
+      def gears(honor_lock = true)
         Enumerator.new do |yielder|
-          gears(skip_stopped).each do |gear|
-            yielder.yield(gear.uuid)
-          end
-        end
-      end
-
-      # Public: Enumerate all non-stopped gears.
-      def gears(skip_stopped=true)
-        Enumerator.new do |yielder|
-          gear_set = []
-          if @uuids
-            @uuids.each do |uuid|
-              gear = ApplicationContainer.from_uuid(uuid)
-              if skip_stopped & gear.stop_lock?
-                raise ArgumentError, "Gear is locked: #{uuid}"
-              end
-              gear_set << gear
+          if @uuids.nil?
+            ApplicationContainer.all(nil, false).each do |gear|
+              yielder.yield(gear) unless honor_lock && gear.stop_lock?
             end
           else
-            gear_set = ApplicationContainer.all(nil, false)
-          end
-          gear_set.each do |gear|
-            begin
-              if not (skip_stopped & gear.stop_lock?)
-                yielder.yield(gear)
-              end
-            rescue => e
-              NodeLogger.logger.error("Gear evaluation failed for: #{gear.uuid}")
-              NodeLogger.logger.error("Exception: #{e}")
-              NodeLogger.logger.error("#{e.backtrace}")
+            @uuids.each do |uuid|
+              gear = ApplicationContainer.from_uuid(uuid)
+              raise "Gear is locked: #{gear.uuid}" if honor_lock && gear.stop_lock?
+              yielder.yield(gear)
             end
           end
         end
@@ -283,7 +266,8 @@ def unlock_if_good
 end
 
 command :startall do |c|
-  c.syntax = "#{$name} #{c.name}"
+  c.syntax      = "#{$name} #{c.name}"
+  c.description = %q(start all gears that do not have a stop_lock in background)
 
   c.action do |_, options|
     cpid = fork do
@@ -297,75 +281,70 @@ command :startall do |c|
       end
       Process.setsid
       OpenShift::Runtime::NodeLogger.logger.reinitialize
-      exitval = lock_if_good do
-        OpenShift::Runtime::AdminGearsControl.new(options).start
-      end
-      exit(exitval)
+      exit lock_if_good { OpenShift::Runtime::AdminGearsControl.new(options).start }
     end
+
     OpenShift::Runtime::NodeLogger.logger.info("Background start initiated - process id = #{cpid}")
-    $stdout.puts "Background start initiated - process id = #{cpid}"
-    $stdout.puts "Check /var/log/openshift/node/platform.log for more details."
-    $stdout.puts
-    $stdout.puts "Note: In the future, if you wish to start the OpenShift services in the"
-    $stdout.puts "      foreground (waited), use:  service openshift-gears waited-start"
+    $stdout.puts %Q(
+Background start initiated - process id = #{cpid}
+  Check /var/log/openshift/node/platform.log for more details.
+
+  Note: In the future, if you wish to start the OpenShift services in the
+        foreground (waited), use:  service openshift-gears waited-start
+)
     $stdout.flush
     exit!(0)
   end
 end
 
-command :stopall do |c|
-  c.syntax = "#{$name} #{c.name}"
+command :'waited-startall' do |c|
+  c.syntax      = "#{$name} #{c.name}"
+  c.description = %q(start all gears without a stop_lock in foreground)
 
   c.action do |_, options|
-    exit unlock_if_good {
-      OpenShift::Runtime::AdminGearsControl.new(options).stop
-    }
+    exit lock_if_good { OpenShift::Runtime::AdminGearsControl.new(options).start }
+  end
+end
+
+command :stopall do |c|
+  c.syntax      = "#{$name} #{c.name}"
+  c.description = %q(stop all gears)
+
+  c.action do |_, options|
+    exit unlock_if_good { OpenShift::Runtime::AdminGearsControl.new(options).stop }
   end
 end
 
 command :forcestopall do |c|
-  c.syntax = "#{$name} #{c.name}"
+  c.syntax      = "#{$name} #{c.name}"
+  c.description = %q(stop all gears with prejudice)
 
   c.action do |_, options|
-    exit unlock_if_good {
-      OpenShift::Runtime::AdminGearsControl.new(options).stop(true)
-    }
+    exit unlock_if_good { OpenShift::Runtime::AdminGearsControl.new(options).stop(HONOR_LOCK, FORCE_STOP) }
   end
 end
 
 command :restartall do |c|
-  c.syntax = "#{$name} #{c.name}"
+  c.syntax      = "#{$name} #{c.name}"
+  c.description = %q(restart all gears without a stop_lock)
 
   c.action do |_, options|
-    exit lock_if_good {
-      OpenShift::Runtime::AdminGearsControl.new(options).restart
-    }
+    exit lock_if_good { OpenShift::Runtime::AdminGearsControl.new(options).restart }
   end
 end
 
 command :condrestartall do |c|
-  c.syntax = "#{$name} #{c.name}"
+  c.syntax      = "#{$name} #{c.name}"
+  c.description = %q(restart all gears without a stop_lock ensuring singleton script)
 
   c.action do |_, options|
-    if File.exists?($lockfile)
-      exit OpenShift::Runtime::AdminGearsControl.new(options).restart
-    end
-  end
-end
-
-
-command :'waited-startall' do |c|
-  c.syntax = "#{$name} #{c.name}"
-
-  c.action do |_, options|
-    exit lock_if_good {
-      OpenShift::Runtime::AdminGearsControl.new(options).start
-    }
+    (exit OpenShift::Runtime::AdminGearsControl.new(options).restart) if File.exists?($lockfile)
   end
 end
 
 command :status do |c|
-  c.syntax = "#{$name} #{c.name}"
+  c.syntax      = "#{$name} #{c.name}"
+  c.description = %q(report status for all cartridges from all gears)
 
   c.action do |_, options|
     $stdout.puts("Checking OpenShift Services: \n")
@@ -374,86 +353,89 @@ command :status do |c|
 end
 
 command :startgear do |c|
-  c.syntax = "#{$name} #{c.name} <login name>"
+  c.syntax      = "#{$name} #{c.name} <login name>"
+  c.description = %q(start given gear)
 
   c.action do |args, options|
-    raise "Requires a gear uuid." if args.empty?
-    exit OpenShift::Runtime::AdminGearsControl.new(options, args).start
+    raise 'Requires a gear uuid' if args.empty?
+    exit OpenShift::Runtime::AdminGearsControl.new(options, args).start(IGNORE_LOCK)
   end
 end
 
 command :stopgear do |c|
-  c.syntax = "#{$name} #{c.name} <login name>"
+  c.syntax      = "#{$name} #{c.name} <login name>"
+  c.description = %q(stop given gear ignoring stop_lock)
 
   c.action do |args, options|
-    raise "Requires a gear uuid." if args.empty?
-    exit OpenShift::Runtime::AdminGearsControl.new(options, args).stop
+    raise 'Requires a gear uuid' if args.empty?
+    exit OpenShift::Runtime::AdminGearsControl.new(options, args).stop(IGNORE_LOCK)
   end
 end
 
 command :forcestopgear do |c|
-  c.syntax = "#{$name} #{c.name} <login name>"
+  c.syntax      = "#{$name} #{c.name} <login name>"
+  c.description = %q(stop given gear ignoring stop_lock with prejudice)
 
   c.action do |args, options|
-    raise "Requires a gear uuid." if args.empty?
-    exit OpenShift::Runtime::AdminGearsControl.new(options, args).stop(true)
+    raise 'Requires a gear uuid' if args.empty?
+    exit OpenShift::Runtime::AdminGearsControl.new(options, args).stop(IGNORE_LOCK, FORCE_STOP)
   end
 end
 
 command :restartgear do |c|
-  c.syntax = "#{$name} #{c.name} <login name>"
+  c.syntax      = "#{$name} #{c.name} <login name>"
+  c.description = %q(restart given gear ignoring stop_lock)
 
   c.action do |args, options|
-    raise "Requires a gear uuid." if args.empty?
-    exit OpenShift::Runtime::AdminGearsControl.new(options, args).restart
+    raise 'Requires a gear uuid' if args.empty?
+    exit OpenShift::Runtime::AdminGearsControl.new(options, args).restart(IGNORE_LOCK)
   end
 end
 
 command :statusgear do |c|
-  c.syntax = "#{$name} #{c.name} <login name>"
+  c.syntax      = "#{$name} #{c.name} <login name>"
+  c.description = %q(report status of cartridges for given gear)
 
   c.action do |args, options|
-    raise "Requires a gear uuid." if args.empty?
+    raise "Requires a gear uuid" if args.empty?
     exit OpenShift::Runtime::AdminGearsControl.new(options, args).status
   end
 end
 
 command :idlegear do |c|
-  c.syntax = "#{$name} #{c.name} <login name>"
+  c.syntax      = "#{$name} #{c.name} <login name>"
+  c.description = %q(change gear state to idle)
 
   c.action do |args, options|
-    raise "Requires a gear uuid." if args.empty?
-    exit OpenShift::Runtime::AdminGearsControl.new(options, args).idle
+    raise "Requires a gear uuid" if args.empty?
+    exit OpenShift::Runtime::AdminGearsControl.new(options, args).idlegear
   end
 end
 
 command :unidlegear do |c|
-  c.syntax = "#{$name} #{c.name} <login name>"
+  c.syntax      = "#{$name} #{c.name} <login name>"
+  c.description = %q(change gear state to started)
 
   c.action do |args, options|
-    raise "Requires a gear uuid." if args.empty?
-    exit OpenShift::Runtime::AdminGearsControl.new(options, args).unidle
+    raise "Requires a gear uuid" if args.empty?
+    exit OpenShift::Runtime::AdminGearsControl.new(options, args).unidlegear
   end
 end
 
 command :list do |c|
-  c.syntax = "#{$name} #{c.name} <login name>"
+  c.syntax      = "#{$name} #{c.name}"
+  c.description = %q(list all gears on node)
 
-  c.action do |_, options|
-    OpenShift::Runtime::AdminGearsControl.new(options).gear_uuids(false).each do |uuid|
-      $stdout.puts uuid
-    end
-  end
+  c.action { OpenShift::Runtime::ApplicationContainer.all_uuids.each { |u| $stdout.puts u } }
 end
 
 command :listidle do |c|
   c.syntax = "#{$name} #{c.name}"
 
-  c.action do |_, options|
-    OpenShift::Runtime::AdminGearsControl.new(options).gear_uuids(false).each do |uuid|
-      if OpenShift::Runtime::FrontendHttpServer.new(OpenShift::Runtime::ApplicationContainer.from_uuid(uuid)).idle?
-        $stdout.puts "#{uuid} is idled"
-      end
+  c.action do
+    OpenShift::Runtime::ApplicationContainer.all.each do |container|
+      next unless container.stop_lock?
+      $stdout.puts "#{container.uuid} is idled" if OpenShift::Runtime::FrontendHttpServer.new(container).idle?
     end
   end
 end


### PR DESCRIPTION
- The *restartall commands didn't honor stop_lock originally to
  support Online Ops usage. They no longer require the specialized
  behavior.
- Refactor to efficiently use ApplicationContainer
