### PR TITLE
cron/mongo logs does not get cleaned via rhc app-tidy

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/control
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/control
@@ -93,6 +93,11 @@ function reload() {
     restart
 }
 
+function tidy() {
+  client_message "Emptying 10gen-mms-agent logs in dir: $OPENSHIFT_LOG_DIR"
+  shopt -s dotglob
+  rm -rf $OPENSHIFT_LOG_DIR/10gen-mms-agent.log*
+}
 
 case "$1" in
   start)      start ;;
@@ -100,5 +105,6 @@ case "$1" in
   restart)    restart ;;
   status)     status ;;
   reload)     reload ;;
+  tidy)      tidy ;;
   *)          exit 0
 esac

--- a/cartridges/openshift-origin-cartridge-cron/bin/control
+++ b/cartridges/openshift-origin-cartridge-cron/bin/control
@@ -65,6 +65,12 @@ function status() {
    fi
 }
 
+function tidy() {
+  client_message "Emptying cron logs in dir: $OPENSHIFT_LOG_DIR"
+  shopt -s dotglob
+  rm -rf $OPENSHIFT_LOG_DIR/cron_*
+}
+
 case "$1" in
   start)     start ;;
   stop)      stop ;;

--- a/cartridges/openshift-origin-cartridge-haproxy/bin/control
+++ b/cartridges/openshift-origin-cartridge-haproxy/bin/control
@@ -294,6 +294,12 @@ function update-cluster() {
     ${OPENSHIFT_HAPROXY_DIR}/usr/bin/update-cluster "$@"
 }
 
+function tidy() {
+    client_message "Emptying haproxy logs in dir: $OPENSHIFT_LOG_DIR"
+    shopt -s dotglob
+    rm -rf $OPENSHIFT_LOG_DIR/haproxy.log*
+}
+
 #
 # main():
 #
@@ -315,4 +321,5 @@ case "$1" in
     disable-server) disable-server "$@" ;;
     enable-server)  enable-server  "$@" ;;
     update-cluster) update-cluster "$@" ;;
+    tidy)      tidy ;;
 esac

--- a/cartridges/openshift-origin-cartridge-mariadb/bin/control
+++ b/cartridges/openshift-origin-cartridge-mariadb/bin/control
@@ -222,6 +222,14 @@ function cleanup_dump {
   rm -f $OPENSHIFT_DATA_DIR/mariadb_db_dbname
 }
 
+# Clean up any log files
+
+function tidy() {
+  client_message "Deleting mariadb logs from $OPENSHIFT_LOG_DIR"
+  shopt -s dotglob
+  rm -rf $OPENSHIFT_LOG_DIR/mariadb.log*
+}
+  
 case "$1" in
   start)
     start
@@ -248,5 +256,6 @@ case "$1" in
   post-restore)
     post_restore
   ;;
+  tidy)          tidy ;;
 esac
 

--- a/cartridges/openshift-origin-cartridge-mongodb/bin/control
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/control
@@ -247,6 +247,13 @@ function post_restore {
     fi
 }
 
+# Clean up any log files
+function tidy() {
+  client_message "Deleting mongodb logs from $OPENSHIFT_LOG_DIR"
+  shopt -s dotglob
+  rm -rf $OPENSHIFT_LOG_DIR/mongodb.log*
+}
+
 case "$1" in
     start)
         start
@@ -282,4 +289,5 @@ case "$1" in
     post-restore)
         post_restore
     ;;
+    tidy)      tidy ;;
 esac

--- a/cartridges/openshift-origin-cartridge-mysql/bin/control
+++ b/cartridges/openshift-origin-cartridge-mysql/bin/control
@@ -233,6 +233,13 @@ function cleanup_dump {
   rm -f $OPENSHIFT_DATA_DIR/mysql_db_dbname
 }
 
+# Clean up any log files
+function tidy() {
+  client_message "Deleting mysql logs from $OPENSHIFT_LOG_DIR"
+  shopt -s dotglob
+  rm -rf $OPENSHIFT_LOG_DIR/mysql.log*
+}
+
 case "$1" in
   start)
     start
@@ -259,4 +266,5 @@ case "$1" in
   post-restore)
     post_restore
   ;;
+  tidy)          tidy ;;
 esac


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1080967 Try to clean logs via rhc
app-tidy, cron and mongo logs are not cleaned.
