### PR TITLE
Show failure in jenkins log but success in STDOUT when jenkins build aerogear app

### DIFF
--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_build
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_build
@@ -84,7 +84,7 @@ if job_available?
   # Block until a result shows up
   print "Waiting for job to complete..."
   json = get_job_info(next_build_num)
-  until json["result"]
+  until !json["building"]
     print "."
     sleep 1
     json = get_job_info(next_build_num)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1085266

Jenkins builds initially report success, but then fail during the archiving
step and report status as failure.  Jenkins client needs to wait until the
archive step is complete before checking the build status.
