### PR TITLE
Multiple fixes for stability

### DIFF
--- a/broker-util/oo-admin-clear-pending-ops
+++ b/broker-util/oo-admin-clear-pending-ops
@@ -74,61 +74,22 @@ end
 $count = 0
 def clean_app(a)
   $count += 1
-  delete_app = false
-  dlist = []
-  Application.run_in_application_lock(a) do
-    a.reload
-    a.pending_op_groups.each { |op| 
-      if op._type.nil? 
-        puts "ERROR in cleaning up application's op because the _type is nil. App uuid - #{a.uuid}. Op - #{op.inspect}"
-        next
-      end
-      puts "WARNING : Application #{a.uuid} has created_at field nil for op - #{op.inspect}" if op.created_at.nil?
+  begin
+    Application.run_in_application_lock(a) do
+      a.run_jobs(nil, true)
+    end
 
-      if op.created_at.nil? or op.created_at < $t 
-        puts
-        puts "Executing op for app (#{a.uuid}) - #{op.inspect} "
-        success = false
-        begin
-          if op.pending_ops.where(:state => :rolledback).count > 0
-            raise Exception.new("Op already being rolled back.. continuing.")
-          end
-          op.execute 
-          op.unreserve_gears(op.num_gears_removed, a)
-          success = true
-          delete_app = true if (op.class == DeleteAppOpGroup) or (op.class == RemoveFeaturesOpGroup and op.remove_all_features)
-        rescue Exception => e
-          print "Execution failed. Rolling back.."
-          begin
-            op.execute_rollback
-            num_gears_recovered = op.num_gears_added - op.num_gears_created + op.num_gears_rolled_back + op.num_gears_destroyed
-            op.unreserve_gears(num_gears_recovered, a)
-            success = true
-            puts " complete."
-          rescue Exception=> ex
-            success = false
-            puts " failed again!"
-            puts ex.backtrace.inspect
-          end
-        end
-        dlist << op if success
-      end
-      break if !success
-    } 
-    dlist.each { |op| op.delete }
-  end # end of lock
-  if not delete_app
-    a.save!
-    a.pending_op_groups.each { |op|
+    a.reload
+    a.pending_op_groups.each do |op|
       if op.created_at.nil? or op.created_at < $t 
         next if op._type.nil?
         puts
         puts "Failed to clear op for app (#{a.uuid}) - #{op.inspect} "
       end
-    } 
-    unless a.group_instances.present? or a.component_instances.present?
-      a.delete
     end
+  rescue Mongoid::Errors::DocumentNotFound => ex
+    # ignore the exception if the application has been deleted
+    raise ex unless Application.where(_id: a._id).count == 0
   end
 end
 

--- a/broker/test/functional/application_test.rb
+++ b/broker/test/functional/application_test.rb
@@ -1,7 +1,7 @@
 ENV["TEST_NAME"] = "functional_application_test"
-require 'test_helper'
+require_relative '../test_helper'
 require 'openshift-origin-controller'
-require 'helpers/rest/api'
+require_relative '../helpers/rest/api'
 
 class ApplicationsTest < ActionDispatch::IntegrationTest
   def setup
@@ -41,11 +41,8 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
     assert_equal 1, app.group_instances.length
     assert_equal 1, app.gears.length
 
-    app.config['auto_deploy'] = true
-    app.config['deployment_branch'] = "stage"
-    app.config['keep_deployments'] = 3
-    app.config['deployment_type'] = "binary"
-    app.update_configuration
+    new_config = {'auto_deploy' => true, 'deployment_branch' => "stage", 'keep_deployments' => 3, 'deployment_type' => "binary"}
+    app.update_configuration(new_config)
     app = Application.find_by(canonical_name: @appname.downcase, domain_id: @domain._id) rescue nil
 
     assert app.config['auto_deploy'] == true
@@ -98,11 +95,8 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
     app = Application.find_by(canonical_name: @appname.downcase, domain_id: @domain._id) rescue nil
 
     assert_equal "https://github.com/foobar/test.git", app.init_git_url
