### PR TITLE
Add support for multiple platforms in OpenShift.

### DIFF
--- a/broker-util/oo-admin-ctl-cartridge
+++ b/broker-util/oo-admin-ctl-cartridge
@@ -8,7 +8,22 @@ PATH = "#{ENV['OPENSHIFT_BROKER_DIR'] || '/var/www/openshift/broker'}/config/env
 class Command
   def import_node(options)
     env!(options)
-    carts = OpenShift::ApplicationContainerProxy.send(options.node ? :instance : :find_one, *[options.node].compact).get_available_cartridges
+
+    carts = []
+
+    if options.node
+      carts = OpenShift::ApplicationContainerProxy.instance(options.node)
+    else
+      node_platforms = Rails.configuration.openshift[:node_platforms]
+
+      node_platforms.each do |platform|
+        node_carts = OpenShift::ApplicationContainerProxy.find_one(nil, platform).get_available_cartridges
+        node_carts.each do |cart|
+          carts << cart unless carts.any? {|existing_cart| existing_cart.name == cart.name }
+        end
+      end
+    end
+
     types = CartridgeType.update_from(carts, nil, options.force)
     update_types(options, types)
   rescue OpenShift::NodeException

--- a/broker/conf/broker.conf
+++ b/broker/conf/broker.conf
@@ -159,3 +159,8 @@ ALLOW_ALIAS_IN_DOMAIN="false"
 # WARNING: do not include private credentials in any URL; they would be visible in every app's cloned repository.
 DEFAULT_APP_TEMPLATES=
 
+# List the node platforms available on the cloud
+# Comma-separated list of node platforms (e.g.:linux,windows).
+# All node platforms must be present in the node network.
+# In the case of conflicting cartridges, priority is given to the platforms with a lower index.
+# NODE_PLATFORMS=linux

--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -103,7 +103,8 @@ Broker::Application.configure do
     :allow_multiple_haproxy_on_node => conf.get_bool('ALLOW_MULTIPLE_HAPROXY_ON_NODE', "true"),
     :syslog_enabled => conf.get_bool('SYSLOG_ENABLED', 'false'),
     :app_template_for => OpenShift::Controller::Configuration.parse_url_hash(conf.get('DEFAULT_APP_TEMPLATES', nil)),
-    :default_max_teams => (conf.get("DEFAULT_MAX_TEAMS", "0")).to_i
+    :default_max_teams => (conf.get("DEFAULT_MAX_TEAMS", "0")).to_i,
+    :node_platforms => OpenShift::Controller::Configuration.parse_list(conf.get('NODE_PLATFORMS', 'linux')).map { |platform| platform.downcase }
   }
 
   config.auth = {

--- a/broker/config/environments/production.rb
+++ b/broker/config/environments/production.rb
@@ -92,7 +92,8 @@ Broker::Application.configure do
     :allow_multiple_haproxy_on_node => conf.get_bool('ALLOW_MULTIPLE_HAPROXY_ON_NODE', "false"),
     :syslog_enabled => conf.get_bool('SYSLOG_ENABLED', 'false'),
     :app_template_for => OpenShift::Controller::Configuration.parse_url_hash(conf.get('DEFAULT_APP_TEMPLATES', nil)),
-    :default_max_teams => (conf.get("DEFAULT_MAX_TEAMS", "0")).to_i
+    :default_max_teams => (conf.get("DEFAULT_MAX_TEAMS", "0")).to_i,
+    :node_platforms => OpenShift::Controller::Configuration.parse_list(conf.get('NODE_PLATFORMS', 'linux')).map { |platform| platform.downcase }    
   }
 
   config.auth = {

--- a/broker/config/environments/test.rb
+++ b/broker/config/environments/test.rb
@@ -101,7 +101,8 @@ Broker::Application.configure do
     :allow_multiple_haproxy_on_node => conf.get_bool('ALLOW_MULTIPLE_HAPROXY_ON_NODE', "true"),
     :syslog_enabled => conf.get_bool('SYSLOG_ENABLED', 'false'),
     :app_template_for => OpenShift::Controller::Configuration.parse_url_hash(conf.get('DEFAULT_APP_TEMPLATES', nil)),
-    :default_max_teams => (conf.get("DEFAULT_MAX_TEAMS", "0")).to_i
+    :default_max_teams => (conf.get("DEFAULT_MAX_TEAMS", "0")).to_i,
+    :node_platforms => OpenShift::Controller::Configuration.parse_list(conf.get('NODE_PLATFORMS', 'linux')).map { |platform| platform.downcase }
   }
 
   config.auth = {

--- a/broker/test/functional/application_controller_test.rb
+++ b/broker/test/functional/application_controller_test.rb
@@ -758,6 +758,14 @@ class ApplicationControllerTest < ActionController::TestCase
       Categories:
       - web_proxy
       MANIFEST
+
+    php_cart = CartridgeCache.find_cartridge(php_version)
+
+    mock_cart = mock
+    mock_cart.expects(:platform).at_least_once.with.returns('linux')
+    CartridgeCache.expects(:find_cartridge).at_least_once.with('mock-mock-0.1').returns(mock_cart)
+    CartridgeCache.expects(:find_cartridge).at_least_once.with(php_version).returns(php_cart)
+
     @app_name = "app#{@random}"
     post :create, {"name" => @app_name, "cartridge" => [php_version, {"url" => "manifest://test"}], "domain_id" => @domain.namespace, "scale" => true}
     assert_response :success
@@ -784,6 +792,7 @@ class ApplicationControllerTest < ActionController::TestCase
       Categories:
       - web_proxy
       MANIFEST
+
     @app_name = "app#{@random}"
     post :create, {"name" => @app_name, "cartridge" => [php_version, haproxy_version, {"url" => "manifest://test"}], "domain_id" => @domain.namespace, "scale" => true}
     assert_response :unprocessable_entity

--- a/broker/test/functional/application_controller_test.rb
+++ b/broker/test/functional/application_controller_test.rb
@@ -763,8 +763,9 @@ class ApplicationControllerTest < ActionController::TestCase
 
     mock_cart = mock
     mock_cart.expects(:platform).at_least_once.with.returns('linux')
-    CartridgeCache.expects(:find_cartridge).at_least_once.with('mock-mock-0.1').returns(mock_cart)
-    CartridgeCache.expects(:find_cartridge).at_least_once.with(php_version).returns(php_cart)
+
+    CartridgeCache.expects(:find_cartridge).at_least_once.with('mock-mock-0.1', anything).returns(mock_cart)
+    CartridgeCache.expects(:find_cartridge).at_least_once.with(php_version, anything).returns(php_cart)
 
     @app_name = "app#{@random}"
     post :create, {"name" => @app_name, "cartridge" => [php_version, {"url" => "manifest://test"}], "domain_id" => @domain.namespace, "scale" => true}

--- a/common/lib/openshift-origin-common/models/cartridge.rb
+++ b/common/lib/openshift-origin-common/models/cartridge.rb
@@ -93,7 +93,7 @@ module OpenShift
                   :provides, :requires, :conflicts, :suggests, :native_requires,
                   :path, :license_url, :categories, :website, :suggests_feature,
                   :help_topics, :cart_data_def, :additional_control_actions, :versions, :cartridge_vendor,
-                  :endpoints, :cartridge_version, :obsolete
+                  :endpoints, :cartridge_version, :obsolete, :platform
 
     # Profile information
     attr_accessor :components, :group_overrides,
@@ -148,6 +148,10 @@ module OpenShift
       @components.each {|comp| @_component_name_map[comp.name] = comp }
     end
 
+    def scaling_required?
+      @components.any? { |comp| comp.scaling.required }
+    end
+
     def get_component(comp_name)
       @_component_name_map[comp_name]
     end
@@ -179,6 +183,7 @@ module OpenShift
       self.cart_data_def = spec_hash["Cart-Data"] || {}
       self.additional_control_actions = spec_hash["Additional-Control-Actions"] || []
       self.cartridge_version = spec_hash["Cartridge-Version"] || "0.0.0"
+      self.platform = (spec_hash["Platform"] || "linux").downcase
 
       self.provides = [self.provides] if self.provides.class == String
       self.requires = [self.requires] if self.requires.class == String

--- a/common/lib/openshift-origin-common/models/scaling.rb
+++ b/common/lib/openshift-origin-common/models/scaling.rb
@@ -1,12 +1,13 @@
 module OpenShift
   class Scaling < OpenShift::Model
-    attr_accessor :min, :max, :min_managed, :multiplier
+    attr_accessor :min, :max, :required, :min_managed, :multiplier
 
     def initialize
       self.min = 1
       self.max = -1
       self.min_managed = 1
       self.multiplier = 1
+      self.required = false
     end
 
 # def multiplier
@@ -25,6 +26,7 @@ module OpenShift
       self.max = spec_hash["Max"].to_i || -1
       self.min_managed = spec_hash["Min-Managed"].to_i || 1
       self.multiplier = spec_hash["Multiplier"].nil? ? 1 : spec_hash["Multiplier"].to_i
+      self.required = spec_hash["Required"]
       self
     end
 
@@ -33,7 +35,8 @@ module OpenShift
         "Min" => self.min,
         "Max" => self.max,
         "Min-Managed" => self.min_managed,
-        "Multiplier" => self.multiplier
+        "Multiplier" => self.multiplier,
+        "Required" => self.required,
       }
     end
   end

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1826,7 +1826,7 @@ class Application
         app_dns_gear_id = gear_id.to_s
       end
 
-      cartridge = CartridgeCache.find_cartridge(comp_specs.first.cartridge_name)
+      cartridge = CartridgeCache.find_cartridge(comp_specs.first.cartridge_name, self)
       platform = cartridge ? cartridge.platform : nil
 
       init_gear_op = InitGearOp.new(group_instance_id: ginst_id, platform: platform, gear_id: gear_id,

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -518,24 +518,30 @@ class Application
 
     # Overrides from the basic cartridge definitions.
     overrides = []
+
     specs.each do |spec|
       # Cartridges can contribute overrides
       spec.cartridge.group_overrides.each do |override|
         if o = GroupOverride.resolve_from(specs, override)
-          overrides << o.implicit
+          platforms = o.components.map {|component| CartridgeCache.find_cartridge(component.cartridge_name, self).platform }.uniq
+
+          # only allow grouping if we're working with a single platform
+          if platforms.size == 1
+            overrides << o.implicit
+          end
         end
       end
 
       # Each component has an implicit override based on its scaling
       comp = spec.component
       overrides <<
-        if comp.is_sparse?
-          GroupOverride.new([spec]).implicit
-        elsif spec.cartridge.is_external?
-          GroupOverride.new([spec], 0, 0).implicit
-        else
-          GroupOverride.new([spec], comp.scaling.min, comp.scaling.max).implicit
-        end
+          if comp.is_sparse?
+            GroupOverride.new([spec]).implicit
+          elsif spec.cartridge.is_external?
+            GroupOverride.new([spec], 0, 0).implicit
+          else
+            GroupOverride.new([spec], comp.scaling.min, comp.scaling.max).implicit
+          end
     end
 
     # Overrides that are implicit to applications of this type
@@ -712,6 +718,11 @@ class Application
             ((ssl_endpoint == "force") and not cart_req_ssl_endpoint))
           raise OpenShift::UserException.new("Invalid cartridge '#{cart.name}' conflicts with platform SSL_ENDPOINT setting.", 109, "cartridge")
         end
+      end
+
+      # Validate that we are not trying to create a non-scalable app with carts that need to be scalable
+      if cart.scaling_required? && !self.scalable
+        raise OpenShift::UserException.new("#{cart.name} must be embedded in a scalable app.", 109)
       end
 
       # Validate that the cartridges support scalable if necessary
@@ -1745,6 +1756,13 @@ class Application
     end
   end
 
+  # Determines if the application's cartridges are colocatable
+  # == Returns:
+  # True if the app is hosted on a single platform, false otherwise
+  def is_collocatable?()
+    self.component_instances.map {|comp| comp.get_cartridge.platform }.uniq.size == 1
+  end
+
   def update_requirements(cartridges, replacements, overrides, init_git_url=nil, user_env_vars=nil)
     current = group_instances_with_overrides
     connections, updated = elaborate(cartridges, overrides)
@@ -1808,7 +1826,10 @@ class Application
         app_dns_gear_id = gear_id.to_s
       end
 
-      init_gear_op = InitGearOp.new(group_instance_id: ginst_id, gear_id: gear_id,
+      cartridge = CartridgeCache.find_cartridge(comp_specs.first.cartridge_name)
+      platform = cartridge ? cartridge.platform : nil
+
+      init_gear_op = InitGearOp.new(group_instance_id: ginst_id, platform: platform, gear_id: gear_id,
                                     gear_size: gear_size, addtl_fs_gb: additional_filesystem_gb,
                                     comp_specs: gear_comp_specs[gear_id], host_singletons: host_singletons,
                                     app_dns: app_dns, pre_save: (not self.persisted?))
@@ -2033,7 +2054,11 @@ class Application
         end
 
         git_url = nil
-        git_url = init_git_url if gear_id == deploy_gear_id && cartridge.is_deployable?
+
+        if gear_id == deploy_gear_id and needs_git_url?(cartridge)
+          git_url = init_git_url
+        end
+
         add_component_op = AddCompOp.new(gear_id: gear_id, comp_spec: comp_spec, init_git_url: git_url, prereq: new_component_op_id + [prereq_id])
         ops << add_component_op
         component_ops[comp_spec][:adds] << add_component_op
@@ -2957,5 +2982,12 @@ class Application
         h[ComponentSpec.for_model(f.components.first, f)] = ComponentSpec.for_model(t.components.first, t)
         h
       end
+    end
+
+    def needs_git_url?(cartridge)
+      # we need the template git url for the component if the cartridge is deployable
+      # or if we have a standalone web cartridge
+      is_standalone_web_proxy = (cartridge.is_web_proxy? and !self.is_collocatable?)
+      (cartridge.is_deployable? or is_standalone_web_proxy)
     end
 end

--- a/controller/app/models/cartridge_type.rb
+++ b/controller/app/models/cartridge_type.rb
@@ -181,6 +181,10 @@ class CartridgeType
     provides.include?(feature)
   end
 
+  def scaling_required?
+    self.components.any? { |comp| comp.scaling.required }
+  end
+
   def ===(other)
     return true if other == self
     if other.is_a?(String)

--- a/controller/app/models/gear.rb
+++ b/controller/app/models/gear.rb
@@ -94,9 +94,8 @@ class Gear
 
   def reserve_uid(gear_size = nil)
     gear_size = group_instance.gear_size unless gear_size
-   
     opts = { :node_profile => gear_size, :least_preferred_servers => non_ha_server_identities,
-             :restricted_servers => restricted_server_identities, :gear => self }
+             :restricted_servers => restricted_server_identities, :gear => self, :platform => group_instance.platform}
     @container = OpenShift::ApplicationContainerProxy.find_available(opts)
     reserved_uid = @container.reserve_uid
     Application.where({"_id" => application._id, "gears.uuid" => self.uuid}).update({"$set" => {"gears.$.server_identity" => @container.id, "gears.$.uid" => reserved_uid}})

--- a/controller/app/models/group_instance.rb
+++ b/controller/app/models/group_instance.rb
@@ -17,6 +17,8 @@ class GroupInstance
   include Mongoid::Document
   embedded_in :application, class_name: Application.name
 
+  field :platform, type: String, default: "linux"
+
   field :gear_size, type: String
   field :addtl_fs_gb, type: Integer
 
@@ -30,9 +32,14 @@ class GroupInstance
   #   @Note used when this gear is hosting the web_proxy component
   def initialize(attrs = nil, options = nil)
     custom_id = attrs[:custom_id]
+    custom_platform = attrs[:custom_platform]
+
     attrs.delete(:custom_id)
+    attrs.delete(:custom_platform)
+
     super(attrs, options)
     self._id = custom_id unless custom_id.nil?
+    self.platform = custom_platform unless custom_platform.nil?
   end
 
   def gears

--- a/controller/app/pending_ops_models/init_gear_op.rb
+++ b/controller/app/pending_ops_models/init_gear_op.rb
@@ -2,6 +2,7 @@ class InitGearOp < PendingAppOp
 
   field :gear_id, type: String
   field :group_instance_id, type: String
