### PR TITLE
Report lingering httpd procs following graceful shutdown

### DIFF
--- a/cartridges/openshift-origin-cartridge-perl/bin/control
+++ b/cartridges/openshift-origin-cartridge-perl/bin/control
@@ -33,9 +33,7 @@ function stop() {
   echo "Stopping Perl cartridge"
   ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
   if [ -f "$HTTPD_PID_FILE" ]; then
-    httpd_pid=`cat "$HTTPD_PID_FILE" 2> /dev/null`
-    kill -WINCH $httpd_pid
-    wait_for_stop $httpd_pid
+    shutdown_httpd_graceful_pidfile $HTTPD_PID_FILE
   fi
 }
 

--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -60,8 +60,7 @@ function stop() {
     if [ -f "$HTTPD_PID_FILE" ]; then
       # If we still have a PID file, then ensure_valid_httpd_process's call to
       # killall_httpds didn't happen.
-      httpd_pid=`cat "$HTTPD_PID_FILE" 2> /dev/null`
-      kill -WINCH $httpd_pid && wait_for_stop $httpd_pid
+      shutdown_httpd_graceful_pidfile $HTTPD_PID_FILE
     fi
 }
 

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/bin/control
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/bin/control
@@ -25,9 +25,7 @@ function stop {
   echo "Stopping PHPMyAdmin cartridge"
   ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
   if [ -f "$HTTPD_PID_FILE" ]; then
-      httpd_pid=`cat "$HTTPD_PID_FILE" 2> /dev/null`
-      kill -WINCH $httpd_pid
-      wait_for_stop $httpd_pid
+      shutdown_httpd_graceful_pidfile $HTTPD_PID_FILE
   fi
 }
 

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
@@ -22,7 +22,7 @@ export APPDIR=$OPENSHIFT_PYTHON_DIR
 function start_app() {
     echo "Starting Python ${OPENSHIFT_PYTHON_VERSION} cartridge (app.py server)"
     cd "$OPENSHIFT_REPO_DIR"
-    nohup python -u app.py |& /usr/bin/logshifter -tag python &
+    nohup python -u app.py &> >(/usr/bin/logshifter -tag python) &
     echo $! > $OPENSHIFT_PYTHON_DIR/run/appserver.pid
 }
 
@@ -67,8 +67,7 @@ function stop_app() {
 function stop_apache() {
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     if [ -f "$HTTPD_PID_FILE" ]; then
-        httpd_pid=`cat "$HTTPD_PID_FILE" 2> /dev/null`
-        kill -WINCH $httpd_pid && wait_for_stop $httpd_pid
+        shutdown_httpd_graceful_pidfile $HTTPD_PID_FILE
     fi
 }
 

--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -51,9 +51,7 @@ function stop() {
     echo "Stopping Ruby cartridge"
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     if [ -f "$HTTPD_PID_FILE" ]; then
-        httpd_pid=`cat "$HTTPD_PID_FILE" 2> /dev/null`
-        kill -WINCH $httpd_pid
-        wait_for_stop $httpd_pid
+      shutdown_httpd_graceful_pidfile $HTTPD_PID_FILE
     fi
 }
 
@@ -90,7 +88,7 @@ function pre-repo-archive() {
 
   # Backup .bundle and vendor unless force_clean_build
   if ! force_clean_build_enabled_for_latest_deployment \
-    && [ -d ${OPENSHIFT_REPO_DIR}.bundle ]                                   \
+    && [ -d ${OPENSHIFT_REPO_DIR}.bundle ] \
     && [ -d ${OPENSHIFT_REPO_DIR}vendor/bundle ]
   then
     echo 'Saving away previously bundled RubyGems'

--- a/node/misc/usr/lib/cartridge_sdk/bash/sdk
+++ b/node/misc/usr/lib/cartridge_sdk/bash/sdk
@@ -440,6 +440,31 @@ function has_web_proxy() {
     return 1
 }
 
+function shutdown_httpd_graceful_pidfile {
+  local pidfile=$1
+  local pid=$(cat ${pidfile} 2> /dev/null)
+  shutdown_httpd_graceful ${pid}
+}
+
+function shutdown_httpd_graceful {
+  local pid=$1
+
+  kill -WINCH ${pid}
+  wait_for_stop ${pid}
+
+  if $(ps --pid ${pid} > /dev/null 2>&1); then
+    local msg=$(cat <<EOF
+Warning: Apache has not yet exited in response to a graceful
+shutdown. This usually means Apache is still waiting for
+outstanding requests to complete, and shutdown will proceed
+once those requests finish. To force an immediate shutdown
+and cancel any outstanding requests, use force-stop.
+EOF
+    )
+    client_message "${msg}"
+  fi
+}
+
 
 # Wrapper for the OpenShift Ruby SDK
 #


### PR DESCRIPTION
When doing a graceful httpd shutdown, detect and report any
lingering httpd processes that remain.

Resolve bug: https://bugzilla.redhat.com/show_bug.cgi?id=1080465