-    app.config['auto_deploy'] = true
-    app.config['deployment_branch'] = "stage"
-    app.config['keep_deployments'] = 3
-    app.config['deployment_type'] = "binary"
-    app.update_configuration
+    new_config = {'auto_deploy' => true, 'deployment_branch' => "stage", 'keep_deployments' => 3, 'deployment_type' => "binary"}
+    app.update_configuration(new_config)
     app = Application.find_by(canonical_name: @appname.downcase, domain_id: @domain._id) rescue nil
 
     assert app.config['auto_deploy'] == true
@@ -267,7 +261,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
     assert_equal app.errors.messages[:config].length, 4, "Wrong number of error messages"
 
     #check validation on update_config
-    assert_raise(OpenShift::UserException){app.update_configuration}
+    assert_raise(OpenShift::UserException){app.update_configuration(app.config)}
   end
 
   test "app metadata validation" do

--- a/controller/app/controllers/applications_controller.rb
+++ b/controller/app/controllers/applications_controller.rb
@@ -199,11 +199,12 @@ class ApplicationsController < BaseController
     return render_error(:unprocessable_entity, "Invalid deployment_branch: #{deployment_branch}. Deployment branches are limited to 256 characters",
                         1, "deployment_branch") if deployment_branch and deployment_branch.length > 256
 
-    @application.config['auto_deploy'] = auto_deploy if !auto_deploy.nil?
-    @application.config['deployment_branch'] = deployment_branch if deployment_branch
-    @application.config['keep_deployments'] = keep_deployments if keep_deployments
-    @application.config['deployment_type'] = deployment_type if deployment_type
-    result = @application.update_configuration
+    new_config = {}
+    new_config['auto_deploy'] = auto_deploy unless auto_deploy.nil?
+    new_config['deployment_branch'] = deployment_branch unless deployment_branch.nil?
+    new_config['keep_deployments'] = keep_deployments unless keep_deployments.nil?
+    new_config['deployment_type'] = deployment_type unless deployment_type.nil?
+    result = @application.update_configuration(new_config)
 
     include_cartridges = (params[:include] == "cartridges")
     app = get_rest_application(@application, include_cartridges)

--- a/controller/app/helpers/admin_helper.rb
+++ b/controller/app/helpers/admin_helper.rb
@@ -145,7 +145,7 @@ module AdminHelper
     options ||= {}
     options.reverse_merge!({:timeout => false})
     query = {}
-    query['_id'] = BSON::ObjectId(user_id.to_s) if user_id
+    query['_id'] = BSON::ObjectId(user_id.to_s) if user_id.present?
     OpenShift::DataStore.find(:cloud_users, query, options) do |user|
       unless user["login"].present?
         print_message "User with Id #{user['_id']} has a null, empty, or missing login."
@@ -166,7 +166,7 @@ module AdminHelper
     options ||= {}
     options.reverse_merge!({:timeout => false})
     query = {}
-    query['_id'] = BSON::ObjectId(domain_id.to_s) if domain_id
+    query['_id'] = BSON::ObjectId(domain_id.to_s) if domain_id.present?
     OpenShift::DataStore.find(:domains, query, options) do |domain|
       owner_id = domain["owner_id"].to_s
       $domain_hash[domain["_id"].to_s] = {"owner_id" => owner_id, "canonical_namespace" => domain["canonical_namespace"]}

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -395,7 +395,13 @@ class Application
   ##
   # Updates the configuration of the application.
   # @return [ResultIO] Output from cartridges
-  def update_configuration
+  def update_configuration(new_config={})
+    # set the new config in the application object without persisting for validation 
+    self.config['auto_deploy'] = new_config['auto_deploy'] unless new_config['auto_deploy'].nil?
+    self.config['deployment_branch'] = new_config['deployment_branch'] unless new_config['deployment_branch'].nil?
+    self.config['keep_deployments'] = new_config['keep_deployments'] unless new_config['keep_deployments'].nil?
+    self.config['deployment_type'] = new_config['deployment_type'] unless new_config['deployment_type'].nil?
+
     if self.invalid?
       messages = []
       if self.errors.messages[:config]
