### PR TITLE
[ui_166] Teams UI support, part 1

### DIFF
--- a/console/app/models/member.rb
+++ b/console/app/models/member.rb
@@ -4,7 +4,7 @@ class Member < RestApi::Base
   attr_accessor :me
 
   schema do
-    string :id, :login, :name, :role, :type
+    string :id, :login, :name, :role, :explicit_role, :type
     boolean :owner
   end
 
@@ -17,7 +17,33 @@ class Member < RestApi::Base
     super || login
   end
 
-  def <=>(other)
-    [name, id] <=> [other.name, other.id]
+  def type
+    super || 'user'
   end
+
+  def from
+    Array(super)
+  end
+
+  def explicit_role?
+    explicit_role.present?
+  end
+
+  def team?
+    type == 'team'
+  end
+
+  def grant_from?(type, id)
+    from.detect {|f| f[:type] == type && f[:id] == id}
+  end
+
+  def <=>(other)
+    [type, name, id] <=> [other.type, other.name, other.id]
+  end
+
+  def teams(members)
+    team_ids = from.inject([]) {|ids, f| ids << f[:id] if f[:type] == 'team'; ids }
+    members.select {|m| m.type == 'team' && team_ids.include?(m.id) }
+  end
+
 end

--- a/console/app/models/member.rb
+++ b/console/app/models/member.rb
@@ -41,9 +41,14 @@ class Member < RestApi::Base
     [type, name, id] <=> [other.type, other.name, other.id]
   end
 
+  # return the items in the members array corresponding to the team grants this member has
   def teams(members)
     team_ids = from.inject([]) {|ids, f| ids << f[:id] if f[:type] == 'team'; ids }
-    members.select {|m| m.type == 'team' && team_ids.include?(m.id) }
+    if team_ids.present?
+      members.select {|m| m.type == 'team' && team_ids.include?(m.id) }
+    else
+      []
+    end
   end
 
 end

--- a/console/app/models/membership.rb
+++ b/console/app/models/membership.rb
@@ -58,7 +58,8 @@ module Membership
         {
           :id => (m.id if m.respond_to? :id),
           :login => (m.login if m.respond_to? :login),
-          :role => m.role
+          :role => m.role,
+          :type => m.type
         }
       end
     }

--- a/console/app/models/role.rb
+++ b/console/app/models/role.rb
@@ -5,7 +5,7 @@ class Role < RestApi::Base
   end
 
   def self.description_for(role)
-    case role
+    case role.to_s
     when 'admin'
       'Can administer'
     when 'edit'
@@ -17,10 +17,17 @@ class Role < RestApi::Base
     end
   end
 
-  def self.role_descriptions(include_blank=false)
-    if include_blank
+  def self.role_descriptions(include_blank=false, has_team_role=false)
+    if include_blank && has_team_role
+      @blank_descriptions_with_team ||= [
+        ['Team access only', 'none'],
+        ['Can view (+ team access)','view'],
+        ['Can edit (+ team access)','edit'],
+        ['Can administer (+ team access)','admin']
+      ]
+    elsif include_blank
       @blank_descriptions ||= [
-        ['No access', 'none'],
+        ['No role', 'none'],
         ['Can view','view'],
         ['Can edit','edit'],
         ['Can administer','admin']
@@ -33,4 +40,13 @@ class Role < RestApi::Base
       ]
     end
   end
+
+  def self.higher_of(*args)
+    ROLES[args.map{ |r| ROLES.index(r.to_s) }.compact.max]
+  rescue
+    nil
+  end
+
+  private
+    ROLES = ['view', 'edit', 'admin'].freeze
 end

--- a/console/app/views/domains/delete.html.haml
+++ b/console/app/views/domains/delete.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, "Delete Application"
+- content_for :page_title, "Delete Domain"
 
 %h1 Delete Domain
 

--- a/console/app/views/domains/show.html.haml
+++ b/console/app/views/domains/show.html.haml
@@ -30,12 +30,12 @@
   %section
 
   .row
-    .span8#app-list
+    .span6#app-list
       %h2 Applications
       - @domain.applications.each do |application|
         = render :partial => 'applications/application2', :locals => {:application => application}
 
-    .span4.sidebar
+    .span6.sidebar
       %h2 Settings
       - if @domain.owner?
         - field = 'domain[allowed_gear_sizes][]'

