### PR TITLE
Bug 1074237 - Exclude python template *.pyc and *.pyo from spec file

### DIFF
--- a/cartridges/openshift-origin-cartridge-python/openshift-origin-cartridge-python.spec
+++ b/cartridges/openshift-origin-cartridge-python/openshift-origin-cartridge-python.spec
@@ -89,6 +89,8 @@ Python cartridge for OpenShift. (Cartridge Format V2)
 %doc %{cartridgedir}/README.md
 %doc %{cartridgedir}/COPYRIGHT
 %doc %{cartridgedir}/LICENSE
+%exclude %{cartridgedir}/usr/versions/*/template/*.pyc
+%exclude %{cartridgedir}/usr/versions/*/template/*.pyo
 
 %changelog
 * Thu Mar 27 2014 Adam Miller <admiller@redhat.com> 1.22.5-1


### PR DESCRIPTION
Now the *.pyc and *.pyo files aren't generated on Openshift build, so they aren't present in deployed python example apps.
@mfojtik could you please review  
