### PR TITLE
Bug 1071165 - npm no longer supports its self-signed certificates

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/bin/control
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/control
@@ -187,6 +187,9 @@ function build() {
     #  Newer versions of Node set tmp to $HOME/tmp, which is not available
     nodejs_context "npm config set tmp $OPENSHIFT_TMP_DIR"
 
+    # FIXME: Remove this line once we update NPM to latest version
+    nodejs_context 'npm config set ca ""'
+
     if [ -f "${OPENSHIFT_REPO_DIR}"/deplist.txt ]; then
         mods=$(perl -ne 'print if /^\s*[^#\s]/' "${OPENSHIFT_REPO_DIR}"/deplist.txt)
         [ -n "$mods" ]  &&  print_deprecation_warning

--- a/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml.rhel
+++ b/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml.rhel
@@ -13,8 +13,9 @@ License: MIT License
 License-Url: https://raw.github.com/joyent/node/v0.10/LICENSE
 Vendor: www.nodejs.org
 Website: http://www.nodejs.org/
-Cartridge-Version: 0.0.12
+Cartridge-Version: 0.0.13
 Compatible-Versions:
+- 0.0.12
 - 0.0.11
 Cartridge-Vendor: redhat
 Categories:


### PR DESCRIPTION
Background story: http://blog.npmjs.org/post/78085451721/npms-self-signed-certificate-is-no-more
