### PR TITLE
oo-accept-broker: improve err handling & more

### DIFF
--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -35,6 +35,8 @@ CONSOLE_CONF="/etc/openshift/console.conf"
 
 if [ -e '/etc/openshift/development' ] ; then
   OSO_ENVIRONMENT=${OSO_ENVIRONMENT:=development}
+  BROKER_CONF="/etc/openshift/broker-dev.conf"
+  CONSOLE_CONF="/etc/openshift/console-dev.conf"
 else
   OSO_ENVIRONMENT=${OSO_ENVIRONMENT:=production}
 fi
@@ -70,20 +72,8 @@ fi
 
 BROKER_REST_API_BASE="https://localhost/broker/rest/"
 
-# we will fill APP_VALUES with output from ruby commands corresponding to the map
-declare -A APP_VALUES
-declare -A APP_VALUE_MAP=(
-		["oo_auth_provider"]="OpenShift::AuthService.instance_variable_get('@oo_auth_provider')"
-		["oo_dns_provider"]="OpenShift::DnsService.instance_variable_get('@oo_dns_provider')"
-		["proxy_provider"]="OpenShift::ApplicationContainerProxy.instance_variable_get('@proxy_provider')"
-	)
-
 function safe_bundle() {
     bundle exec "$@"
-}
-
-function safe_ruby() {
-    ruby "$@"
 }
 
 USE_SCL=""
@@ -92,9 +82,6 @@ if which scl 1> /dev/null 2> /dev/null && scl -l | grep -q '^ruby193$' ; then
     USE_SCL="TRUE"
     function safe_bundle() {
         scl enable ruby193 "bundle exec \"$@\""
-    }
-    function safe_ruby() {
-        scl enable ruby193 "ruby \"$@\""
     }
 
     PACKAGES+="  ruby193-rubygem-rails
