### PR TITLE
Card 155 - cpanfile and Makefile.PL support

### DIFF
--- a/cartridges/openshift-origin-cartridge-perl/bin/build
+++ b/cartridges/openshift-origin-cartridge-perl/bin/build
@@ -20,39 +20,55 @@ fi
 function depfile_path_for() {
   local filename=$1
   if [ -f "${OPENSHIFT_REPO_DIR}${filename}" ]; then
-   echo -n "${OPENSHIFT_REPO_DIR}${filename}"
+   echo -n "${OPENSHIFT_REPO_DIR}"
   elif [ -f "${OPENSHIFT_REPO_DIR}perl/${filename}" ]; then
-   echo -n "${OPENSHIFT_REPO_DIR}perl/${filename}"
+   echo -n "${OPENSHIFT_REPO_DIR}/perl/"
+  elif [ -f "${OPENSHIFT_REPO_DIR}.openshift/${filename}" ]; then
+   echo -n "${OPENSHIFT_REPO_DIR}/.openshift/"
   else
-   echo -n "${OPENSHIFT_REPO_DIR}/.openshift/cpan.txt"
+   echo -n ""
   fi
 }
 
-# Check for obsolite deplist.txt, else return new ".openshift/cpan.txt"
+DEPLIST_PATH=$(depfile_path_for deplist.txt)
+CPANFILE_PATH=$(depfile_path_for cpanfile)
+MAKEFILE_PATH=$(depfile_path_for Makefile.PL)
 
-DEPLIST=$(depfile_path_for deplist.txt)
+CPAN="${OPENSHIFT_REPO_DIR}/.openshift/cpan.txt"
+DEPLIST=${DEPLIST_PATH}/deplist.txt
 
-if [[ -n "${DEPLIST}" ]]
+if [ -f ${DEPLIST} ] || [ -f ${CPAN} ]
 then
-  DEPS=$(find $OPENSHIFT_REPO_DIR -type f \( -name \*\.pm -o -name \*\.pl \); )
-  DEPLIST_NAME=$(basename ${DEPLIST})
+  if [ -f ${DEPLIST} ] && [ -f ${CPAN} ]
+  then
+    echo "***  Installing modules from cpan.txt and deplist.txt"
+  elif [ -f ${CPAN} ]; then
+    echo "***  Installing modules from cpan.txt"
+  elif [ -f ${DEPLIST} ]; then
+    echo "***  Installing modules from deplist.txt"
+  fi
 
-  for f in $( ( echo "$DEPS" | xargs /usr/lib/rpm/perl.req | awk '{ print $1 }' | sed 's/^perl(\(.*\))$/\1/'; cat ${DEPLIST} ) | sort -u)
+  DEPS=$(find $OPENSHIFT_REPO_DIR -type f \( -name \*\.pm -o -name \*\.pl \); )
+
+  for f in $(( echo "$DEPS" | xargs /usr/lib/rpm/perl.req | awk '{ print $1 }' | sed 's/^perl(\(.*\))$/\1/'; cat ${DEPLIST} 2>/dev/null; cat ${CPAN_TXT} 2>/dev/null ) | sort -u | grep . )
   do
     # Skip checking if module is available locally or installed in system
     # if module is listed in deplist.txt
     #
-    if ! grep "$f" ${DEPLIST} >/dev/null 2>&1; then
+    if ! grep "$f" ${DEPLIST} >/dev/null 2>&1;
+    then
 
-      if egrep -re "^\s*package\s*$f" $DEPS >/dev/null 2>&1; then
+      if egrep -re "^\s*package\s*$f" $DEPS >/dev/null 2>&1;
+      then
         echo "***  Skipping module $f install from CPAN (found locally)."
-        echo "***  Please add $f to $DEPLIST_NAME to install it from CPAN."
+        echo "***  Please add $f to deplist.txt to install it from CPAN."
         continue;
       fi
 
-      if perl -e "use $f;" 2> /dev/null; then
+      if perl -e "use $f;" 2> /dev/null;
+      then
         echo "***   Skipping module $f install from CPAN (found in system)."
-        echo "***   Please add $f to $DEPLIST_NAME to install it from CPAN."
+        echo "***   Please add $f to deplist.txt to install it from CPAN."
         continue;
       fi
     fi
@@ -66,4 +82,28 @@ then
 
     cpanm $DISABLE_TEST $MIRROR -L ${OPENSHIFT_PERL_DIR}perl5lib "$f"
   done
+fi
+
+# Installing dependencies with Makefile.PL
+if [[ -n ${MAKEFILE_PATH} ]]
+then
+  echo "***  Preparing project via Makefile.pl"
+  pushd ${MAKEFILE_PATH} > /dev/null
+  perl Makefile.PL PREFIX=${PERL5LIB} LIB=${PERL5LIB}
+  make
+  if [ -f "${OPENSHIFT_REPO_DIR}.openshift/markers/enable_cpan_tests" ];
+  then
+    make test
+  fi
+  make install
+  popd > /dev/null
+fi
+
+# Installing dependencies with cpanfile
+if [[ -n ${CPANFILE_PATH} ]]
+then
+  echo "***  Installing modules from cpanfile"
+  pushd ${CPANFILE_PATH} > /dev/null
+  cpanm $MIRROR -L ${OPENSHIFT_PERL_DIR}perl5lib --installdeps .
+  popd > /dev/null
 fi