--- a/console/app/views/members/_members_form.html.haml
+++ b/console/app/views/members/_members_form.html.haml
@@ -31,13 +31,19 @@
   .members tr.error-row td   { padding-top: 0px; }
   .members tr.error-row td p { margin-top: 0; }
   .members tr.template {display: none !important; }
-
+  .members tr.no-role select, .members tr.no-role a.remove-member { opacity: .4; }
+  .members tr.collapsed { display: none; }
+  .members tr.team-details td { white-space: wrap; overflow: hidden; text-overflow: ellipsis; padding-left: 32px; }
+  
   .members .edit-only { display: none; }
   .members.editing .edit-only { display: block; }
   .members.editing tr.edit-only { display: table-row; }
   .members.editing .read-only { display: none; }
 
   .hidden-scripted { display: none; }
+
+  .type-user .icon-user {opacity: .6;}
+
 
 %noscript
   :css
@@ -47,7 +53,12 @@
     .members .edit-only { display: block; }
     .members tr.edit-only { display: table-row; }
     .members .read-only { display: none; }
+    .members tr.no-role select, .members tr.no-role a.remove-member { opacity: 1; }
+    .members tr.collapsed { display: table-row; }
 
+
+- owner = members.find(&:owner)
+- explicit_members = members.reject(&:owner).select(&:explicit_role?).sort
 - if not editable
   .members
     %table.table.table-condensed.table-fixed
@@ -55,23 +66,29 @@
         %col{:width => "50%"}
         %col{:width => "50%"}
 
-      %tr
-        - owner = members.find(&:owner)
-        %td.nowrap.member{:title => owner.name}
-          = owner.name
-        %td Owner
-
-      - members.reject(&:owner).sort.each do |member|
+      - if owner
         %tr
+          %td.nowrap.member{:title => owner.name}
+            %span{:'aria-hidden' => "true", :class => "icon-user"}
+            = owner.name
+          %td Owner
+
+      - explicit_members.each do |member|
+        %tr{:class => "type-#{member.type}"}
           %td.nowrap.member{:title => member.name}
-            = member.name
+            - if member.team?
+              %span{:'aria-hidden' => "true", :class => "icon-users"}
+              = member.name
+            - else
+              %span{:'aria-hidden' => "true", :class => "icon-user"}
+              = member.name
           %td
             = Role.description_for(member.role)
 
 - else
   - if members.count <= 1 && !editing
     %p{:'data-hide-parent' => '1'}
-      No one else can see this domain. #{link_to "Add members...", "javascript:;", :'data-unhide' => '.members'}
+      No one else can see this domain. #{link_to "Add users...", "javascript:;", :'data-unhide' => '.members'}
 
   = form_tag domain_members_path(domain), :method => :put, :class => "members warn-dirty #{'editing' if editing || members.count <= 1} #{'hidden-scripted' if !editing && members.count <= 1} #{'dirty' if new_members.present?}" do
 
@@ -81,28 +98,51 @@
         %col{:width => "45%"}
         %col.script-only{:width => "30"}
 
-      %tr
-        - owner = members.find(&:owner)
-        %td.nowrap.member{:title => owner.name}
-          = owner.name
-        %td Owner
-        %td.script-only
-
-      - members.reject(&:owner).sort.each do |member|
+      - if owner
         %tr
+          %td.nowrap.member{:title => owner.name}
+            %span{:'aria-hidden' => "true", :class => "icon-user"}
+            = owner.name
+          %td Owner
+          %td.script-only
+
+      - explicit_members.each do |member|
+        - member_teams = member.teams(members)
+        %tr{:class => "type-#{member.type}"}
           %td.nowrap.member{:title => member.name}
-            = member.name
+            - if member.team?
+              %span{:'aria-hidden' => "true", :class => "icon-users"}
+              = link_to member.name, "javascript:;", {'data-target' => "#team-#{member.id}", 'data-toggle' => 'team'}
+            - else
+              %span{:'aria-hidden' => "true", :class => "icon-user"}
+              = member.name
           %td.nowrap
