### PR TITLE
Bug 1084090: Using as_document instead of serializable_hash to add/remove keys

### DIFF
--- a/broker-util/oo-admin-repair
+++ b/broker-util/oo-admin-repair
@@ -436,7 +436,7 @@ def repair_stale_keys_vars(domain_ids)
         # fix stale application ssh keys
         app_ssh_keys_to_rm = []
         app.app_ssh_keys.each do |key|
-          app_ssh_keys_to_rm << key.serializable_hash unless app_ref_ids.include? key.component_id.to_s
+          app_ssh_keys_to_rm << key.as_document unless app_ref_ids.include? key.component_id.to_s
         end
 
         if app_ssh_keys_to_rm.present?
@@ -457,7 +457,7 @@ def repair_stale_keys_vars(domain_ids)
 
       # fix stale domain ssh keys
       domain.system_ssh_keys.each do |key|
-        system_ssh_keys_to_rm << key.serializable_hash unless domain_ref_ids.include? key.component_id.to_s
+        system_ssh_keys_to_rm << key.as_document unless domain_ref_ids.include? key.component_id.to_s
       end
 
       if system_ssh_keys_to_rm.present?

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -2828,7 +2828,7 @@ class Application
 
   def get_all_updated_ssh_keys
     ssh_keys = []
-    ssh_keys = self.app_ssh_keys.map {|k| k.serializable_hash } # the app_ssh_keys already have their name "updated"
+    ssh_keys = self.app_ssh_keys.map {|k| k.as_document } # the app_ssh_keys already have their name "updated"
     ssh_keys |= get_updated_ssh_keys(self.domain.system_ssh_keys)
     ssh_keys |= CloudUser.members_of(self){ |m| Ability.has_permission?(m._id, :ssh_to_gears, Application, m.role, self) }.map{ |u| get_updated_ssh_keys(u.ssh_keys) }.flatten(1)
 
@@ -2843,7 +2843,7 @@ class Application
   def get_updated_ssh_keys(keys)
     updated_keys_attrs = []
     keys.flatten.each do |key|
-      key_attrs = key.serializable_hash.deep_dup
+      key_attrs = key.as_document.deep_dup
       case key.class
       when UserSshKey
         key_attrs["name"] = key.cloud_user._id.to_s + "-" + key_attrs["name"]

--- a/controller/app/models/cloud_user.rb
+++ b/controller/app/models/cloud_user.rb
@@ -189,7 +189,7 @@ class CloudUser
   def add_ssh_key(key)
     if persisted?
       Lock.run_in_user_lock(self, 1800) do
-        op_group = AddSshKeysUserOpGroup.new(keys_attrs: [key.serializable_hash])
+        op_group = AddSshKeysUserOpGroup.new(keys_attrs: [key.as_document])
         self.pending_op_groups.push op_group
         result_io = ResultIO.new
         self.run_jobs(result_io)
@@ -213,7 +213,7 @@ class CloudUser
     if persisted?
       Lock.run_in_user_lock(self, 1800) do
         key = self.ssh_keys.find_by(name: name)
-        op_group = RemoveSshKeysUserOpGroup.new(keys_attrs: [key.serializable_hash])
+        op_group = RemoveSshKeysUserOpGroup.new(keys_attrs: [key.as_document])
         self.pending_op_groups.push op_group
         result_io = ResultIO.new
         self.run_jobs(result_io)

--- a/controller/app/models/domain.rb
+++ b/controller/app/models/domain.rb
@@ -201,7 +201,7 @@ class Domain
     ssh_keys.each do |new_key|
       self.system_ssh_keys.each do |cur_key|
         if cur_key.name == new_key.name
-          ssh_keys_to_rm << cur_key.serializable_hash
+          ssh_keys_to_rm << cur_key.as_document
         end
       end
     end
@@ -209,7 +209,7 @@ class Domain
     # if an ssh key being added has the same name as an existing key, then remove the previous keys first
     Domain.where(_id: self.id).update_all({ "$pullAll" => { system_ssh_keys: ssh_keys_to_rm }}) unless ssh_keys_to_rm.empty?
 
-    keys_attrs = ssh_keys.map { |k| k.serializable_hash }
+    keys_attrs = ssh_keys.map { |k| k.as_document }
     pending_op = AddSystemSshKeysDomainOp.new(keys_attrs: keys_attrs)
     pending_op.set_created_at
     Domain.where(_id: self.id).update_all({ "$push" => { pending_ops: pending_op.as_document }, "$pushAll" => { system_ssh_keys: keys_attrs }})
@@ -223,7 +223,7 @@ class Domain
       ssh_keys = [ssh_keys].flatten
     end
     return if ssh_keys.empty?
-    keys_attrs = ssh_keys.map { |k| k.serializable_hash }
+    keys_attrs = ssh_keys.map { |k| k.as_document }
     pending_op = RemoveSystemSshKeysDomainOp.new(keys_attrs: keys_attrs)
     pending_op.set_created_at
     Domain.where(_id: self.id).update_all({ "$push" => { pending_ops: pending_op.as_document }, "$pullAll" => { system_ssh_keys: keys_attrs }})

--- a/controller/app/pending_ops_models/delete_gear_op.rb
+++ b/controller/app/pending_ops_models/delete_gear_op.rb
@@ -43,7 +43,7 @@ class DeleteGearOp < PendingAppOp
     remove_ssh_keys = application.app_ssh_keys.find_by(component_id: gear_id) rescue []
     remove_ssh_keys = [remove_ssh_keys].flatten
     if remove_ssh_keys.length > 0
-      keys_attrs = remove_ssh_keys.map{|k| k.serializable_hash}
+      keys_attrs = remove_ssh_keys.map{|k| k.as_document}
       op_group = UpdateAppConfigOpGroup.new(remove_keys_attrs: keys_attrs, user_agent: application.user_agent)
       Application.where(_id: application._id).update_all({ "$push" => { pending_op_groups: op_group.as_document }, "$pullAll" => { app_ssh_keys: keys_attrs }})
 

--- a/controller/app/pending_ops_models/init_gear_op.rb
+++ b/controller/app/pending_ops_models/init_gear_op.rb
@@ -64,7 +64,7 @@ class InitGearOp < PendingAppOp
     remove_ssh_keys = application.app_ssh_keys.find_by(component_id: gear_id) rescue []
     remove_ssh_keys = [remove_ssh_keys].flatten
     if remove_ssh_keys.length > 0
-      keys_attrs = remove_ssh_keys.map{|k| k.serializable_hash}
+      keys_attrs = remove_ssh_keys.map{|k| k.as_document}
       op_group = UpdateAppConfigOpGroup.new(remove_keys_attrs: keys_attrs, user_agent: application.user_agent)
       Application.where(_id: application._id).update_all({ "$push" => { pending_op_groups: op_group.as_document }, "$pullAll" => { app_ssh_keys: keys_attrs }})
       # remove the ssh keys from the mongoid model in memory


### PR DESCRIPTION
as_document is more resilient in add/remove operations since if the order of the attributes is off, then serializable_hash can fail to remove a key.
