### PR TITLE
Remove excessive grep invocations from oo-scheduled-jobs

### DIFF
--- a/node/misc/bin/oo-scheduled-jobs
+++ b/node/misc/bin/oo-scheduled-jobs
@@ -8,6 +8,7 @@ DOP=5  # Degree of Parallelism.
 
 
 CART_DIRNAME="cron"
+CART_IDENT_NAME="OPENSHIFT_CRON_IDENT"
 IDENT="redhat:cron"
 
 function usage() {
@@ -33,8 +34,11 @@ function daemon_as_user {
 function openshift_origin_cron_users() {
     cron_users=""
     for u in `openshift_origin_users`; do
-        if grep $IDENT $GEAR_BASE_DIR/$u/$CART_DIRNAME/env/OPENSHIFT_*_IDENT; then
-          cron_users="$cron_users $u"
+        if [ -f $GEAR_BASE_DIR/$u/$CART_DIRNAME/env/$CART_IDENT_NAME ] ; then
+            read line < $GEAR_BASE_DIR/$u/$CART_DIRNAME/env/$CART_IDENT_NAME
+            if [[ $line == *$IDENT* ]]; then
+                cron_users="$cron_users $u"
+            fi
         fi
     done
     echo -n "$cron_users"

--- a/node/misc/bin/oo-scheduled-jobs
+++ b/node/misc/bin/oo-scheduled-jobs
@@ -36,7 +36,7 @@ function openshift_origin_cron_users() {
     for u in `openshift_origin_users`; do
         if [ -f $GEAR_BASE_DIR/$u/$CART_DIRNAME/env/$CART_IDENT_NAME ] ; then
             read line < $GEAR_BASE_DIR/$u/$CART_DIRNAME/env/$CART_IDENT_NAME
-            if [[ $line == *$IDENT* ]]; then
+            if [[ $line == $IDENT* ]]; then
                 cron_users="$cron_users $u"
             fi
         fi


### PR DESCRIPTION
A recent change to oo-scheduled-jobs for BZ 1065045 introduced an invocation of grep for every gear on a node.  This is a performance problem for the minutely cron entry, and this patch provides an alternate solution.  In my tests, the elapsed time for the old code was more than 3 seconds, while the new code ran in 0.13 seconds.
