### PR TITLE
Update Cartridge Versions for Stage Cut

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/metadata/manifest.yml
@@ -6,12 +6,8 @@ Description: MongoDB Monitoring Service (MMS) instruments MongoDB and provides i
   about current and historical operational metrics of your system.
 Version: '0.1'
 License-Url: https://mms.mongodb.com/links/terms-of-service
-Cartridge-Version: 0.0.5
-Compatible-Versions:
-- 0.0.1
-- 0.0.2
-- 0.0.3
-- 0.0.4
+Cartridge-Version: 0.0.6
+Compatible-Versions: []
 Cartridge-Vendor: redhat
 Vendor: 10gen.com
 Categories:

--- a/cartridges/openshift-origin-cartridge-cron/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-cron/metadata/manifest.yml
@@ -10,16 +10,8 @@ Description: The Cron cartridge allows you to run command line programs at sched
 License: ASL 2.0
 License-Url: http://www.apache.org/licenses/LICENSE-2.0.txt
 Website: http://www.openshift.com/
-Cartridge-Version: 0.0.11
-Compatible-Versions:
-- 0.0.3
-- 0.0.4
-- 0.0.5
-- 0.0.6
-- 0.0.7
-- 0.0.8
-- 0.0.9
-- 0.0.10
+Cartridge-Version: 0.0.12
+Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:
 - embedded

--- a/cartridges/openshift-origin-cartridge-diy/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-diy/metadata/manifest.yml
@@ -8,16 +8,8 @@ Description: The Do-It-Yourself (DIY) application type is a blank slate for tryi
 Version: '0.1'
 License: ASL 2.0
 License-Url: http://www.apache.org/licenses/LICENSE-2.0.txt
-Cartridge-Version: 0.0.9
-Compatible-Versions:
-- 0.0.1
-- 0.0.2
-- 0.0.3
-- 0.0.4
-- 0.0.5
-- 0.0.6
-- 0.0.7
-- 0.0.8
+Cartridge-Version: 0.0.10
+Compatible-Versions: []
 Cartridge-Vendor: redhat
 Vendor: redhat
 Categories:

--- a/cartridges/openshift-origin-cartridge-haproxy/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-haproxy/metadata/manifest.yml
@@ -10,10 +10,8 @@ Version: '1.4'
 License: GPLv2+
 License-Url: http://www.gnu.org/licenses/gpl-2.0.html
 Vendor: http://haproxy.1wt.eu/
-Cartridge-Version: 0.0.13
-Compatible-Versions:
-- 0.0.11
-- 0.0.12
+Cartridge-Version: 0.0.14
+Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:
 - web_proxy

--- a/cartridges/openshift-origin-cartridge-jbossas/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jbossas/metadata/manifest.yml
@@ -8,7 +8,7 @@ Version: '7'
 License: LGPL
 License-Url: http://www.gnu.org/copyleft/lesser.txt
 Vendor: Red Hat
-Cartridge-Version: 0.0.13
+Cartridge-Version: 0.0.14
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:

--- a/cartridges/openshift-origin-cartridge-jbosseap/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jbosseap/metadata/manifest.yml
@@ -9,7 +9,7 @@ Version: '6'
 License: LGPL
 License-Url: http://www.gnu.org/copyleft/lesser.txt
 Vendor: Red Hat
-Cartridge-Version: 0.0.12
+Cartridge-Version: 0.0.13
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:

--- a/cartridges/openshift-origin-cartridge-jbossews/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jbossews/metadata/manifest.yml
@@ -2,9 +2,8 @@
 Name: jbossews
 Cartridge-Short-Name: JBOSSEWS
 Cartridge-Vendor: redhat
-Cartridge-Version: 0.0.13
-Compatible-Versions:
-- 0.0.12
+Cartridge-Version: 0.0.14
+Compatible-Versions: []
 Display-Name: Tomcat 7 (JBoss EWS 2.0)
 Description: JBoss Enterprise Web Server is the enterprise-class Java web container
   for large-scale lightweight web applications based on Tomcat 7. Build and deploy

--- a/cartridges/openshift-origin-cartridge-jenkins/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jenkins/metadata/manifest.yml
@@ -9,7 +9,7 @@ Description: Jenkins is a continuous integration (CI) build server that is deepl
 Version: '1'
 License: MIT license
 License-Url: https://jenkins-ci.org/mit-license
-Cartridge-Version: 0.0.9
+Cartridge-Version: 0.0.10
 Cartridge-Vendor: redhat
 Categories:
 - web_framework
@@ -52,5 +52,4 @@ Endpoints:
 Scaling:
   Min: 1
   Max: 1
