### PR TITLE
rubygem-openshift-origin-common: Req. parseconfig

### DIFF
--- a/common/rubygem-openshift-origin-common.spec
+++ b/common/rubygem-openshift-origin-common.spec
@@ -25,6 +25,7 @@ Requires:      %{?scl:%scl_prefix}rubygem(activemodel)
 Requires:      %{?scl:%scl_prefix}rubygem(json)
 Requires:      %{?scl:%scl_prefix}rubygem(safe_yaml)
 Requires:      %{?scl:%scl_prefix}rubygem(bundler)
+Requires:      %{?scl:%scl_prefix}rubygem(parseconfig)
 %if 0%{?rhel}
 Requires:      openshift-origin-util-scl
 %endif


### PR DESCRIPTION
rubygem-openshift-origin-common.spec: Add a Requires: on the parseconfig rubygem because oo-diagnostics uses parseconfig.

This commit fixes bug 1083334.