+  field :platform, type: String
   field :host_singletons, type: Boolean, default: false
   field :app_dns, type: Boolean, default: false
 
@@ -21,7 +22,7 @@ class InitGearOp < PendingAppOp
         begin
           get_group_instance
         rescue Mongoid::Errors::DocumentNotFound
-          application.group_instances << GroupInstance.new(custom_id: group_instance_id, addtl_fs_gb: addtl_fs_gb, gear_size: gear_size)
+          application.group_instances << GroupInstance.new(custom_id: group_instance_id, addtl_fs_gb: addtl_fs_gb, gear_size: gear_size, custom_platform: platform)
           get_group_instance
         end
 

--- a/controller/lib/openshift/application_container_proxy.rb
+++ b/controller/lib/openshift/application_container_proxy.rb
@@ -41,8 +41,8 @@ module OpenShift
       @proxy_provider.new(server_id, district)
     end
 
-    def self.find_one(node_profile=nil)
-      server_id = @proxy_provider.find_one_impl(node_profile)
+    def self.find_one(node_profile=nil, platform='linux')
+      server_id = @proxy_provider.find_one_impl(node_profile, platform)
       raise OpenShift::NodeUnavailableException.new("No nodes available", 140) if server_id.blank?
       @proxy_provider.new(server_id)
     end

--- a/node-util/bin/oo-gear-registry
+++ b/node-util/bin/oo-gear-registry
@@ -58,7 +58,7 @@ command :read do |c|
 
     if requested_gears
       requested_gears.each_value do |gear|
-        puts "#{gear.uuid},#{gear.namespace},#{gear.dns},#{gear.proxy_hostname},#{gear.proxy_port}"
+        puts "#{gear.uuid},#{gear.namespace},#{gear.dns},#{gear.proxy_hostname},#{gear.proxy_port},#{gear.platform}"
       end
     end
   end

--- a/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
@@ -71,31 +71,7 @@ module OpenShift
               raise ::OpenShift::Runtime::Utils::Sdk.translate_out_for_client(message, :error)
             end
           elsif cartridge.deployable?
-            deployment_datetime = latest_deployment_datetime
-            deployment_metadata = deployment_metadata_for(deployment_datetime)
-
-            # only do this if we've never activated
-            if deployment_metadata.activations.empty?
-              prepare(deployment_datetime: deployment_datetime)
-
-              # prepare modifies the deployment metadata - need to reload
-              deployment_metadata.load
-
-              application_repository = ApplicationRepository.new(self)
-              git_ref = 'master'
-              git_sha1 = application_repository.get_sha1(git_ref)
-              deployment_metadata.git_sha1 = git_sha1
-              deployment_metadata.git_ref = git_ref
-
-              deployments_dir = PathUtils.join(@container_dir, 'app-deployments')
-              set_rw_permission_R(deployments_dir)
-              reset_permission_R(deployments_dir)
-
-              deployment_metadata.record_activation
-              deployment_metadata.save
-
-              update_current_deployment_datetime_symlink(deployment_datetime)
-            end
+            setup_deployment(latest_deployment_datetime)
           end
 
           output << @cartridge_model.post_configure(cart_name)
@@ -111,6 +87,32 @@ module OpenShift
           end
 
           output
+        end
+
+        def setup_deployment(deployment_datetime)
+          deployment_metadata = deployment_metadata_for(deployment_datetime)
+          # only do this if we've never activated
+          if deployment_metadata.activations.empty?
+            prepare(deployment_datetime: deployment_datetime)
+
+            # prepare modifies the deployment metadata - need to reload
+            deployment_metadata.load
+
+            application_repository = ApplicationRepository.new(self)
+            git_ref = 'master'
+            git_sha1 = application_repository.get_sha1(git_ref)
+            deployment_metadata.git_sha1 = git_sha1
+            deployment_metadata.git_ref = git_ref
+
+            deployments_dir = PathUtils.join(@container_dir, 'app-deployments')
+            set_rw_permission_R(deployments_dir)
+            reset_permission_R(deployments_dir)
+
+            deployment_metadata.record_activation
+            deployment_metadata.save
+
+            update_current_deployment_datetime_symlink(deployment_datetime)
+          end
         end
 
         # Remove cartridge from gear
@@ -745,7 +747,10 @@ module OpenShift
           }
 
           deployments_dir = PathUtils.join(@container_dir, 'app-deployments')
-          out, err, rc = run_in_container_context("rsync -avz --rsh=/usr/bin/oo-ssh --delete-before --exclude=current ./ #{gear}:app-deployments/",
+
+          rsync_options = remote_rsync_options(result[:gear_uuid])
+
+          out, err, rc = run_in_container_context("rsync #{rsync_options} --rsh=/usr/bin/oo-ssh --delete-before --exclude=current ./ #{gear}:app-deployments/",
                                                   env: gear_env,
                                                   chdir: deployments_dir)
 
@@ -800,6 +805,9 @@ module OpenShift
               activate_remote_gear(target_gear, local_gear_env, options)
             end
           end
+
+          # if we have a standalone proxy, the call to 'with_gear_rotation' ignores a gear without a web cart
+          parallel_results << activate_local_gear(options) if @cartridge_model.standalone_web_proxy?
 
           activated_gear_uuids = []
 
@@ -1304,7 +1312,7 @@ module OpenShift
             cloud_domain = @config.get("CLOUD_DOMAIN")
 
             cluster.split(' ').each do |line|
-              gear_uuid, gear_name, namespace, proxy_hostname, proxy_port = line.split(',')
+              gear_uuid, gear_name, namespace, proxy_hostname, proxy_port, platform = line.split(',')
               gear_dns = "#{gear_name}-#{namespace}.#{cloud_domain}"
 
               # add the entry to the gear registry
@@ -1314,14 +1322,15 @@ module OpenShift
                 namespace: namespace,
                 dns: gear_dns,
                 proxy_hostname: proxy_hostname,
-                proxy_port: proxy_port
+                proxy_port: proxy_port,
+                platform: platform
               }
               logger.info "Adding gear registry #{uuid} new web entry: #{new_entry}"
               gear_registry.add(new_entry)
             end
 
             proxies.split(' ').each do |line|
-              gear_uuid, gear_name, namespace, proxy_hostname = line.split(',')
+              gear_uuid, gear_name, namespace, proxy_hostname, platform = line.split(',')
               gear_dns = "#{gear_name}-#{namespace}.#{cloud_domain}"
               new_entry = {
                 type: :proxy,
@@ -1329,7 +1338,8 @@ module OpenShift
                 namespace: namespace,
                 dns: gear_dns,
                 proxy_hostname: proxy_hostname,
-                proxy_port: 0
+                proxy_port: 0,
+                platform: platform
               }
               logger.info "Adding gear registry #{uuid} new proxy entry: #{new_entry}"
               gear_registry.add(new_entry)
@@ -1342,6 +1352,17 @@ module OpenShift
 
             logger.info "Retrieving updated gear registry #{uuid} entries"
             updated_entries = gear_registry.entries
+
+            # we initialize the standalone web proxy git template after we're aware of web gears
+            if @cartridge_model.standalone_web_proxy?
+              repo = ApplicationRepository.new(self)
+
+              unless repo.exist?
+                @cartridge_model.populate_gear_repo(@cartridge_model.web_proxy.name, nil)
+              end
+
+              setup_deployment(latest_deployment_datetime)
+            end
 
             # the broker will inform us if we are supposed to sync and activate new gears
             if sync_new_gears == true
@@ -1361,13 +1382,15 @@ module OpenShift
               end
 
               unless new_web_gears.empty?
-                # convert the new gears to the format uuid@ip
-                ssh_urls = new_web_gears.map { |e| "#{e.uuid}@#{e.proxy_hostname}" }
-
                 # sync from this gear (load balancer) to all new gears
                 # copy app-deployments and make all the new gears look just like it (i.e., use --delete)
-                ssh_urls.each do |gear|
-                  out, err, rc = run_in_container_context("rsync -avz --delete --rsh=/usr/bin/oo-ssh app-deployments/ #{gear}:app-deployments/",
+                new_web_gears.each do |web_gear|
+                  # convert the new gear to the format uuid@ip
+                  gear = "#{web_gear.uuid}@#{web_gear.proxy_hostname}"
+
+                  rsync_options = remote_rsync_options(web_gear)
+
+                  out, err, rc = run_in_container_context("rsync #{rsync_options} --delete --rsh=/usr/bin/oo-ssh app-deployments/ #{gear}:app-deployments/",
                                                           env: gear_env,
                                                           chdir: container_dir,
                                                           expected_exitstatus: 0)
@@ -1427,7 +1450,11 @@ module OpenShift
 
         def sync_git_repo(ssh_urls, gear_env)
           OpenShift::Runtime::Threads::Parallel.map(ssh_urls, :in_threads => MAX_THREADS) do |gear|
-            out, err, rc = run_in_container_context("rsync -avz --delete --exclude hooks --rsh=/usr/bin/oo-ssh git/#{application_name}.git/ #{gear}:git/#{application_name}.git/",
+            gear_uuid = gear.split('@')[0]
+
+            rsync_options = remote_rsync_options(gear_uuid)
+
+            out, err, rc = run_in_container_context("rsync #{rsync_options} --delete --exclude hooks --rsh=/usr/bin/oo-ssh git/#{application_name}.git/ #{gear}:git/#{application_name}.git/",
                                                     env: gear_env,
                                                     chdir: container_dir,
                                                     expected_exitstatus: 0)
@@ -1652,6 +1679,19 @@ module OpenShift
             deployment_metadata.force_clean_build = options[:force_clean_build]
             deployment_metadata.save
           end
+
+        def remote_rsync_options(gear)
+          if gear.is_a? String
+            gear = gear_registry.entries[:web][gear]
+          end
+
+          case gear.platform
+            when 'windows'
+              '-rltgoDOv'
+            else
+              '-avz'
+          end
+        end
       end
     end
   end

--- a/node/lib/openshift-origin-node/model/application_repository.rb
+++ b/node/lib/openshift-origin-node/model/application_repository.rb
@@ -88,6 +88,26 @@ module OpenShift
         ]
 
         template = locations.find {|l| File.directory?(l)}
+
+        if @container.cartridge_model.standalone_web_proxy? and @container.gear_registry.entries[:web]
+          remote_web_gear = @container.gear_registry.entries[:web].values.first
+
+          unless remote_web_gear
+            raise RuntimeError.new("Can't find a remote web gear for solo web proxy gear #{@container.uuid}")
+          end
+
+          ssh_url = "#{remote_web_gear.uuid}@#{remote_web_gear.proxy_hostname}"
+
+          gear_env = ::OpenShift::Runtime::Utils::Environ::for_gear(@container.container_dir)
+
+          out, err, rc = @container.run_in_container_context("mkdir -p #{locations.first} ; rsync -rOv --exclude '.git' --delete --rsh=/usr/bin/oo-ssh #{ssh_url}:git/template/ #{locations.first}",
+                                                             env: gear_env,
+                                                             chdir: @container.container_dir,
+                                                             expected_exitstatus: 0)
+
+          template = locations.find {|l| File.directory?(l)}
+        end
+
         logger.debug("Using '#{template}' to populate git repository for #{@container.uuid}")
         return nil unless template
 

--- a/node/lib/openshift-origin-node/model/frontend_httpd.rb
+++ b/node/lib/openshift-origin-node/model/frontend_httpd.rb
@@ -178,6 +178,8 @@ module OpenShift
         @container_name = container.name
         @namespace = container.namespace
 
+        @standalone_web_proxy = container.cartridge_model.standalone_web_proxy?
+
         # this is ONLY used when invoking "connect" so the app uuid can be stored
         # in the nodes db, so it can be added to the node openshift_log (access log)
         @application_uuid = container.application_uuid
@@ -336,7 +338,7 @@ module OpenShift
 
         paths_to_update = {}
         elems.each do |path, uri, options|
-          if options["target_update"]
+          if options["target_update"] && !@standalone_web_proxy
             paths_to_update[path]=uri
           end
         end

--- a/node/lib/openshift-origin-node/model/gear_registry.rb
+++ b/node/lib/openshift-origin-node/model/gear_registry.rb
@@ -27,7 +27,7 @@ module OpenShift
 
       # Represents an individual entry in the gear registry
       class Entry
-        attr_reader :uuid, :namespace, :dns, :proxy_hostname, :proxy_port
+        attr_reader :uuid, :namespace, :dns, :proxy_hostname, :proxy_port, :platform
 
         def initialize(options)
           @uuid = options[:uuid]
@@ -35,10 +35,11 @@ module OpenShift
           @dns = options[:dns]
           @proxy_hostname = options[:proxy_hostname]
           @proxy_port = options[:proxy_port]
+          @platform = options[:platform]
         end
 
         def as_json(options={})
-          {namespace: @namespace, dns: @dns, proxy_hostname: @proxy_hostname, proxy_port: @proxy_port}
+          {namespace: @namespace, dns: @dns, proxy_hostname: @proxy_hostname, proxy_port: @proxy_port, platform: @platform}
         end
 
         def to_ssh_url
@@ -86,7 +87,7 @@ module OpenShift
 
       def add(options)
         # make sure all required fields are passed in
-        %w(type uuid namespace dns proxy_hostname proxy_port).map(&:to_sym).each { |s| raise "#{s} is required" if options[s].nil?}
+        %w(type uuid namespace dns proxy_hostname proxy_port platform).map(&:to_sym).each { |s| raise "#{s} is required" if options[s].nil?}
 
         # add entry to registry by type
         type = options[:type].to_sym
@@ -104,7 +105,8 @@ module OpenShift
       #      "namespace": "foo",
       #      "dns": "myapp-foo.example.com",
       #      "proxy_hostname": "node1.example.com",
-      #      "proxy_port": 35561
+      #      "proxy_port": 35561,
+      #      "platform": "linux"
       #    },
       #    ...
       #  },

--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -105,6 +105,14 @@ module OpenShift
       end
 
       ##
+      # Returns true if the primary +Cartridge+ is also the +web_proxy+.
+      # This occurs in the case of applications that have a web cartridge
+      # that is deployed on a platform different than the web proxy's.
+      def standalone_web_proxy?
+        (web_proxy != nil) and (web_proxy.name == primary_cartridge.name)
+      end
+
+      ##
       # Detects and returns a builder +Cartridge+ in the gear if present, otherwise +nil+.
       def builder_cartridge
         builder_cart = nil
@@ -284,7 +292,7 @@ module OpenShift
                         "Cartridge created the following directories in the gear home directory: #{illegal_entries.join(', ')}")
             end
 
-            output << populate_gear_repo(c.directory, template_git_url) if cartridge.deployable?
+            output << populate_gear_repo(c.directory, template_git_url) if populate_repository?(cartridge, template_git_url)
           end
 
           validate_cartridge(cartridge)
@@ -1561,6 +1569,12 @@ module OpenShift
 
       def empty_repository?
         ApplicationRepository.new(@container).empty?
+      end
+
+      def populate_repository?(cartridge, template_git_url)
+        # we should populate the gear repo if we have a deployable cartridge
+        # or if we have a standalone web proxy and a git url for a template was provided
+        (cartridge.deployable? or (standalone_web_proxy? and template_git_url))
       end
     end
   end

