### PR TITLE
Log MCollective agent reply details via NodeLogger

### DIFF
--- a/node/lib/openshift-origin-node/utils/hourglass.rb
+++ b/node/lib/openshift-origin-node/utils/hourglass.rb
@@ -41,6 +41,10 @@ module OpenShift
         def expired?
           remaining.zero?
         end
+
+        def to_s
+          "hourglass_remaining=#{remaining}"
+        end
       end
     end
   end


### PR DESCRIPTION
Reduce reliance on MCollective server logs by reporting critical
request/reply details through NodeLogger for actions originating
in the OpenShift MCollective Agent.
