### PR TITLE
Fix bug 1072663, 1072663:

### DIFF
--- a/controller/test/cucumber/platform-upgrade.feature
+++ b/controller/test/cucumber/platform-upgrade.feature
@@ -88,3 +88,23 @@ Feature: Cartridge upgrades
     And the invocation markers from an compatible upgrade should exist
     And the invocation markers from the gear upgrade should exist
     And the application should be accessible
+
+  Scenario: Re-upgrade an application when one of the cartridges is removed
+    Given the 0.0.1 version of the mock-0.1 cartridge is installed
+    And a new client created mock-0.1 application
+    And the embedded mock-plugin-0.1 cartridge is added
+    And a rigged version of the mock-0.1 cartridge set to fail 1 times
+    And a rigged version of the mock-plugin-0.1 cartridge set to fail 2 times
+    And the mock invocation markers are cleared
+    And a gear level upgrade extension exists
+
+    When the application is upgraded to the new cartridge versions
+    And the embedded mock-plugin-0.1 cartridge is removed
+    And the application is upgraded to the new cartridge versions
+
+    Then the upgrade metadata will be cleaned up
+    And the mock cartridge version should be updated
+    And no unprocessed ERB templates should exist
+    And the invocation markers from an incompatible upgrade should exist
+    And the invocation markers from the gear upgrade should exist
+    And the application should be accessible

--- a/controller/test/cucumber/step_definitions/upgrade_steps.rb
+++ b/controller/test/cucumber/step_definitions/upgrade_steps.rb
@@ -240,8 +240,8 @@ def assert_successful_install(next_version, current_manifest)
   sleep 5
 end
 
-Then /^the ([^ ]+) cartridge version should be updated$/ do |cart_name|
-  assert_cart_version_updated(cart_name, @app)
+Then /^the ([^ ]+) cartridge version should (not )?be updated$/ do |cart_name, negate|
+  assert_cart_version_updated(cart_name, @app, negate)
 end
 
 Then /^the ([^ ]+) cartridge version should (not )?be updated in (.+)$/ do |cart_name, negate, app_name|

--- a/node/lib/openshift-origin-node/utils/upgrade_itinerary.rb
+++ b/node/lib/openshift-origin-node/utils/upgrade_itinerary.rb
@@ -22,6 +22,10 @@ module OpenShift
         end
       end
 
+      def remove_entry(cartridge_name)
+        @entries.delete(cartridge_name)
+      end
+
       def has_incompatible_upgrade?
         @has_incompatible
       end


### PR DESCRIPTION
- Remove deleted cartridges from upgrade itinerary before re-run
- Only check status on cartridges being upgraded
