### PR TITLE
Append .log to file writer filenames

### DIFF
--- a/logshifter/README.md
+++ b/logshifter/README.md
@@ -22,19 +22,23 @@ Here are some small examples to verify logshifter is writing events, using the d
 (which writes to syslog):
 
     # single shot
-    echo hello world > >(/tmp/logshifter)
+    echo hello world | logshifter -tag myapp
 
     # 10 messages @ 1 message/second
-    for i in {1..10}; do echo logshifter message ${i}; sleep 1; done > >(/tmp/logshifter -verbose)
+    for i in {1..10}; do echo logshifter message ${i}; sleep 1; done | /tmp/logshifter -tag myapp
 
     # 30 messages @ 1 message/second with stats reporting every 2 seconds
-    for i in {1..30}; do echo logshifter message ${i}; sleep 1; done > >(/tmp/logshifter -verbose -statsfilename /tmp/logshifter.stats -statsinterval 2s)
+    for i in {1..30}; do echo logshifter message ${i}; sleep 1; done | /tmp/logshifter -tag myapp -statsfilename /tmp/logshifter.stats -statsinterval 2s
 
 Configuration
 ---
 An optional configuration file can be supplied to logshifter with the `-config` flag. The file
 is a list of key value pairs in the format `k = v`, one per line. The possible options and their
 defaults are described in the [Config type](config.go). Keys are case insensitive.
+
+If no `-config` flag is specified, logshifter will attempt to load a global config file from
+`/etc/openshift/logshifter.conf`. If no `-config` is specified, and the global config file doesn't
+exist, a default syslog-based configuration will be used.
 
 Statistics
 ---

--- a/logshifter/file_writer.go
+++ b/logshifter/file_writer.go
@@ -24,7 +24,7 @@ type FileWriter struct {
 // Init implements the Writer interface.
 //
 // The destination filename is constructed by joining config.fileWriterDir
-// with tag.
+// with tag and appending a '.log' suffix.
 //
 // A leading `~/` in config.fileWriterDir will be replaced by the
 // current user's home directory path.
@@ -39,7 +39,7 @@ func (writer *FileWriter) Init() error {
 		basedir = strings.Replace(basedir, "~/", (dir + "/"), 1)
 	}
 
-	filename := path.Join(basedir, writer.tag)
+	filename := path.Join(basedir, writer.tag+".log")
 
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {

--- a/logshifter/shifter.go
+++ b/logshifter/shifter.go
@@ -66,7 +66,7 @@ func (shifter *Shifter) Start() error {
 	writeGroup, err := shifter.output.Write()
 
 	if err != nil {
-		return errors.New(fmt.Sprintf("Failed to initialize output writer: %s", err))
+		return errors.New(fmt.Sprintf("Failed to initialize output writer: %v", err))
 	}
 
 	readGroup := shifter.input.Read()


### PR DESCRIPTION
Use a .log suffix for filenames generated by the file writer.

Improve error handling in the CLI.
