### PR TITLE
Stop using direct addressing for upgrade and repair

### DIFF
--- a/broker-util/oo-admin-repair
+++ b/broker-util/oo-admin-repair
@@ -16,27 +16,8 @@
 # limitations under the License.
 #++
 
-require "#{ENV['OPENSHIFT_BROKER_DIR'] || '/var/www/openshift/broker'}/config/environment"
 require 'getoptlong'
 require 'time'
-include AdminHelper
-
-# Disable analytics for admin scripts
-Rails.configuration.analytics[:enabled] = false
-Rails.configuration.msg_broker[:rpc_options][:disctimeout] = 20
-Rails.configuration.msg_broker[:rpc_options][:timeout] = 600
-
-$log_file = "/var/log/openshift/broker/usage-refund.log"
-$billing_api = nil
-if $billing_enabled
-  $billing_api = OpenShift::BillingService.instance
-  $billing_api.set_logger($log_file, false)
-end
-
-trap("INT") do
-  print_message "#{$0} Interrupted", true
-  exit 1
-end
 
 def usage
   puts <<USAGE
@@ -95,7 +76,7 @@ rescue GetoptLong::Error => e
 end
 
 usage if args["--help"]
- 
+
 $verbose = args["--verbose"]
 report_only = args["--report-only"]
 fix_ssh_keys = args["--ssh-keys"]
@@ -115,6 +96,27 @@ if fix_ssh_keys.nil? and fix_district_uids.nil? and fix_consumed_gears.nil? and
    fix_removed_nodes.nil? and fix_usage.nil?
   puts "You must specify at least one item to fix."
   usage
+end
+
+require "#{ENV['OPENSHIFT_BROKER_DIR'] || '/var/www/openshift/broker'}/config/environment"
+include AdminHelper
+
+# Disable analytics for admin scripts
+Rails.configuration.analytics[:enabled] = false
+Rails.configuration.msg_broker[:rpc_options][:disctimeout] = 20
+Rails.configuration.msg_broker[:rpc_options][:timeout] = 600
+
+
+$log_file = "/var/log/openshift/broker/usage-refund.log"
+$billing_api = nil
+if $billing_enabled
+  $billing_api = OpenShift::BillingService.instance
+  $billing_api.set_logger($log_file, false)
+end
+
+trap("INT") do
+  print_message "#{$0} Interrupted", true
+  exit 1
 end
 
 def reset_consumed_gears(user_id)
@@ -347,27 +349,15 @@ def populate_available_servers
 end
 
 def find_unresponsive_servers(available_servers, auto_confirm)
-  unresponsive_servers = []
-  responsive_servers = []
-  message = "ping"
   options = OpenShift::MCollectiveApplicationContainerProxy.rpc_options
   unless auto_confirm.nil? # for test automation
     options[:disctimeout] = 1
     options[:timeout] = 1
   else
-    options[:disctimeout] = 5
-    options[:timeout] = 45
+    options[:disctimeout] = 20
   end
-  OpenShift::MCollectiveApplicationContainerProxy.rpc_exec('openshift', available_servers.keys, false, options) do |client|
-    client.echo(:msg => message).each do |resp|
-      if resp[:data][:msg] != message
-        unresponsive_servers << resp[:sender]
-      else
-        responsive_servers << resp[:sender]
-      end
-    end
-  end
-  unresponsive_servers += (available_servers.keys - responsive_servers)
+  responsive_servers = OpenShift::MCollectiveApplicationContainerProxy.known_server_identities
+  unresponsive_servers = (available_servers.keys - responsive_servers)
 
   # Report unresponsive servers to the admin 
   unless unresponsive_servers.empty?

--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -2310,7 +2310,7 @@ module OpenShift
       #
       # INPUTS:
       # * agent: String
-      # * servers: String|Array
+      # * servers: String
       # * force_rediscovery: Boolean
       # * options: Hash
       #
@@ -2325,27 +2325,21 @@ module OpenShift
       # * uses MCollective::RPC::Client
       # * THIS IS THE MEAT!
       #
-      def self.rpc_exec(agent, servers=nil, force_rediscovery=false, options=rpc_options)
-
-        if servers
-          servers = Array(servers)
-        else
-          servers = []
-        end
+      def self.rpc_exec(agent, server, force_rediscovery=false, options=rpc_options)
 
         # Setup the rpc client
         rpc_client = MCollectiveApplicationContainerProxy.get_rpc_client(agent, options)
 
-        if !servers.empty?
-          Rails.logger.debug("DEBUG: rpc_exec: Filtering rpc_exec to servers #{servers.pretty_inspect}")
-          rpc_client.discover :nodes => servers
-        end
+        #if !servers.empty?
+        #  Rails.logger.debug("DEBUG: rpc_exec: Filtering rpc_exec to servers #{servers.pretty_inspect}")
+        #  rpc_client.discover :nodes => servers
+        #end
 
         # Filter to the specified server
-        #if server
-        #  Rails.logger.debug("DEBUG: rpc_exec: Filtering rpc_exec to server #{server}")
-        #  rpc_client.identity_filter(server)
-        #end
+        if server
+          Rails.logger.debug("DEBUG: rpc_exec: Filtering rpc_exec to server #{server}")
+          rpc_client.identity_filter(server)
+        end
 
         if force_rediscovery
           rpc_client.reset
@@ -2882,14 +2876,14 @@ module OpenShift
       #
       def self.known_server_identities(force_rediscovery=false, rpc_opts=nil)
         server_identities = nil
-        server_identities = Rails.cache.read('known_server_identities') unless force_rediscovery
+        #server_identities = Rails.cache.read('known_server_identities') unless force_rediscovery
         unless server_identities
           server_identities = []
-          rpc_get_fact('active_capacity', nil, true, force_rediscovery, nil, rpc_opts) do |server, capacity|
+          rpc_get_fact('active_capacity', nil, force_rediscovery, nil, rpc_opts) do |server, capacity|
             #Rails.logger.debug "Next server: #{server} active capacity: #{capacity}"
             server_identities << server
           end
-          Rails.cache.write('known_server_identities', server_identities, {:expires_in => 1.hour}) unless server_identities.empty?
+          #Rails.cache.write('known_server_identities', server_identities, {:expires_in => 1.hour}) unless server_identities.empty?
         end
         server_identities
       end
@@ -3263,7 +3257,6 @@ module OpenShift
       # NOTES:
       # * uses rpc_exec
       #
-
       def self.rpc_get_fact(fact, servers=nil, force_rediscovery=false, additional_filters=nil, custom_rpc_opts=nil)
         result = nil
         options = custom_rpc_opts ? custom_rpc_opts : MCollectiveApplicationContainerProxy.rpc_options


### PR DESCRIPTION
- Use broadcast call to determine known server identities
- Make it so --help doesn't have to load the broker
