### PR TITLE
[TO_STAGE_41] Fix oo-admin-clear-pending-ops

### DIFF
--- a/broker-util/oo-admin-clear-pending-ops
+++ b/broker-util/oo-admin-clear-pending-ops
@@ -232,7 +232,11 @@ if uuid.nil?
       puts e.backtrace
     end
   }
-  CloudUser.no_timeout.lt("pending_ops.created_at" => $t).each { |u| 
+  
+  time = (hours == 0) ? nil : $t
+  user_query = {"pending_ops.0" => {"$exists" => true}}
+  user_query["pending_ops.created_at"] = {"$lt" => time} if time
+  CloudUser.no_timeout.where(user_query).each { |u| 
     begin
       clean_user(u)
     rescue Exception=>e


### PR DESCRIPTION
With '--time 0' option, ignore created_at field for user pending_ops and clear any user pending ops
