### PR TITLE
virtualenv and mod_wsgi are required for python 2.6, 2.7 and 3.3.

### DIFF
--- a/cartridges/dependencies/openshift-origin-cartridge-dependencies.spec
+++ b/cartridges/dependencies/openshift-origin-cartridge-dependencies.spec
@@ -305,10 +305,8 @@ Requires:  python-psycopg2
 Requires:  redhat-lsb-core
 Requires:  symlinks
 %if 0%{?fedora}%{?rhel} <= 6
-Requires:  python27-mod_wsgi
 Requires:  python27-MySQL-python
 Requires:  python27-python-psycopg2
-Requires:  python33-mod_wsgi
 Requires:  python33-python-psycopg2
 %endif
 
@@ -334,13 +332,10 @@ Requires:  numpy
 Requires:  numpy-f2py
 Requires:  pymongo
 Requires:  pymongo-gridfs
-Requires:  python-virtualenv
 Requires:  ta-lib-devel
 %if 0%{?fedora}%{?rhel} <= 6
 Requires:  python27-numpy
-Requires:  python27-python-pip-virtualenv
 Requires:  python33-numpy
-Requires:  python33-python-virtualenv
 Requires:  python33-python-pymongo
 %endif
 

--- a/cartridges/openshift-origin-cartridge-python/openshift-origin-cartridge-python.spec
+++ b/cartridges/openshift-origin-cartridge-python/openshift-origin-cartridge-python.spec
@@ -27,6 +27,13 @@ Requires:      python < 2.8
 Requires:      mod_wsgi >= 3.4
 Requires:      mod_wsgi < 3.5
 %endif
+Requires:      python-virtualenv
+%if 0%{?fedora}%{?rhel} <= 6
+Requires:      python27-python-pip-virtualenv
+Requires:      python27-mod_wsgi
+Requires:      python33-python-virtualenv
+Requires:      python33-mod_wsgi
+%endif
 Provides:      openshift-origin-cartridge-community-python-2.7 = 2.0.0
 Provides:      openshift-origin-cartridge-community-python-3.3 = 2.0.0
 Provides:      openshift-origin-cartridge-python-2.6 = 2.0.0


### PR DESCRIPTION
The -recommended and -optional metapackages are for dependencies that are not
strictly required.
