### PR TITLE
Restorer: Use dbus-send, not oddjob_request

### DIFF
--- a/node-util/sbin/oo-restorer-wrapper.sh
+++ b/node-util/sbin/oo-restorer-wrapper.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-/usr/bin/oddjob_request -s com.redhat.oddjob_openshift -o /com/redhat/oddjob/openshift -i com.redhat.oddjob_restorer restore $1
+# Use dbus-send instead of oddjob_request so that we can specify
+# a timeout.  See Bug 1085489.
+
+exec /bin/dbus-send --system --dest=com.redhat.oddjob_openshift --print-reply --reply-timeout=600000 /com/redhat/oddjob/openshift com.redhat.oddjob_restorer.restore "string:$1"
+
+#/usr/bin/oddjob_request -s com.redhat.oddjob_openshift -o /com/redhat/oddjob/openshift -i com.redhat.oddjob_restorer restore $1


### PR DESCRIPTION
oo-restorer-wrapper.sh: Use dbus-send instead of oddjob_request, and specify a higher timeout.

oddjob_request has a fixed timeout of 25 seconds, which means that oo-restorer-wrapper.sh was timing out and returning before the gear was finished unidling.  As a consequence, restorer.php was sending the HTTP 302 redirect before the gear was ready, so the client would follow the redirect and get a HTTP 503.

This commit fixes bug 1085489.