--- a/node/test/unit/application_container_test.rb
+++ b/node/test/unit/application_container_test.rb
@@ -1,1004 +1,1161 @@
-#!/usr/bin/env oo-ruby
-#--
-# Copyright 2013 Red Hat, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#++
-#
-# Test the OpenShift application_container model
-#
-require_relative '../test_helper'
-require 'fileutils'
-require 'yaml'
-
-module OpenShift
-  ;
-end
-
-class ApplicationContainerTest < OpenShift::NodeTestCase
-
-  def setup
-    @ports_begin    = 35531
-    @ports_per_user = 5
-    @uid_begin      = 500
-
-    @config.stubs(:get).with("PORT_BEGIN").returns(@ports_begin.to_s)
-    @config.stubs(:get).with("PORTS_PER_USER").returns(@ports_per_user.to_s)
-    @config.stubs(:get).with("UID_BEGIN").returns(@uid_begin.to_s)
-    @config.stubs(:get).with("GEAR_BASE_DIR").returns("/tmp")
-
-    script_dir     = File.expand_path(File.dirname(__FILE__))
-    cart_base_path = File.join(script_dir, '..', '..', '..', 'cartridges')
-
-    raise "Couldn't find cart base path at #{cart_base_path}" unless File.exists?(cart_base_path)
-
-    @config.stubs(:get).with("CARTRIDGE_BASE_PATH").returns(cart_base_path)
-    #@config.stubs(:get).with("CONTAINERIZATION_PLUGIN").returns('openshift-origin-container-selinux')
-
-    # Set up the container
-    @gear_uuid = '5504'
-    @user_uid  = '5504'
-    @app_name  = 'ApplicatioContainerTestCase'
-    @gear_name = @app_name
-    @namespace = 'jwh201204301647'
-    @gear_ip   = '127.0.0.1'
-
-    Etc.stubs(:getpwnam).returns(
-        OpenStruct.new(
-            uid:   @user_uid.to_i,
-            gid:   @user_uid.to_i,
-            gecos: "OpenShift guest",
-            dir:   "/var/lib/openshift/#{@gear_uuid}"
-        )
-    )
-
-    @container = OpenShift::Runtime::ApplicationContainer.new(@gear_uuid, @gear_uuid, @user_uid,
-                                                              @app_name, @gear_uuid, @namespace, nil, nil, nil)
-
-
-    @mock_manifest = %q{#
-        Name: mock
-        Cartridge-Short-Name: MOCK
-        Cartridge-Version: 1.0
-        Cartridge-Vendor: unit_test
-        Display-Name: Mock
-        Description: "A mock cartridge for development use only."
-        Version: 0.1
-        License: "None"
-        Vendor: Red Hat
-        Categories:
-        - service
-        Provides:
-        - mock
-        Scaling:
-        Min: 1
-        Max: -1
-        Group-Overrides:
-        - components:
-        - mock
-        Endpoints:
-          - Private-IP-Name:   EXAMPLE_IP1
-            Private-Port-Name: EXAMPLE_PORT1
-            Private-Port:      8080
-            Public-Port-Name:  EXAMPLE_PUBLIC_PORT1
-            Options:           { primary: true }
-            Mappings:
-              - Frontend:      "/front1a"
-                Backend:       "/back1a"
-                Options:       { websocket: true, tohttps: true }
-              - Frontend:      "/front1b"
-                Backend:       "/back1b"
-                Options:       { noproxy: true }
-
-          - Private-IP-Name:   EXAMPLE_IP1
-            Private-Port-Name: EXAMPLE_PORT2
-            Private-Port:      8081
-            Public-Port-Name:  EXAMPLE_PUBLIC_PORT2
-            Mappings:
-              - Frontend:      "/front2"
-                Backend:       "/back2"
-                Options:       { file: true }
-
-          - Private-IP-Name:   EXAMPLE_IP1
-            Private-Port-Name: EXAMPLE_PORT3
-            Private-Port:      8082
-            Public-Port-Name:  EXAMPLE_PUBLIC_PORT3
-            Mappings:
-              - Frontend:      "/front3"
-                Backend:       "/back3"
-
-          - Private-IP-Name:   EXAMPLE_IP2
-            Private-Port-Name: EXAMPLE_PORT4
-            Private-Port:      9090
-            Public-Port-Name:  EXAMPLE_PUBLIC_PORT4
-            Mappings:
-              - Frontend:      "/front4"
-                Backend:       "/back4"
-
-          - Private-IP-Name:   EXAMPLE_IP2
-            Private-Port-Name: EXAMPLE_PORT5
-            Private-Port:      9091
-    }
-
-    manifest = "/tmp/manifest-#{Process.pid}"
-    IO.write(manifest, @mock_manifest, 0)
-    @mock_cartridge = OpenShift::Runtime::Manifest.new(manifest, nil, :file)
-    @container.cartridge_model.stubs(:get_cartridge).with("mock").returns(@mock_cartridge)
-  end
-
-  def teardown
-    FileUtils.rm_rf @container.container_dir
-  end
-
-  def test_public_endpoints_create
-    OpenShift::Runtime::Utils::Environ.stubs(:for_gear).returns({
-                                                                    "OPENSHIFT_MOCK_EXAMPLE_IP1" => "127.0.0.1",
-                                                                    "OPENSHIFT_MOCK_EXAMPLE_IP2" => "127.0.0.2"
-                                                                })
-
-    proxy = mock('OpenShift::Runtime::FrontendProxyServer')
-    OpenShift::Runtime::FrontendProxyServer.stubs(:new).returns(proxy)
-
-    proxy.expects(:add).with(@user_uid.to_i, "127.0.0.1", 8080).returns(@ports_begin)
-    proxy.expects(:add).with(@user_uid.to_i, "127.0.0.1", 8081).returns(@ports_begin+1)
-    proxy.expects(:add).with(@user_uid.to_i, "127.0.0.1", 8082).returns(@ports_begin+2)
-    proxy.expects(:add).with(@user_uid.to_i, "127.0.0.2", 9090).returns(@ports_begin+3)
-
-    @container.expects(:add_env_var).with('OPENSHIFT_MOCK_EXAMPLE_PUBLIC_PORT1', @ports_begin)
-    @container.expects(:add_env_var).with('OPENSHIFT_MOCK_EXAMPLE_PUBLIC_PORT2', @ports_begin+1)
-    @container.expects(:add_env_var).with('OPENSHIFT_MOCK_EXAMPLE_PUBLIC_PORT3', @ports_begin+2)
-    @container.expects(:add_env_var).with('OPENSHIFT_MOCK_EXAMPLE_PUBLIC_PORT4', @ports_begin+3)
-
-    @container.create_public_endpoints(@mock_cartridge.name)
-  end
-
-  def test_public_endpoints_delete
-    OpenShift::Runtime::Utils::Environ.stubs(:for_gear).returns({
-                                                                    "OPENSHIFT_MOCK_EXAMPLE_IP1" => "127.0.0.1",
-                                                                    "OPENSHIFT_MOCK_EXAMPLE_IP2" => "127.0.0.2"
-                                                                })
-
-    proxy = mock('OpenShift::Runtime::FrontendProxyServer')
-    OpenShift::Runtime::FrontendProxyServer.stubs(:new).returns(proxy)
-    OpenShift::Runtime::V2CartridgeModel.any_instance.expects(:list_proxy_mappings).returns([
-                                                                                                {public_port_name: "Endpoint_1", proxy_port: @ports_begin},
-                                                                                                {public_port_name: "Endpoint_2", proxy_port: @ports_begin+1},
-                                                                                                {public_port_name: "Endpoint_3", proxy_port: @ports_begin+2},
-                                                                                                {public_port_name: "Endpoint_4", proxy_port: @ports_begin+3}])
-    #proxy.expects(:find_mapped_proxy_port).with(@user_uid, "127.0.0.1", 8080).returns(@ports_begin)
-    #proxy.expects(:find_mapped_proxy_port).with(@user_uid, "127.0.0.1", 8081).returns(@ports_begin+1)
-    #proxy.expects(:find_mapped_proxy_port).with(@user_uid, "127.0.0.1", 8082).returns(@ports_begin+2)
-    #proxy.expects(:find_mapped_proxy_port).with(@user_uid, "127.0.0.2", 9090).returns(@ports_begin+3)
-
-    delete_all_args = [@ports_begin, @ports_begin+1, @ports_begin+2, @ports_begin+3]
-    proxy.expects(:delete_all).with(delete_all_args, true).returns(nil)
-
-    @container.expects(:remove_env_var).returns(nil).times(4)
-
-    @container.delete_public_endpoints(@mock_cartridge.name)
-  end
-
-  def test_tidy_success
-    OpenShift::Runtime::Utils::Environ.stubs(:for_gear).returns(
-        {'OPENSHIFT_HOMEDIR' => '/foo', 'OPENSHIFT_APP_NAME' => 'app_name'})
-
-    @container.stubs(:stop_gear)
-    @container.stubs(:gear_level_tidy_tmp).with('/foo/.tmp')
-    @container.cartridge_model.expects(:tidy)
-    @container.stubs(:gear_level_tidy_git).with('/foo/git/app_name.git')
-    @container.stubs(:start_gear)
-
-    @container.stubs(:cartridge_model).returns(mock())
-
-    @container.tidy
-  end
-
-  def test_tidy_stop_gear_fails
-    OpenShift::Runtime::Utils::Environ.stubs(:for_gear).returns(
-        {'OPENSHIFT_HOMEDIR' => '/foo', 'OPENSHIFT_APP_NAME' => 'app_name'})
-
-    @container.stubs(:stop_gear).raises(Exception.new)
-    @container.stubs(:gear_level_tidy_tmp).with('/foo/.tmp')
-    @container.cartridge_model.expects(:tidy).never
-    @container.stubs(:gear_level_tidy_git).with('/foo/git/app_name.git')
-    @container.stubs(:start_gear).never
-
-    assert_raise Exception do
-      @container.tidy
-    end
-  end
-
-  def test_tidy_gear_level_tidy_fails
-    OpenShift::Runtime::Utils::Environ.stubs(:for_gear).returns(
-        {'OPENSHIFT_HOMEDIR' => '/foo', 'OPENSHIFT_APP_NAME' => 'app_name'})
-
-    @container.expects(:stop_gear)
-    @container.expects(:gear_level_tidy_tmp).with('/foo/.tmp').raises(Exception.new)
-    @container.expects(:start_gear)
-
-    @container.tidy
-  end
-
-  def test_force_stop
-    FileUtils.mkpath("/tmp/#@user_uid/app-root/runtime")
-    OpenShift::Runtime::Containerization::Plugin.stubs(:kill_procs).with(@user_uid).returns(nil)
-    @container.state.expects(:value=).with(OpenShift::Runtime::State::STOPPED)
-    @container.cartridge_model.expects(:create_stop_lock)
-    @container.force_stop
-  end
-
-  def test_connector_execute
-    cart_name      = 'mock-0.1'
-    pub_cart_name  = 'mock-plugin-0.1'
-    connector_type = 'ENV:NET_TCP'
-    connector      = 'set-db-connection-info'
-    args           = 'foo'
-
-    @container.cartridge_model.expects(:connector_execute).with(cart_name, pub_cart_name, connector_type, connector, args)
-
-    @container.connector_execute(cart_name, pub_cart_name, connector_type, connector, args)
-  end
-
-  # Tests a variety of UID/host ID to IP address conversions.
+  #!/usr/bin/env oo-ruby
+  #--
+  # Copyright 2013 Red Hat, Inc.
   #
-  # TODO: Is there a way to do this algorithmically?
-  def test_get_ip_addr_success
-    scenarios = [
-        [501, 1, "127.0.250.129"],
-        [501, 10, "127.0.250.138"],
-        [501, 20, "127.0.250.148"],
-        [501, 100, "127.0.250.228"],
-        [540, 1, "127.1.14.1"],
-        [560, 7, "127.1.24.7"]
-    ]
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #    http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  #++
+  #
+  # Test the OpenShift application_container model
+  #
+  require_relative '../test_helper'
+  require 'fileutils'
+  require 'yaml'
 
-    scenarios.each do |s|
+  module OpenShift
+    ;
+  end
+
+  class ApplicationContainerTest < OpenShift::NodeTestCase
+
+    def setup
+      @ports_begin    = 35531
+      @ports_per_user = 5
+      @uid_begin      = 500
+
+      @config.stubs(:get).with("PORT_BEGIN").returns(@ports_begin.to_s)
+      @config.stubs(:get).with("PORTS_PER_USER").returns(@ports_per_user.to_s)
+      @config.stubs(:get).with("UID_BEGIN").returns(@uid_begin.to_s)
+      @config.stubs(:get).with("GEAR_BASE_DIR").returns("/tmp")
+
+      script_dir     = File.expand_path(File.dirname(__FILE__))
+      cart_base_path = File.join(script_dir, '..', '..', '..', 'cartridges')
+
+      raise "Couldn't find cart base path at #{cart_base_path}" unless File.exists?(cart_base_path)
+
+      @config.stubs(:get).with("CARTRIDGE_BASE_PATH").returns(cart_base_path)
+      #@config.stubs(:get).with("CONTAINERIZATION_PLUGIN").returns('openshift-origin-container-selinux')
+
+      # Set up the container
+      @gear_uuid = '5504'
+      @user_uid  = '5504'
+      @app_name  = 'ApplicatioContainerTestCase'
+      @gear_name = @app_name
+      @namespace = 'jwh201204301647'
+      @gear_ip   = '127.0.0.1'
+
       Etc.stubs(:getpwnam).returns(
           OpenStruct.new(
-              uid:   s[0].to_i,
-              gid:   s[0].to_i,
+              uid:   @user_uid.to_i,
+              gid:   @user_uid.to_i,
               gecos: "OpenShift guest",
-              dir:   "/var/lib/openshift/gear_uuid"
+              dir:   "/var/lib/openshift/#{@gear_uuid}"
           )
       )
 
-      container = OpenShift::Runtime::ApplicationContainer.new("gear_uuid", "gear_uuid", s[0],
-                                                               "app_name", "gear_uuid", "namespace", nil, nil, nil)
+      @container = OpenShift::Runtime::ApplicationContainer.new(@gear_uuid, @gear_uuid, @user_uid,
+                                                                @app_name, @gear_uuid, @namespace, nil, nil, nil)
 
-      assert_equal container.get_ip_addr(s[1]), s[2]
+
+      @mock_manifest = %q{#
+          Name: mock
+          Cartridge-Short-Name: MOCK
+          Cartridge-Version: 1.0
+          Cartridge-Vendor: unit_test
+          Display-Name: Mock
+          Description: "A mock cartridge for development use only."
+          Version: 0.1
+          License: "None"
+          Vendor: Red Hat
+          Categories:
+          - service
+          Provides:
+          - mock
+          Scaling:
+          Min: 1
+          Max: -1
+          Group-Overrides:
+          - components:
+          - mock
+          Endpoints:
+            - Private-IP-Name:   EXAMPLE_IP1
+              Private-Port-Name: EXAMPLE_PORT1
+              Private-Port:      8080
+              Public-Port-Name:  EXAMPLE_PUBLIC_PORT1
+              Options:           { primary: true }
+              Mappings:
+                - Frontend:      "/front1a"
+                  Backend:       "/back1a"
+                  Options:       { websocket: true, tohttps: true }
+                - Frontend:      "/front1b"
+                  Backend:       "/back1b"
+                  Options:       { noproxy: true }
+
+            - Private-IP-Name:   EXAMPLE_IP1
+              Private-Port-Name: EXAMPLE_PORT2
+              Private-Port:      8081
+              Public-Port-Name:  EXAMPLE_PUBLIC_PORT2
+              Mappings:
+                - Frontend:      "/front2"
+                  Backend:       "/back2"
+                  Options:       { file: true }
+
+            - Private-IP-Name:   EXAMPLE_IP1
+              Private-Port-Name: EXAMPLE_PORT3
+              Private-Port:      8082
+              Public-Port-Name:  EXAMPLE_PUBLIC_PORT3
+              Mappings:
+                - Frontend:      "/front3"
+                  Backend:       "/back3"
+
+            - Private-IP-Name:   EXAMPLE_IP2
+              Private-Port-Name: EXAMPLE_PORT4
+              Private-Port:      9090
+              Public-Port-Name:  EXAMPLE_PUBLIC_PORT4
+              Mappings:
+                - Frontend:      "/front4"
+                  Backend:       "/back4"
+
+            - Private-IP-Name:   EXAMPLE_IP2
+              Private-Port-Name: EXAMPLE_PORT5
+              Private-Port:      9091
+      }
+
+      manifest = "/tmp/manifest-#{Process.pid}"
+      IO.write(manifest, @mock_manifest, 0)
+      @mock_cartridge = OpenShift::Runtime::Manifest.new(manifest, nil, :file)
+      @container.cartridge_model.stubs(:get_cartridge).with("mock").returns(@mock_cartridge)
     end
-  end
 
