### PR TITLE
Bug 1082696 - Add lua-devel as dependency

### DIFF
--- a/cartridges/dependencies/openshift-origin-cartridge-dependencies.spec
+++ b/cartridges/dependencies/openshift-origin-cartridge-dependencies.spec
@@ -91,6 +91,7 @@ an OpenShift cartrige.
 Summary:   Optional user dependencies for DIY OpenShift Cartridges
 BuildArch: noarch
 Requires: %{name}-recommended-diy
+Requires:  lua-devel
 
 %description optional-diy
 This package pulls in other packages that a user


### PR DESCRIPTION
Adding lua-devel to openshift-origin-cartridge-dependencies-optional-diy
It is in optional because it is in the RHEL optional repo.
