### PR TITLE
Redirect streams to /dev/null unless verbose enabled

### DIFF
--- a/logshifter/main.go
+++ b/logshifter/main.go
@@ -42,6 +42,16 @@ func main() {
 	flag.StringVar(&tag, "tag", "", "tag used by outputs for extra message context (e.g. program name)")
 	flag.Parse()
 
+	// Unless verbose mode is enabled, redirect stdout/stderr to /dev/null. This
+	// prevents readers of a pipeline including logshifter from blocking awaiting
+	// output which is never coming.
+	if !verbose {
+		if devnull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0); err == nil {
+			syscall.Dup2(int(devnull.Fd()), int(os.Stdout.Fd()))
+			syscall.Dup2(int(devnull.Fd()), int(os.Stderr.Fd()))
+		}
+	}
+
 	if len(tag) == 0 {
 		fmt.Println("Error: the `tag` argument is required")
 		os.Exit(1)


### PR DESCRIPTION
Redirect stdout and stderr to /dev/null unless the verbose option
is specified. This is a usability enhancement for the majority
use case which is a daemon-like mode for logshifter in which no
output should ever be expected from the program. If the streams
are left open and undirected, readers may block waiting for
output from logshifter itself.

Resolves bug https://bugzilla.redhat.com/show_bug.cgi?id=1085068
