### PR TITLE
Bug 989941: preventing colocation of cartridges that independently scale

### DIFF
--- a/common/lib/openshift-origin-common/models/manifest.rb
+++ b/common/lib/openshift-origin-common/models/manifest.rb
@@ -352,9 +352,8 @@ module OpenShift
           raise InvalidElementError.new('Source-Url') unless @manifest['Source-Url'] =~ URI::ABS_URI
           @source_url = @manifest['Source-Url']
           @source_md5 = @manifest['Source-Md5']
-        else
-          raise MissingElementError.new('Source-Url', 'is required in manifest to obtain cartridge via URL',
-                                        ) if :url == @manifest_path
+        elsif :url == @manifest_path and !(@manifest['Categories'] || []).include?('external')
+          raise MissingElementError.new('Source-Url', 'is required in manifest to obtain cartridge via URL')
         end
 
         @short_name.upcase!


### PR DESCRIPTION
Also, we are skipping the validation for Source-Url in case of "external" cartridges
