### PR TITLE
Bug 1077501 - Sourcing Bash SDK

### DIFF
--- a/cartridges/openshift-origin-cartridge-perl/bin/build
+++ b/cartridges/openshift-origin-cartridge-perl/bin/build
@@ -1,5 +1,7 @@
 #!/bin/bash -eu
 
+source $OPENSHIFT_CARTRIDGE_SDK_BASH
+
 echo "Building Perl cartridge"
 
 if [ -f ${OPENSHIFT_REPO_DIR}.openshift/markers/force_clean_build ]


### PR DESCRIPTION
Meet "//bin/build: line 29 client_message: command not found " error messages during git push when deplist.txt exists -perl-5.10

Due to calling the client_message function had to add sourcing of the bash SDK.