@@ -410,9 +416,17 @@ class Application
       raise OpenShift::UserException.new("Invalid application configuration: #{messages}", 1)
     end
     Application.run_in_application_lock(self) do
-      op_group = UpdateAppConfigOpGroup.new(config: self.config)
-      self.pending_op_groups << op_group
-      self.save!
+      # set the config parameters not specified in new_config based on the updates values in the application
+      ['auto_deploy', 'deployment_branch', 'keep_deployments', 'deployment_type'].each {|k| new_config[k] = self.config[k] if new_config[k].nil?}
+      op_group = UpdateAppConfigOpGroup.new(config: new_config)
+      op_group.set_created_at
+      app_updates = {"$push" => { pending_op_groups: op_group.as_document }, "$set" => {}}
+      new_config.keys.each { |k| app_updates["$set"]["config.#{k}"] = new_config[k] unless new_config[k].nil? }
+
+      # do an atomic update and reload the application
+      Application.where(_id: self._id).update(app_updates)
+      self.reload
+
       result_io = ResultIO.new
       self.run_jobs(result_io)
       result_io
@@ -894,7 +908,6 @@ class Application
 
     Application.run_in_application_lock(self) do
       pending_op_groups << MakeAppHaOpGroup.new(user_agent: self.user_agent)
-      self.save!
       result_io = ResultIO.new
       self.run_jobs(result_io)
       result_io
@@ -919,7 +932,6 @@ class Application
     Application.run_in_application_lock(self) do
       op_group = UpdateCompLimitsOpGroup.new(comp_spec: component_instance.to_component_spec, min: scale_from, max: scale_to, multiplier: multiplier, additional_filesystem_gb: additional_filesystem_gb, user_agent: self.user_agent)
       pending_op_groups << op_group
-      self.save!
       result_io = ResultIO.new
       self.run_jobs(result_io)
       result_io
@@ -934,7 +946,6 @@ class Application
     Application.run_in_application_lock(self) do
       if group_instances_with_overrides.find {|group| group.additional_filesystem_gb > 0 }
         pending_op_groups << ChangeMaxUntrackedStorageOpGroup.new(user_agent: self.user_agent, old_untracked: old_untracked, new_untracked: new_untracked)
-        self.save!
         result_io = ResultIO.new
         self.run_jobs(result_io)
         result_io
@@ -1585,6 +1596,7 @@ class Application
         domain_env_vars_to_add.push({"key" => command_item[:args][0], "value" => command_item[:args][1], "component_id" => component_id})
       when "BROKER_KEY_ADD"
         op_group = AddBrokerAuthKeyOpGroup.new(user_agent: self.user_agent)
+        op_group.set_created_at
         Application.where(_id: self._id).update_all({ "$push" => { pending_op_groups: op_group.as_document } })
       when "NOTIFY_ENDPOINT_CREATE"
         if gear
@@ -1606,10 +1618,12 @@ class Application
     if add_ssh_keys.length > 0
       keys_attrs = get_updated_ssh_keys(add_ssh_keys)
       op_group = UpdateAppConfigOpGroup.new(add_keys_attrs: keys_attrs, user_agent: self.user_agent)
+      op_group.set_created_at
       Application.where(_id: self._id).update_all({ "$push" => { pending_op_groups: op_group.as_document }, "$pushAll" => { app_ssh_keys: keys_attrs }})
     end
     if remove_env_vars.length > 0
       op_group = UpdateAppConfigOpGroup.new(remove_env_vars: remove_env_vars)
+      op_group.set_created_at
       Application.where(_id: self._id).update_all({ "$push" => { pending_op_groups: op_group.as_document }})
     end
 
@@ -1629,9 +1643,8 @@ class Application
   #
   # == Returns:
   # True on success or False if no pending jobs.
-  def run_jobs(result_io=nil)
+  def run_jobs(result_io=nil, continue_on_successful_rollback=false)
     result_io = ResultIO.new if result_io.nil?
-    self.reload
     op_group = nil
     while self.pending_op_groups.count > 0
       rollback_pending = false
@@ -1643,6 +1656,9 @@ class Application
 
         if op_group.pending_ops.where(:state => :rolledback).count > 0
           rollback_pending = true
