### PR TITLE
Multiple fixes

### DIFF
--- a/controller/app/helpers/cartridge_cache.rb
+++ b/controller/app/helpers/cartridge_cache.rb
@@ -21,7 +21,7 @@ class CartridgeCache
   end
 
   #
-  # Returns an Array of web framework cartridge names.
+  # Returns an Array of names of non web framework cartridges.
   #
   def self.other_names
     Rails.cache.fetch("other_cartridge_names", :expires_in => DURATION) do

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1693,6 +1693,7 @@ class Application
         Rails.logger.debug e_orig.backtrace.inspect unless rollback_pending
 
         #rollback
+        rollback_successful = false
         begin
           # reload the application before a rollback
           self.reload
@@ -1700,6 +1701,8 @@ class Application
           op_group.delete
           num_gears_recovered = op_group.num_gears_added - op_group.num_gears_created + op_group.num_gears_rolled_back + op_group.num_gears_destroyed
           op_group.unreserve_gears(num_gears_recovered, self)
+
+          rollback_successful = true
         rescue Mongoid::Errors::DocumentNotFound
           # ignore if the application is already deleted
         rescue Exception => e_rollback
@@ -1716,7 +1719,7 @@ class Application
         # if not, then we should just continue execution of any remaining op_groups.
         # The continue_on_successful_rollback flag is used by the oo-admin-clear-pending-ops script
         # Note: If the rollback was blocked, do not continue as this can lead to an infinite loop
-        if !(rollback_pending or continue_on_successful_rollback) or op_group.rollback_blocked
+        unless ( rollback_successful and (continue_on_successful_rollback or rollback_pending) )
           if e_orig.respond_to? 'resultIO' and e_orig.resultIO
             e_orig.resultIO.append result_io unless e_orig.resultIO == result_io
           end
@@ -1876,9 +1879,11 @@ class Application
     end
 
     prereq_op_id = prereq_op._id.to_s rescue nil
+    # since this component add operation is part of a new gear creation, we can skip rollback for everything other that gear creation
+    is_gear_creation = true
     add, usage = calculate_add_component_ops(gear_comp_specs, comp_spec_gears, ginst_id, deploy_gear_id, gear_id_prereqs, component_ops,
                                              is_scale_up, (user_vars_op_id || prereq_op_id), init_git_url,
-                                             app_dns_gear_id)
+                                             app_dns_gear_id, is_gear_creation)
     ops.concat(add)
     track_usage_ops.concat(usage)
 
@@ -2002,7 +2007,9 @@ class Application
     false
   end
 
-  def calculate_add_component_ops(gear_comp_specs, comp_spec_gears, group_instance_id, deploy_gear_id, gear_id_prereqs, component_ops, is_scale_up, prereq_id, init_git_url=nil, app_dns_gear_id=nil)
+  def calculate_add_component_ops(gear_comp_specs, comp_spec_gears, group_instance_id, deploy_gear_id, 
+                                  gear_id_prereqs, component_ops, is_scale_up, prereq_id, init_git_url=nil, 
+                                  app_dns_gear_id=nil, is_gear_creation=false)
     ops = []
     usage_ops = []
 
@@ -2046,19 +2053,22 @@ class Application
           git_url = init_git_url
         end
 
-        add_component_op = AddCompOp.new(gear_id: gear_id, comp_spec: comp_spec, init_git_url: git_url, prereq: new_component_op_id + [prereq_id])
+        add_component_op = AddCompOp.new(gear_id: gear_id, comp_spec: comp_spec, init_git_url: git_url, 
+                                         skip_rollback: is_gear_creation, prereq: new_component_op_id + [prereq_id])
         ops << add_component_op
         component_ops[comp_spec][:adds] << add_component_op
         usage_op_prereq = [add_component_op._id.to_s]
 
         # if this is a web_proxy, send any existing alias and SSL cert information to it
         if cartridge.is_web_proxy? and self.aliases.present?
-          resend_aliases_op = ResendAliasesOp.new(gear_id: gear_id, fqdns: self.aliases.map {|app_alias| app_alias.fqdn}, prereq: [add_component_op._id.to_s])
+          resend_aliases_op = ResendAliasesOp.new(gear_id: gear_id, fqdns: self.aliases.map {|app_alias| app_alias.fqdn}, 
+                                                  skip_rollback: is_gear_creation, prereq: [add_component_op._id.to_s])
           ops.push resend_aliases_op
 
           aliases_with_certs = self.aliases.select {|app_alias| app_alias.has_private_ssl_certificate}
           if aliases_with_certs.present?