-            .read-only= Role.description_for(member.role)
+            .read-only
+              - if member.explicit_role == member.role
+                = Role.description_for(member.role)
+              - elsif member_teams.present?
+                = Role.description_for(member.role)
+                via 
+                %span{:'aria-hidden' => "true", :class => "icon-users", :title => "Has access via these teams:\n#{member_teams.map(&:name).join(", \n")}"}
+              - else
+                = Role.description_for(member.role)
             .edit-only
               -# Always start with a common field to make param hashes group correctly
-              = hidden_field_tag('members[][x]', 0)
+              = hidden_field_tag('members[][type]', member.type)
               = hidden_field_tag('members[][id]', member.id)
-              = select_tag('members[][role]', options_for_select(Role.role_descriptions(true), {:selected => member.role}))
+              = select_tag('members[][role]', options_for_select(Role.role_descriptions(true, member_teams.present?), {:selected => member.explicit_role || :none}))
           %td.script-only
             .edit-only
               = link_to('javascript:;', :class => 'remove-member btn btn-mini') do
                 %span.icon-remove{'aria-hidden'=>"true"}
+        - if member.team?
+          %tr.team-details.collapsed{:id => "team-#{member.id}"}
+            %td{:colspan => 3}
+              - if (team_members = members.select {|m| m.grant_from?('team', member.id)}).present?
+                Team members: 
+                = team_members.map(&:name).to_sentence
+              - else
+                No team members
 
       - new_members = (new_members || []).dup
       - new_members << Domain::Member.new(:role => :edit) if new_members.blank? and members.count == 1
@@ -112,7 +152,7 @@
         %tr.edit-only.control-group{:class => "#{'error' if error} #{'template' if new_member.equal?(template)}"}
           %td
             -# Always start with a common field to make param hashes group correctly
-            = hidden_field_tag('members[][x]', 0)
+            = hidden_field_tag('members[][type]', 'user')
             = text_field_tag('members[][login]', new_member.login, {:placeholder => 'User Login', :title => 'User Login', :autocomplete => 'off', :class => ('error' if error)})
           %td
             = select_tag('members[][role]', options_for_select(Role.role_descriptions(false), new_member.role))
@@ -127,7 +167,7 @@
       %tr.borderless
         %td{:colspan => 3}
           .form-actions.edit-only
-            = link_to 'Add another member...', 'javascript:;', :class => 'add-member'
+            = link_to 'Add another user...', 'javascript:;', :class => 'add-member'
           .form-actions.read-only.script-only
             = link_to "Edit members...", "javascript:;", :class => 'edit-members'
 
@@ -157,7 +197,7 @@
         $('.members').find('select').change(function() {
           var $this = $(this);
           var $tr = $this.closest('tr');
-          $tr.css({opacity: ($this.val() == 'none') ? ".4":"1"});
+          $tr.toggleClass("no-role", $this.val() == 'none');
         }).on('keypress', function(){
           var $this = $(this);
           var was = $this.val();
@@ -188,5 +228,15 @@
           setTimeout(function() {
             $members.find('input[type=text]:visible').first().focus();
           }, 1);
+        });
+
+        $("[data-toggle=team]").click(function(){
+          var target = $(this).data("target");
+          console.log(target);
+          if (target) {
+            var $target = $(target);
+            console.log($target);
+            $target.toggleClass("collapsed");
+          }
         });
       });

--- a/console/test/functional/domains_controller_test.rb
+++ b/console/test/functional/domains_controller_test.rb
@@ -294,6 +294,7 @@ class DomainsControllerTest < ActionController::TestCase
     assert_response :success
     assert_select "tr.type-team"
     assert_select "tr.type-user", :count => 0
+    assert_select "tr.team-details td:content(?)", /alice/
     assert_select "a:content(?)", "Add users...", :count => 0
     assert_select "a:content(?)", "Add another user..."
     assert_select "a.edit-members:content(?)", "Edit members..."
@@ -317,6 +318,7 @@ class DomainsControllerTest < ActionController::TestCase
     assert_response :success
     assert_select "tr.type-team"
     assert_select "tr.type-team select[name='members[][role]'] option[selected='selected'][value='edit']"
+    assert_select "tr.team-details td:content(?)", /alice/
 
     assert_select "tr.type-user", :count => 2
     # Ensure the explicit role is the one pre-selected in the dropdown for the user


### PR DESCRIPTION
Add member type to API calls
Add indicators for teams
Only show explicit members in UI
Show team members within collapsed section
