### PR TITLE
vhost-plugin: switch from rewrite back to proxypass

### DIFF
--- a/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
+++ b/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
@@ -184,7 +184,7 @@ module OpenShift
                     if gen_default_rule
                       tpath = path.empty? ? "/" : path
 
-                      f.puts("ProxyPass #{tpath} #{proxy_proto}://#{uri}/ keepalive=On")
+                      f.puts("ProxyPass #{tpath} #{proxy_proto}://#{uri}/")
 
                       if uri.empty?
                         turi = "127.0.0.1:80"

--- a/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
+++ b/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
@@ -182,13 +182,9 @@ module OpenShift
                     end
 
                     if gen_default_rule
-                      f.puts("RewriteRule ^#{path}(/.*)?$ #{proxy_proto}://#{uri}$1 [P,NS]")
+                      tpath = path.empty? ? "/" : path
 
-                      if path.empty?
-                        tpath = "/"
-                      else
-                        tpath = path
-                      end
+                      f.puts("ProxyPass #{tpath} #{proxy_proto}://#{uri}/ keepalive=On")
 
                       if uri.empty?
                         turi = "127.0.0.1:80"


### PR DESCRIPTION
Switch the primary traffic proxy for the vhost frontend plugin.
There are still other RewriteRule's that do the setting of
variables, etc.
