### PR TITLE
Bug 1077664: oo-diagnostics: Fix test_node_mco_log when no log

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -768,22 +768,22 @@ class OODiag
 
   def test_node_mco_log
     skip_test unless @is_node
-    #
-    # create a tmp file with all of the unique log statements after most recent mcollective start
+
     logfile = "#{@scl_prefix}mcollective.log"
     logfile = [ "/var/log/openshift/node/#{logfile}", "/var/log/#{logfile}" ].find {|f| File.exist? f}
     if logfile.nil? || logfile.empty?
-      do_fail <<-"FAIL"
-        No node mcollective log file found.
-      FAIL
+      verbose 'No node mcollective log file found.'
       skip_test
     end
+
+    # Create a tmp file with all of the unique log statements after most recent mcollective start.
     tmpfile = Tempfile.new("oodiag-mco-#{$$}").path
     system %Q! sed -n 'H; /INFO.*The Marionette Collective.*started logging/h; ${g;p;}' #{logfile} | sed 's|^\w, \[[^]]*\]||' | sort -u > #{tmpfile} !
-    # if no restart seen, just use the whole thing
+
+    # If no restart seen, just use the whole thing.
     system %Q! sort -u /var/log/#{@scl_prefix}mcollective.log > #{tmpfile} ! unless File.exists? tmpfile
     return unless File.exists? tmpfile
-    #
+
     # Look for the mco timeout warning
     out = `grep 'WARN.*created at [0-9]* is [0-9]* seconds old, TTL is' #{tmpfile}`
     unless out.empty?
@@ -802,8 +802,8 @@ class OODiag
       TIMEOUT
       do_fail errors
     end
-    #
-    # clean up temp file
+
+    # Clean up temp file.
     system "rm #{tmpfile}"
   end
 

--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -772,6 +772,12 @@ class OODiag
     # create a tmp file with all of the unique log statements after most recent mcollective start
     logfile = "#{@scl_prefix}mcollective.log"
     logfile = [ "/var/log/openshift/node/#{logfile}", "/var/log/#{logfile}" ].find {|f| File.exist? f}
+    if logfile.nil? || logfile.empty?
+      do_fail <<-"FAIL"
+        No node mcollective log file found.
+      FAIL
+      skip_test
+    end
     tmpfile = Tempfile.new("oodiag-mco-#{$$}").path
     system %Q! sed -n 'H; /INFO.*The Marionette Collective.*started logging/h; ${g;p;}' #{logfile} | sed 's|^\w, \[[^]]*\]||' | sort -u > #{tmpfile} !
     # if no restart seen, just use the whole thing


### PR DESCRIPTION
 oo-diagnostics: Fix test_node_mco_log when no log

Make test_node_mco_log fail gracefully when the node mcollective log file is absent.  Before this commit, the test would hang because it would run a sed command with no input file provided.

This commit fixes bug 1077664.

 oo-diagnostics: Fix comments for test_node_mco_log

Place comments with relevant code, consistently use proper case and punctuation, and use whitespace for better logical grouping.
