### PR TITLE
Fix oo-admin-clear-pending-ops

### DIFF
--- a/broker-util/oo-admin-clear-pending-ops
+++ b/broker-util/oo-admin-clear-pending-ops
@@ -150,11 +150,14 @@ end
 
 hours = args["--time"] || 1
 hours = hours.to_i
-$t = Time.now - hours*60*60
 uuid = args["--uuid"]
 
 if uuid.nil?
-  Application.no_timeout.lt("pending_op_groups.created_at" => $t).each { |a| 
+  time = (hours == 0) ? nil : (Time.now.utc - hours*60*60)
+   
+  app_query = {"pending_op_groups.0" => {"$exists" => true}}
+  app_query["pending_op_groups.created_at"] = {"$lt" => time} if time
+  Application.no_timeout.where(app_query).each { |a| 
     begin
       clean_app(a) 
     rescue Exception=>e
@@ -162,7 +165,10 @@ if uuid.nil?
       puts e.backtrace
     end
   }
-  Domain.no_timeout.lt("pending_ops.created_at" => $t).each { |d| 
+   
+  domain_query = {"pending_ops.0" => {"$exists" => true}}
+  domain_query["pending_ops.created_at"] = {"$lt" => time} if time
+  Domain.no_timeout.where(domain_query).each { |d| 
     begin
       clean_domain(d)
     rescue Exception=>e
@@ -170,7 +176,10 @@ if uuid.nil?
       puts e.backtrace
     end
   }
-  Team.no_timeout.lt("pending_ops.created_at" => $t).each { |t| 
+   
+  team_query = {"pending_ops.0" => {"$exists" => true}}
+  team_query["pending_ops.created_at"] = {"$lt" => time} if time
+  Team.no_timeout.where(team_query).each { |t| 
     begin
       clean_team(t)
     rescue Exception=>e
@@ -178,7 +187,10 @@ if uuid.nil?
       puts e.backtrace
     end
   }
-  CloudUser.no_timeout.lt("pending_op_groups.created_at" => $t).each { |u| 
+   
+  user_query = {"pending_op_groups.0" => {"$exists" => true}}
+  user_query["pending_op_groups.created_at"] = {"$lt" => time} if time
+  CloudUser.no_timeout.where(user_query).each { |u| 
     begin
       clean_user(u)
     rescue Exception=>e
@@ -187,7 +199,7 @@ if uuid.nil?
     end
   }
 else
-  Application.where("_id" => uuid).lt("pending_op_groups.created_at" => $t).each { |a| clean_app(a) }
+  Application.where({"_id" => uuid, "pending_op_groups.0" => {"$exists" => true}}).each { |a| clean_app(a) }
 end
 
 puts "#{$app_count} applications were cleaned up. #{$user_count} users were cleaned up. #{$domain_count} domains were cleaned up. #{$team_count} teams were cleaned up."


### PR DESCRIPTION
With '--time 0' option, ignore pending_ops or pending_op_groups created_at field and process any pending op or op-groups if it exists
