### PR TITLE
Remove on_domains/on_apps from user/domain/team pending op.

### DIFF
--- a/controller/app/models/domain.rb
+++ b/controller/app/models/domain.rb
@@ -210,7 +210,7 @@ class Domain
     Domain.where(_id: self.id).update_all({ "$pullAll" => { system_ssh_keys: ssh_keys_to_rm }}) unless ssh_keys_to_rm.empty?
 
     keys_attrs = ssh_keys.map { |k| k.serializable_hash }
-    pending_op = AddSystemSshKeysDomainOp.new(keys_attrs: keys_attrs, on_apps: applications)
+    pending_op = AddSystemSshKeysDomainOp.new(keys_attrs: keys_attrs)
     pending_op.set_created_at
     Domain.where(_id: self.id).update_all({ "$push" => { pending_ops: pending_op.as_document }, "$pushAll" => { system_ssh_keys: keys_attrs }})
   end
@@ -224,7 +224,7 @@ class Domain
     end
     return if ssh_keys.empty?
     keys_attrs = ssh_keys.map { |k| k.serializable_hash }
-    pending_op = RemoveSystemSshKeysDomainOp.new(keys_attrs: keys_attrs, on_apps: applications)
+    pending_op = RemoveSystemSshKeysDomainOp.new(keys_attrs: keys_attrs)
     pending_op.set_created_at
     Domain.where(_id: self.id).update_all({ "$push" => { pending_ops: pending_op.as_document }, "$pullAll" => { system_ssh_keys: keys_attrs }})
   end
@@ -248,7 +248,7 @@ class Domain
     # if this is an update to an existing environment variable, remove the previous ones first
     Domain.where(_id: self.id).update_all({ "$pullAll" => { env_vars: env_vars_to_rm }}) unless env_vars_to_rm.empty?
 
-    pending_op = AddEnvVarsDomainOp.new(variables: variables, on_apps: applications)
+    pending_op = AddEnvVarsDomainOp.new(variables: variables)
     pending_op.set_created_at
     Domain.where(_id: self.id).update_all({ "$push" => { pending_ops: pending_op.as_document }, "$pushAll" => { env_vars: variables }})
   end
@@ -260,7 +260,7 @@ class Domain
       variables = self.env_vars.select { |env| env["component_id"]==remove_key }
     end
     return if variables.empty?
-    pending_op = RemoveEnvVarsDomainOp.new(variables: variables, on_apps: applications)
+    pending_op = RemoveEnvVarsDomainOp.new(variables: variables)
     pending_op.set_created_at
     Domain.where(_id: self.id).update_all({ "$push" => { pending_ops: pending_op.as_document }, "$pullAll" => { env_vars: variables }})
   end

--- a/controller/app/models/pending_domain_ops.rb
+++ b/controller/app/models/pending_domain_ops.rb
@@ -9,8 +9,6 @@
 #   @return [Hash] Arguments hash.
 # @!attribute [rw] parent_op_id
 #   @return [Moped::BSON::ObjectId] ID of the {PendingUserOps} operation that this operation is part of.
-# @!attribute [r] on_apps
-#   @return [Array[Moped::BSON::ObjectId]] IDs of the {Application} that are part of this operation.
 # @!attribute [r] completed_apps
 #   @return [Array[Moped::BSON::ObjectId]] IDs of the {Application} that have completed their sub-tasks.
 #     @see {PendingDomainOps#child_completed}
@@ -24,7 +22,6 @@ class PendingDomainOps
 
   field :parent_op_id, type: Moped::BSON::ObjectId
   field :state, type: Symbol, :default => :init
-  has_and_belongs_to_many :on_apps, class_name: Application.name, inverse_of: nil
   has_and_belongs_to_many :completed_apps, class_name: Application.name, inverse_of: nil
   field :on_completion_method, type: Symbol
 
@@ -39,8 +36,7 @@ class PendingDomainOps
   end
 
   def pending_apps
-    pending_apps = on_apps - completed_apps
-    pending_apps
+    (domain.applications - completed_apps)
   end
 
   def completed?

--- a/controller/app/models/pending_user_op.rb
+++ b/controller/app/models/pending_user_op.rb
@@ -1,8 +1,6 @@
 # Class to represent pending operations that need to occur for the {CloudUser}
 # @!attribute [r] state
 #   @return [Symbol] Operation state. One of init, queued or completed
-# @!attribute [r] on_domain_ids
-#   @return [Array] Ids for domains on which this operation needs to be run
 # @!attribute [r] completed_domain_ids
 #   @return [Array] Ids for domains on which this operation has been completed
 # @!attribute [r] on_completion_method
@@ -15,17 +13,11 @@ class PendingUserOp
 
   field :state, type: Symbol, :default => :init
   field :prereq, type: Array
-  has_and_belongs_to_many :on_domains, class_name: Domain.name, inverse_of: nil
   has_and_belongs_to_many :completed_domains, class_name: Domain.name, inverse_of: nil
   field :on_completion_method, type: Symbol
 
-  # List of domains that are still pending
-  #
-  # == Returns:
-  # Array of {Domain}s
   def pending_domains
-    pending_domains = on_domains - completed_domains
-    pending_domains
+    (user.domains - completed_domains)
   end
 
   def prereq


### PR DESCRIPTION
Now on_domains/on_apps are not passed from op-group instead current domains/apps are used during pending op execution.