-  def test_user_var_add()
-    target   = ".env/user_vars"
-    source   = "/var/lib/openshift/#{@gear_uuid}/#{target}"
-    filename = "#{source}/UNIT_TEST"
-    gears    = ['unit_test.example.com']
-
-    @container.expects(:user_var_push).with(gears, true)
-
-    @container.user_var_add({'UNIT_TEST' => 'true'}, gears)
-
-    assert_path_exist filename
-  end
-
-  def test_user_var_remove()
-    path  = "/var/lib/openshift/#{@gear_uuid}/.env/user_vars/UNIT_TEST"
-    gears = ['unit_test.example.com']
-
-    @container.expects(:user_var_push).with(gears, true)
-    @container.expects(:user_var_push).with(gears)
-
-    @container.user_var_add({'UNIT_TEST' => 'true'}, gears)
-    assert_path_exist path
-
-    @container.user_var_remove(['UNIT_TEST'], gears)
-    refute_path_exist path
-  end
-
-  def test_user_var_list()
-    @container.user_var_remove(['UNIT_TEST', 'FUNC_TEST'])
-    assert_equal({}, @container.user_var_list())
-
-    @container.user_var_add({'UNIT_TEST' => 'true'})
-    actual = @container.user_var_list()
-    assert_equal({'UNIT_TEST' => 'true'}, actual)
-
-    @container.user_var_add({'FUNC_TEST' => 'false'})
-    actual = @container.user_var_list(['FUNC_TEST'])
-    assert_equal({'FUNC_TEST' => 'false'}, actual)
-  end
-
-  def test_bad_user_var()
-    env = {'OPENSHIFT_TEST_IDENT'            => 'x:x:x:x',
-           'OPENSHIFT_NAMESPACE'             => 'namespace',
-           'OPENSHIFT_PRIMARY_CARTRIDGE_DIR' => 'mine',
-           'PATH'                            => '/usr/bin',
-           'IFS'                             => '/',
-           'USER'                            => 'none',
-           'SHELL'                           => 'tcsh',
-           'HOSTNAME'                        => 'remotehost',
-           'LOGNAME'                         => '/tmp/log'}
-
-    env.each do |key, value|
-      rc, msg = @container.user_var_add({key => value})
-      assert_equal 255, rc, "#{key} should have failed."
-      assert_equal "CLIENT_ERROR: #{key} cannot be overridden", msg
+    def teardown
+      FileUtils.rm_rf @container.container_dir
     end
 
-    rc, msg = @container.user_var_add({'TOO_BIG' => '*' * 513})
-    assert_equal 255, rc
-    assert_equal "CLIENT_ERROR: 'TOO_BIG' value exceeds maximum size of 512b\n", msg
-  end
+    def test_public_endpoints_create
+      OpenShift::Runtime::Utils::Environ.stubs(:for_gear).returns({
+                                                                      "OPENSHIFT_MOCK_EXAMPLE_IP1" => "127.0.0.1",
+                                                                      "OPENSHIFT_MOCK_EXAMPLE_IP2" => "127.0.0.2"
+                                                                  })
 
-  # Tests that no_overcommit logic works as intended
-  def test_no_overcommit
-        scenarios = [
-        [5507, true, 0.0],
-        [5508, true, 100.0],
-        [5509, false, 0.0],
-        [5510, false, 100.0],
-    ]
+      proxy = mock('OpenShift::Runtime::FrontendProxyServer')
+      OpenShift::Runtime::FrontendProxyServer.stubs(:new).returns(proxy)
 
-    scenarios.each do |s|
-      if s[1]
-        @config.stubs(:get_bool).with('no_overcommit_active', false).returns(true)
-      else
-        @config.stubs(:get_bool).with('no_overcommit_active', false).returns(false)
+      proxy.expects(:add).with(@user_uid.to_i, "127.0.0.1", 8080).returns(@ports_begin)
+      proxy.expects(:add).with(@user_uid.to_i, "127.0.0.1", 8081).returns(@ports_begin+1)
+      proxy.expects(:add).with(@user_uid.to_i, "127.0.0.1", 8082).returns(@ports_begin+2)
+      proxy.expects(:add).with(@user_uid.to_i, "127.0.0.2", 9090).returns(@ports_begin+3)
+
+      @container.expects(:add_env_var).with('OPENSHIFT_MOCK_EXAMPLE_PUBLIC_PORT1', @ports_begin)
+      @container.expects(:add_env_var).with('OPENSHIFT_MOCK_EXAMPLE_PUBLIC_PORT2', @ports_begin+1)
+      @container.expects(:add_env_var).with('OPENSHIFT_MOCK_EXAMPLE_PUBLIC_PORT3', @ports_begin+2)
+      @container.expects(:add_env_var).with('OPENSHIFT_MOCK_EXAMPLE_PUBLIC_PORT4', @ports_begin+3)
+
+      @container.create_public_endpoints(@mock_cartridge.name)
+    end
+
+    def test_public_endpoints_delete
+      OpenShift::Runtime::Utils::Environ.stubs(:for_gear).returns({
+                                                                      "OPENSHIFT_MOCK_EXAMPLE_IP1" => "127.0.0.1",
+                                                                      "OPENSHIFT_MOCK_EXAMPLE_IP2" => "127.0.0.2"
+                                                                  })
+
+      proxy = mock('OpenShift::Runtime::FrontendProxyServer')
+      OpenShift::Runtime::FrontendProxyServer.stubs(:new).returns(proxy)
+      OpenShift::Runtime::V2CartridgeModel.any_instance.expects(:list_proxy_mappings).returns([
+                                                                                                  {public_port_name: "Endpoint_1", proxy_port: @ports_begin},
+                                                                                                  {public_port_name: "Endpoint_2", proxy_port: @ports_begin+1},
+                                                                                                  {public_port_name: "Endpoint_3", proxy_port: @ports_begin+2},
+                                                                                                  {public_port_name: "Endpoint_4", proxy_port: @ports_begin+3}])
+      #proxy.expects(:find_mapped_proxy_port).with(@user_uid, "127.0.0.1", 8080).returns(@ports_begin)
+      #proxy.expects(:find_mapped_proxy_port).with(@user_uid, "127.0.0.1", 8081).returns(@ports_begin+1)
+      #proxy.expects(:find_mapped_proxy_port).with(@user_uid, "127.0.0.1", 8082).returns(@ports_begin+2)
+      #proxy.expects(:find_mapped_proxy_port).with(@user_uid, "127.0.0.2", 9090).returns(@ports_begin+3)
+
+      delete_all_args = [@ports_begin, @ports_begin+1, @ports_begin+2, @ports_begin+3]
+      proxy.expects(:delete_all).with(delete_all_args, true).returns(nil)
+
+      @container.expects(:remove_env_var).returns(nil).times(4)
+
+      @container.delete_public_endpoints(@mock_cartridge.name)
+    end
+
+    def test_tidy_success
+      OpenShift::Runtime::Utils::Environ.stubs(:for_gear).returns(
+          {'OPENSHIFT_HOMEDIR' => '/foo', 'OPENSHIFT_APP_NAME' => 'app_name'})
+
+      @container.stubs(:stop_gear)
+      @container.stubs(:gear_level_tidy_tmp).with('/foo/.tmp')
+      @container.cartridge_model.expects(:tidy)
+      @container.stubs(:gear_level_tidy_git).with('/foo/git/app_name.git')
+      @container.stubs(:start_gear)
+
+      @container.stubs(:cartridge_model).returns(mock())
+
+      @container.tidy
+    end
+
+    def test_tidy_stop_gear_fails
+      OpenShift::Runtime::Utils::Environ.stubs(:for_gear).returns(
+          {'OPENSHIFT_HOMEDIR' => '/foo', 'OPENSHIFT_APP_NAME' => 'app_name'})
+
+      @container.stubs(:stop_gear).raises(Exception.new)
+      @container.stubs(:gear_level_tidy_tmp).with('/foo/.tmp')
+      @container.cartridge_model.expects(:tidy).never
+      @container.stubs(:gear_level_tidy_git).with('/foo/git/app_name.git')
+      @container.stubs(:start_gear).never
+
+      assert_raise Exception do
+        @container.tidy
       end
-      OpenShift::Runtime::Node.stubs(:node_utilization).returns({'gears_active_usage_pct' => s[2]})
-      OpenShift::Runtime::Node.stubs(:resource_limits).returns(@config)
+    end
 