-Compatible-Versions:
-- 0.0.8
+Compatible-Versions: []

--- a/cartridges/openshift-origin-cartridge-mariadb/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mariadb/metadata/manifest.yml
@@ -7,7 +7,7 @@ Description: MariaDB is a multi-user, multi-threaded SQL database server.
 Version: '5.5'
 Versions:
 - '5.5'
-Cartridge-Version: 0.2.6
+Cartridge-Version: 0.2.7
 Cartridge-Vendor: redhat
 License: GPL
 Vendor: MariaDB Foundation

--- a/cartridges/openshift-origin-cartridge-mongodb/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mongodb/metadata/manifest.yml
@@ -7,13 +7,8 @@ Description: MongoDB is a scalable, high-performance, open source NoSQL database
 Version: '2.4'
 Versions:
 - '2.4'
-Cartridge-Version: 0.2.7
-Compatible-Versions:
-- 0.2.2
-- 0.2.3
-- 0.2.4
-- 0.2.5
-- 0.2.6
+Cartridge-Version: 0.2.8
+Compatible-Versions: []
 Cartridge-Vendor: redhat
 License: ASL 2.0
 Vendor: 10gen

--- a/cartridges/openshift-origin-cartridge-mysql/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mysql/metadata/manifest.yml
@@ -8,7 +8,7 @@ Version: '5.5'
 Versions:
 - '5.1'
 - '5.5'
-Cartridge-Version: 0.2.9
+Cartridge-Version: 0.2.10
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 License: GPL

--- a/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-nodejs/metadata/manifest.yml
@@ -13,7 +13,7 @@ License: MIT License
 License-Url: https://raw.github.com/joyent/node/v0.10/LICENSE
 Vendor: www.nodejs.org
 Website: http://www.nodejs.org/
-Cartridge-Version: 0.0.14
+Cartridge-Version: 0.0.15
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:

--- a/cartridges/openshift-origin-cartridge-perl/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-perl/metadata/manifest.yml
@@ -9,10 +9,8 @@ Version: '5.10'
 License: GPL v2
 License-Url: http://dev.perl.org/licenses/
 Vendor: perl.org
-Cartridge-Version: 0.0.11
-Compatible-Versions:
-- 0.0.9
-- 0.0.10
+Cartridge-Version: 0.0.12
+Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:
 - service

--- a/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml
@@ -21,10 +21,8 @@ Version-Overrides:
 License: The PHP License, version 3.0
 License-Url: http://www.php.net/license/3_0.txt
 Vendor: php.net
-Cartridge-Version: 0.0.12
-Compatible-Versions:
-- 0.0.10
-- 0.0.11
+Cartridge-Version: 0.0.13
+Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:
 - service

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/metadata/manifest.yml
@@ -6,7 +6,7 @@ Description: Web based MySQL admin tool. Requires the MySQL cartridge to be inst
 Version: '4'
 License: GPLv2
 Vendor: Red Hat
-Cartridge-Version: 0.0.8
+Cartridge-Version: 0.0.9
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 Website: http://www.phpmyadmin.net/
@@ -45,5 +45,5 @@ Endpoints:
   Protocols:
   - http
   Mappings:
-  - Frontend: "/phpmyadmin"
-    Backend: "/phpmyadmin"
+  - Frontend: /phpmyadmin
+    Backend: /phpmyadmin

--- a/cartridges/openshift-origin-cartridge-postgresql/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-postgresql/metadata/manifest.yml
@@ -2,7 +2,7 @@
 Name: postgresql
 Architecture: noarch
 Cartridge-Short-Name: POSTGRESQL
-Cartridge-Version: 0.3.9
+Cartridge-Version: 0.3.10
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 Display-Name: PostgreSQL 9.2

--- a/cartridges/openshift-origin-cartridge-python/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-python/metadata/manifest.yml
@@ -13,7 +13,7 @@ Versions:
 License: The Python License, version 2.6
 License-Url: http://docs.python.org/3/license.html
 Vendor: python.org
-Cartridge-Version: 0.0.13
+Cartridge-Version: 0.0.14
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:

--- a/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml
@@ -11,7 +11,7 @@ Versions:
 License: Ruby BSDL
 License-Url: http://www.ruby-lang.org/en/about/license.txt
 Vendor: ruby.org
-Cartridge-Version: 0.0.14
+Cartridge-Version: 0.0.15
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:


### PR DESCRIPTION
- Mark all cartridges (except for jenkins-client and switchyard) for incompatible
  upgrade, mainly because of the logshifter code

https://trello.com/c/tvLrlNrM - origin_cartridge_160
