### PR TITLE
facter ipaddress does not always return the ip that we would want

### DIFF
--- a/node-proxy/scripts/init.d/openshift-node-web-proxy
+++ b/node-proxy/scripts/init.d/openshift-node-web-proxy
@@ -36,7 +36,7 @@ childpidfile="/var/run/openshift-node-web-proxy.pid"
 logfile="/var/log/node-web-proxy/supervisor.log"
 
 # Set public IP on devenv images
-public_ip=$(facter ipaddress_eth0)
+public_ip=$(facter host_ip)
 sed -i "s/^\( *\"host\" *:\) *undefined,/\1 \"$public_ip\",/" /etc/openshift/web-proxy-config.json
 
 start() {

--- a/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
@@ -175,10 +175,7 @@ module OpenShift
 
           output = ''
 
-          # TODO this is a quick fix because the PUBLIC_IP from the node config
-          # isn't the one we want - the port proxy binds to the 10.x IPs, not
-          # to the public EC2 IP addresses
-          ip_address = `facter ipaddress_eth0`.chomp
+          ip_address = `facter host_ip`.chomp
 
           env  = ::OpenShift::Runtime::Utils::Environ::for_gear(@container_dir)
           # TODO: better error handling

--- a/plugins/msg-node/mcollective/facts/openshift_facts.rb
+++ b/plugins/msg-node/mcollective/facts/openshift_facts.rb
@@ -39,6 +39,13 @@ Facter.add(:public_ip) { setcode { public_ip } }
 Facter.add(:public_hostname) { setcode { public_hostname } }
 
 #
+# public_ip assigned to the config specified NIC (default eth0)
+#
+public_nic = get_node_config_value("PUBLIC_NIC", "eth0").gsub(/['"]/,"")
+host_public_ip = `ifconfig #{public_nic} | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'`
+Facter.add(:host_ip) { setcode { host_public_ip } }
+
+#
 # Pull node_utilization data from node model
 #
 results = OpenShift::Runtime::Node.node_utilization


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1079575 facter ipaddress runs
ifconfig and grabs the first IP that it finds that is not a local loopback