-      containerization_plugin_mock = mock('OpenShift::Runtime::Containerization::Plugin')
-      containerization_plugin_mock.stubs(:create).returns(nil)
-      OpenShift::Runtime::Containerization::Plugin.stubs(:new).returns(containerization_plugin_mock)
-      Etc.stubs(:getpwnam).returns(
-        OpenStruct.new(
-          uid: s[0],
-          gid: s[0],
-          gecos: "OpenShift guest",
-          container_dir: "/var/lib/openshift/#{s[0].to_s}"
+    def test_tidy_gear_level_tidy_fails
+      OpenShift::Runtime::Utils::Environ.stubs(:for_gear).returns(
+          {'OPENSHIFT_HOMEDIR' => '/foo', 'OPENSHIFT_APP_NAME' => 'app_name'})
+
+      @container.expects(:stop_gear)
+      @container.expects(:gear_level_tidy_tmp).with('/foo/.tmp').raises(Exception.new)
+      @container.expects(:start_gear)
+
+      @container.tidy
+    end
+
+    def test_force_stop
+      FileUtils.mkpath("/tmp/#@user_uid/app-root/runtime")
+      OpenShift::Runtime::Containerization::Plugin.stubs(:kill_procs).with(@user_uid).returns(nil)
+      @container.state.expects(:value=).with(OpenShift::Runtime::State::STOPPED)
+      @container.cartridge_model.expects(:create_stop_lock)
+      @container.force_stop
+    end
+
+    def test_connector_execute
+      cart_name      = 'mock-0.1'
+      pub_cart_name  = 'mock-plugin-0.1'
+      connector_type = 'ENV:NET_TCP'
+      connector      = 'set-db-connection-info'
+      args           = 'foo'
+
+      @container.cartridge_model.expects(:connector_execute).with(cart_name, pub_cart_name, connector_type, connector, args)
+
+      @container.connector_execute(cart_name, pub_cart_name, connector_type, connector, args)
+    end
+
+    # Tests a variety of UID/host ID to IP address conversions.
+    #
+    # TODO: Is there a way to do this algorithmically?
+    def test_get_ip_addr_success
+      scenarios = [
+          [501, 1, "127.0.250.129"],
+          [501, 10, "127.0.250.138"],
+          [501, 20, "127.0.250.148"],
+          [501, 100, "127.0.250.228"],
+          [540, 1, "127.1.14.1"],
+          [560, 7, "127.1.24.7"]
+      ]
+
+      scenarios.each do |s|
+        Etc.stubs(:getpwnam).returns(
+            OpenStruct.new(
+                uid:   s[0].to_i,
+                gid:   s[0].to_i,
+                gecos: "OpenShift guest",
+                dir:   "/var/lib/openshift/gear_uuid"
+            )
         )
-      )
 
-      container = OpenShift::Runtime::ApplicationContainer.new(s[0].to_s, s[0].to_s, s[0],
-                                                               @app_name, s[0].to_s, @namespace, nil, nil, nil)
-      container.stubs(:generate_ssh_key).returns('generate_ssh_key stub')
-      if s[1] and (s[2] == 100.0)
-        assert_raise OpenShift::Runtime::GearCreationException do
+        container = OpenShift::Runtime::ApplicationContainer.new("gear_uuid", "gear_uuid", s[0],
+                                                                 "app_name", "gear_uuid", "namespace", nil, nil, nil)
+
+        assert_equal container.get_ip_addr(s[1]), s[2]
+      end
+    end
+
+    def test_user_var_add()
+      target   = ".env/user_vars"
+      source   = "/var/lib/openshift/#{@gear_uuid}/#{target}"
+      filename = "#{source}/UNIT_TEST"
+      gears    = ['unit_test.example.com']
+
+      @container.expects(:user_var_push).with(gears, true)
+
+      @container.user_var_add({'UNIT_TEST' => 'true'}, gears)
+
+      assert_path_exist filename
+    end
+
+    def test_user_var_remove()
+      path  = "/var/lib/openshift/#{@gear_uuid}/.env/user_vars/UNIT_TEST"
+      gears = ['unit_test.example.com']
+
+      @container.expects(:user_var_push).with(gears, true)
+      @container.expects(:user_var_push).with(gears)
+
+      @container.user_var_add({'UNIT_TEST' => 'true'}, gears)
+      assert_path_exist path
+
+      @container.user_var_remove(['UNIT_TEST'], gears)
+      refute_path_exist path
+    end
+
+    def test_user_var_list()
+      @container.user_var_remove(['UNIT_TEST', 'FUNC_TEST'])
+      assert_equal({}, @container.user_var_list())
+
+      @container.user_var_add({'UNIT_TEST' => 'true'})
+      actual = @container.user_var_list()
+      assert_equal({'UNIT_TEST' => 'true'}, actual)
+
+      @container.user_var_add({'FUNC_TEST' => 'false'})
+      actual = @container.user_var_list(['FUNC_TEST'])
+      assert_equal({'FUNC_TEST' => 'false'}, actual)
+    end
+
+    def test_bad_user_var()
+      env = {'OPENSHIFT_TEST_IDENT'            => 'x:x:x:x',
+             'OPENSHIFT_NAMESPACE'             => 'namespace',
+             'OPENSHIFT_PRIMARY_CARTRIDGE_DIR' => 'mine',
+             'PATH'                            => '/usr/bin',
+             'IFS'                             => '/',
+             'USER'                            => 'none',
+             'SHELL'                           => 'tcsh',
+             'HOSTNAME'                        => 'remotehost',
+             'LOGNAME'                         => '/tmp/log'}
+
+      env.each do |key, value|
+        rc, msg = @container.user_var_add({key => value})
+        assert_equal 255, rc, "#{key} should have failed."
+        assert_equal "CLIENT_ERROR: #{key} cannot be overridden", msg
+      end
+
+      rc, msg = @container.user_var_add({'TOO_BIG' => '*' * 513})
+      assert_equal 255, rc
+      assert_equal "CLIENT_ERROR: 'TOO_BIG' value exceeds maximum size of 512b\n", msg
+    end
+
+    # Tests that no_overcommit logic works as intended
+    def test_no_overcommit
+          scenarios = [
+          [5507, true, 0.0],
+          [5508, true, 100.0],
+          [5509, false, 0.0],
+          [5510, false, 100.0],
+      ]
+
+      scenarios.each do |s|
+        if s[1]
+          @config.stubs(:get_bool).with('no_overcommit_active', false).returns(true)
+        else
+          @config.stubs(:get_bool).with('no_overcommit_active', false).returns(false)
+        end
+        OpenShift::Runtime::Node.stubs(:node_utilization).returns({'gears_active_usage_pct' => s[2]})
+        OpenShift::Runtime::Node.stubs(:resource_limits).returns(@config)
+
+        containerization_plugin_mock = mock('OpenShift::Runtime::Containerization::Plugin')
+        containerization_plugin_mock.stubs(:create).returns(nil)
+        OpenShift::Runtime::Containerization::Plugin.stubs(:new).returns(containerization_plugin_mock)
+        Etc.stubs(:getpwnam).returns(
+          OpenStruct.new(
+            uid: s[0],
+            gid: s[0],
+            gecos: "OpenShift guest",
+            container_dir: "/var/lib/openshift/#{s[0].to_s}"
+          )
+        )
+
+        container = OpenShift::Runtime::ApplicationContainer.new(s[0].to_s, s[0].to_s, s[0],
+                                                                 @app_name, s[0].to_s, @namespace, nil, nil, nil)
+        container.stubs(:generate_ssh_key).returns('generate_ssh_key stub')
+        if s[1] and (s[2] == 100.0)
+          assert_raise OpenShift::Runtime::GearCreationException do
+            container.create
+          end
+        else
           container.create
         end
-      else
-        container.create
       end
     end
-  end
 
-  def test_deconfigure
-    @container.cartridge_model.expects(:deconfigure).with('mock-0.1')
-    @container.deconfigure('mock-0.1')
-  end
+    def test_standalone_proxy_repo
+      cartridge_model = mock()
+      cartridge_model.expects(:standalone_web_proxy?).returns(true)
+      @container.expects(:cartridge_model).returns(cartridge_model)
 
-  def test_unsubscribe
-    @container.cartridge_model.expects(:unsubscribe).with('mock-0.1', 'pub-cart')
-    @container.unsubscribe('mock-0.1', 'pub-cart')
-  end
+      uuid1 = '1'
 
-  def test_update_cluster_no_web_proxy
-    @container.cartridge_model.expects(:web_proxy).returns(nil)
-    ::OpenShift::Runtime::Utils::Environ::expects(:for_gear).never
-    ::OpenShift::Runtime::GearRegistry.expects(:new).never
-    @config.expects(:get).never
-    ::OpenShift::Runtime::GearRegistry::Entry.expects(:new).never
-    @container.expects(:run_in_container_context).never
-    @container.expects(:current_deployment_datetime).never
-    @container.expects(:deployment_metadata_for).never
-    @container.expects(:activate).never
-    @container.cartridge_model.expects(:do_control).never
-
-    @container.update_cluster("", "", false, false)
-  end
-
-  def test_update_cluster_rollback
-    web_proxy = mock()
-    @container.cartridge_model.expects(:web_proxy).returns(web_proxy)
-
-    gear_env = {'OPENSHIFT_APP_DNS' => 'foo-bar.example.com', 'OPENSHIFT_GEAR_DNS' => 'foo-bar.example.com'}
-    ::OpenShift::Runtime::Utils::Environ::expects(:for_gear).with(@container.container_dir).returns(gear_env)
-
-    gear_registry = mock()
-    @container.expects(:gear_registry).returns(gear_registry)
-
-    gear_registry.expects(:restore_from_backup)
-    args = "args"
-    @container.expects(:generate_update_cluster_control_args).with(nil).returns(args)
-
-    @container.cartridge_model.expects(:do_control).with('update-cluster', web_proxy, args: args)
-    @container.update_cluster("", "", true, false)
-  end
-
-  def test_update_cluster_add_gears
-    web_proxy = mock()
-    @container.cartridge_model.expects(:web_proxy).returns(web_proxy)
-
-    gear_env = {'OPENSHIFT_APP_DNS' => 'foo-bar.example.com', 'OPENSHIFT_GEAR_DNS' => '123-bar.example.com'}
-    ::OpenShift::Runtime::Utils::Environ::expects(:for_gear).with(@container.container_dir).returns(gear_env)
-
-    gear_registry = mock()
-    @container.expects(:gear_registry).returns(gear_registry).at_least_once
-
-    @container.expects(:run_in_container_context).with("rsync -aAX --rsh=/usr/bin/oo-ssh /var/lib/openshift/#{@gear_uuid}/.openshift_ssh/id_rsa{,.pub} #{@gear_uuid.to_i + 2}@node1.example.com:.openshift_ssh/",
-                                                            env: gear_env,
-                                                            chdir: @container.container_dir,
-                                                            expected_exitstatus: 0)
-
-    uuid1 = @container.uuid
-    gear1 = {
-      uuid: uuid1,
-      namespace: 'bar',
-      dns: 'foo-bar.example.com',
-      proxy_hostname: 'node1.example.com',
-      proxy_port: '35561'
-    }
-    web_entry1 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear1)
-    proxy_entry1 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear1.merge(proxy_port: 0))
-
-    uuid2 = (@container.uuid.to_i + 1).to_s
-    gear2 = {
-      uuid: uuid2,
-      namespace: 'bar',
-      dns: "#{uuid2}-bar.example.com",
-      proxy_hostname: 'node1.example.com',
-      proxy_port: '35566'
-    }
-    web_entry2 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear2)
-    proxy_entry2 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear2.merge(proxy_port: 0))
-
-    uuid3 = (@container.uuid.to_i + 2).to_s
-    gear3 = {
-      uuid: uuid3,
-      namespace: 'bar',
-      dns: "#{uuid3}-bar.example.com",
-      proxy_hostname: 'node1.example.com',
-      proxy_port: '35571'
-    }
-    web_entry3 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear3)
-    proxy_entry3 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear3.merge(proxy_port: 0))
-
-    old_entries = {
-      :web => {
-        uuid1 => web_entry1
-      },
-      :proxy => {
-        uuid1 => proxy_entry1
+      entry1 = {
+          uuid: "#{uuid1}",
+          namespace: 'bar',
+          dns: "#{uuid1}-bar.example.com",
+          proxy_hostname: 'node1.example.com',
+          proxy_port: '35571',
+          platform: 'windows'
       }
-    }
 
-    updated_entries = {
-      :web => {
-        uuid1 => web_entry1,
-        uuid2 => web_entry2,
-        uuid3 => web_entry3
-      },
-      :proxy => {
-        uuid1 => proxy_entry1,
-        uuid3 => proxy_entry3
+      web_entry1 = ::OpenShift::Runtime::GearRegistry::Entry.new(entry1)
+
+      entries = {
+          :web => {
+              uuid1 => web_entry1,
+          }
       }
-    }
 
-    gear_registry.expects(:backup)
-    gear_registry.expects(:entries).times(2).returns(old_entries, updated_entries)
-    gear_registry.expects(:clear)
+      gear_registry = mock()
+      gear_registry.expects(:entries).times(2).returns(entries)
 
-    @config.expects(:get).with('CLOUD_DOMAIN').returns('example.com')
-    web_uuids = [uuid1, uuid2, uuid3]
+      @container.expects(:gear_registry).times(2).returns(gear_registry)
 
-    dns_entries = %W(foo #{uuid2} #{uuid3})
-    ports = %w(35561 35566 35571)
+      gear_env = {'FOO' => 'bar'}
 
-    web_uuids.each_with_index do |uuid, index|
-      gear_registry.expects(:add).with(type: :web,
-                                       uuid: uuid,
-                                       namespace: "bar",
-                                       dns: "#{dns_entries[index]}-bar.example.com",
-                                       proxy_hostname: "node1.example.com",
-                                       proxy_port: ports[index])
+      ::OpenShift::Runtime::Utils::Environ::expects(:for_gear).with(@container.container_dir).returns(gear_env)
+
+      ssh_url = "#{entry1[:uuid]}@#{entry1[:proxy_hostname]}"
+      location = PathUtils.join(@container.container_dir, 'mock', 'template')
+
+      @container.expects(:run_in_container_context).with("mkdir -p #{location} ; rsync -rOv --exclude '.git' --delete --rsh=/usr/bin/oo-ssh #{ssh_url}:git/template/ #{location}",
+                                                         env: gear_env,
+                                                         chdir: @container.container_dir,
+                                                         expected_exitstatus: 0)
+
+      repo = OpenShift::Runtime::ApplicationRepository.new(@container)
+      repo.destroy
+      repo.populate_from_cartridge('mock')
     end
 
-    proxy_uuids = [uuid1, uuid3]
-    proxy_uuids.each_with_index do |uuid, index|
-      gear_registry.expects(:add).with(type: :proxy,
-                                       uuid: uuid,
-                                       namespace: "bar",
-                                       dns: "#{dns_entries[index]}-bar.example.com",
-                                       proxy_hostname: "node1.example.com",
-                                       proxy_port: 0)
-    end
+    def test_remote_rsync_options
+      uuid1 = '1'
+      uuid2 = '2'
 
-    gear_registry.expects(:save)
-
-    [web_entry2, web_entry3].each do |new_entry|
-      @container.expects(:run_in_container_context).with("rsync -avz --delete --rsh=/usr/bin/oo-ssh app-deployments/ #{new_entry.uuid}@#{new_entry.proxy_hostname}:app-deployments/",
-                                                        env: gear_env,
-                                                        chdir: @container.container_dir,
-                                                        expected_exitstatus: 0)
-    end
-    current_deployment_datetime = '2013-08-16_13-36-36.880'
-    @container.expects(:current_deployment_datetime).returns(current_deployment_datetime)
-
-    deployment_id = 'abcd1234'
-    metadata = mock()
-    @container.expects(:deployment_metadata_for).with(current_deployment_datetime).returns(metadata)
-    metadata.expects(:id).returns(deployment_id)
-
-    @container.expects(:activate).with(gears: [uuid2, uuid3],
-                                       deployment_id: deployment_id,
-                                       post_install: true,
-                                       rotate: false)
-                                 .returns(status: 'success')
-
-    @container.expects(:run_in_container_context).with("rsync -avz --delete --exclude hooks --rsh=/usr/bin/oo-ssh git/#{@app_name}.git/ #{proxy_entry3.uuid}@#{proxy_entry3.proxy_hostname}:git/#{@app_name}.git/",
-                                                        env: gear_env,
-                                                        chdir: @container.container_dir,
-                                                        expected_exitstatus: 0)
-
-    do_control_args = web_uuids.each_with_index.map do |uuid, index|
-      "#{dns_entries[index]}-bar.example.com|node1.example.com:#{ports[index]}"
-    end.join(' ')
-
-    @container.cartridge_model.expects(:do_control).with('update-cluster', web_proxy, args: do_control_args)
-
-    proxy_arg = proxy_uuids.each_with_index.map do |uuid, index|
-      "#{uuid},#{dns_entries[index]},bar,node1.example.com"
-    end.join(' ')
-
-    cluster_arg = web_uuids.each_with_index.map do |uuid, index|
-      "#{uuid},#{dns_entries[index]},bar,node1.example.com,#{ports[index]}"
-    end.join(' ')
-
-    @container.update_cluster(proxy_arg, cluster_arg, false, true)
-  end
-
-  def test_update_cluster_add_multiple_gears_first_time
-    web_proxy = mock()
-    @container.cartridge_model.expects(:web_proxy).returns(web_proxy)
-
-    gear_env = {'OPENSHIFT_APP_DNS' => 'foo-bar.example.com', 'OPENSHIFT_GEAR_DNS' => '123-bar.example.com'}
-    ::OpenShift::Runtime::Utils::Environ::expects(:for_gear).with(@container.container_dir).returns(gear_env)
-
-    gear_registry = mock()
-    @container.expects(:gear_registry).returns(gear_registry).at_least_once
-
-    uuid1 = @container.uuid
-    gear1 = {
-      uuid: uuid1,
-      namespace: 'bar',
-      dns: 'foo-bar.example.com',
-      proxy_hostname: 'node1.example.com',
-      proxy_port: '35561'
-    }
-    web_entry1 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear1)
-    proxy_entry1 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear1.merge(proxy_port: 0))
-
-    uuid2 = (@container.uuid.to_i + 1).to_s
-    gear2 = {
-      uuid: uuid2,
-      namespace: 'bar',
-      dns: "#{uuid2}-bar.example.com",
-      proxy_hostname: 'node1.example.com',
-      proxy_port: '35566'
-    }
-    web_entry2 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear2)
-
-    uuid3 = (@container.uuid.to_i + 2).to_s
-    gear3 = {
-      uuid: uuid3,
-      namespace: 'bar',
-      dns: "#{uuid3}-bar.example.com",
-      proxy_hostname: 'node1.example.com',
-      proxy_port: '35571'
-    }
-    web_entry3 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear3)
-
-    old_entries = {
-    }
-
-    updated_entries = {
-      :web => {
-        uuid1 => web_entry1,
-        uuid2 => web_entry2,
-        uuid3 => web_entry3
-      },
-      :proxy => {
-        uuid1 => proxy_entry1,
+      entry1 = {
+          uuid: "#{uuid1}",
+          namespace: 'bar',
+          dns: "#{uuid1}-bar.example.com",
+          proxy_hostname: 'node1.example.com',
+          proxy_port: '35571',
+          platform: 'linux'
       }
-    }
 
-    gear_registry.expects(:backup)
-    gear_registry.expects(:entries).times(2).returns(old_entries, updated_entries)
-    gear_registry.expects(:clear)
-
-    @config.expects(:get).with('CLOUD_DOMAIN').returns('example.com')
-    web_uuids = [uuid1, uuid2, uuid3]
-
-    dns_entries = %W(foo #{uuid2} #{uuid3})
-    ports = %w(35561 35566 35571)
-
-    web_uuids.each_with_index do |uuid, index|
-      gear_registry.expects(:add).with(type: :web,
-                                       uuid: uuid,
-                                       namespace: "bar",
-                                       dns: "#{dns_entries[index]}-bar.example.com",
-                                       proxy_hostname: "node1.example.com",
-                                       proxy_port: ports[index])
-    end
-
-    proxy_uuids = [uuid1]
-    proxy_uuids.each_with_index do |uuid, index|
-      gear_registry.expects(:add).with(type: :proxy,
-                                       uuid: uuid,
-                                       namespace: "bar",
-                                       dns: "#{dns_entries[index]}-bar.example.com",
-                                       proxy_hostname: "node1.example.com",
-                                       proxy_port: 0)
-    end
-
-    gear_registry.expects(:save)
-
-    [web_entry2, web_entry3].each do |new_entry|
-      @container.expects(:run_in_container_context).with("rsync -avz --delete --rsh=/usr/bin/oo-ssh app-deployments/ #{new_entry.uuid}@#{new_entry.proxy_hostname}:app-deployments/",
-                                                        env: gear_env,
-                                                        chdir: @container.container_dir,
-                                                        expected_exitstatus: 0)
-    end
-    current_deployment_datetime = '2013-08-16_13-36-36.880'
-    @container.expects(:current_deployment_datetime).returns(current_deployment_datetime)
-
-    deployment_id = 'abcd1234'
-    metadata = mock()
-    @container.expects(:deployment_metadata_for).with(current_deployment_datetime).returns(metadata)
-    metadata.expects(:id).returns(deployment_id)
-
-    @container.expects(:activate).with(gears: [uuid2, uuid3],
-                                       deployment_id: deployment_id,
-                                       post_install: true,
-                                       rotate: false)
-                                 .returns(status: 'success')
-
-    do_control_args = web_uuids.each_with_index.map do |uuid, index|
-      "#{dns_entries[index]}-bar.example.com|node1.example.com:#{ports[index]}"
-    end.join(' ')
-
-    @container.cartridge_model.expects(:do_control).with('update-cluster', web_proxy, args: do_control_args)
-
-    proxy_arg = proxy_uuids.each_with_index.map do |uuid, index|
-      "#{uuid},#{dns_entries[index]},bar,node1.example.com"
-    end.join(' ')
-
-    cluster_arg = web_uuids.each_with_index.map do |uuid, index|
-      "#{uuid},#{dns_entries[index]},bar,node1.example.com,#{ports[index]}"
-    end.join(' ')
-
-    @container.update_cluster(proxy_arg, cluster_arg, false, true)
-  end
-
-  def test_with_gear_rotation_no_proxy_no_all
-    count = 0
-    yielded_target_gear = nil
-    yielded_local_gear_env = nil
-
-    gear_env = {a: 1}
-    ::OpenShift::Runtime::Utils::Environ.expects(:for_gear).with(@container.container_dir).returns(gear_env)
-
-    @container.cartridge_model.expects(:web_proxy).returns(nil)
-
-    @container.expects(:calculate_batch_size).with(1, 0.2).returns(1)
-    Parallel.expects(:map).with([@container.uuid], :in_threads => 1).yields(@container.uuid)
-
-    with_gear_rotation_options = {b:2}
-    @container.expects(:rotate_and_yield).with(@container.uuid, gear_env, with_gear_rotation_options).yields(@container.uuid, gear_env, with_gear_rotation_options)
-
-    @container.with_gear_rotation(with_gear_rotation_options) do |target_gear, local_gear_env|
-      count += 1
-      yielded_target_gear = target_gear
-      yielded_local_gear_env = local_gear_env
-    end
-
-    assert_equal 1, count
-    assert_equal @container.uuid, yielded_target_gear
-    assert_equal gear_env, yielded_local_gear_env
-  end
-
-  def test_with_gear_rotation_with_proxy_no_all
-    count = 0
-    yielded_target_gear = nil
-    yielded_local_gear_env = nil
-
-    gear_env = {a: 1}
-    ::OpenShift::Runtime::Utils::Environ.expects(:for_gear).with(@container.container_dir).returns(gear_env)
-
-    proxy_cart = mock()
-    @container.cartridge_model.expects(:web_proxy).returns(proxy_cart)
-
-    gear_registry = mock()
-    @container.expects(:gear_registry).returns(gear_registry)
-    entry = mock()
-    entries = { :web => { @container.uuid => entry, 'a' => 'b' } }
-    gear_registry.expects(:entries).returns(entries)
-
-    @container.expects(:calculate_batch_size).with(1, 0.2).returns(1)
-    Parallel.expects(:map).with([entry], :in_threads => 1).yields(entry)
-
-    with_gear_rotation_options = {b:2}
-    @container.expects(:rotate_and_yield).with(entry, gear_env, with_gear_rotation_options).yields(entry, gear_env, with_gear_rotation_options)
-
-    @container.with_gear_rotation(with_gear_rotation_options) do |target_gear, local_gear_env|
-      count += 1
-      yielded_target_gear = target_gear
-      yielded_local_gear_env = local_gear_env
-    end
-
-    assert_equal 1, count
-    assert_equal entry, yielded_target_gear
-    assert_equal gear_env, yielded_local_gear_env
-  end
-
-  def test_with_gear_rotation_proxy_and_all
-    count = 0
-    yielded_target_gears = []
-    yielded_local_gear_envs = []
-
-    gear_env = {a: 1}
-    ::OpenShift::Runtime::Utils::Environ.expects(:for_gear).with(@container.container_dir).returns(gear_env)
-
-    proxy_cart = mock()
-    @container.cartridge_model.expects(:web_proxy).returns(proxy_cart)
-
-    gear_registry = mock()
-    @container.expects(:gear_registry).returns(gear_registry)
-    entry1 = mock()
-    entry2 = mock()
-    uuid2 = '5505'
-    entries = { :web => { @container.uuid => entry1, uuid2 => entry2 } }
-    gear_registry.expects(:entries).returns(entries)
-
-    @container.expects(:calculate_batch_size).with(2, 0.2).returns(1)
-    Parallel.expects(:map).with([entry1, entry2], :in_threads => 1).multiple_yields(entry1, entry2)
-
-    with_gear_rotation_options = {b:2, all: true}
-    @container.expects(:rotate_and_yield).with(entry1, gear_env, with_gear_rotation_options).yields(entry1, gear_env, with_gear_rotation_options)
-    @container.expects(:rotate_and_yield).with(entry2, gear_env, with_gear_rotation_options).yields(entry2, gear_env, with_gear_rotation_options)
-
-    @container.with_gear_rotation(with_gear_rotation_options) do |target_gear, local_gear_env|
-      count += 1
-      yielded_target_gears << target_gear
-      yielded_local_gear_envs << local_gear_env
-    end
-
-    assert_equal 2, count
-    assert_equal entry1, yielded_target_gears[0]
-    assert_equal gear_env, yielded_local_gear_envs[0]
-    assert_equal entry2, yielded_target_gears[1]
-    assert_equal gear_env, yielded_local_gear_envs[1]
-  end
-
-  def test_rotate_and_yield_no_proxy
-    options = {a: 1}
-    yielded_values = []
-    target_gear = '1234'
-    local_gear_env = mock()
-
-    @container.expects(:update_proxy_status).never
-
-    @container.rotate_and_yield(target_gear, local_gear_env, options) do |*values|
-      yielded_values = values
-      {
-        status: 'success',
-        messages: %w(a b),
-        errors: %w(b c),
-        foo: 'bar'
+      entry2 = {
+          uuid: "#{uuid2}",
+          namespace: 'bar',
+          dns: "#{uuid2}-bar.example.com",
+          proxy_hostname: 'node1.example.com',
+          proxy_port: '35571',
+          platform: 'windows'
       }
+
+      web_entry1 = ::OpenShift::Runtime::GearRegistry::Entry.new(entry1)
+      web_entry2 = ::OpenShift::Runtime::GearRegistry::Entry.new(entry2)
+
+      entries = {
+          :web => {
+              uuid1 => web_entry1,
+              uuid2 => web_entry2,
+          }
+      }
+
+      gear_registry = mock()
+      gear_registry.expects(:entries).times(2).returns(entries)
+
+      @container.expects(:gear_registry).times(2).returns(gear_registry)
+
+      rsync_options = @container.send(:remote_rsync_options, uuid1)
+      assert_equal '-avz', rsync_options
+
+      rsync_options = @container.send(:remote_rsync_options, uuid2)
+      assert_equal '-rltgoDOv', rsync_options
     end
 
-    assert_equal [target_gear, local_gear_env, options], yielded_values
-  end
+    def test_deconfigure
+      @container.cartridge_model.expects(:deconfigure).with('mock-0.1')
+      @container.deconfigure('mock-0.1')
+    end
 
-  def test_rotate_and_yield_proxy
-    proxy_cart = mock()
-    options = {a: 1, proxy_cart: proxy_cart}
-    yielded_values = []
-    target_gear = mock()
-    target_gear.expects(:uuid).returns('1234')
-    local_gear_env = mock()
+    def test_unsubscribe
+      @container.cartridge_model.expects(:unsubscribe).with('mock-0.1', 'pub-cart')
+      @container.unsubscribe('mock-0.1', 'pub-cart')
+    end
 
-    rotate_out_results = {
-      status: 'success',
-      target_gear_uuid: '1234',
-      proxy_results: {
-        '1234' => {
-          target_gear_uuid: '1234',
-          proxy_gear_uuid: '1234',
-          status: 'success',
-          messages: [1,2],
-          errors: [2,3]
+    def test_update_cluster_no_web_proxy
+      @container.cartridge_model.expects(:web_proxy).returns(nil)
+      ::OpenShift::Runtime::Utils::Environ::expects(:for_gear).never
+      ::OpenShift::Runtime::GearRegistry.expects(:new).never
+      @config.expects(:get).never
+      ::OpenShift::Runtime::GearRegistry::Entry.expects(:new).never
+      @container.expects(:run_in_container_context).never
+      @container.expects(:current_deployment_datetime).never
+      @container.expects(:deployment_metadata_for).never
+      @container.expects(:activate).never
+      @container.cartridge_model.expects(:do_control).never
+
+      @container.update_cluster("", "", false, false)
+    end
+
+    def test_update_cluster_rollback
+      web_proxy = mock()
+      @container.cartridge_model.expects(:web_proxy).returns(web_proxy)
+
+      gear_env = {'OPENSHIFT_APP_DNS' => 'foo-bar.example.com', 'OPENSHIFT_GEAR_DNS' => 'foo-bar.example.com'}
+      ::OpenShift::Runtime::Utils::Environ::expects(:for_gear).with(@container.container_dir).returns(gear_env)
+
+      gear_registry = mock()
+      @container.expects(:gear_registry).returns(gear_registry)
+
+      gear_registry.expects(:restore_from_backup)
+      args = "args"
+      @container.expects(:generate_update_cluster_control_args).with(nil).returns(args)
+
+      @container.cartridge_model.expects(:do_control).with('update-cluster', web_proxy, args: args)
+      @container.update_cluster("", "", true, false)
+    end
+
+    def test_update_cluster_add_gears
+      web_proxy = mock()
+      web_proxy.expects(:name).at_least_once.returns('foo')
+
+      primary_cartridge = mock()
+      primary_cartridge.expects(:name).at_least_once.returns('bar')
+
+      @container.cartridge_model.expects(:primary_cartridge).at_least_once.returns(primary_cartridge)
+      @container.cartridge_model.expects(:web_proxy).at_least_once.returns(web_proxy)
+
+      gear_env = {'OPENSHIFT_APP_DNS' => 'foo-bar.example.com', 'OPENSHIFT_GEAR_DNS' => '123-bar.example.com'}
+      ::OpenShift::Runtime::Utils::Environ::expects(:for_gear).with(@container.container_dir).returns(gear_env)
+
+      gear_registry = mock()
+
+      @container.expects(:gear_registry).returns(gear_registry).at_least_once
+
+      @container.expects(:run_in_container_context).with("rsync -aAX --rsh=/usr/bin/oo-ssh /var/lib/openshift/#{@gear_uuid}/.openshift_ssh/id_rsa{,.pub} #{@gear_uuid.to_i + 2}@node1.example.com:.openshift_ssh/",
+                                                              env: gear_env,
+                                                              chdir: @container.container_dir,
+                                                              expected_exitstatus: 0)
+
+      uuid1 = @container.uuid
+      gear1 = {
+        uuid: uuid1,
+        namespace: 'bar',
+        dns: 'foo-bar.example.com',
+        proxy_hostname: 'node1.example.com',
+        proxy_port: '35561',
+        platform: 'linux'
+      }
+      web_entry1 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear1)
+      proxy_entry1 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear1.merge(proxy_port: 0))
+
+      uuid2 = (@container.uuid.to_i + 1).to_s
+      gear2 = {
+        uuid: uuid2,
+        namespace: 'bar',
+        dns: "#{uuid2}-bar.example.com",
+        proxy_hostname: 'node1.example.com',
+        proxy_port: '35566',
+        platform: 'linux'
+      }
+      web_entry2 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear2)
+      proxy_entry2 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear2.merge(proxy_port: 0))
+
+      uuid3 = (@container.uuid.to_i + 2).to_s
+      gear3 = {
+        uuid: uuid3,
+        namespace: 'bar',
+        dns: "#{uuid3}-bar.example.com",
+        proxy_hostname: 'node1.example.com',
+        proxy_port: '35571',
+        platform: 'linux'
+      }
+      web_entry3 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear3)
+      proxy_entry3 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear3.merge(proxy_port: 0))
+
+      old_entries = {
+        :web => {
+          uuid1 => web_entry1
+        },
+        :proxy => {
+          uuid1 => proxy_entry1
         }
       }
