### PR TITLE
Bug 1079072 - Hide quota error messsages

### DIFF
--- a/controller/test/cucumber/step_definitions/node_steps.rb
+++ b/controller/test/cucumber/step_definitions/node_steps.rb
@@ -317,7 +317,7 @@ Then /^disk quotas on the account home directory should be correct$/ do
   #     /dev/xvde      24       0  131072               7       0   10000        
   #    
 
-  result = `quota -u #{@account['accountname']}`
+  result = `quota -u #{@account['accountname']} 2>/dev/null`
     
   result.should_not match /does not exist./
   result.should_not match /: none\s*\n?/

--- a/node/misc/bin/rhcsh
+++ b/node/misc/bin/rhcsh
@@ -82,13 +82,13 @@ function welcome {
   # Quota returns nonzero if you are over limit
   if quota >/dev/null 2>&1
   then
-    local usage=$(quota -w | grep '^.*/dev/' | awk '{printf "%3.1f", ($2 / $4 * 100)}')
+    local usage=$(quota -w 2>/dev/null| grep '^.*/dev/' | awk '{printf "%3.1f", ($2 / $4 * 100)}')
     if float_test "$usage > 90.0"
     then
       echo "Warning: Gear ${OPENSHIFT_GEAR_UUID} is using ${usage}% of disk quota"
     fi
 
-    local usage=$(quota -w | grep '^.*/dev/' | awk '{printf "%3.1f",  ($5 / $7 * 100)}')
+    local usage=$(quota -w 2>/dev/null| grep '^.*/dev/' | awk '{printf "%3.1f",  ($5 / $7 * 100)}')
     if float_test "$usage > 90.0"
     then
       echo "Warning: Gear ${OPENSHIFT_GEAR_UUID} is using ${usage}% of inodes allowed"
@@ -100,6 +100,7 @@ function welcome {
 
 alias ctl_app=gear
 alias lsof='lsof -w'
+alias quota='quota 2>/dev/null'
 
 function ctl_all() {
   case "$1" in

--- a/node/misc/libexec/lib/quota_attrs.sh
+++ b/node/misc/libexec/lib/quota_attrs.sh
@@ -3,7 +3,8 @@
 
 uuid=$1
 
-q=$(quota --always-resolve -w -u ${uuid} | tail -n1)
+# Ignore errors about bind mounts user cannot read
+q=$(quota --always-resolve -w -u ${uuid} 2>/dev/null | tail -n1)
 quota_blocks=`echo $q | gawk '{print $4}'`
 echo "ATTR: quota_blocks=$quota_blocks"
 quota_files=`echo $q | gawk '{print $7}'`


### PR DESCRIPTION
- When run as a gear user, quota generates error messages on
  each bind mount in /proc/mounts
- Any command that runs /usr/bin/quota vs. quota alias will
  continue to show errors
