### PR TITLE
Revert "Updated cartridges to stop after post_restore"

### DIFF
--- a/cartridges/openshift-origin-cartridge-mariadb/bin/control
+++ b/cartridges/openshift-origin-cartridge-mariadb/bin/control
@@ -208,7 +208,6 @@ function post_restore {
     fi
 
     cleanup_dump
-    stop
   else
     echo "MariaDB restore attempted but no dump found!" 1>&2
     echo "$OPENSHIFT_DATA_DIR/mariadb_dump_snapshot.gz does not exist" 1>&2

--- a/cartridges/openshift-origin-cartridge-mongodb/bin/control
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/control
@@ -238,12 +238,10 @@ function post_restore {
     start
     _wait_for_mongod_to_startup
     if [ ! -f $OPENSHIFT_DATA_DIR/mongodb_dump_snapshot.tar.gz ]; then
-        stop
         client_result "MongoDB restore attempted but no dump was found!"
         die 0 "ERROR" "$OPENSHIFT_DATA_DIR/mongodb_dump_snapshot.tar.gz does not exist"
     else
         restore_from_mongodb_snapshot
-        stop
     fi
 }
 

--- a/cartridges/openshift-origin-cartridge-mysql/bin/control
+++ b/cartridges/openshift-origin-cartridge-mysql/bin/control
@@ -219,7 +219,6 @@ function post_restore {
     fi
 
     cleanup_dump
-    stop
   else
     echo "MySQL restore attempted but no dump found!" 1>&2
     echo "$OPENSHIFT_DATA_DIR/mysql_dump_snapshot.gz does not exist" 1>&2

--- a/cartridges/openshift-origin-cartridge-postgresql/bin/control
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/control
@@ -205,7 +205,6 @@ function post_restore {
     fi
 
     cleanup_dump
-    stop
   else
     warning "Postgres restore attempted, but no dump found"
     warning "${dump_file} does not exist"


### PR DESCRIPTION
This reverts commit b8baa4c4ccae27b3cc50081f08d9eef9e3ee581b.

Conflicts:
cartridges/openshift-origin-cartridge-mongodb/bin/control