-    }
-    @container.expects(:update_proxy_status).with(action: :disable, gear_uuid: '1234', cartridge: proxy_cart).returns(rotate_out_results)
 
-    rotate_in_results = {
-      status: 'success',
-      target_gear_uuid: '1234',
-      proxy_results: {
-        '1234' => {
-          target_gear_uuid: '1234',
-          proxy_gear_uuid: '1234',
-          status: 'success',
-          messages: [3,4],
-          errors: [4,5]
+      updated_entries = {
+        :web => {
+          uuid1 => web_entry1,
+          uuid2 => web_entry2,
+          uuid3 => web_entry3
+        },
+        :proxy => {
+          uuid1 => proxy_entry1,
+          uuid3 => proxy_entry3
         }
       }
-    }
-    @container.expects(:update_proxy_status).with(action: :enable, gear_uuid: '1234', cartridge: proxy_cart).returns(rotate_in_results)
 
-    result = @container.rotate_and_yield(target_gear, local_gear_env, options) do |*values|
-      yielded_values = values
-      {
-        status: 'success',
-        messages: %w(a b),
-        errors: %w(b c),
-        foo: 'bar'
-      }
+      gear_registry.expects(:backup)
+      gear_registry.expects(:entries).times(3).returns(old_entries, updated_entries)
+      gear_registry.expects(:clear)
+
+      @config.expects(:get).with('CLOUD_DOMAIN').returns('example.com')
+      web_uuids = [uuid1, uuid2, uuid3]
+
+      dns_entries = %W(foo #{uuid2} #{uuid3})
+      ports = %w(35561 35566 35571)
+
+      web_uuids.each_with_index do |uuid, index|
+        gear_registry.expects(:add).with(type: :web,
+                                         uuid: uuid,
+                                         namespace: "bar",
+                                         dns: "#{dns_entries[index]}-bar.example.com",
+                                         proxy_hostname: "node1.example.com",
+                                         proxy_port: ports[index],
+                                         platform: 'linux')
+      end
+
+      proxy_uuids = [uuid1, uuid3]
+      proxy_uuids.each_with_index do |uuid, index|
+        gear_registry.expects(:add).with(type: :proxy,
+                                         uuid: uuid,
+                                         namespace: "bar",
+                                         dns: "#{dns_entries[index]}-bar.example.com",
+                                         proxy_hostname: "node1.example.com",
+                                         proxy_port: 0,
+                                         platform: 'linux')
+      end
+
+      gear_registry.expects(:save)
+
+      [web_entry2, web_entry3].each do |new_entry|
+        @container.expects(:run_in_container_context).with("rsync -avz --delete --rsh=/usr/bin/oo-ssh app-deployments/ #{new_entry.uuid}@#{new_entry.proxy_hostname}:app-deployments/",
+                                                          env: gear_env,
+                                                          chdir: @container.container_dir,
+                                                          expected_exitstatus: 0)
+      end
+      current_deployment_datetime = '2013-08-16_13-36-36.880'
+      @container.expects(:current_deployment_datetime).returns(current_deployment_datetime)
+
+      deployment_id = 'abcd1234'
+      metadata = mock()
+      @container.expects(:deployment_metadata_for).with(current_deployment_datetime).returns(metadata)
+      metadata.expects(:id).returns(deployment_id)
+
+      @container.expects(:activate).with(gears: [uuid2, uuid3],
+                                         deployment_id: deployment_id,
+                                         post_install: true,
+                                         rotate: false)
+                                   .returns(status: 'success')
+
+      @container.expects(:run_in_container_context).with("rsync -avz --delete --exclude hooks --rsh=/usr/bin/oo-ssh git/#{@app_name}.git/ #{proxy_entry3.uuid}@#{proxy_entry3.proxy_hostname}:git/#{@app_name}.git/",
+                                                          env: gear_env,
+                                                          chdir: @container.container_dir,
+                                                          expected_exitstatus: 0)
+
+      do_control_args = web_uuids.each_with_index.map do |uuid, index|
+        "#{dns_entries[index]}-bar.example.com|node1.example.com:#{ports[index]}"
+      end.join(' ')
+
+      @container.cartridge_model.expects(:do_control).with('update-cluster', web_proxy, args: do_control_args)
+
+      proxy_arg = proxy_uuids.each_with_index.map do |uuid, index|
+        "#{uuid},#{dns_entries[index]},bar,node1.example.com,linux"
+      end.join(' ')
+
+      cluster_arg = web_uuids.each_with_index.map do |uuid, index|
+        "#{uuid},#{dns_entries[index]},bar,node1.example.com,#{ports[index]},linux"
+      end.join(' ')
+
+      @container.update_cluster(proxy_arg, cluster_arg, false, true)
     end
 
-    assert_equal [target_gear, local_gear_env, options], yielded_values
-    expected_result = HashWithIndifferentAccess.new({
-      status: 'success',
-      foo: 'bar',
-      messages: ['Rotating out gear in proxies', 'a', 'b', 'Rotating in gear in proxies'],
-      errors: ['b', 'c'],
-      rotate_out_results: rotate_out_results,
-      rotate_in_results: rotate_in_results
-    })
+    def test_update_cluster_standalone_proxy
+      web_proxy = mock()
+      web_proxy.expects(:name).at_least_once.returns('foo')
 
-    assert_equal expected_result, result
-  end
+      @container.cartridge_model.expects(:primary_cartridge).at_least_once.returns(web_proxy)
+      @container.cartridge_model.expects(:web_proxy).at_least_once.returns(web_proxy)
 
-  def test_restart_success
-    options = {a: 1, all:true}
-    target_gear1 = mock()
-    target_gear2 = mock()
-    local_gear_env = mock()
-    cart_name = 'proxy_cart_name'
+      gear_env = {'OPENSHIFT_APP_DNS' => 'foo-bar.example.com', 'OPENSHIFT_GEAR_DNS' => '123-bar.example.com'}
+      ::OpenShift::Runtime::Utils::Environ::expects(:for_gear).twice.with(@container.container_dir).returns(gear_env)
 
-    local_result = {
-      status: 'success',
-      target_gear_uuid: '1234',
-      messages: [],
-      errors: []
-    }
+      gear_registry = mock()
 
-    remote_result = {
-      target_gear_uuid: '2345',
-      messages: [],
-      errors: [],
-      status: 'success'
-    }
+      @container.expects(:gear_registry).returns(gear_registry).at_least_once
 
-    @container.expects(:with_gear_rotation).multiple_yields([target_gear1, local_gear_env, options], [target_gear2, local_gear_env, options]).returns([local_result, remote_result])
+      uuid1 = @container.uuid
+      gear1 = {
+          uuid: uuid1,
+          namespace: 'bar',
+          dns: 'foo-bar.example.com',
+          proxy_hostname: 'node1.example.com',
+          proxy_port: '35561',
+          platform: 'windows'
+      }
 
-    @container.expects(:restart_gear).with(target_gear1, local_gear_env, cart_name, options).returns(local_result)
-    @container.expects(:restart_gear).with(target_gear2, local_gear_env, cart_name, options).returns(remote_result)
+      location = PathUtils.join(@container.container_dir, 'foo', 'template')
+      ssh_url = "#{uuid1}@#{gear1[:proxy_hostname]}"
 
-    result = @container.restart(cart_name, options)
-    assert_equal 'success', result[:status]
-    assert_equal 2, result[:gear_results].size
-    assert_equal local_result, result[:gear_results]['1234']
-    assert_equal remote_result, result[:gear_results]['2345']
-  end
+      @container.expects(:run_in_container_context).with("mkdir -p #{location} ; rsync -rOv --exclude '.git' --delete --rsh=/usr/bin/oo-ssh #{ssh_url}:git/template/ #{location}",
+                                                         env: gear_env,
+                                                         chdir: @container.container_dir,
+                                                         expected_exitstatus: 0)
 
-  def test_restart_failure
-    options = {a: 1}
-    target_gear = mock()
-    local_gear_env = mock()
-    cart_name = 'proxy_cart_name'
+      @container.expects(:setup_deployment)
+      @container.expects(:latest_deployment_datetime).returns('abc')
 
-    target_result = {
-      status: 'failure',
-      target_gear_uuid: '1234',
-      messages: [],
-      errors: []
-    }
+      web_entry1 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear1)
+      proxy_entry1 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear1.merge(proxy_port: 0, platform: 'linux'))
 
-    @container.expects(:with_gear_rotation).yields(target_gear, local_gear_env, options).returns([target_result])
+      entries = {
+          :web => {
+              uuid1 => web_entry1
+          },
+          :proxy => {
+              uuid1 => proxy_entry1
+          }
+      }
 
-    @container.expects(:restart_gear).with(target_gear, local_gear_env, cart_name, options).returns(target_result)
+      gear_registry.expects(:backup)
+      gear_registry.expects(:entries).times(4).returns(entries)
+      gear_registry.expects(:clear)
 
-    result = @container.restart(cart_name, options)
-    assert_equal target_result, result
-  end
+      @config.expects(:get).with('CLOUD_DOMAIN').returns('example.com')
 
-  def test_restart_gear_string
-    target_gear = @container.uuid
-    local_gear_env = {a: 1}
-    cart_name = 'cart_name'
-    options = {b: 2}
-    restart_output = 'restart output'
+      web_uuid = uuid1
+      dns_entry = 'foo'
+      port = '35561'
 
-    @container.cartridge_model.expects(:start_cartridge).with('restart',
-                                                              cart_name,
-                                                              user_initiated: true,
-                                                              out: options[:out],
-                                                              err: options[:err]).returns(restart_output)
+      gear_registry.expects(:add).with(type: :web,
+                                       uuid: web_uuid,
+                                       namespace: "bar",
+                                       dns: "#{dns_entry}-bar.example.com",
+                                       proxy_hostname: "node1.example.com",
+                                       proxy_port: port,
+                                         platform: 'windows')
 
-    result = @container.restart_gear(target_gear, local_gear_env, cart_name, options)
+      proxy_uuid = uuid1
 
-    assert_equal 'success', result[:status]
-    assert_equal target_gear, result[:target_gear_uuid]
-    assert_equal [restart_output], result[:messages]
-    assert_empty result[:errors]
-  end
+      gear_registry.expects(:add).with(type: :proxy,
+                                       uuid: proxy_uuid,
+                                       namespace: "bar",
+                                       dns: "#{dns_entry}-bar.example.com",
+                                       proxy_hostname: "node1.example.com",
+                                       proxy_port: 0,
+                                       platform: 'linux')
 
-  def test_restart_gear_entry_success
-    target_gear = mock()
-    target_gear_uuid = 'uuid'
-    local_gear_env = {a: 1}
-    cart_name = 'cart_name'
-    options = {b: 2}
-    restart_output = {status: 'success', from_json: true}
-    restart_output_json = restart_output.to_json
+      gear_registry.expects(:save)
 
-    target_gear.expects(:uuid).returns(target_gear_uuid)
-    target_gear_ssh_url = 'uuid@host'
-    target_gear.expects(:to_ssh_url).returns(target_gear_ssh_url)
-    @container.expects(:run_in_container_context).with("/usr/bin/oo-ssh #{target_gear_ssh_url} gear restart --cart #{cart_name} --as-json",
-                                                      env: local_gear_env,
-                                                      expected_exitstatus: 0).returns([restart_output_json, '', 0])
+      do_control_args ="#{dns_entry}-bar.example.com|node1.example.com:#{port}"
 
-    result = @container.restart_gear(target_gear, local_gear_env, cart_name, options)
+      @container.cartridge_model.expects(:do_control).with('update-cluster', web_proxy, args: do_control_args)
 
-    restart_output.each_key { |k| assert_equal restart_output[k], result[k]}
-  end
+      proxy_arg = "#{proxy_uuid},#{dns_entry},bar,node1.example.com,linux"
+      cluster_arg = "#{proxy_uuid},#{dns_entry},bar,node1.example.com,#{port},windows"
 
-  def test_restart_gear_entry_nil_or_empty_output
-    [nil, ''].each do |output|
+      @container.update_cluster(proxy_arg, cluster_arg, false, true)
+    end
+
+    def test_update_cluster_add_multiple_gears_first_time
+      web_proxy = mock()
+      web_proxy.expects(:name).at_least_once.returns('foo')
+
+      primary_cartridge = mock()
+      primary_cartridge.expects(:name).at_least_once.returns('bar')
+
+      @container.cartridge_model.expects(:primary_cartridge).at_least_once.returns(primary_cartridge)
+      @container.cartridge_model.expects(:web_proxy).at_least_once.returns(web_proxy)
+
+      gear_env = {'OPENSHIFT_APP_DNS' => 'foo-bar.example.com', 'OPENSHIFT_GEAR_DNS' => '123-bar.example.com'}
+      ::OpenShift::Runtime::Utils::Environ::expects(:for_gear).with(@container.container_dir).returns(gear_env)
+
+      gear_registry = mock()
+      @container.expects(:gear_registry).returns(gear_registry).at_least_once
+
+      uuid1 = @container.uuid
+      gear1 = {
+        uuid: uuid1,
+        namespace: 'bar',
+        dns: 'foo-bar.example.com',
+        proxy_hostname: 'node1.example.com',
+        proxy_port: '35561',
+        platform: 'linux'
+      }
+      web_entry1 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear1)
+      proxy_entry1 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear1.merge(proxy_port: 0))
+
+      uuid2 = (@container.uuid.to_i + 1).to_s
+      gear2 = {
+        uuid: uuid2,
+        namespace: 'bar',
+        dns: "#{uuid2}-bar.example.com",
+        proxy_hostname: 'node1.example.com',
+        proxy_port: '35566',
+        platform: 'linux'
+      }
+      web_entry2 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear2)
+
+      uuid3 = (@container.uuid.to_i + 2).to_s
+      gear3 = {
+        uuid: uuid3,
+        namespace: 'bar',
+        dns: "#{uuid3}-bar.example.com",
+        proxy_hostname: 'node1.example.com',
+        proxy_port: '35571',
+        platform: 'linux'
+      }
+      web_entry3 = ::OpenShift::Runtime::GearRegistry::Entry.new(gear3)
+
+      old_entries = {
+      }
+
+      updated_entries = {
+        :web => {
+          uuid1 => web_entry1,
+          uuid2 => web_entry2,
+          uuid3 => web_entry3
+        },
+        :proxy => {
+          uuid1 => proxy_entry1,
+        }
+      }
+
+      gear_registry.expects(:backup)
+      gear_registry.expects(:entries).times(2).returns(old_entries, updated_entries)
+      gear_registry.expects(:clear)
+
+      @config.expects(:get).with('CLOUD_DOMAIN').returns('example.com')
+      web_uuids = [uuid1, uuid2, uuid3]
+
+      dns_entries = %W(foo #{uuid2} #{uuid3})
+      ports = %w(35561 35566 35571)
+
+      web_uuids.each_with_index do |uuid, index|
+        gear_registry.expects(:add).with(type: :web,
+                                         uuid: uuid,
+                                         namespace: "bar",
+                                         dns: "#{dns_entries[index]}-bar.example.com",
+                                         proxy_hostname: "node1.example.com",
+                                         proxy_port: ports[index],
+                                         platform: 'linux')
+      end
+
+      proxy_uuids = [uuid1]
+      proxy_uuids.each_with_index do |uuid, index|
+        gear_registry.expects(:add).with(type: :proxy,
+                                         uuid: uuid,
+                                         namespace: "bar",
+                                         dns: "#{dns_entries[index]}-bar.example.com",
+                                         proxy_hostname: "node1.example.com",
+                                         proxy_port: 0,
+                                         platform: 'linux')
+      end
+
+      gear_registry.expects(:save)
+
+      [web_entry2, web_entry3].each do |new_entry|
+        @container.expects(:run_in_container_context).with("rsync -avz --delete --rsh=/usr/bin/oo-ssh app-deployments/ #{new_entry.uuid}@#{new_entry.proxy_hostname}:app-deployments/",
+                                                          env: gear_env,
+                                                          chdir: @container.container_dir,
+                                                          expected_exitstatus: 0)
+      end
+      current_deployment_datetime = '2013-08-16_13-36-36.880'
+      @container.expects(:current_deployment_datetime).returns(current_deployment_datetime)
+
+      deployment_id = 'abcd1234'
+      metadata = mock()
+      @container.expects(:deployment_metadata_for).with(current_deployment_datetime).returns(metadata)
+      metadata.expects(:id).returns(deployment_id)
+
+      @container.expects(:activate).with(gears: [uuid2, uuid3],
+                                         deployment_id: deployment_id,
+                                         post_install: true,
+                                         rotate: false)
+                                   .returns(status: 'success')
+
+      do_control_args = web_uuids.each_with_index.map do |uuid, index|
+        "#{dns_entries[index]}-bar.example.com|node1.example.com:#{ports[index]}"
+      end.join(' ')
+
+      @container.cartridge_model.expects(:do_control).with('update-cluster', web_proxy, args: do_control_args)
+
+      proxy_arg = proxy_uuids.each_with_index.map do |uuid, index|
+        "#{uuid},#{dns_entries[index]},bar,node1.example.com,linux"
+      end.join(' ')
+
+      cluster_arg = web_uuids.each_with_index.map do |uuid, index|
+        "#{uuid},#{dns_entries[index]},bar,node1.example.com,#{ports[index]},linux"
+      end.join(' ')
+
+      @container.update_cluster(proxy_arg, cluster_arg, false, true)
+    end
+
+    def test_with_gear_rotation_no_proxy_no_all
+      count = 0
+      yielded_target_gear = nil
+      yielded_local_gear_env = nil
+
+      gear_env = {a: 1}
+      ::OpenShift::Runtime::Utils::Environ.expects(:for_gear).with(@container.container_dir).returns(gear_env)
+
+      @container.cartridge_model.expects(:web_proxy).returns(nil)
+
+      @container.expects(:calculate_batch_size).with(1, 0.2).returns(1)
+      Parallel.expects(:map).with([@container.uuid], :in_threads => 1).yields(@container.uuid)
+
+      with_gear_rotation_options = {b:2}
+      @container.expects(:rotate_and_yield).with(@container.uuid, gear_env, with_gear_rotation_options).yields(@container.uuid, gear_env, with_gear_rotation_options)
+
+      @container.with_gear_rotation(with_gear_rotation_options) do |target_gear, local_gear_env|
+        count += 1
+        yielded_target_gear = target_gear
+        yielded_local_gear_env = local_gear_env
+      end
+
+      assert_equal 1, count
+      assert_equal @container.uuid, yielded_target_gear
+      assert_equal gear_env, yielded_local_gear_env
+    end
+
+    def test_with_gear_rotation_with_proxy_no_all
+      count = 0
+      yielded_target_gear = nil
+      yielded_local_gear_env = nil
+
+      gear_env = {a: 1}
+      ::OpenShift::Runtime::Utils::Environ.expects(:for_gear).with(@container.container_dir).returns(gear_env)
+
+      proxy_cart = mock()
+      @container.cartridge_model.expects(:web_proxy).returns(proxy_cart)
+
+      gear_registry = mock()
+      @container.expects(:gear_registry).returns(gear_registry)
+      entry = mock()
+      entries = { :web => { @container.uuid => entry, 'a' => 'b' } }
+      gear_registry.expects(:entries).returns(entries)
+
+      @container.expects(:calculate_batch_size).with(1, 0.2).returns(1)
+      Parallel.expects(:map).with([entry], :in_threads => 1).yields(entry)
+
+      with_gear_rotation_options = {b:2}
+      @container.expects(:rotate_and_yield).with(entry, gear_env, with_gear_rotation_options).yields(entry, gear_env, with_gear_rotation_options)
+
+      @container.with_gear_rotation(with_gear_rotation_options) do |target_gear, local_gear_env|
+        count += 1
+        yielded_target_gear = target_gear
+        yielded_local_gear_env = local_gear_env
+      end
+
+      assert_equal 1, count
+      assert_equal entry, yielded_target_gear
+      assert_equal gear_env, yielded_local_gear_env
+    end
+
+    def test_with_gear_rotation_proxy_and_all
+      count = 0
+      yielded_target_gears = []
+      yielded_local_gear_envs = []
+
+      gear_env = {a: 1}
+      ::OpenShift::Runtime::Utils::Environ.expects(:for_gear).with(@container.container_dir).returns(gear_env)
+
+      proxy_cart = mock()
+      @container.cartridge_model.expects(:web_proxy).returns(proxy_cart)
+
+      gear_registry = mock()
+      @container.expects(:gear_registry).returns(gear_registry)
+      entry1 = mock()
+      entry2 = mock()
+      uuid2 = '5505'
+      entries = { :web => { @container.uuid => entry1, uuid2 => entry2 } }
+      gear_registry.expects(:entries).returns(entries)
+
+      @container.expects(:calculate_batch_size).with(2, 0.2).returns(1)
+      Parallel.expects(:map).with([entry1, entry2], :in_threads => 1).multiple_yields(entry1, entry2)
+
+      with_gear_rotation_options = {b:2, all: true}
+      @container.expects(:rotate_and_yield).with(entry1, gear_env, with_gear_rotation_options).yields(entry1, gear_env, with_gear_rotation_options)
+      @container.expects(:rotate_and_yield).with(entry2, gear_env, with_gear_rotation_options).yields(entry2, gear_env, with_gear_rotation_options)
+
+      @container.with_gear_rotation(with_gear_rotation_options) do |target_gear, local_gear_env|
+        count += 1
+        yielded_target_gears << target_gear
+        yielded_local_gear_envs << local_gear_env
+      end
+
+      assert_equal 2, count
+      assert_equal entry1, yielded_target_gears[0]
+      assert_equal gear_env, yielded_local_gear_envs[0]
+      assert_equal entry2, yielded_target_gears[1]
+      assert_equal gear_env, yielded_local_gear_envs[1]
+    end
+
+    def test_rotate_and_yield_no_proxy
+      options = {a: 1}
+      yielded_values = []
+      target_gear = '1234'
+      local_gear_env = mock()
+
+      @container.expects(:update_proxy_status).never
+
+      @container.rotate_and_yield(target_gear, local_gear_env, options) do |*values|
+        yielded_values = values
+        {
+          status: 'success',
+          messages: %w(a b),
+          errors: %w(b c),
+          foo: 'bar'
+        }
+      end
+
+      assert_equal [target_gear, local_gear_env, options], yielded_values
+    end
+
+    def test_rotate_and_yield_proxy
+      proxy_cart = mock()
+      options = {a: 1, proxy_cart: proxy_cart}
+      yielded_values = []
       target_gear = mock()
-      target_gear_uuid = 'uuid'
+      target_gear.expects(:uuid).returns('1234')
+      local_gear_env = mock()
+
+      rotate_out_results = {
+        status: 'success',
+        target_gear_uuid: '1234',
+        proxy_results: {
+          '1234' => {
+            target_gear_uuid: '1234',
+            proxy_gear_uuid: '1234',
+            status: 'success',
+            messages: [1,2],
+            errors: [2,3]
+          }
+        }
+      }
+      @container.expects(:update_proxy_status).with(action: :disable, gear_uuid: '1234', cartridge: proxy_cart).returns(rotate_out_results)
+
+      rotate_in_results = {
+        status: 'success',
+        target_gear_uuid: '1234',
+        proxy_results: {
+          '1234' => {
+            target_gear_uuid: '1234',
+            proxy_gear_uuid: '1234',
+            status: 'success',
+            messages: [3,4],
+            errors: [4,5]
+          }
+        }
+      }
+      @container.expects(:update_proxy_status).with(action: :enable, gear_uuid: '1234', cartridge: proxy_cart).returns(rotate_in_results)
+
+      result = @container.rotate_and_yield(target_gear, local_gear_env, options) do |*values|
+        yielded_values = values
+        {
+          status: 'success',
+          messages: %w(a b),
+          errors: %w(b c),
+          foo: 'bar'
+        }
+      end
+
+      assert_equal [target_gear, local_gear_env, options], yielded_values
+      expected_result = HashWithIndifferentAccess.new({
+        status: 'success',
+        foo: 'bar',
+        messages: ['Rotating out gear in proxies', 'a', 'b', 'Rotating in gear in proxies'],
+        errors: ['b', 'c'],
+        rotate_out_results: rotate_out_results,
+        rotate_in_results: rotate_in_results
+      })
+
+      assert_equal expected_result, result
+    end
+
+    def test_restart_success
+      options = {a: 1, all:true}
+      target_gear1 = mock()
+      target_gear2 = mock()
+      local_gear_env = mock()
+      cart_name = 'proxy_cart_name'
+
+      local_result = {
+        status: 'success',
+        target_gear_uuid: '1234',
+        messages: [],
+        errors: []
+      }
+
+      remote_result = {
+        target_gear_uuid: '2345',
+        messages: [],
+        errors: [],
+        status: 'success'
+      }
+
+      @container.expects(:with_gear_rotation).multiple_yields([target_gear1, local_gear_env, options], [target_gear2, local_gear_env, options]).returns([local_result, remote_result])
+
+      @container.expects(:restart_gear).with(target_gear1, local_gear_env, cart_name, options).returns(local_result)
+      @container.expects(:restart_gear).with(target_gear2, local_gear_env, cart_name, options).returns(remote_result)
+
+      result = @container.restart(cart_name, options)
+      assert_equal 'success', result[:status]
+      assert_equal 2, result[:gear_results].size
+      assert_equal local_result, result[:gear_results]['1234']
+      assert_equal remote_result, result[:gear_results]['2345']
+    end
+
+    def test_restart_failure
+      options = {a: 1}
+      target_gear = mock()
+      local_gear_env = mock()
+      cart_name = 'proxy_cart_name'
+
+      target_result = {
+        status: 'failure',
+        target_gear_uuid: '1234',
+        messages: [],
+        errors: []
+      }
+
+      @container.expects(:with_gear_rotation).yields(target_gear, local_gear_env, options).returns([target_result])
+
+      @container.expects(:restart_gear).with(target_gear, local_gear_env, cart_name, options).returns(target_result)
+
+      result = @container.restart(cart_name, options)
+      assert_equal target_result, result
+    end
+
+    def test_restart_gear_string
+      target_gear = @container.uuid
       local_gear_env = {a: 1}
       cart_name = 'cart_name'
       options = {b: 2}
+      restart_output = 'restart output'
 
-      target_gear.expects(:uuid).returns(target_gear_uuid)
-      target_gear_ssh_url = 'uuid@host'
-      target_gear.expects(:to_ssh_url).returns(target_gear_ssh_url)
-      @container.expects(:run_in_container_context).with("/usr/bin/oo-ssh #{target_gear_ssh_url} gear restart --cart #{cart_name} --as-json",
-                                                        env: local_gear_env,
-                                                        expected_exitstatus: 0).returns([output, '', 0])
+      @container.cartridge_model.expects(:start_cartridge).with('restart',
+                                                                cart_name,
+                                                                user_initiated: true,
+                                                                out: options[:out],
+                                                                err: options[:err]).returns(restart_output)
 
       result = @container.restart_gear(target_gear, local_gear_env, cart_name, options)
-      assert_equal 'failure', result[:status]
-      assert_match 'No result JSON was received from the remote gear restart call', result[:errors][0]
-    end
-  end
 
-  def test_restart_gear_entry_missing_status_in_result
-    [nil, ''].each do |output|
+      assert_equal 'success', result[:status]
+      assert_equal target_gear, result[:target_gear_uuid]
+      assert_equal [restart_output], result[:messages]
+      assert_empty result[:errors]
+    end
+
+    def test_restart_gear_entry_success
       target_gear = mock()
       target_gear_uuid = 'uuid'
       local_gear_env = {a: 1}
       cart_name = 'cart_name'
       options = {b: 2}
-      restart_output = {from_json: true}
+      restart_output = {status: 'success', from_json: true}
       restart_output_json = restart_output.to_json
 
       target_gear.expects(:uuid).returns(target_gear_uuid)
@@ -1009,53 +1166,96 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
                                                         expected_exitstatus: 0).returns([restart_output_json, '', 0])
 
       result = @container.restart_gear(target_gear, local_gear_env, cart_name, options)
