### PR TITLE
node spec: add rubygem(json)

### DIFF
--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -36,6 +36,9 @@ Requires:      %{?scl:%scl_prefix}rubygem(parallel)
 # non-scl open4 required for ruby 1.8 cartridge
 # Also see related bugs 924556 and 912215
 Requires:      rubygem(open4)
+# non-scl json required for oo-cgroup-read
+# Also see related bugs 924556 and 912215
+Requires:      rubygem(json)
 %endif
 Requires:      %{?scl:%scl_prefix}rubygem(parseconfig)
 Requires:      %{?scl:%scl_prefix}rubygem(safe_yaml)


### PR DESCRIPTION
Bug 1077077

`oo-cgroup-read` needs rubygem-json to run (see related bugs 924556 and
912215)

Cherry-pick to backport fix from https://github.com/openshift/enterprise-server/commit/1cf89024a9d77ad1daee3cf05f765a5e3865f090