--- a/cartridges/openshift-origin-cartridge-perl/env/PERL5LIB.erb
+++ b/cartridges/openshift-origin-cartridge-perl/env/PERL5LIB.erb
@@ -1,1 +1,1 @@
-<%= ENV['OPENSHIFT_REPO_DIR'] %>libs:<%= ENV['OPENSHIFT_PERL_DIR'] %>perl5lib/lib/perl5/
+<%= ENV['OPENSHIFT_PERL_DIR'] %>perl5lib/lib/perl5/

--- a/controller/test/cucumber/cartridge-lifecycle-perl.feature
+++ b/controller/test/cucumber/cartridge-lifecycle-perl.feature
@@ -76,3 +76,31 @@ Feature: Cartridge Lifecycle Perl Verification Tests
     Scenarios: RHEL scenarios
       | cart_name |
       | perl-5.10 |
+
+
+  Scenario Outline: Application with cpanfile
+    Given the libra client tools
+    When 1 <cart_name> applications are created
+    Then the applications should be accessible
+    Given an existing <cart_name> application
+
+    When a cpanfile is added into repo directory
+    Then the applications should be accessible
+
+    Scenarios: RHEL scenarios
+      | cart_name |
+      | perl-5.10 |
+
+
+  Scenario Outline: Application with Makefile.PL
+    Given the libra client tools
+    When 1 <cart_name> applications are created
+    Then the applications should be accessible
+    Given an existing <cart_name> application
+
+    When a Makefile is added into repo directory
+    Then the applications should be accessible
+
+    Scenarios: RHEL scenarios
+      | cart_name |
+      | perl-5.10 |

--- a/controller/test/cucumber/step_definitions/cartridge-perl_steps.rb
+++ b/controller/test/cucumber/step_definitions/cartridge-perl_steps.rb
@@ -10,7 +10,7 @@ When /^the application document root is changed to ([^ ]*) directory$/ do |direc
       run("mv index.pl .htaccess #{directory}/")
       run("git add perl/")
       run("git commit -am 'Test commit - Change document root'")
-      run("git push >> " + @app.get_log("git_push_php_create_file") + " 2>&1")
+      run("git push >> " + @app.get_log("git_push_perl_create_file") + " 2>&1")
     end
 end
 
@@ -21,6 +21,29 @@ When /^the application document root is changed from ([^ ]*) directory back to d
       run("git add .")
       run("git rm #{directory}/")
       run("git commit -am 'Test commit - Change document root back to default directory'")
-      run("git push >> " + @app.get_log("git_push_php_create_file") + " 2>&1")
+      run("git push >> " + @app.get_log("git_push_perl_create_file") + " 2>&1")
+    end
+end
+
+When /^a cpanfile is added into repo directory$/ do
+    Dir.chdir(@app.repo) do
+      File.open("cpanfile",'w') {|f| f.write('requires "YAML", "== 0.90";')}
+      run("git add cpanfile")
+      run("git commit -m 'Test commit - Adding cpanfile into repo'")
+      run("git push >> " + @app.get_log("git_push_perl_create_file") + " 2>&1")
+    end
+end
+
+When /^a Makefile is added into repo directory$/ do
+    Dir.chdir(@app.repo) do
+      File.open("Makefile",'w') do |f|
+        f.write('use strict;')
+        f.write('use warnings;')
+        f.write('use ExtUtils::MakeMaker;')
+        f.write('WriteMakefile(PREREQ_PM => {"YAML" => "0.90"});')
+      end
+      run("git add cpanfile")
+      run("git commit -m 'Test commit - Adding cpanfile into repo'")
+      run("git push >> " + @app.get_log("git_push_perl_create_file") + " 2>&1")
     end
 end

--- a/documentation/oo_cartridge_guide.adoc
+++ b/documentation/oo_cartridge_guide.adoc
@@ -793,9 +793,9 @@ index.pl
 ----
 <1> link:oo_user_guide.html#action-hooks[Action Hooks] documentation
 
-Due to latest changes in Perl cartridge template layout, the application is now stored in `$OPENSHIFT_REPO_DIR`, but is also backward compatible with deprecated `perl` directory.
+Due to changes in Perl cartridge template layout, the application root is now stored in `$OPENSHIFT_REPO_DIR`, but is also backward compatible with deprecated `perl/` directory.
 
-Modules are installed with `cpan.txt`, located in `.openshift` directory. Older deplist.txt is depricated, but still working.
+Modules are installed with `cpan.txt`, located in `.openshift` directory. `deplist.txt` is deprecated, but still working. Besides that application dependencies can be installed using `cpanfile` or `Makefile.PL`, which needs to be placed at the root of the application.
 
 === Cartridge Layout
 ----


### PR DESCRIPTION
Added support for cpanfile and Makefile.PL.
The dependencies are installed primarily form the .openshift/cpan.txt or from the obsolete deplist.txt
However if user uses for dependency installation cpanfile or Makefile.PL, which is widely known in the Perl community, the build script will use those files and install dependencies which are described in them .
