### PR TITLE
Force httpd into its own pgroup

### DIFF
--- a/cartridges/openshift-origin-cartridge-perl/bin/control
+++ b/cartridges/openshift-origin-cartridge-perl/bin/control
@@ -25,7 +25,11 @@ function start() {
   select_perl_document_root ${OPENSHIFT_REPO_DIR}
   oo-erb ${ERB_HTTPD_CFG_DIR}openshift.conf.erb > ${HTTPD_CFG_DIR}/openshift.conf
   ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
+  # Force httpd into its own pgroup, as httpd is hard-coded to TERM everything in
+  # its pgroup during shutdown (even while foregrounded)
+  set -m
   eval "nohup /usr/sbin/httpd $HTTPD_CMD_CONF -D FOREGROUND |& /usr/bin/logshifter -tag perl &"
+  set +m
   [ "$?" == "0" ] && wait_for_pid_file $HTTPD_PID_FILE
 }
 

--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -32,8 +32,12 @@ function pre_start_httpd_config {
 function start() {
     echo "Starting PHP ${OPENSHIFT_PHP_VERSION} cartridge (Apache+mod_php)"
     pre_start_httpd_config
+    # Force httpd into its own pgroup, as httpd is hard-coded to TERM everything in
+    # its pgroup during shutdown (even while foregrounded)
+    set -m
     php_context "nohup /usr/sbin/httpd $HTTPD_CMD_CONF -D FOREGROUND |& /usr/bin/logshifter -tag php &" \
       && wait_for_pid_file $HTTPD_PID_FILE
+    set +m
     return $?
 }
 

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/bin/control
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/bin/control
@@ -18,7 +18,11 @@ function start {
   echo "Starting PHPMyAdmin cartridge"
   write_httpd_passenv $HTTPD_PASSENV_FILE
   ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
+  # Force httpd into its own pgroup, as httpd is hard-coded to TERM everything in
+  # its pgroup during shutdown (even while foregrounded)
+  set -m
   eval "nohup /usr/sbin/httpd $HTTPD_CMD_CONF -D FOREGROUND |& /usr/bin/logshifter -tag phpmyadmin &"
+  set +m
 }
 
 function stop {

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
@@ -38,7 +38,11 @@ function start_apache() {
     echo "Starting Python ${OPENSHIFT_PYTHON_VERSION} cartridge (Apache+mod_wsgi)"
     pre_start_apache_config
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
+    # Force httpd into its own pgroup, as httpd is hard-coded to TERM everything in
+    # its pgroup during shutdown (even while foregrounded)
+    set -m
     eval "nohup /usr/sbin/httpd $HTTPD_CMD_CONF -DFOREGROUND |& /usr/bin/logshifter -tag python &"
+    set +m
     [ "$?" == "0" ] && wait_for_pid_file $HTTPD_PID_FILE
 }
 

--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -37,7 +37,11 @@ function start() {
     write_httpd_passenv $HTTPD_PASSENV_FILE
     ensure_valid_httpd_process "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     update_passenger_performance
+    # Force httpd into its own pgroup, as httpd is hard-coded to TERM everything in
+    # its pgroup during shutdown (even while foregrounded)
+    set -m
     ruby_context "umask 002 &>/dev/null ; RAILS_ENV=${RAILS_ENV:-production} nohup /usr/sbin/httpd $HTTPD_CMD_CONF -D FOREGROUND |& /usr/bin/logshifter -tag ruby &"
+    set +m
     [ "$?" == "0" ] && wait_for_pid_file $HTTPD_PID_FILE
 }
 


### PR DESCRIPTION
Force httpd into its own pgroup to prevent it from TERMing processes
it doesn't own during shutdown.

Resolve bug https://bugzilla.redhat.com/show_bug.cgi?id=1083756
