### PR TITLE
MySQL table_open_cache size unusually small

### DIFF
--- a/cartridges/openshift-origin-cartridge-mariadb/conf/my.cnf.erb
+++ b/cartridges/openshift-origin-cartridge-mariadb/conf/my.cnf.erb
@@ -14,7 +14,7 @@ bind-address=<%= ENV['OPENSHIFT_MARIADB_DB_HOST'] %>
 symbolic-links=0
 key_buffer_size = 16K
 max_allowed_packet = 200M
-table_open_cache = 4
+table_open_cache = <%= ENV['OPENSHIFT_MARIADB_TABLE_OPEN_CACHE'] ? ENV['OPENSHIFT_MARIADB_TABLE_OPEN_CACHE'] : '4' %>
 sort_buffer_size = 128K
 read_buffer_size = 256K
 read_rnd_buffer_size = 256K

--- a/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb
+++ b/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb
@@ -19,7 +19,7 @@ bind-address=<%= ENV['OPENSHIFT_MYSQL_DB_HOST'] %>
 symbolic-links=0
 key_buffer_size = <%= ENV['OPENSHIFT_APP_DNS'] == ENV['OPENSHIFT_GEAR_DNS'] ? '32' : (ENV['OPENSHIFT_GEAR_MEMORY_MB'].to_i * 0.1).to_i %>M
 max_allowed_packet = 200M
-table_open_cache = 4
+table_open_cache = <%= ENV['OPENSHIFT_MYSQL_TABLE_OPEN_CACHE'] ? ENV['OPENSHIFT_MYSQL_TABLE_OPEN_CACHE'] : '4' %>
 sort_buffer_size = 128K
 read_buffer_size = <%= ENV['OPENSHIFT_APP_DNS'] == ENV['OPENSHIFT_GEAR_DNS'] ? '8' : (ENV['OPENSHIFT_GEAR_MEMORY_MB'].to_i * 0.05).to_i %>M
 read_rnd_buffer_size = 256K


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1080547 Users do not have the
ability to change table_open_cache to values other than 4 (and have them
stick).  The set value seems too low to allow database operations to remain
efficient.  For example, in my app I have 18 tables that are constantly being
written to from a single persistent connection, but can only have four tables
cached at a time.  This leads to tables having to be re-opened which causes
fairly significant disk I/O.
