### PR TITLE
fix auto-idler bz1072472 

### DIFF
--- a/node-util/sbin/oo-auto-idler
+++ b/node-util/sbin/oo-auto-idler
@@ -18,9 +18,10 @@ $config = OpenShift::Config.new
 $last_access_dir = $config.get("LAST_ACCESS_DIR")
 $log = Logger.new($stderr)
 $log.level = Logger::WARN
+$exit_status = 0
 
 # Return whether app has been accessed within the specified number of hours.
-def app_accessed?(uuid, interval)
+def app_accessed?(uuid, interval, max_interval)
   file_path = File.join($last_access_dir, uuid)
   if File.exists?(file_path)
     File.open(file_path, 'r') do |file|
@@ -29,8 +30,17 @@ def app_accessed?(uuid, interval)
       d2 = DateTime.now
       idle_hours = ((d2 - d1) * 24).to_i
       if idle_hours >= interval
-        $log.debug "NO ACCESS"
-        false
+        if (max_interval >= interval and idle_hours >= max_interval)
+          msg = "Gear #{uuid} has last access time (#{idle_hours} idle hours) which is more than the max_interval (#{max_interval}). Check if the last_time has been updated properly or not."
+          $log.error msg
+          puts msg
+          $exit_status = 1
+          $log.debug "ACCESS"
+          true
+        else
+          $log.debug "NO ACCESS"
+          false
+        end
       else
         $log.debug "ACCESS"
         true
@@ -95,9 +105,9 @@ def code_committed?(gear_dir, interval)
 end
 
 # Determine if a gear is stale i.e. ready to be idled
-def gear_stale?(gear_dir, gear_uuid, interval)
+def gear_stale?(gear_dir, gear_uuid, interval, max_interval)
   $log.debug "Evaluating #{gear_uuid}"
-  has_frontend?(gear_dir) and not code_committed?(gear_dir, interval) and not app_accessed?(gear_uuid, interval) and is_head_gear?(gear_dir)
+  has_frontend?(gear_dir) and not code_committed?(gear_dir, interval) and not app_accessed?(gear_uuid, interval, max_interval) and is_head_gear?(gear_dir)
 end
 
 # Idle a gear
@@ -127,7 +137,7 @@ def populate_ignorelist()
 end
 
 # Idle all gears on the node unless the list only option has been passed
-def idle_gears(interval, list_only)
+def idle_gears(interval, max_interval, list_only)
   puts "Only listing idle gears" if list_only
   gear_gecos = $config.get("GEAR_GECOS")
   ignorelist = populate_ignorelist()
@@ -139,7 +149,7 @@ def idle_gears(interval, list_only)
       $log.debug("Skipping #{gear_uuid}: IGNORELIST")
       next
     end
-    if gear_stale?(gear_dir, gear_uuid, interval)
+    if gear_stale?(gear_dir, gear_uuid, interval, max_interval)
       puts "#{gear_dir} is STALE"
       if not list_only
         begin
@@ -157,15 +167,19 @@ command :idle do |c|
   c.syntax = "#{name} idle [options]"
   c.description = "List the gears ready to be idled"
   c.option "--interval HOURS", Integer, "Hours for which gears have been idle"
+  c.option "--max_interval HOURS", Integer, "Gears unaccessed longer than these hours will be ignored for auto-idling. Any value less than '--interval' will disable this check."
   c.option "--list", "Only list the stale gears"
   c.option "--verbose", "Print debug information"
 
   c.action do |args, options|
     options.default :interval => 240
+    options.default :max_interval => (options.interval*10)
     $log.level = Logger::DEBUG if options.verbose
     puts "Gears idle for #{options.interval} hours"
     %x[(echo -n "Before: ";  /usr/sbin/oo-idler-stats) | /usr/bin/logger -p local0.notice -t oo-auto-idler]
-    idle_gears(options.interval, options.list || false)
+    idle_gears(options.interval, options.max_interval, options.list || false)
     %x[(echo -n "After: ";  /usr/sbin/oo-idler-stats) | /usr/bin/logger -p local0.notice -t oo-auto-idler]
   end
 end
+
+exit $exit_status


### PR DESCRIPTION
Provide a max_interval limit for idle_hours of a gear beyond which the said will not get idled (indicating that there is something wrong with logging the last access time).
