### PR TITLE
Bug 1075673 - Unable to perform git deploy after binary deployment

### DIFF
--- a/node/lib/openshift-origin-node/model/deployment_metadata.rb
+++ b/node/lib/openshift-origin-node/model/deployment_metadata.rb
@@ -55,11 +55,11 @@ module OpenShift
           load
         else
           File.new(@file, 'w', 0644)
-          container.set_rw_permission(@file)
-
           @metadata = defaults
 
           save
+          container.set_rw_permission(@file)
+
         end
       rescue => e
         container.logger.warn("Unable to create or update #{@file}. Gear may be exceeding quota. #{e.message}")


### PR DESCRIPTION
After doing a successful binary deployment, the node is unable to process a
git deployment
