### PR TITLE
util: add nodejs context for bundle exec call

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/lib/util
+++ b/cartridges/openshift-origin-cartridge-ruby/lib/util
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Utility functions for use in the cartridge scripts.
 
+# BZ 1030873 - need nodejs context for bundle exec
+source "${OPENSHIFT_RUBY_DIR}/lib/ruby_context"
+
 function ruby_in_development_mode {
   if [ "$RAILS_ENV" == "development" ]; then
     return 0
@@ -132,7 +135,7 @@ function has_assets {
   [ ! -f Rakefile ] && return 1
   ! grep " rails " Gemfile.lock >/dev/null && return 1
   ! grep " execjs " Gemfile.lock >/dev/null && return 1
-  ! bundle exec "rake -T" | grep "assets:precompile" >/dev/null && return 1
+  ! ruby_with_nodejs_context "bundle exec 'rake -T'" | grep "assets:precompile" >/dev/null && return 1
 
   return 0
 }


### PR DESCRIPTION
Bug 1030873
https://bugzilla.redhat.com/show_bug.cgi?id=1030873

NodeJS needs to be available for `bundle exec` call in `ruby/lib/util`
since it triggers asset compilation

See also:
- https://github.com/openshift/rails-example/commit/07d01120b308f415416a78d0bd7e9bd339d9ead3
- https://github.com/openshift/origin-server/commit/608c94857d26dd3242928c91fd30097b3775896b

Thanks to @jianlinliu for the tip.
