### PR TITLE
Ensure modified confs are replaced during upgrades

### DIFF
--- a/cartridges/openshift-origin-cartridge-phpmyadmin/bin/install
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/bin/install
@@ -14,9 +14,6 @@ case "$1" in
 esac
 
 echo "$version" > "$OPENSHIFT_PHPMYADMIN_DIR/env/OPENSHIFT_PHPMYADMIN_VERSION"
-cp -r ${OPENSHIFT_PHPMYADMIN_DIR}/versions/$version/conf/* ${OPENSHIFT_PHPMYADMIN_DIR}/conf/
-cp -r ${OPENSHIFT_PHPMYADMIN_DIR}/versions/$version/conf.d/* ${OPENSHIFT_PHPMYADMIN_DIR}/conf.d/
-cp -r ${OPENSHIFT_PHPMYADMIN_DIR}/versions/$version/phpMyAdmin/* ${OPENSHIFT_PHPMYADMIN_DIR}/phpMyAdmin/
 
 ln -s ${_libdir}/httpd/modules ${OPENSHIFT_PHPMYADMIN_DIR}modules
 ln -s /etc/httpd/conf/magic ${OPENSHIFT_PHPMYADMIN_DIR}conf/magic

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/bin/setup
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/bin/setup
@@ -1,6 +1,15 @@
 #!/bin/bash -e
 
+case "$1" in
+  -v|--version)
+    version="$2"
+esac
+
 # Create/truncate Apache PassEnv configuration file
 echo > $OPENSHIFT_PHPMYADMIN_DIR/conf.d/passenv.conf
 
 mkdir -p $OPENSHIFT_PHPMYADMIN_DIR/{run,sessions,tmp,conf,conf.d}
+
+cp -r ${OPENSHIFT_PHPMYADMIN_DIR}/versions/$version/conf/* ${OPENSHIFT_PHPMYADMIN_DIR}/conf/
+cp -r ${OPENSHIFT_PHPMYADMIN_DIR}/versions/$version/conf.d/* ${OPENSHIFT_PHPMYADMIN_DIR}/conf.d/
+cp -r ${OPENSHIFT_PHPMYADMIN_DIR}/versions/$version/phpMyAdmin/* ${OPENSHIFT_PHPMYADMIN_DIR}/phpMyAdmin/


### PR DESCRIPTION
Version specific ERB files should be copied during setup rather
than install; otherwise, new conf files will never be copied
to the live cartridge conf directory during upgrades (as install
is only called once during the life of the cart, whereas setup
is invoked during install/upgrades but prior to ERB processing).

Resolve bug: https://bugzilla.redhat.com/show_bug.cgi?id=1080836