-      assert_equal 'failure', result[:status]
-      assert_match 'Invalid result JSON received from remote gear restart call:', result[:errors][0]
+
+      restart_output.each_key { |k| assert_equal restart_output[k], result[k]}
+    end
+
+    def test_restart_gear_entry_nil_or_empty_output
+      [nil, ''].each do |output|
+        target_gear = mock()
+        target_gear_uuid = 'uuid'
+        local_gear_env = {a: 1}
+        cart_name = 'cart_name'
+        options = {b: 2}
+
+        target_gear.expects(:uuid).returns(target_gear_uuid)
+        target_gear_ssh_url = 'uuid@host'
+        target_gear.expects(:to_ssh_url).returns(target_gear_ssh_url)
+        @container.expects(:run_in_container_context).with("/usr/bin/oo-ssh #{target_gear_ssh_url} gear restart --cart #{cart_name} --as-json",
+                                                          env: local_gear_env,
+                                                          expected_exitstatus: 0).returns([output, '', 0])
+
+        result = @container.restart_gear(target_gear, local_gear_env, cart_name, options)
+        assert_equal 'failure', result[:status]
+        assert_match 'No result JSON was received from the remote gear restart call', result[:errors][0]
+      end
+    end
+
+    def test_restart_gear_entry_missing_status_in_result
+      [nil, ''].each do |output|
+        target_gear = mock()
+        target_gear_uuid = 'uuid'
+        local_gear_env = {a: 1}
+        cart_name = 'cart_name'
+        options = {b: 2}
+        restart_output = {from_json: true}
+        restart_output_json = restart_output.to_json
+
+        target_gear.expects(:uuid).returns(target_gear_uuid)
+        target_gear_ssh_url = 'uuid@host'
+        target_gear.expects(:to_ssh_url).returns(target_gear_ssh_url)
+        @container.expects(:run_in_container_context).with("/usr/bin/oo-ssh #{target_gear_ssh_url} gear restart --cart #{cart_name} --as-json",
+                                                          env: local_gear_env,
+                                                          expected_exitstatus: 0).returns([restart_output_json, '', 0])
+
+        result = @container.restart_gear(target_gear, local_gear_env, cart_name, options)
+        assert_equal 'failure', result[:status]
+        assert_match 'Invalid result JSON received from remote gear restart call:', result[:errors][0]
+      end
+    end
+
+    def test_stop_gear_no_proxy
+      options = {}
+      @container.cartridge_model.expects(:web_proxy).returns(nil)
+      @container.cartridge_model.expects(:stop_gear).with(options).returns('stop')
+      @container.expects(:stopped_status_attr).returns('attr')
+      @container.stop_gear(options)
+    end
+
+    def test_stop_gear_no_hot_deploy_no_init
+      options = {}
+      proxy_cart = mock()
+      @container.cartridge_model.expects(:web_proxy).returns(proxy_cart)
+      proxy_result = {
+        proxy_results: []
+      }
+      @container.expects(:update_proxy_status).with(cartridge: proxy_cart,
+                                                    action: :disable,
+                                                    gear_uuid: @container.uuid,
+                                                    persist: false)
+                                              .returns(proxy_result)
+      @container.cartridge_model.expects(:stop_gear).with(options).returns('stop')
+      @container.expects(:stopped_status_attr).returns('attr')
+      @container.stop_gear(options)
+    end
+
+    def test_stop_gear_hot_deploy
+      options = {hot_deploy: true}
+      proxy_cart = mock()
+      @container.cartridge_model.expects(:web_proxy).returns(proxy_cart)
+      @container.expects(:update_proxy_status).never
+      @container.cartridge_model.expects(:stop_gear).with(options).returns('stop')
+      @container.expects(:stopped_status_attr).returns('attr')
+      @container.stop_gear(options)
+    end
+
+    def test_stop_gear_init
+      options = {init: true}
+      proxy_cart = mock()
+      @container.cartridge_model.expects(:web_proxy).returns(proxy_cart)
+      @container.expects(:update_proxy_status).never
+      @container.cartridge_model.expects(:stop_gear).with(options).returns('stop')
+      @container.expects(:stopped_status_attr).returns('attr')
+      @container.stop_gear(options)
     end
   end
