### PR TITLE
frontend logging: keep openshift_log (bug 1069837)

### DIFF
--- a/plugins/frontend/apache-mod-rewrite/httpd/openshift_route.include
+++ b/plugins/frontend/apache-mod-rewrite/httpd/openshift_route.include
@@ -213,12 +213,11 @@ ProxyPassReverse ${V_MATCH_PATH} http://${V_ROUTE} interpolate
   LogFormat "%h %{V_MATCH_HOST}e %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X %{V_ROUTE}e%{V_PATH}e" openshift
 </IfDefine>
 
+CustomLog logs/openshift_log openshift env=V_PATH
 #
-# If the `OpenShiftFrontendSyslogEnabled` option is defined, pipe output to syslog rather than a file.
+# If the `OpenShiftFrontendSyslogEnabled` option is defined, pipe output to syslog in addition to file.
+# File is used by the autoidler to assess gear (in)activity.
 #
 <IfDefine OpenShiftFrontendSyslogEnabled>
   CustomLog "|logger -t openshift-node-frontend" openshift env=V_PATH
-</IfDefine>
-<IfDefine !OpenShiftFrontendSyslogEnabled>
-  CustomLog logs/openshift_log openshift env=V_PATH
 </IfDefine>

--- a/plugins/frontend/apache-vhost/httpd/frontend-vhost-http-template.erb
+++ b/plugins/frontend/apache-vhost/httpd/frontend-vhost-http-template.erb
@@ -26,14 +26,13 @@
     LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" openshift
   </IfDefine>
 
+  CustomLog logs/openshift_log openshift
   #
-  # If the `OpenShiftFrontendSyslogEnabled` option is defined, pipe output to syslog rather than a file.
+  # If the `OpenShiftFrontendSyslogEnabled` option is defined, pipe output to syslog in addition to file.
+  # File is used by the autoidler to assess gear (in)activity.
   #
   <IfDefine OpenShiftFrontendSyslogEnabled>
     CustomLog "|logger -t openshift-node-frontend" openshift
-  </IfDefine>
-  <IfDefine !OpenShiftFrontendSyslogEnabled>
-    CustomLog logs/openshift_log openshift
   </IfDefine>
 
   ProxyTimeout 300

--- a/plugins/frontend/apache-vhost/httpd/frontend-vhost-https-template.erb
+++ b/plugins/frontend/apache-vhost/httpd/frontend-vhost-https-template.erb
@@ -39,14 +39,13 @@
     LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" openshift
   </IfDefine>
 
+  CustomLog logs/openshift_log openshift
   #
-  # If the `OpenShiftFrontendSyslogEnabled` option is defined, pipe output to syslog rather than a file.
+  # If the `OpenShiftFrontendSyslogEnabled` option is defined, pipe output to syslog in addition to file.
+  # File is used by the autoidler to assess gear (in)activity.
   #
   <IfDefine OpenShiftFrontendSyslogEnabled>
     CustomLog "|logger -t openshift-node-frontend" openshift
-  </IfDefine>
-  <IfDefine !OpenShiftFrontendSyslogEnabled>
-    CustomLog logs/openshift_log openshift
   </IfDefine>
 
   ProxyTimeout 300


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1069837
  -DOpenShiftFrontendSyslogEnabled disables openshift_log entries

When the -DOpenShiftFrontendSyslogEnabled cmdline option is added to the
node host httpd in order to direct gear logs to syslog, it stops writing
openshift_log entries. This is what the idler uses to assess whether a
gear is inactive or not, so it should keep writing this log.
