### PR TITLE
ruby cart: Explicitly req. ruby-rdoc dep for rhel

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/openshift-origin-cartridge-ruby.spec
+++ b/cartridges/openshift-origin-cartridge-ruby/openshift-origin-cartridge-ruby.spec
@@ -25,6 +25,9 @@ Requires:      rubygem-passenger
 Requires:      rubygem-passenger-native
 Requires:      rubygem-passenger-native-libs
 Requires:      rubygems
+# BZ1066246 - specify ruby-rdoc dep explicitly, even though it
+# currently is pulled in by rubygems
+Requires:      ruby-rdoc
 Requires:      rubygem-thread-dump
 Requires:      %{?scl:%scl_prefix}rubygem-fastthread
 Requires:      %{?scl:%scl_prefix}runtime


### PR DESCRIPTION
Bug 1066246
https://bugzilla.redhat.com/show_bug.cgi?id=1066246

Although `ruby-rdoc` gets pulled in by `rubygems`, it's commonly needed
or desired for typical ruby usage and so should be required here as well.
