### PR TITLE
Copy PHP extensions INI files to the cartridge code for maintainability

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/bin/install
+++ b/cartridges/openshift-origin-cartridge-php/bin/install
@@ -15,8 +15,9 @@ export OPENSHIFT_PHP_VERSION="$version"
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source ${OPENSHIFT_PHP_DIR}usr/lib/php_context
 
-echo "$version" > "$OPENSHIFT_PHP_DIR/env/OPENSHIFT_PHP_VERSION"
-echo "$OPENSHIFT_PHP_DIR/configuration/etc/php.ini" > "$OPENSHIFT_PHP_DIR/env/PHPRC"
+echo "$version" > ${OPENSHIFT_PHP_DIR}env/OPENSHIFT_PHP_VERSION
+echo "${OPENSHIFT_PHP_DIR}configuration/etc/php.ini" > ${OPENSHIFT_PHP_DIR}env/PHPRC
+echo "${OPENSHIFT_PHP_DIR}configuration/etc/php.d" > ${OPENSHIFT_PHP_DIR}env/PHP_INI_SCAN_DIR
 
 # Create additional directories required by PHP
 mkdir -p $OPENSHIFT_PHP_DIR/phplib/pear/{docs,ext,php,cache,cfg,data,download,temp,tests,www}

--- a/cartridges/openshift-origin-cartridge-php/bin/setup
+++ b/cartridges/openshift-origin-cartridge-php/bin/setup
@@ -10,7 +10,7 @@ shopt -s dotglob
 
 mkdir -p $OPENSHIFT_PHP_DIR/configuration/etc/
 cp -Hr $OPENSHIFT_PHP_DIR/versions/shared/configuration/etc/* $OPENSHIFT_PHP_DIR/configuration/etc/
-cp -Hr $OPENSHIFT_PHP_DIR/versions/$version/configuration/etc/* $OPENSHIFT_PHP_DIR/configuration/etc/ || :
+cp -Hr $OPENSHIFT_PHP_DIR/versions/$version/configuration/etc/* $OPENSHIFT_PHP_DIR/configuration/etc/
 
 # Create/truncate gear-editable Apache configuration files
 echo > $OPENSHIFT_PHP_DIR/configuration/etc/conf.d/openshift.conf

--- a/cartridges/openshift-origin-cartridge-php/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-php/bin/upgrade
@@ -22,3 +22,7 @@ if [[ $next == 0.0.12 ]]; then
     chown $OPENSHIFT_GEAR_UUID:$OPENSHIFT_GEAR_UUID $OPENSHIFT_PHP_DIR/configuration/etc/conf.d/openshift.conf
     chcon -u unconfined_u $OPENSHIFT_PHP_DIR/configuration/etc/conf.d/openshift.conf
 fi
+
+if [[ $curr == 0.0.12 ]]; then
+  echo "$OPENSHIFT_PHP_DIR/configuration/etc/php.d" > "$OPENSHIFT_PHP_DIR/env/PHP_INI_SCAN_DIR"
+fi

--- a/cartridges/openshift-origin-cartridge-php/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-php/metadata/managed_files.yml
@@ -12,6 +12,8 @@ locked_files:
 - configuration/etc/conf.d/
 - configuration/etc/conf.d/php.conf
 - configuration/etc/php.ini
+- configuration/etc/php.d/
+- configuration/etc/php.d/[^_]*
 - metadata/
 - metadata/*
 - env/

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/apc.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/apc.ini
@@ -1,0 +1,70 @@
+; Enable apc extension module
+extension = apc.so
+
+; Options for the APC module version >= 3.1.3
+; See http://www.php.net/manual/en/apc.configuration.php
+
+; This can be set to 0 to disable APC. 
+apc.enabled=1
+; The number of shared memory segments to allocate for the compiler cache. 
+apc.shm_segments=1
+; The size of each shared memory segment, with M/G suffix
+apc.shm_size=64M
+; A "hint" about the number of distinct source files that will be included or 
+; requested on your web server. Set to zero or omit if you are not sure;
+apc.num_files_hint=1024
+; Just like num_files_hint, a "hint" about the number of distinct user cache
+; variables to store.  Set to zero or omit if you are not sure;
+apc.user_entries_hint=4096
+; The number of seconds a cache entry is allowed to idle in a slot in case this
+; cache entry slot is needed by another entry.
+apc.ttl=7200
+; use the SAPI request start time for TTL
+apc.use_request_time=1
+; The number of seconds a user cache entry is allowed to idle in a slot in case
+; this cache entry slot is needed by another entry.
+apc.user_ttl=7200
+; The number of seconds that a cache entry may remain on the garbage-collection list. 
+apc.gc_ttl=3600
+; On by default, but can be set to off and used in conjunction with positive
+; apc.filters so that files are only cached if matched by a positive filter.
+apc.cache_by_default=1
+; A comma-separated list of POSIX extended regular expressions.
+apc.filters
+; The mktemp-style file_mask to pass to the mmap module 
+apc.mmap_file_mask=/tmp/apc.XXXXXX
+; This file_update_protection setting puts a delay on caching brand new files.
+apc.file_update_protection=2
+; Setting this enables APC for the CLI version of PHP (Mostly for testing and debugging).
+apc.enable_cli=0
+; Prevents large files from being cached
+apc.max_file_size=1M
+; Whether to stat the main script file and the fullpath includes.
+apc.stat=1
+; Vertification with ctime will avoid problems caused by programs such as svn or rsync by making 
+; sure inodes have not changed since the last stat. APC will normally only check mtime.
+apc.stat_ctime=0
+; Whether to canonicalize paths in stat=0 mode or fall back to stat behaviour
+apc.canonicalize=0
+; With write_lock enabled, only one process at a time will try to compile an 
+; uncached script while the other processes will run uncached
+apc.write_lock=1
+; Logs any scripts that were automatically excluded from being cached due to early/late binding issues.
+apc.report_autofilter=0
+; RFC1867 File Upload Progress hook handler
+apc.rfc1867=0
+apc.rfc1867_prefix =upload_
+apc.rfc1867_name=APC_UPLOAD_PROGRESS
+apc.rfc1867_freq=0
+apc.rfc1867_ttl=3600
+; Optimize include_once and require_once calls and avoid the expensive system calls used.
+apc.include_once_override=0
+apc.lazy_classes=0
+apc.lazy_functions=0
+; Enables APC handling of signals, such as SIGSEGV, that write core files when signaled. 
+; APC will attempt to unmap the shared memory segment in order to exclude it from the core file
+apc.coredump_unmap=0
+; Records a md5 hash of files. 
+apc.file_md5=0
+; not documented
+apc.preload_path

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/bcmath.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/bcmath.ini
@@ -1,0 +1,2 @@
+; Enable bcmath extension module
+extension=bcmath.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/curl.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/curl.ini
@@ -1,0 +1,2 @@
+; Enable curl extension module
+extension=curl.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/dom.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/dom.ini
@@ -1,0 +1,2 @@
+; Enable dom extension module
+extension=dom.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/fileinfo.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/fileinfo.ini
@@ -1,0 +1,2 @@
+; Enable fileinfo extension module
+extension=fileinfo.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/gd.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/gd.ini
@@ -1,0 +1,2 @@
+; Enable gd extension module
+extension=gd.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/imagick.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/imagick.ini
@@ -1,0 +1,2 @@
+; Enable imagick extension module
+extension=imagick.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/imap.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/imap.ini
@@ -1,0 +1,2 @@
+; Enable imap extension module
+extension=imap.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/intl.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/intl.ini
@@ -1,0 +1,2 @@
+; Enable intl extension module
+extension=intl.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/json.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/json.ini
@@ -1,0 +1,2 @@
+; Enable json extension module
+extension=json.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/mbstring.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/mbstring.ini
@@ -1,0 +1,2 @@
+; Enable mbstring extension module
+extension=mbstring.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/mcrypt.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/mcrypt.ini
@@ -1,0 +1,2 @@
+; Enable mcrypt extension module
+extension=mcrypt.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/memcached.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/memcached.ini
@@ -1,0 +1,10 @@
+; Enable memcached extension module
+extension=memcached.so
+
+
+; ----- Options to use the memcached session handler
+
+;  Use memcache as a session handler
+;session.save_handler=memcached
+;  Defines a comma separated list of server urls to use for session storage
+;session.save_path="localhost:11211"

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/mongo.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/mongo.ini
@@ -1,0 +1,35 @@
+; Enable mongo extension module
+extension=mongo.so
+
+;  option documentation: http://www.php.net/manual/en/mongo.configuration.php
+
+;  If persistent connections are allowed.
+;mongo.allow_persistent = 1
+
+;  Whether to reconnect to the database if the connection is lost. 
+;mongo.auto_reconnect = 1
+
+;  The number of bytes-per-chunk. 
+;  This number must be at least 100 less than 4 megabytes (max: 4194204) 
+;mongo.chunk_size = 262144
+
+;  A character to be used in place of $ in modifiers and comparisons.
+;mongo.cmd = $
+
+;  Default hostname when nothing is passed to the constructor. 
+;mongo.default_host = localhost
+
+;  The default TCP port number. The database's default is 27017. 
+;mongo.default_port = 27017
+
+;  Return a BSON_LONG as an instance of MongoInt64  
+;  (instead of a primitive type). 
+;mongo.long_as_object = 0
+
+;  Use MongoDB native long (this will default to true for 1.1.0)
+mongo.native_long = true
+
+;  If an exception should be thrown for non-UTF8 strings. 
+;  This option will be eliminated and exceptions always thrown for non-UTF8 
+;  strings starting with version 1.1.0. 
+mongo.utf8 = 1

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/mysql.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/mysql.ini
@@ -1,0 +1,2 @@
+; Enable mysql extension module
+extension=mysql.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/mysqli.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/mysqli.ini
@@ -1,0 +1,2 @@
+; Enable mysqli extension module
+extension=mysqli.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/pdo.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/pdo.ini
@@ -1,0 +1,2 @@
+; Enable pdo extension module
+extension=pdo.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/pdo_mysql.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/pdo_mysql.ini
@@ -1,0 +1,2 @@
+; Enable pdo_mysql extension module
+extension=pdo_mysql.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/pdo_pgsql.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/pdo_pgsql.ini
@@ -1,0 +1,2 @@
+; Enable pdo_pgsql extension module
+extension=pdo_pgsql.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/pdo_sqlite.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/pdo_sqlite.ini
@@ -1,0 +1,2 @@
+; Enable pdo_sqlite extension module
+extension=pdo_sqlite.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/pgsql.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/pgsql.ini
@@ -1,0 +1,2 @@
+; Enable pgsql extension module
+extension=pgsql.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/phar.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/phar.ini
@@ -1,0 +1,2 @@
+; Enable phar extension module
+extension=phar.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/posix.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/posix.ini
@@ -1,0 +1,2 @@
+; Enable posix extension module
+extension=posix.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/soap.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/soap.ini
@@ -1,0 +1,2 @@
+; Enable soap extension module
+extension=soap.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/sqlite3.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/sqlite3.ini
@@ -1,0 +1,2 @@
+; Enable sqlite3 extension module
+extension=sqlite3.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/sysvmsg.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/sysvmsg.ini
@@ -1,0 +1,2 @@
+; Enable sysvmsg extension module
+extension=sysvmsg.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/sysvsem.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/sysvsem.ini
@@ -1,0 +1,2 @@
+; Enable sysvsem extension module
+extension=sysvsem.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/sysvshm.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/sysvshm.ini
@@ -1,0 +1,2 @@
+; Enable sysvshm extension module
+extension=sysvshm.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/tidy.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/tidy.ini
@@ -1,0 +1,2 @@
+; Enable tidy extension module
+extension=tidy.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/wddx.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/wddx.ini
@@ -1,0 +1,2 @@
+; Enable wddx extension module
+extension=wddx.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/xdebug.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/xdebug.ini
@@ -1,0 +1,2 @@
+; Enable xdebug extension module
+zend_extension=/usr/lib64/php/modules/xdebug.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/xmlreader.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/xmlreader.ini
@@ -1,0 +1,2 @@
+; Enable xmlreader extension module
+extension=xmlreader.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/xmlwriter.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/xmlwriter.ini
@@ -1,0 +1,2 @@
+; Enable xmlwriter extension module
+extension=xmlwriter.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/xsl.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/xsl.ini
@@ -1,0 +1,2 @@
+; Enable xsl extension module
+extension=xsl.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/zip.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.3/configuration/etc/php.d/zip.ini
@@ -1,0 +1,2 @@
+; Enable zip extension module
+extension=zip.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/apc.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/apc.ini
@@ -1,0 +1,98 @@
+; Enable apc extension module
+extension = apc.so
+
+; Options for the APC module version >= 3.1.3
+; See http://www.php.net/manual/en/apc.configuration.php
+
+
+; This can be set to enable the APC opcode cache
+; Don't set this option if another opcode cache is enabled
+apc.enable_opcode_cache=0
+
+; This can be set to 0 to disable APC. 
+;apc.enabled=1
+
+; The size of each shared memory segment, with M/G suffixe
+apc.shm_size=64M
+
+; The shared memory size reserved for strings, with M/G suffixe
+apc.shm_strings_buffer=8M
+
+; A "hint" about the number of distinct source files that will be included or 
+; requested on your web server. Set to zero or omit if you are not sure;
+;apc.num_files_hint=1000
+
+; Just like num_files_hint, a "hint" about the number of distinct user cache
+; variables to store.  Set to zero or omit if you are not sure;
+;apc.user_entries_hint=4096
+
+; The number of seconds a cache entry is allowed to idle in a slot in case this
+; cache entry slot is needed by another entry.
+;apc.ttl=0
+
+; use the SAPI request start time for TTL
+;apc.use_request_time=1
+
+; The number of seconds a user cache entry is allowed to idle in a slot in case
+; this cache entry slot is needed by another entry.
+;apc.user_ttl=0
+
+; The number of seconds that a cache entry may remain on the garbage-collection list. 
+;apc.gc_ttl=3600
+
+; On by default, but can be set to off and used in conjunction with positive
+; apc.filters so that files are only cached if matched by a positive filter.
+;apc.cache_by_default=1
+
+; A comma-separated list of POSIX extended regular expressions.
+;apc.filters=
+
+; The mktemp-style file_mask to pass to the mmap module 
+apc.mmap_file_mask=/tmp/apc.XXXXXX
+
+
+; This file_update_protection setting puts a delay on caching brand new files.
+;apc.file_update_protection=2
+
+; Setting this enables APC for the CLI version of PHP (Mostly for testing and debugging).
+;apc.enable_cli=0
+
+; Prevents large files from being cached
+;apc.max_file_size=1M
+
+; Whether to stat the main script file and the fullpath includes.
+;apc.stat=1
+
+; Vertification with ctime will avoid problems caused by programs such as svn or rsync by making 
+; sure inodes have not changed since the last stat. APC will normally only check mtime.
+;apc.stat_ctime=0
+
+; If on, then relative paths are canonicalized in no-stat mode.
+; If set, then files included via stream wrappers can not be cached
+; as realpath() does not support stream wrappers.
+;apc.canonicalize=1
+
+; With write_lock enabled, only one process at a time will try to compile an 
+; uncached script while the other processes will run uncached
+;apc.write_lock=1
+
+; Logs any scripts that were automatically excluded from being cached due to early/late binding issues.
+;apc.report_autofilter=0
+
+; RFC1867 File Upload Progress hook handler
+;apc.rfc1867=0
+;apc.rfc1867_prefix =upload_
+;apc.rfc1867_name=APC_UPLOAD_PROGRESS
+;apc.rfc1867_freq=0
+;apc.rfc1867_ttl=3600
+
+; Enables APC handling of signals, such as SIGSEGV, that write core files when signaled. 
+; APC will attempt to unmap the shared memory segment in order to exclude it from the core file
+;apc.coredump_unmap=0
+
+; Records a md5 hash of files. 
+;apc.file_md5=0
+
+; not documented
+;apc.preload_path=
+

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/bcmath.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/bcmath.ini
@@ -1,0 +1,2 @@
+; Enable bcmath extension module
+extension=bcmath.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/curl.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/curl.ini
@@ -1,0 +1,2 @@
+; Enable curl extension module
+extension=curl.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/dom.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/dom.ini
@@ -1,0 +1,2 @@
+; Enable dom extension module
+extension=dom.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/fileinfo.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/fileinfo.ini
@@ -1,0 +1,2 @@
+; Enable fileinfo extension module
+extension=fileinfo.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/gd.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/gd.ini
@@ -1,0 +1,2 @@
+; Enable gd extension module
+extension=gd.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/imagick.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/imagick.ini
@@ -1,0 +1,10 @@
+; Enable imagick extension module
+extension = imagick.so
+
+; Extension documentation: http://php.net/imagick
+
+; Fixes a drawing bug with locales that use ',' as float separators.
+;imagick.locale_fix=0
+
+; Used to enable the image progress monitor.
+;imagick.progress_monitor=0

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/intl.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/intl.ini
@@ -1,0 +1,2 @@
+; Enable intl extension module
+extension=intl.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/json.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/json.ini
@@ -1,0 +1,2 @@
+; Enable json extension module
+extension=json.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/ldap.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/ldap.ini
@@ -1,0 +1,2 @@
+; Enable ldap extension module
+extension=ldap.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/mbstring.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/mbstring.ini
@@ -1,0 +1,2 @@
+; Enable mbstring extension module
+extension=mbstring.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/mongo.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/mongo.ini
@@ -1,0 +1,44 @@
+; Enable Mongo extension module
+extension=mongo.so
+
+;  option documentation: http://www.php.net/manual/en/mongo.configuration.php
+
+;  If empty strings ("") should be allowed as key names.
+;mongo.allow_empty_keys = 0
+
+;  If persistent connections are allowed.
+;mongo.allow_persistent = 1
+
+;  The number of bytes-per-chunk. 
+;  This number must be at least 100 less than 4 megabytes (max: 4194204) 
+;mongo.chunk_size = 262144
+
+;  A character to be used in place of $ in modifiers and comparisons.
+;mongo.cmd = $
+
+;  Default hostname when nothing is passed to the constructor. 
+;mongo.default_host = localhost
+
+;  The default TCP port number. The database's default is 27017. 
+;mongo.default_port = 27017
+
+;  For replicaset connections: The minimum interval with which the driver
+;  will send "isMaster" requests to the MongoDB server.
+;mongo.is_master_interval = 60
+
+;  Return a BSON_LONG as an instance of MongoInt64  
+;  (instead of a primitive type). 
+;mongo.long_as_object = 0
+
+;  Use MongoDB native long (this will default to true for 2.0.0)
+mongo.native_long = true
+
+;  For replicaset connections: The minimum interval with which the driver
+;  will send "ping" requests to the MongoDB server.
+;mongo.ping_interval = 5
+
+;  If an exception should be thrown for non-UTF8 strings. 
+;  This option will be eliminated and exceptions always thrown for non-UTF8 
+;  strings starting with version 1.1.0. 
+mongo.utf8 = 1
+

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/mysqlnd.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/mysqlnd.ini
@@ -1,0 +1,2 @@
+; Enable mysqlnd extension module
+extension=mysqlnd.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/mysqlnd_mysql.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/mysqlnd_mysql.ini
@@ -1,0 +1,2 @@
+; Enable mysqlnd_mysql extension module
+extension=mysqlnd_mysql.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/mysqlnd_mysqli.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/mysqlnd_mysqli.ini
@@ -1,0 +1,2 @@
+; Enable mysqlnd_mysqli extension module
+extension=mysqlnd_mysqli.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/pdo.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/pdo.ini
@@ -1,0 +1,2 @@
+; Enable pdo extension module
+extension=pdo.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/pdo_mysqlnd.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/pdo_mysqlnd.ini
@@ -1,0 +1,2 @@
+; Enable pdo_mysqlnd extension module
+extension=pdo_mysqlnd.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/pdo_pgsql.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/pdo_pgsql.ini
@@ -1,0 +1,2 @@
+; Enable pdo_pgsql extension module
+extension=pdo_pgsql.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/pdo_sqlite.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/pdo_sqlite.ini
@@ -1,0 +1,2 @@
+; Enable pdo_sqlite extension module
+extension=pdo_sqlite.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/pgsql.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/pgsql.ini
@@ -1,0 +1,2 @@
+; Enable pgsql extension module
+extension=pgsql.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/phar.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/phar.ini
@@ -1,0 +1,2 @@
+; Enable phar extension module
+extension=phar.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/posix.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/posix.ini
@@ -1,0 +1,2 @@
+; Enable posix extension module
+extension=posix.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/soap.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/soap.ini
@@ -1,0 +1,2 @@
+; Enable soap extension module
+extension=soap.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/sqlite3.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/sqlite3.ini
@@ -1,0 +1,2 @@
+; Enable sqlite3 extension module
+extension=sqlite3.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/sysvmsg.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/sysvmsg.ini
@@ -1,0 +1,2 @@
+; Enable sysvmsg extension module
+extension=sysvmsg.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/sysvsem.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/sysvsem.ini
@@ -1,0 +1,2 @@
+; Enable sysvsem extension module
+extension=sysvsem.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/sysvshm.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/sysvshm.ini
@@ -1,0 +1,2 @@
+; Enable sysvshm extension module
+extension=sysvshm.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/wddx.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/wddx.ini
@@ -1,0 +1,2 @@
+; Enable wddx extension module
+extension=wddx.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/xmlreader.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/xmlreader.ini
@@ -1,0 +1,2 @@
+; Enable xmlreader extension module
+extension=xmlreader.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/xmlwriter.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/xmlwriter.ini
@@ -1,0 +1,2 @@
+; Enable xmlwriter extension module
+extension=xmlwriter.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/xsl.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/xsl.ini
@@ -1,0 +1,2 @@
+; Enable xsl extension module
+extension=xsl.so

--- a/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/zip.ini
+++ b/cartridges/openshift-origin-cartridge-php/versions/5.4/configuration/etc/php.d/zip.ini
@@ -1,0 +1,2 @@
+; Enable zip extension module
+extension=zip.so


### PR DESCRIPTION
- PHP 5.3: Copy RHEL /etc/php.d/*.ini files
- PHP 5.4: Copy RHEL /opt/rh/php54/root/etc/php.d/*.ini files

Motivation:
- We want to be able to enable/disable PHP extensions in gears
- We want to be able to edit PHP extensions settings in gears
- We want consistency for all the INI files across all nodes.
  Currently, the INI files are marked %config(noreplace) in RPMs
  and may theoretically differ from node to node.

PHP_INI_SCAN_DIR (PHP/PECL extensions):
- Set PHP_INI_SCAN_DIR env var to scan customized INI files
    from ${OPENSHIFT_PHP_DIR}etc/php.d/ directory
    instead of the default system's scan dir (eg. /etc/php.d/)

[test] [extended:cartridge]
