### PR TITLE
Empty postgres.pid file is still existing in gear after stop

### DIFF
--- a/cartridges/openshift-origin-cartridge-postgresql/bin/control
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/control
@@ -50,7 +50,7 @@ function stop {
       error "Could not stop Postgres" 70
     else
       echo "Stopping Postgres cartridge"
-      truncate -s0 $OPENSHIFT_POSTGRESQL_DB_PID
+      rm $OPENSHIFT_POSTGRESQL_DB_PID
     fi
   else
     echo "Postgres already stopped"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1080822 Create one app(e.g.,
myphp53), embedded with postgresql-8.4/9.2, stop postgresql db cartridge,
found postgresql/pid/postgres.pid still existing in rhcsh and even though
prompts "Stopping postgresql-8.4 ... done"
