### PR TITLE
rpm-build is required for the perl cartridge's build script

### DIFF
--- a/cartridges/dependencies/openshift-origin-cartridge-dependencies.spec
+++ b/cartridges/dependencies/openshift-origin-cartridge-dependencies.spec
@@ -216,7 +216,6 @@ Requires:  gd-devel
 Requires:  gdbm-devel
 Requires:  ImageMagick-perl
 Requires:  perl-MongoDB
-Requires:  rpm-build
 
 %description optional-perl
 This package pulls in other packages that a user

--- a/cartridges/openshift-origin-cartridge-perl/openshift-origin-cartridge-perl.spec
+++ b/cartridges/openshift-origin-cartridge-perl/openshift-origin-cartridge-perl.spec
@@ -14,6 +14,8 @@ Requires:      openshift-origin-node-util
 Requires:      mod_perl
 Requires:      perl-App-cpanminus
 Requires:      perl-IO-Socket-SSL
+# required for bin/build's usage of /usr/lib/rpm/perl.req
+Requires:      rpm-build
 Provides:      openshift-origin-cartridge-perl-5.10 = 2.0.0
 Obsoletes:     openshift-origin-cartridge-perl-5.10 <= 1.99.9
 BuildArch:     noarch


### PR DESCRIPTION
[merge]
