### PR TITLE
Bug 1085339 - cleaning up the remote user auth configs

### DIFF
--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -663,6 +663,7 @@ function check_auth_remote_user() {
     verbose "Auth trusted header: ${APP_VALUES[RU_TRUSTED_HEADER]}"
 
     if grep -q 'BrowserMatchNoCase\s\+\^OpenShift\s\+passthrough' ${OSO_HTTPD_CONF_DIR}/*.conf \
+       && grep -q 'SetEnvIf\s\+broker_auth_key' ${OSO_HTTPD_CONF_DIR}/*.conf \
        && grep -q 'Allow\s\+from\s\+env=passthrough' ${OSO_HTTPD_CONF_DIR}/*.conf \
        && grep -q 'SetEnvIfNoCase\s\+Authorization\s\+Bearer\s\+passthrough' ${OSO_HTTPD_CONF_DIR}/*.conf
     then

--- a/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-basic.conf.sample
+++ b/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-basic.conf.sample
@@ -7,39 +7,27 @@ LoadModule authz_user_module modules/mod_authz_user.so
   AuthType Basic
   AuthUserFile /etc/openshift/htpasswd
   require valid-user
-
+ 
+  # Broker handles auth tokens
   SetEnvIfNoCase Authorization Bearer passthrough
 
-  # The node->broker auth is handled in the Ruby code
+  # Console traffic will hit the local port.  mod_proxy will set this header automatically.
+  SetEnvIf X-Forwarded-For "^$" passthrough=1
+  # Turn the Console output header into the Apache environment variable for the broker remote-user plugin
+  SetEnvIf X-Remote-User "(..*)" REMOTE_USER=$1
+
+  # Old-style auth keys are POSTed as parameters. The deployment registration
+  # and snapshot-save use this.
   BrowserMatchNoCase ^OpenShift passthrough
+  # Older-style auth keys are POSTed in a header.  The Jenkins cartridge does
+  # this.
+  SetEnvIf broker_auth_key "^[A-Za-z0-9+/=]+$" passthrough=1
 
   <IfVersion >= 2.4>
     Require env passthrough
   </IfVersion>
   <IfVersion < 2.4>
     Allow from env=passthrough
-  </IfVersion>
-
-  # Console traffic will hit the local port.  mod_proxy will set this header automatically.
-  SetEnvIf X-Forwarded-For "^$" local_traffic=1
-  # Turn the Console output header into the Apache environment variable for the broker remote-user plugin
-  SetEnvIf X-Remote-User "(..*)" REMOTE_USER=$1
-
-  <IfVersion >= 2.4>
-    Require env local_traffic
-  </IfVersion>
-  <IfVersion < 2.4>
-    Allow from env=local_traffic
-  </IfVersion>
-
-  # Broker auth based on iv/token generated and verified by broker
-  SetEnvIf broker_auth_key "^[A-Za-z0-9+/=]+$" BROKER_AUTH=1
-
-  <IfVersion >= 2.4>
-    Require env BROKER_AUTH
-  </IfVersion>
-  <IfVersion < 2.4>
-    Allow from env=BROKER_AUTH
   </IfVersion>
 
   <IfVersion < 2.4>

--- a/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-kerberos.conf.sample
+++ b/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-kerberos.conf.sample
@@ -16,36 +16,26 @@ LoadModule auth_kerb_module modules/mod_auth_kerb.so
   Krb5KeyTab /var/www/openshift/broker/httpd/conf.d/http.keytab
   require valid-user
 
+  # Broker handles auth tokens
   SetEnvIfNoCase Authorization Bearer passthrough
 
-  # The node->broker auth is handled in the Ruby code
+  # Console traffic will hit the local port.  mod_proxy will set this header automatically.
+  SetEnvIf X-Forwarded-For "^$" passthrough=1
+  # Turn the Console output header into the Apache environment variable for the broker remote-user plugin
+  SetEnvIf X-Remote-User "(..*)" REMOTE_USER=$1
+
+  # Old-style auth keys are POSTed as parameters. The deployment registration
+  # and snapshot-save use this.
   BrowserMatchNoCase ^OpenShift passthrough
+  # Older-style auth keys are POSTed in a header.  The Jenkins cartridge does
+  # this.
+  SetEnvIf broker_auth_key "^[A-Za-z0-9+/=]+$" passthrough=1
+
   <IfVersion >= 2.4>
     Require env passthrough
   </IfVersion>
   <IfVersion < 2.4>
     Allow from env=passthrough
-  </IfVersion>
-
-  # Console traffic will hit the local port.  mod_proxy will set this header automatically.
-  SetEnvIf X-Forwarded-For "^$" local_traffic=1
-  # Turn the Console output header into the Apache environment variable for the broker remote-user plugin
-  SetEnvIf X-Remote-User "(..*)" REMOTE_USER=$1
-  <IfVersion >= 2.4>
-    Require env local_traffic
-  </IfVersion>
-  <IfVersion < 2.4>
-    Allow from env=local_traffic
-  </IfVersion>
-
-  # Broker auth based on iv/token generated and verified by broker
-  SetEnvIf broker_auth_key "^[A-Za-z0-9+/=]+$" BROKER_AUTH=1
-
-  <IfVersion >= 2.4>
-    Require env BROKER_AUTH
-  </IfVersion>
-  <IfVersion < 2.4>
-    Allow from env=BROKER_AUTH
   </IfVersion>
 
   <IfVersion < 2.4>

--- a/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-ldap.conf.sample
+++ b/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-ldap.conf.sample
@@ -17,37 +17,26 @@ LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
   AuthLDAPURL "ldap://ldap.example.com:389/ou=People,dc=my-domain,dc=com?uid?sub?(objectClass=*)"
   require valid-user
 
+  # Broker handles auth tokens
   SetEnvIfNoCase Authorization Bearer passthrough
 
-  # The node->broker auth is handled in the Ruby code
+  # Console traffic will hit the local port.  mod_proxy will set this header automatically.
+  SetEnvIf X-Forwarded-For "^$" passthrough=1
+  # Turn the Console output header into the Apache environment variable for the broker remote-user plugin
+  SetEnvIf X-Remote-User "(..*)" REMOTE_USER=$1
+
+  # Old-style auth keys are POSTed as parameters. The deployment registration
+  # and snapshot-save use this.
   BrowserMatchNoCase ^OpenShift passthrough
+  # Older-style auth keys are POSTed in a header.  The Jenkins cartridge does
+  # this.
+  SetEnvIf broker_auth_key "^[A-Za-z0-9+/=]+$" passthrough=1
+
   <IfVersion >= 2.4>
     Require env passthrough
   </IfVersion>
   <IfVersion < 2.4>
     Allow from env=passthrough
-  </IfVersion>
-
-  # Console traffic will hit the local port.  mod_proxy will set this header automatically.
-  SetEnvIf X-Forwarded-For "^$" local_traffic=1
-  # Turn the Console output header into the Apache environment variable for the broker remote-user plugin
-  SetEnvIf X-Remote-User "(..*)" REMOTE_USER=$1
-  <IfVersion >= 2.4>
-    Require env local_traffic
-  </IfVersion>
-  <IfVersion < 2.4>
-    Allow from env=local_traffic
-  </IfVersion>
-
-
-  # Broker auth based on iv/token generated and verified by broker
-  SetEnvIf broker_auth_key "^[A-Za-z0-9+/=]+$" BROKER_AUTH=1
-
-  <IfVersion >= 2.4>
-    Require env BROKER_AUTH
-  </IfVersion>
-  <IfVersion < 2.4>
-    Allow from env=BROKER_AUTH
   </IfVersion>
 
   <IfVersion < 2.4>


### PR DESCRIPTION
While our current remote-user auth plugin Apache configs are confusing there
are really only two scenarios:

1) Auth happens in Apache
2) Apache is bypassed and auth happens in Rails

Now for #2 in all cases we set the 'passthrough' environment variable instead
of sometimes setting BROKER_KEY, sometimes passthrough and sometimes
local_traffic.

This makes the configuration much more readable.  I picked the passthrough
variable since that was the most backwards compatible for OpenShift Enterprise
perspective.  Also, oo-accept-broker's check was a little stale so I fixed that
too.
