### PR TITLE
<cron cart> Load env. vars. recursively

### DIFF
--- a/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
+++ b/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
@@ -3,6 +3,16 @@
 # source OpenShift environment variable into context
 function load_env {
     [ -z "$1" ] && return 1
+
+    if [ -d "$1" ]
+    then
+      for f in ${1}/*
+      do
+        load_env $f
+      done
+      return
+    fi
+
     [ -f "$1" ] || return 0
 
     local contents=$(< $1)


### PR DESCRIPTION
cron_runjobs.sh: Recursively load environment-variable directories, as oo-trap-user does.

In particular, we want cronjobs that run on one gear of a scalable application to load the environment variables of all cartridges, which may be in subdirectories of ~/.env/.

This commit fixes bug 1069321.
