### PR TITLE
Limit initial build client output to 10Kb

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
@@ -83,7 +83,7 @@ module OpenShift
 
           if perform_initial_build
             pattern   = Utils::Sdk::CLIENT_OUTPUT_PREFIXES.join('|')
-            out, _, _ = Utils.oo_spawn("grep -E '#{pattern}' #{build_log}",
+            out, _, _ = Utils.oo_spawn("grep -E '#{pattern}' #{build_log} | head -c 10K",
                                       env:                 env,
                                       chdir:               @container_dir,
                                       uid:                 @uid,

--- a/node/test/unit/build_lifecycle_test.rb
+++ b/node/test/unit/build_lifecycle_test.rb
@@ -701,7 +701,7 @@ class BuildLifecycleTest < OpenShift::NodeTestCase
 
     @cartridge_model.expects(:post_configure).with(cart_name).returns('')
     pattern = OpenShift::Runtime::Utils::Sdk::CLIENT_OUTPUT_PREFIXES.join('|')
-    OpenShift::Runtime::Utils.expects(:oo_spawn).with("grep -E '#{pattern}' /tmp/initial-build.log",
+    OpenShift::Runtime::Utils.expects(:oo_spawn).with("grep -E '#{pattern}' /tmp/initial-build.log | head -c 10K",
                                                       env:                 gear_env,
                                                       chdir:               @container.container_dir,
                                                       uid:                 @container.uid,
@@ -744,7 +744,7 @@ class BuildLifecycleTest < OpenShift::NodeTestCase
     @cartridge_model.expects(:post_configure).with(cart_name).returns('')
 
     pattern = OpenShift::Runtime::Utils::Sdk::CLIENT_OUTPUT_PREFIXES.join('|')
-    OpenShift::Runtime::Utils.expects(:oo_spawn).with("grep -E '#{pattern}' /tmp/initial-build.log",
+    OpenShift::Runtime::Utils.expects(:oo_spawn).with("grep -E '#{pattern}' /tmp/initial-build.log | head -c 10K",
                                                       env:                 gear_env,
                                                       chdir:               @container.container_dir,
                                                       uid:                 @container.uid,


### PR DESCRIPTION
Following an Initial-Build, limit the capture of client_message
data to 10Kb.
