### PR TITLE
Incorrect log file name in the output when threaddump jbossews app.

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossews/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/control
@@ -10,7 +10,7 @@ then
     exit 1
 fi
 
-source ${OPENSHIFT_JBOSSEWS_DIR}/bin/util
+cartridge_type="jbossews"
 
 JBOSS_PID_FILE="${OPENSHIFT_JBOSSEWS_DIR}/run/jboss.pid"
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1080417 When threaddump jbossews,
incorrect file name show: Success The thread dump file will be available via:
rhc tail ews -g 533169e2da83ddca91000297 -f
/var/lib/openshift/533169e2da83ddca91000297/app-root/logs/.log -o '-n 250'