@@ -183,11 +170,10 @@ EOF`
 }
 
 function check_logfile_perms() {
-    ENABLE_USER_ACTION_LOG=`fetch_config ${BROKER_CONF} ENABLE_USER_ACTION_LOG`
-    if [ $ENABLE_USER_ACTION_LOG = "true" ]
+    if [ "${APP_VALUE_MAP[ENABLE_USER_ACTION_LOG]}" = "true" ]
     then 
-      USER_ACTION_LOG_FILE=`fetch_config ${BROKER_CONF} USER_ACTION_LOG_FILE`
-      if [ ! -f $USER_ACTION_LOG_FILE ]
+      USER_ACTION_LOG_FILE=${APP_VALUE_MAP[USER_ACTION_LOG_FILE]}
+      if [ ! -f "${USER_ACTION_LOG_FILE}" ]
       then
         fail "Rest API Logging enabled but the log file does not exist -- run touch ${USER_ACTION_LOG_FILE} && chown apache:apache ${USER_ACTION_LOG_FILE} && chmod 640 ${USER_ACTION_LOG_FILE}"
       else
@@ -200,44 +186,24 @@ function check_logfile_perms() {
 }
 
 function check_missing_and_insecure_secrets() {
-    AUTH_SALT=`fetch_config ${BROKER_CONF} AUTH_SALT`
-    if [ "$AUTH_SALT" = "ClWqe5zKtEW4CJEMyjzQ" ]
+    if [ "${APP_VALUE_MAP[AUTH_SALT]}" = "ClWqe5zKtEW4CJEMyjzQ" ]
     then
       fail "Default AUTH_SALT detected in ${BROKER_CONF}! Change the the value and use oo-admin-broker-auth to regenerate authentication tokens. (Hint: use 'openssl rand -base64 64' to generate a unique salt)"
     fi
 
-    BROKER_SECRET=`fetch_config ${BROKER_CONF} SESSION_SECRET`
-    if [ "$BROKER_SECRET" = "nil" -o "$BROKER_SECRET" = "" ]
+    if [ "${APP_VALUE_MAP[SESSION_SECRET]}" = "nil" -o "${APP_VALUE_MAP[SESSION_SECRET]}" = "" ]
     then
       fail "SESSION_SECRET must be set in $BROKER_CONF (Hint: use 'openssl rand -hex 64' to generate a unique secret."
     fi
 
     if [ -f ${CONSOLE_CONF} ]
     then
-      CONSOLE_SECRET=`fetch_config ${CONSOLE_CONF} SESSION_SECRET`
+      CONSOLE_SECRET="${APP_VALUE_MAP[CONSOLE_SESSION_SECRET]}"
       if [ "$CONSOLE_SECRET" = "nil" -o "$CONSOLE_SECRET" = "" ]
       then
         fail "SESSION_SECRET must be set in ${CONSOLE_CONF} (Hint: use 'openssl rand -hex 64' to generate a unique secret."
       fi
     fi
-}
-
-# This is another way to parse the config settings.  You could argue that it's
-# less accurate than loading the Rails application but it's better than plain
-# grep and it's way more readable/flexible than the bash array stuff.  I plan
-# to replace that soon.
-#
-# TODO: It would be trivial to add all the configuration assertions in the ruby
-# code and check them all at once.  This would be much faster than loading the
-# rails apps multiple times.
-function fetch_config() {
-    pushd /var/www/openshift/broker > /dev/null
-    safe_bundle "ruby -rubygems --" <<EOF
-      require 'openshift-origin-common'
-      conf = OpenShift::Config.new('$1')
-      puts conf.get('$2')
-EOF
-    popd > /dev/null
 }
 
 #
@@ -247,15 +213,15 @@ EOF
 #
 
 function load_application_values() {
-	# Build ruby program statements from APP_VALUE_MAP and
-	# read the output values into the APP_VALUES hash.
+	# Build ruby program statements from global APP_VALUE_MAP and
+	# read the output values into the global APP_VALUES hash.
 	# This is all predicated on each value landing on one line;
 	# if there are any multiline values, we're in trouble.
 	# Also if there are any errors this won't work. Which is why we
 	# can't get all the values in one go - some exist conditionally.
 
 	ruby_program=""
-	declare -a keys=( ${!APP_VALUE_MAP[@]} )
+	local keys=( ${!APP_VALUE_MAP[@]} )
 	for key in ${keys[@]}
 	do
 		ruby_program+="
@@ -263,29 +229,32 @@ function load_application_values() {
 	done
 
 	# run those statements after initializing the Rails env
-	OLD_IFS=$IFS; IFS=$'\n' # read into array one line per element
-    # Tail the output on the next line, since deprecation warnings and
-    # other unrelated output will make this test fail, even when it
-    # works
-	declare -a new_app_values=( `run_ruby_rails_command "$ruby_program" | tail --lines="${#keys[@]}"` )
+	local OLD_IFS=$IFS; IFS=$'\n' # read into array one line per element
+        local tempfile=`mktemp`  # for recording errors
+	new_app_values=(`run_ruby_rails_command "$ruby_program" 2> $tempfile`) # NOT local - loses $?
+	RETVAL=$?
+        [ -s $tempfile ] && notice "stderr output loading broker settings:" `cat $tempfile | head -n 5`
+        rm -f $tempfile
 	IFS=$OLD_IFS # back to normal
-	if [ $? -ne 0 ]
+	if [ $RETVAL -ne 0 ]
 	then
-		fail "Error while running ruby code.
+		fail "Error while loading broker settings.
 #####
 $ruby_program
 #####
 ${new_app_values[@]}
 #####"
+                return 1
 	elif (( ${#new_app_values[@]} != ${#keys[@]} ))
 	then
-		fail "wrong number of values returned from ruby code
+		fail "wrong number of values loaded from broker settings:
 keys: ${#keys[@]}; values: ${#new_app_values[@]}
 #####
 $ruby_program
 #####
 ${new_app_values[@]}
 #####"
+                return 1
 	fi
 
 	# now read the array of output ruby values into the values hash
@@ -293,6 +262,7 @@ ${new_app_values[@]}
 	do
 		APP_VALUES["${keys[$i]}"]=${new_app_values[$i]}
 	done
+	return 0
 }
 
 function run_ruby_rails_command() {
@@ -310,15 +280,18 @@ function run_ruby_rails_command() {
   if which oo-ruby 2>/dev/null >/dev/null
   then
       pushd /var/www/openshift/broker > /dev/null
-      safe_bundle "ruby -I ${OSO_BROKER_ROOT} -r rubygems --" <<EOF 2>&1
+      safe_bundle "ruby -I ${OSO_BROKER_ROOT} -r rubygems --" <<EOF
         begin
           require 'config/environment'
           require 'config/environments/$OSO_ENVIRONMENT'
+          broker_conf = OpenShift::Config.new('$BROKER_CONF')
+          console_conf = OpenShift::Config.new('$CONSOLE_CONF') if File.exists? '$CONSOLE_CONF'
         rescue Bundler::GemNotFound => gem_error
-          puts "Error loading libs or gems: #{gem_error}"
+          \$stderr.puts "Error loading libs or gems: #{gem_error}"
           exit 1
         end
         $1
+	exit 0
 EOF
       RETVAL=$?
       popd > /dev/null
@@ -424,10 +397,10 @@ function check_services() {
 
 function check_selinux_enforcing() {
   verbose "checking that selinux modules are loaded"
-  # if not enforcing, just say so
-  notice "SELinux is" `getenforce`
   if [ `getenforce 2>/dev/null` != "Enforcing" ]
   then
+    # if not enforcing, just say so
+    notice "SELinux is" `getenforce`
     return
   fi
 
@@ -454,10 +427,11 @@ function check_firewall() {
 # Check SELinux
 #
 function check_selinux_booleans() {
-  # if not enforcing, just say so
-  notice "SELinux is " `getenforce`
+  verbose "checking that selinux booleans are correct"
   if [ `getenforce 2>/dev/null` != "Enforcing" ]
   then
+    # if not enforcing, just say so
+    notice "SELinux is" `getenforce`
     return
   fi
 
@@ -526,7 +500,7 @@ function check_datastore_mongo() {
 		["DS_NAME"]="Rails.application.config.datastore[:db]"
                 ["DS_SSL"]="Rails.application.config.datastore[:ssl]"
 		)
-	load_application_values
+	load_application_values || return 1
     verbose "Datastore Host: ${APP_VALUES[DS_HOST]}"
     verbose "Datastore Port: ${APP_VALUES[DS_PORT]}"
     verbose "Datastore User: ${APP_VALUES[DS_USER]}"
@@ -614,7 +588,7 @@ function check_auth_mongo() {
 		["DS_NAME"]="Rails.application.config.auth[:mongo_db]"
 		["DS_SSL"]="Rails.application.config.auth[:mongo_ssl]"
 		)
-	load_application_values
+	load_application_values || return 1
     verbose "Auth Host: ${APP_VALUES[DS_HOST]}"
     verbose "Auth Port: ${APP_VALUES[DS_PORT]}"
     verbose "Auth User: ${APP_VALUES[DS_USER]}"
@@ -683,11 +657,6 @@ assert_rest_api_returns() {
 
 function check_auth_remote_user() {
     verbose checking remote-user auth configuration
-
-	APP_VALUE_MAP=(
-		["RU_TRUSTED_HEADER"]="Rails.application.config.auth[:trusted_header]"
-		)
-	load_application_values
     verbose "Auth trusted header: ${APP_VALUES[RU_TRUSTED_HEADER]}"
 
     if grep -q 'BrowserMatchNoCase\s\+\^OpenShift\s\+passthrough' ${OSO_HTTPD_CONF_DIR}/*.conf \
@@ -720,10 +689,6 @@ function check_auth_remote_user() {
 
 function check_authentication() {
     verbose checking cloud user authentication
-    APP_VALUE_MAP=(
-            ["oo_auth_provider"]="OpenShift::AuthService.instance_variable_get('@oo_auth_provider')"
-            )
-    load_application_values
  
     AUTH_PLUGIN=${APP_VALUES[oo_auth_provider]}
     verbose auth plugin = $AUTH_PLUGIN
@@ -816,7 +781,7 @@ function check_dns_bind() {
 		["DNS_SUFFIX"]="Rails.application.config.openshift[:domain_suffix]"
 		["DNS_AUTH"]='(not Rails.application.config.dns[:keyname].blank?)?"key":(not Rails.application.config.dns[:krb_principal].blank?)?"krb":"unauthenticated"'
 		)
-	load_application_values
+	load_application_values || return 1
 
     verbose "DNS Server: ${APP_VALUES[DNS_SERVER]}"
     verbose "DNS Port: ${APP_VALUES[DNS_PORT]}"
@@ -830,7 +795,7 @@ function check_dns_bind() {
 		["DNS_KEYNAME"]="Rails.application.config.dns[:keyname]"
 		["DNS_KEYVAL"]="Rails.application.config.dns[:keyvalue]"
 		)
-	load_application_values
+	load_application_values || return 1
         verbose "DNS Key Name: ${APP_VALUES[DNS_KEYNAME]}"
         verbose "DNS Key Value: *****"
     elif [ "${APP_VALUES[DNS_AUTH]}" = "krb" ]
@@ -839,7 +804,7 @@ function check_dns_bind() {
 		["DNS_KRB_KEYTAB"]="Rails.application.config.dns[:krb_keytab]"
 		["DNS_KRB_PRINCIPAL"]="Rails.application.config.dns[:krb_principal]"
 		)
-	load_application_values
+	load_application_values || return 1
         verbose "DNS Kerberos Keytab: ${APP_VALUES[DNS_KRB_KEYTAB]}"
         verbose "DNS Kerberos Principal: ${APP_VALUES[DNS_KRB_PRINCIPAL]}"
     fi
@@ -880,7 +845,7 @@ function check_dns_avahi() {
 		["MDNS_ZONE"]="Rails.application.config.dns[:zone]"
 		["DNS_SUFFIX"]="Rails.application.config.openshift[:domain_suffix]"
 		)
-	load_application_values
+	load_application_values || return 1
 
     verbose "DNS Server: ${APP_VALUES[MDNS_SERVER]}"
     verbose "DNS Port: ${APP_VALUES[MDNS_PORT]}"
@@ -895,10 +860,6 @@ function check_dns_avahi() {
 
 function check_dynamic_dns() {
     verbose checking dynamic dns plugin
-    APP_VALUE_MAP=(
-            ["oo_dns_provider"]="OpenShift::DnsService.instance_variable_get('@oo_dns_provider')"
-            )
-    load_application_values
 
     NAME_PLUGIN=${APP_VALUES[oo_dns_provider]}
     case $NAME_PLUGIN in
@@ -936,10 +897,6 @@ function check_dynamic_dns() {
 
 function check_messaging() {
     verbose checking messaging configuration
-    APP_VALUE_MAP=(
-            ["proxy_provider"]="OpenShift::ApplicationContainerProxy.instance_variable_get('@proxy_provider')"
-            )
-    load_application_values
 
     MSG_PLUGIN=${APP_VALUES[proxy_provider]}
     case $MSG_PLUGIN in
@@ -1006,21 +963,33 @@ done
 STATUS=0
 
 probe_version
-
-check_missing_and_insecure_secrets
-check_logfile_perms
 check_packages $PACKAGES
 check_ruby_requirements $OSO_RUBY_LIBS
 check_selinux_enforcing
 check_selinux_booleans
 check_firewall
-check_datastore_mongo
 check_services
 
-load_application_values
-check_authentication
-check_dynamic_dns
-check_messaging
+# we will fill APP_VALUES with output from ruby commands corresponding to the map
+declare -A APP_VALUES
+declare -A APP_VALUE_MAP=(
+	["RU_TRUSTED_HEADER"]="Rails.application.config.auth[:trusted_header]"
+        ["oo_auth_provider"]="OpenShift::AuthService.instance_variable_get('@oo_auth_provider')"
+        ["oo_dns_provider"]="OpenShift::DnsService.instance_variable_get('@oo_dns_provider')"
+        ["proxy_provider"]="OpenShift::ApplicationContainerProxy.instance_variable_get('@proxy_provider')"
+	)
+[ -f ${CONSOLE_CONF} ] && APP_VALUE_MAP["CONSOLE_SESSION_SECRET"]="console_conf.get('SESSION_SECRET')"
+for var in ENABLE_USER_ACTION_LOG USER_ACTION_LOG_FILE AUTH_SALT SESSION_SECRET
+  do APP_VALUE_MAP[$var]="broker_conf.get('$var')"
+done
+if load_application_values; then
+	check_logfile_perms
+	check_missing_and_insecure_secrets
+	check_datastore_mongo
+	check_authentication
+	check_dynamic_dns
+	check_messaging
+fi
 
 if [ "$STATUS" -eq 0 ]
 then


### PR DESCRIPTION
https://trello.com/c/CBLIqG00/214-1-oo-diagnostics-improvements

Somewhere along the way, oo-accept-broker stopped handling broker load
and run errors gracefully. Error output got combined with stdout, and
then that was truncated to the expected number of lines and used as the
expected response, meaning we got bits of stack trace instead of the
configuration values intended, and tried to actually use those.

Now, any error output is routed and noted separately. The error bubbles
up properly and is generally only noted once.

Also, a lot of separate calls invoking the broker for settings were
combined into a single call. This makes the script execute in about half
the time it required before.

Also, some settings were potentially being read from the production
settings file when the development one should have been used. This is
fixed too.

The order of the tests was changed around a little bit but everything
should otherwise work the same.
