### PR TITLE
[DO_NOT_MERGE]Bug 980562 - jgroups initial_hosts ordering causing 30s blocking for non-primary gears

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/hooks/set-jboss-cluster
+++ b/cartridges/openshift-origin-cartridge-jbossas/hooks/set-jboss-cluster
@@ -10,11 +10,21 @@ kvargs=$(echo "${@:4}" | tr -d "\n" )
 for arg in $kvargs; do
     ip=$(echo "$arg" | cut -f 2 -d '=' | tr -d "'")
     ip=$(echo "$ip" | sed "s/:/[/g")
-    if [ -z "$list" ]; then
-        list="$ip]"
-    else
-        list="$list,$ip]"
+    if [[ ! $ip  =~ $OPENSHIFT_GEAR_DNS ]]
+    then
+        if [ -z "$list" ]; then
+            list="$ip]"
+        else
+            list="$list,$ip]"
+        fi
     fi
 done
+
+# put this gear first in the list of hosts
+if [ -z "$list" ]; then
+    list="${OPENSHIFT_GEAR_DNS}[${OPENSHIFT_JBOSSEAP_CLUSTER_PROXY_PORT}]"
+else
+    list="${OPENSHIFT_GEAR_DNS}[${OPENSHIFT_JBOSSEAP_CLUSTER_PROXY_PORT}],$list"
+fi
 
 echo $list > $OPENSHIFT_JBOSSAS_DIR/env/OPENSHIFT_JBOSSAS_CLUSTER

--- a/cartridges/openshift-origin-cartridge-jbosseap/hooks/set-jboss-cluster
+++ b/cartridges/openshift-origin-cartridge-jbosseap/hooks/set-jboss-cluster
@@ -10,11 +10,21 @@ kvargs=$(echo "${@:4}" | tr -d "\n" )
 for arg in $kvargs; do
     ip=$(echo "$arg" | cut -f 2 -d '=' | tr -d "'")
     ip=$(echo "$ip" | sed "s/:/[/g")
-    if [ -z "$list" ]; then
-        list="$ip]"
-    else
-        list="$list,$ip]"
+    if [[ ! $ip  =~ $OPENSHIFT_GEAR_DNS ]]
+    then
+        if [ -z "$list" ]; then
+            list="$ip]"
+        else
+            list="$list,$ip]"
+        fi
     fi
 done
+
+# put this gear first in the list of hosts
+if [ -z "$list" ]; then
+    list="${OPENSHIFT_GEAR_DNS}[${OPENSHIFT_JBOSSEAP_CLUSTER_PROXY_PORT}]"
+else
+    list="${OPENSHIFT_GEAR_DNS}[${OPENSHIFT_JBOSSEAP_CLUSTER_PROXY_PORT}],$list"
+fi
 
 echo $list > $OPENSHIFT_JBOSSEAP_DIR/env/OPENSHIFT_JBOSSEAP_CLUSTER


### PR DESCRIPTION
The timeout is 30s waiting for number_initial_hosts to respond (==1). For all
gears the order is the same (coming from the hooks). It should be ordered that
the 1st gear in the list is always the current gear vs always being the
primary gear 1st. This results in all of the non-primary gears to block for
30s while waiting for the primary gear to come up.