-
-  def test_stop_gear_no_proxy
-    options = {}
-    @container.cartridge_model.expects(:web_proxy).returns(nil)
-    @container.cartridge_model.expects(:stop_gear).with(options).returns('stop')
-    @container.expects(:stopped_status_attr).returns('attr')
-    @container.stop_gear(options)
-  end
-
-  def test_stop_gear_no_hot_deploy_no_init
-    options = {}
-    proxy_cart = mock()
-    @container.cartridge_model.expects(:web_proxy).returns(proxy_cart)
-    proxy_result = {
-      proxy_results: []
-    }
-    @container.expects(:update_proxy_status).with(cartridge: proxy_cart,
-                                                  action: :disable,
-                                                  gear_uuid: @container.uuid,
-                                                  persist: false)
-                                            .returns(proxy_result)
-    @container.cartridge_model.expects(:stop_gear).with(options).returns('stop')
-    @container.expects(:stopped_status_attr).returns('attr')
-    @container.stop_gear(options)
-  end
-
-  def test_stop_gear_hot_deploy
-    options = {hot_deploy: true}
-    proxy_cart = mock()
-    @container.cartridge_model.expects(:web_proxy).returns(proxy_cart)
-    @container.expects(:update_proxy_status).never
-    @container.cartridge_model.expects(:stop_gear).with(options).returns('stop')
-    @container.expects(:stopped_status_attr).returns('attr')
-    @container.stop_gear(options)
-  end
-
-  def test_stop_gear_init
-    options = {init: true}
-    proxy_cart = mock()
-    @container.cartridge_model.expects(:web_proxy).returns(proxy_cart)
-    @container.expects(:update_proxy_status).never
-    @container.cartridge_model.expects(:stop_gear).with(options).returns('stop')
-    @container.expects(:stopped_status_attr).returns('attr')
-    @container.stop_gear(options)
-  end
-end

--- a/node/test/unit/build_lifecycle_test.rb
+++ b/node/test/unit/build_lifecycle_test.rb
@@ -1146,6 +1146,7 @@ class BuildLifecycleTest < OpenShift::NodeTestCase
     deployment_metadata = mock()
     @container.expects(:deployment_metadata_for).with(deployment_datetime).returns(deployment_metadata)
     deployment_metadata.expects(:hot_deploy).returns(false)
+    @container.cartridge_model.expects(:standalone_web_proxy?).returns(false)
 
     gear_result1 = { gear_uuid: @container.uuid, status: 'success', errors: [], messages: [] }
     @container.expects(:with_gear_rotation)
@@ -1179,6 +1180,8 @@ class BuildLifecycleTest < OpenShift::NodeTestCase
     deployment_metadata = mock()
     @container.expects(:deployment_metadata_for).with(deployment_datetime).returns(deployment_metadata)
     deployment_metadata.expects(:hot_deploy).returns(false)
+
+    @container.cartridge_model.expects(:standalone_web_proxy?).returns(false)
 
     gear_result1 = { gear_uuid: gear_uuids[0], status: 'success', errors: [], messages: [] }
     gear_result2 = { gear_uuid: gear_uuids[1], status: 'success', errors: [], messages: [] }
@@ -1220,6 +1223,8 @@ class BuildLifecycleTest < OpenShift::NodeTestCase
     deployment_metadata = mock()
     @container.expects(:deployment_metadata_for).with(deployment_datetime).returns(deployment_metadata)
     deployment_metadata.expects(:hot_deploy).returns(false)
+
+    @container.cartridge_model.expects(:standalone_web_proxy?).returns(false)
 
     gear_result1 = { gear_uuid: gear_uuids[0], status: 'success', errors: [], messages: [] }
     gear_result2 = { gear_uuid: gear_uuids[1], status: 'success', errors: [], messages: [] }

--- a/node/test/unit/frontend_httpd_test.rb
+++ b/node/test/unit/frontend_httpd_test.rb
@@ -33,6 +33,11 @@ class FrontendHttpServerModelTest < OpenShift::NodeTestCase
     @container.stubs(:application_uuid).returns(@application_uuid)
     @container.stubs(:name).returns(@container_name)
     @container.stubs(:namespace).returns(@namespace)
+
+    @cartridge_model = mock('OpenShift::Runtime::V2CartridgeModel')
+    @cartridge_model.stubs(:standalone_web_proxy?).returns(false)
+    @container.stubs(:cartridge_model).returns(@cartridge_model)
+
     OpenShift::Runtime::ApplicationContainer.stubs(:from_uuid).with(@container_uuid).returns(@container)
 
     @cloud_domain = "example.com"

--- a/node/test/unit/gear_registry_test.rb
+++ b/node/test/unit/gear_registry_test.rb
@@ -34,13 +34,15 @@ class GearRegistryTest < OpenShift::NodeTestCase
       "namespace": "namespace1",
       "dns": "dns1",
       "proxy_hostname": "proxy_host1",
-      "proxy_port": 35561
+      "proxy_port": 35561,
+      "platform": "linux"
     },
     "uuid2": {
       "namespace": "namespace2",
       "dns": "dns2",
       "proxy_hostname": "proxy_host2",
-      "proxy_port": 35562
+      "proxy_port": 35562,
+      "platform": "linux"
     }
   },
   "proxy": {
@@ -48,13 +50,15 @@ class GearRegistryTest < OpenShift::NodeTestCase
       "namespace": "namespace3",
       "dns": "dns3",
       "proxy_hostname": "proxy_host3",
-      "proxy_port": 35563
+      "proxy_port": 35563,
+      "platform": "linux"
     },
     "uuid4": {
       "namespace": "namespace4",
       "dns": "dns4",
       "proxy_hostname": "proxy_host4",
-      "proxy_port": 35564
+      "proxy_port": 35564,
+      "platform": "linux"
     }
   }
 }
@@ -79,7 +83,8 @@ EOF
       namespace: "namespace#{suffix}",
       dns: "dns#{suffix}",
       proxy_hostname: "proxy_host#{suffix}",
-      proxy_port: "3556#{suffix}".to_i
+      proxy_port: "3556#{suffix}".to_i,
+      platform: "linux"
     }
   end
 
@@ -108,12 +113,13 @@ EOF
     assert_equal 'dns1', entry.dns
     assert_equal 'proxy_host1', entry.proxy_hostname
     assert_equal 35561, entry.proxy_port
+    assert_equal 'linux', entry.platform
   end
 
   def test_entry_to_json
     entry = create_entry("1")
 
-    assert_equal '{"namespace":"namespace1","dns":"dns1","proxy_hostname":"proxy_host1","proxy_port":35561}', entry.to_json
+    assert_equal '{"namespace":"namespace1","dns":"dns1","proxy_hostname":"proxy_host1","proxy_port":35561,"platform":"linux"}', entry.to_json
   end
 
   def test_gear_registry_initialize_creates_files


### PR DESCRIPTION
Changes span both the broker and the node.

Add a setting named 'NODE_PLATFORMS' to broker.conf.
Add an optional attribute named 'platform' to cartridge manifests.
Add an optional 'Required' attribute for the 'Scaling' key to cartridge manifest.

Broker queries nodes of all platforms when building its cartridge cache.
Broker does not allow group overrides for cartridges of different platforms.
Broker uses the cartridge platform to filter nodes based on the 'kernel' fact.

Node handles the case when a web proxy cartridge is not collocated with a web cartridge.

Modify tests to take new logic into account.
Add tests to cover new code paths.
