### PR TITLE
Bug 1076008 - Fix pgrep regex usage

### DIFF
--- a/node-util/init.d/openshift-watchman
+++ b/node-util/init.d/openshift-watchman
@@ -33,7 +33,7 @@ Options = {
 }
 
 def daemon_running?
-  %x[/usr/bin/pgrep -f '^watchman$']
+  %x[/usr/bin/pgrep -f '^watchman']
   $?.exitstatus == 0 ? true : false
 end
 


### PR DESCRIPTION
- procps-3.2.8 has a bug where trailing $ in regexp causes match
  failure. Fixed in procps-ng
