### PR TITLE
Check for pid existence in graceful shutdown func

### DIFF
--- a/node/misc/usr/lib/cartridge_sdk/bash/sdk
+++ b/node/misc/usr/lib/cartridge_sdk/bash/sdk
@@ -449,6 +449,9 @@ function shutdown_httpd_graceful_pidfile {
 function shutdown_httpd_graceful {
   local pid=$1
 
+  # if the pid doesn't exist, there's nothing to do
+  [ ! $(ps --pid ${pid} > /dev/null 2>&1) ] && return
+
   kill -WINCH ${pid}
   wait_for_stop ${pid}
 


### PR DESCRIPTION
Check for the existence of the given pid before trying to
perform commands on it during graceful shutdowns.

Resolve bug https://bugzilla.redhat.com/show_bug.cgi?id=1081020
