### PR TITLE
Fix raise during initial deployment meta creation

### DIFF
--- a/node/lib/openshift-origin-node/model/deployment_metadata.rb
+++ b/node/lib/openshift-origin-node/model/deployment_metadata.rb
@@ -48,7 +48,7 @@ module OpenShift
       def initialize(container, deployment_datetime)
         @file = PathUtils.join(container.container_dir, 'app-deployments', deployment_datetime, 'metadata.json')
 
-        empty = File.stat(@file).size == 0
+        empty = File.exists?(@file) && File.stat(@file).size == 0
         container.logger.warn("#{@file} was found empty. Will attempt to write defaults") if empty
 
         if File.exists?(@file) && !empty


### PR DESCRIPTION
Add a File.exists? check to prevent File.stat from raising when
no deployment metadata yet exists and allow defaults to be
written.

Resolve bug https://bugzilla.redhat.com/show_bug.cgi?id=1075673
