### PR TITLE
Bug 1069457 - UpdateCompLimits drops gear size

### DIFF
--- a/controller/app/pending_ops_models/update_comp_limits_op_group.rb
+++ b/controller/app/pending_ops_models/update_comp_limits_op_group.rb
@@ -17,7 +17,7 @@ class UpdateCompLimitsOpGroup < PendingAppOpGroup
         if component = override.components.find{ |c| c == spec } && ComponentOverrideSpec === component
           found = true
           component.reset(min || component.min_gears, max || component.max_gears, multiplier || component.multiplier)
-          override.reset(nil, nil, nil, additional_filesystem_gb || override.additional_filesystem_gb)
+          override.reset(override.min_gears, override.max_gears, override.gear_size, additional_filesystem_gb || override.additional_filesystem_gb)
         end
       end
       unless found
@@ -27,7 +27,7 @@ class UpdateCompLimitsOpGroup < PendingAppOpGroup
       overrides.each do |override|
         if override.components.any?{ |c| c == spec }
           found = true
-          override.reset(min || override.min_gears, max || override.max_gears, nil, additional_filesystem_gb || override.additional_filesystem_gb)
+          override.reset(min || override.min_gears, max || override.max_gears, override.gear_size, additional_filesystem_gb || override.additional_filesystem_gb)
         end
       end
       unless found


### PR DESCRIPTION
The gear size can't be reset otherwise the user will be given a warning

[test]
