### PR TITLE
Switch my.cnf.erb to use innodb_file_per_table.

### DIFF
--- a/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb
+++ b/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb
@@ -45,6 +45,7 @@ innodb_log_file_size = <%= ENV['OPENSHIFT_APP_DNS'] == ENV['OPENSHIFT_GEAR_DNS']
 innodb_log_buffer_size = <%= ENV['OPENSHIFT_APP_DNS'] == ENV['OPENSHIFT_GEAR_DNS'] ? 16 : (ENV['OPENSHIFT_GEAR_MEMORY_MB'].to_i * 0.15).to_i %>M
 innodb_flush_log_at_trx_commit = 1
 innodb_lock_wait_timeout = 50
+innodb_file_per_table = 1
 
 [mysqld_safe]
 pid-file=<%= ENV['OPENSHIFT_MYSQL_DIR'] %>pid/mysql.pid


### PR DESCRIPTION
This prevents users' tablespaces from growing and using the whole gear
quota. Without this option, users will eventually get to a point where
they are out of space, and they must back up, remove the MySQL
cartridge, and then re-add it and restore, which I doubt is the smooth
PaaS experience we want to give them.
