### PR TITLE
correct typo of depricated to deprecated

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/setup
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/setup
@@ -34,7 +34,7 @@ then
     popd >/dev/null
 	fi
 else
-	client_message "The settings.py was depricated, please check your 10gen-mms-agent cartridge documentation at http://openshift.github.io/documentation/oo_cartridge_guide.html#10gen-mms-agent"
+	client_message "The settings.py was deprecated, please check your 10gen-mms-agent cartridge documentation at http://openshift.github.io/documentation/oo_cartridge_guide.html#10gen-mms-agent"
   shopt -s dotglob
   pushd "$OPENSHIFT_10GENMMSAGENT_DIR" > /dev/null
   cp -r /usr/local/share/mms-agent/* $OPENSHIFT_10GENMMSAGENT_DIR/mms-agent/


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1079295 Add mms-agent to gear with
old settings.py, check the warning message, typo in it.

The settings.py was depricated, please check your 10gen-mms-agent cartridge
documentation at 
http://openshift.github.io/documentation/oo_cartridge_guide.html#10gen-mms-agent
