### PR TITLE
Bug 1085282 - Disable Linux Native AIO in my.cnf.erb to support the InnoDB storage engine

### DIFF
--- a/cartridges/openshift-origin-cartridge-mariadb/conf/my.cnf.erb
+++ b/cartridges/openshift-origin-cartridge-mariadb/conf/my.cnf.erb
@@ -34,6 +34,7 @@ innodb_log_file_size = <%= ENV['OPENSHIFT_APP_DNS'] == ENV['OPENSHIFT_GEAR_DNS']
 innodb_log_buffer_size = <%= ENV['OPENSHIFT_APP_DNS'] == ENV['OPENSHIFT_GEAR_DNS'] ? 8 : 24 %>M
 innodb_flush_log_at_trx_commit = 1
 innodb_lock_wait_timeout = 50
+innodb_use_native_aio = 0
 
 [mysqld_safe]
 pid-file=<%= ENV['OPENSHIFT_MARIADB_DIR'] %>/pid/mariadb.pid

--- a/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb
+++ b/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb
@@ -45,6 +45,7 @@ innodb_log_file_size = <%= ENV['OPENSHIFT_APP_DNS'] == ENV['OPENSHIFT_GEAR_DNS']
 innodb_log_buffer_size = <%= ENV['OPENSHIFT_APP_DNS'] == ENV['OPENSHIFT_GEAR_DNS'] ? 16 : (ENV['OPENSHIFT_GEAR_MEMORY_MB'].to_i * 0.15).to_i %>M
 innodb_flush_log_at_trx_commit = 1
 innodb_lock_wait_timeout = 50
+innodb_use_native_aio = 0
 
 [mysqld_safe]
 pid-file=<%= ENV['OPENSHIFT_MYSQL_DIR'] %>pid/mysql.pid


### PR DESCRIPTION
Adding setting to both MySQL and MariaDB.
