### PR TITLE
[TO_STAGE]Revert "Card origin_cartridge_133 - Maintain application state across sn...

### DIFF
--- a/controller/test/cucumber/cartridge-lifecycle-mysql.feature
+++ b/controller/test/cucumber/cartridge-lifecycle-mysql.feature
@@ -10,19 +10,10 @@ Feature: MySQL Tests
     When I snapshot the application
     And I insert additional test data into mysql
     Then the additional test data will be present in mysql
-    And the cartridge <cart_name> status should be running
 
     When I restore the application
     Then the test data will be present in mysql
     And the additional test data will not be present in mysql
-    And the cartridge <cart_name> status should be running
-
-    When the application is stopped
-    And I snapshot the application
-    Then the cartridge <cart_name> status should be stopped
-
-    When I restore the application
-    Then the cartridge <cart_name> status should be stopped
 
     Scenarios: MySQL versions
       | cart_name |

--- a/controller/test/cucumber/platform-scalable-snapshot.feature
+++ b/controller/test/cucumber/platform-scalable-snapshot.feature
@@ -11,9 +11,7 @@ Feature: Scalable snapshot and restore
     And the mock control_post_snapshot marker will exist in the gear
     And the mock-plugin control_pre_snapshot marker will exist in the plugin gear
     And the mock-plugin control_post_snapshot marker will exist in the plugin gear
-    And the plugin gear state will be started
-    And the gear state will be started
-    
+
     When a new file is added and pushed to the client-created application repo
     Then the new file will be present in the gear app-root repo
 
@@ -21,15 +19,3 @@ Feature: Scalable snapshot and restore
     And the mock control_post_restore marker will exist in the gear
     And the new file will not be present in the gear app-root repo
     And the mock-plugin control_post_restore marker will exist in the plugin gear
-    Then the plugin gear state will be started
-    And the gear state will be started
-    
-    When the application is stopped
-    And I snapshot the application
-    Then the plugin gear state will be stopped
-    And the gear state will be stopped
-    
-    When I restore the application
-    Then the plugin gear state will be stopped
-    And the gear state will be stopped
-    

--- a/controller/test/cucumber/platform-snapshot-restore.feature
+++ b/controller/test/cucumber/platform-snapshot-restore.feature
@@ -7,20 +7,10 @@ Feature: Snapshot and restore
     When I snapshot the application
     Then the mock control_pre_snapshot marker will exist in the gear
     And the mock control_post_snapshot marker will exist in the gear
-    And the gear state will be started
 
     When a new file is added and pushed to the client-created application repo
     Then the new file will be present in the gear app-root repo
 
     When I restore the application
-    Then the mock control_post_restore marker will exist in the gear
+    And the mock control_post_restore marker will exist in the gear
     And the new file will not be present in the gear app-root repo
-    And the gear state will be started
-    
-    When the application is stopped
-    And I snapshot the application
-    Then the gear state will be stopped
-    
-    When I restore the application
-    Then the gear state will be stopped
-    

--- a/controller/test/cucumber/runtime-cartridge-postgresql.feature
+++ b/controller/test/cucumber/runtime-cartridge-postgresql.feature
@@ -52,19 +52,10 @@ Feature: Postgres Application Sub-Cartridge
     When I snapshot the application
     And I insert additional test data into postgres
     Then the additional test data will be present in postgres
-    And the cartridge postgresql-<postgres_version> status should be running
 
     When I restore the application
     Then the test data will be present in postgres
     And the additional test data will not be present in postgres
-    And the cartridge postgresql-<postgres_version> status should be running
-
-    When the application is stopped
-    And I snapshot the application
-    Then the cartridge postgresql-<postgres_version> status should be stopped
-
-    When I restore the application
-    Then the cartridge postgresql-<postgres_version> status should be stopped
 
     Scenarios: RHEL
       | postgres_version |

--- a/controller/test/cucumber/step_definitions/cartridge-mock_steps.rb
+++ b/controller/test/cucumber/step_definitions/cartridge-mock_steps.rb
@@ -73,18 +73,6 @@ Then /^the ([^ ]+) ([^ ]+) marker will( not)? exist in the( plugin)? gear$/ do |
   end  
 end
 
-Then /^the( plugin)? gear state will be (.*?)$/ do |plugin, state|
-  state_file = File.join($home_root, @app.uid, 'app-root', 'runtime', '.state')
-  if plugin
-    plugin_gear_uuid = IO.read(File.join($home_root, @app.uid, '.env', 'mock-plugin', 'OPENSHIFT_MOCK_PLUGIN_GEAR_UUID')).chomp
-    plugin_gear_uuid.sub!(/export OPENSHIFT_MOCK_PLUGIN_GEAR_UUID=\'/, '')
-    plugin_gear_uuid.chomp!('\'')
-    marker_file = File.join($home_root, plugin_gear_uuid, 'app-root', 'runtime', '.state')
-  end
-  gear_state = File.read(state_file).chomp
-  assert_equal state, gear_state
-end
-
 When /^the minimum scaling parameter is set to (\d+)$/ do |min|
   rhc_ctl_scale(@app, min) 
 end

--- a/node/lib/openshift-origin-node/model/application_container_ext/snapshots.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/snapshots.rb
@@ -49,7 +49,6 @@ module OpenShift
             $stderr.puts "depending on the amount of data present and the snapshot procedure used by your application's cartridges."
           end
 
-          pre_snapshot_state = @state.value
           stop_gear
 
           scalable_snapshot = !!@cartridge_model.web_proxy
@@ -82,7 +81,7 @@ module OpenShift
 
           write_snapshot_archive(exclusions)
 
-          result = @cartridge_model.each_cartridge do |cartridge|
+          @cartridge_model.each_cartridge do |cartridge|
             @cartridge_model.do_control('post-snapshot',
                                         cartridge,
                                         err: $stderr,
@@ -90,13 +89,7 @@ module OpenShift
                                         post_action_hooks_enabled: false)
           end
 
-          # Revert to the pre-snapshot state of the currently snapshotted gear
-          #
-          if @state.value != pre_snapshot_state
-            (@state.value != State::STARTED) && start_gear
-          end
-
-          result
+          start_gear
         end
 
         def handle_scalable_snapshot
@@ -140,7 +133,6 @@ module OpenShift
             gear_groups = get_gear_groups(gear_env)
           end
 
-          pre_restore_state = @state.value
           stop_gear
 
           @cartridge_model.each_cartridge do |cartridge|
@@ -201,12 +193,6 @@ module OpenShift
             if report_deployment
               report_deployments(gear_env)
             end
-          end
-
-          # Revert to the pre-restore state of the currently restored gear
-          #
-          if @state.value != pre_restore_state
-            (@state.value != State::STARTED) ? start_gear : stop_gear
           end
 
           result[:status] = RESULT_SUCCESS


### PR DESCRIPTION
...apshot/restore"

This reverts commit 2b90c5fcf9cee4ddf95dece0546970d7da13780e.

Revert "Bug 1030305 - 'rhc app show --state/--gear' shows db gear stop after"

This reverts commit 01feb57a151b8829d6900efb2b8d1b05a6b78fdf.

Conflicts:
    controller/test/cucumber/step_definitions/application_steps.rb
