### PR TITLE
Add messaging throughput configuration to EAP

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/standalone/configuration/standalone.xml
+++ b/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/standalone/configuration/standalone.xml
@@ -367,10 +367,18 @@
  	            
 				<connectors>
 					<netty-connector name="netty" socket-binding="messaging" />
+                    <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
+                        <param key="batch-delay" value="50"/>
+                    </netty-connector>
+
 					<in-vm-connector name="in-vm" server-id="0" />
 				</connectors>
 				<acceptors>
 					<netty-acceptor name="netty" socket-binding="messaging" />
+                    <netty-acceptor name="netty-throughput" socket-binding="messaging-throughput">
+                        <param key="batch-delay" value="50"/>
+                        <param key="direct-deliver" value="false"/>
+                   </netty-acceptor>
 					<in-vm-acceptor name="in-vm" server-id="0" />
 				</acceptors>
 				
@@ -534,6 +542,8 @@
 			port="3529" />
 		<socket-binding name="jgroups-tcp" port="${env.OPENSHIFT_JBOSSEAP_CLUSTER_PORT}" />
 		<socket-binding name="messaging" port="${env.OPENSHIFT_JBOSSEAP_MESSAGING_PORT}" />
+        <socket-binding name="messaging-throughput" 
+        	port="${env.OPENSHIFT_JBOSSEAP_MESSAGING_THROUGHPUT_PORT}"/>
 		<socket-binding name="osgi-http" interface="management"
 			port="8090" />
 		<socket-binding name="remoting" port="${env.OPENSHIFT_JBOSSEAP_REMOTING_PORT}" />


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1078669 Check ports of jbosseap
app, found the messaging throughput port is defined in manifest.yml but not
bound to gear. Check the standalone.xml, does not find the port bind define
for it.