-            resend_ssl_certs_op = ResendSslCertsOp.new(gear_id: gear_id, ssl_certs: get_ssl_certs(), prereq: [resend_aliases_op._id.to_s])
+            resend_ssl_certs_op = ResendSslCertsOp.new(gear_id: gear_id, ssl_certs: get_ssl_certs(), 
+                                                       skip_rollback: is_gear_creation, prereq: [resend_aliases_op._id.to_s])
             ops.push resend_ssl_certs_op
           end
         end
@@ -2657,7 +2667,17 @@ class Application
             break
           end
         end
-        raise OpenShift::UserException.new("Cartridge '#{spec.cartridge_name}' can not be added without #{Array(deps).join(' or ')}.", 185) if !match
+
+        # check if any platform cartridge can satisfy the dependency
+        # if so, include them in the message being sent back to the user
+        error_message = "Cartridge '#{spec.cartridge_name}' can not be added without #{Array(deps).join(' or ')}."
+        platform_carts = CartridgeCache.get_all_cartridges
+        Array(deps).each do |name|
+          matching_carts = platform_carts.select { |cart| cart.names.include?(name) || cart.categories.include?(name) }
+          error_message += " The dependency '#{name}' can be satisfied with #{matching_carts.map(&:name).join(' or ')}." if matching_carts.present?
+        end
+
+        raise OpenShift::UserException.new(error_message, 185) if !match
         order << match
       end
       next if order.empty?

--- a/controller/app/pending_ops_models/add_comp_op.rb
+++ b/controller/app/pending_ops_models/add_comp_op.rb
@@ -3,6 +3,7 @@ class AddCompOp < PendingAppOp
   field :gear_id, type: String
   field :comp_spec, type: ComponentSpec
   field :init_git_url, type: String
+  field :skip_rollback, type: Boolean
 
   def execute
     gear = get_gear
@@ -10,8 +11,15 @@ class AddCompOp < PendingAppOp
   end
 
   def rollback
-    gear = get_gear
-    gear.remove_component(get_component_instance)
+    result_io = nil
+    unless skip_rollback
+      gear = get_gear
+      # do not check for gear.removed in here
+      # it is being checked inside the gear.remove_component method
+      # since, in addition to a node operation, this also involves a mongo update for sparse carts
+      result_io = gear.remove_component(get_component_instance)
+    end
+    result_io
   end
 
 end

--- a/controller/app/pending_ops_models/resend_aliases_op.rb
+++ b/controller/app/pending_ops_models/resend_aliases_op.rb
@@ -2,6 +2,7 @@ class ResendAliasesOp < PendingAppOp
 
   field :gear_id, type: String
   field :fqdns, type: Array
+  field :skip_rollback, type: Boolean
 
   def execute
     result_io = ResultIO.new 
@@ -11,9 +12,11 @@ class ResendAliasesOp < PendingAppOp
   end
 
   def rollback
-    result_io = ResultIO.new
-    gear = get_gear()
-    result_io = gear.remove_aliases(fqdns) unless gear.removed
+    result_io = nil
+    unless skip_rollback
+      gear = get_gear()
+      result_io = gear.remove_aliases(fqdns) unless gear.removed
+    end
     result_io
   end
 

--- a/controller/app/pending_ops_models/resend_ssl_certs_op.rb
+++ b/controller/app/pending_ops_models/resend_ssl_certs_op.rb
@@ -2,6 +2,7 @@ class ResendSslCertsOp < PendingAppOp
 
   field :gear_id, type: String
   field :ssl_certs, type: Array
+  field :skip_rollback, type: Boolean
 
   def execute
     result_io = ResultIO.new
@@ -16,11 +17,13 @@ class ResendSslCertsOp < PendingAppOp
   end
 
   def rollback
-    result_io = ResultIO.new
-    gear = get_gear()
-    unless gear.removed
-      ssl_certs.each do |cert_info|
-        result_io.append gear.remove_ssl_cert(cert_info[2])
+    result_io = nil
+    unless skip_rollback
+      gear = get_gear()
+      unless gear.removed
+        ssl_certs.each do |cert_info|
+          result_io.append gear.remove_ssl_cert(cert_info[2])
+        end
       end
     end
     result_io


### PR DESCRIPTION
- Checking the platform cart list for cartridge matches for Configure-Order
- Skipping rollback for configure and similar operations in case of a new gear creation. Instead, we will just delete the gear
- Fixing exception raising logic on rollback success/failure
