### PR TITLE
Bug 1076032 - Attempting to unlock closed file descriptor

### DIFF
--- a/common/lib/openshift-origin-common/utils/path_utils.rb
+++ b/common/lib/openshift-origin-common/utils/path_utils.rb
@@ -93,7 +93,7 @@ module PathUtils
         yield(lock)
       ensure
         FileUtils.rm_f(lock_file) if unlink_file
-        lock.flock(File::LOCK_UN)
+        lock.flock(File::LOCK_UN) unless lock.closed?
       end
     end
   end


### PR DESCRIPTION
- Add guard to stop attempting to unlock a closed file descriptor
