### PR TITLE
Set umask when starting Passenger/httpd

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -37,7 +37,7 @@ function start() {
     write_httpd_passenv $HTTPD_PASSENV_FILE
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     update_passenger_performance
-    ruby_context "RAILS_ENV=${RAILS_ENV:-production} nohup /usr/sbin/httpd $HTTPD_CMD_CONF -D FOREGROUND |& /usr/bin/logshifter -tag ruby &"
+    ruby_context "umask 002 &>/dev/null ; RAILS_ENV=${RAILS_ENV:-production} nohup /usr/sbin/httpd $HTTPD_CMD_CONF -D FOREGROUND |& /usr/bin/logshifter -tag ruby &"
     [ "$?" == "0" ] && wait_for_pid_file $HTTPD_PID_FILE
 }
 


### PR DESCRIPTION
Explicitly set umask 002 when starting Passenger/httpd. This ensures
the correct tmp directory permissions are used when Passenger creates
new directories in response to shutdown and restart signals.

Resolve bugs:
- https://bugzilla.redhat.com/show_bug.cgi?id=1080397
- https://bugzilla.redhat.com/show_bug.cgi?id=1080357