+          # making sure that the rollback_blocked flag is not accidentally set to true
+          # triggering a rollback while blocking the rollback at the same time could result in an infinite loop
+          op_group.set :rollback_blocked, false if op_group.rollback_blocked
           raise Exception.new("Op group is already being rolled back.")
         end
 
@@ -1672,10 +1688,12 @@ class Application
           # if the original exception was raised just to trigger a rollback
           # then the rollback exception is the only thing of value and hence return/raise it
           raise e_rollback if rollback_pending
-        end
+        end unless op_group.rollback_blocked
 
         # raise the original exception if it was the actual exception that led to the rollback
-        unless rollback_pending
+        # if not, then we should just continue execution of any remaining op_groups.
+        # The continue_on_successful_rollback flag is used by the oo-admin-clear-pending-ops script
+        unless rollback_pending or continue_on_successful_rollback
           if e_orig.respond_to? 'resultIO' and e_orig.resultIO
             e_orig.resultIO.append result_io unless e_orig.resultIO == result_io
           end
@@ -1716,6 +1734,8 @@ class Application
     end
     if got_lock
       begin
+        # reload the application to reflect any changes made by any previous operation holding the lock 
+        application.reload if application.persisted?
         block.arity == 1 ? block.call(application) : yield
       ensure
         Lock.unlock_application(application)

--- a/controller/app/models/pending_app_op_group.rb
+++ b/controller/app/models/pending_app_op_group.rb
@@ -20,6 +20,7 @@ class PendingAppOpGroup
   field :num_gears_destroyed, type: Integer, default: 0
   field :num_gears_rolled_back, type: Integer, default: 0
   field :user_agent, type: String, default: ""
+  field :rollback_blocked, type: Boolean, default: false
 
   def initialize(attrs = nil, options = nil)
     parent_opid = nil

--- a/controller/app/pending_ops_models/add_features_op_group.rb
+++ b/controller/app/pending_ops_models/add_features_op_group.rb
@@ -18,6 +18,18 @@ class AddFeaturesOpGroup < PendingAppOpGroup
     try_reserve_gears(gears_added, gears_removed, app, ops)
   end
 
+  def execute_rollback(result_io=nil)
+    super(result_io)
+
+    # if a rollback was triggered and was successful,
+    # and if the app no longer has group_instances or component_instances,
+    # then delete this application
+    if self.application.group_instances.blank? and self.application.component_instances.blank?
+      self.application.delete
+      self.application.pending_op_groups.clear
+    end
+  end
+
   def cartridges
     @cartridges ||= begin
       if attributes['cartridges'].presence

--- a/controller/app/pending_ops_models/destroy_gear_op.rb
+++ b/controller/app/pending_ops_models/destroy_gear_op.rb
@@ -6,6 +6,10 @@ class DestroyGearOp < PendingAppOp
     result_io = ResultIO.new
     gear = get_gear()
     result_io = gear.destroy_gear(true) unless gear.removed
+    
+    # setting the rollback_blocked flag to true since after this point, the operation is not reversible
+    self.pending_app_op_group.set :rollback_blocked, true
+    
     result_io
   end
 

--- a/controller/app/pending_ops_models/remove_comp_op.rb
+++ b/controller/app/pending_ops_models/remove_comp_op.rb
@@ -7,6 +7,10 @@ class RemoveCompOp < PendingAppOp
     gear = get_gear
     component_instance = get_component_instance
     result_io = gear.remove_component(component_instance)
+    
+    # setting the rollback_blocked flag to true since after this point, the operation is not reversible
+    self.pending_app_op_group.set :rollback_blocked, true
+    
     result_io
   end
 


### PR DESCRIPTION
- Adding option to prevent rollback in case of successful execution of a destructive operation that is not reversible (deleting gear or deconfiguring cartridge on the node)
- Checking for the existence of the application after obtaining the lock
- Reloading the application after acquiring the lock to reflect any changes made by the previous operation holding the lock
- Using regular run_jobs code in clear-pending-ops script
- Handling DocumentNotFound exception in clear-pending-ops script if the application is deleted
