### PR TITLE
Use named pipes for logshifter redirection where appropriate

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/control
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/control
@@ -45,7 +45,11 @@ function start() {
       sed -i "s/^mms_key\s*=.*/${new_mms_key_line}/g" ${OPENSHIFT_10GENMMSAGENT_DIR}/mms-agent/settings.py
       sed -i "s/^secret_key\s*=.*/${new_secret_key_line}/g" ${OPENSHIFT_10GENMMSAGENT_DIR}/mms-agent/settings.py
 
-      nohup python ${OPENSHIFT_10GENMMSAGENT_DIR}/mms-agent/${OPENSHIFT_GEAR_UUID}_agent.py &> >(/usr/bin/logshifter -tag 10gen-mms-agent) &
+      LOGPIPE=${OPENSHIFT_HOMEDIR}/app-root/runtime/logshifter-10gen-mms-agent
+      rm -f $LOGPIPE && mkfifo $LOGPIPE
+
+      /usr/bin/logshifter -tag 10gen-mms-agent < $LOGPIPE &
+      nohup python ${OPENSHIFT_10GENMMSAGENT_DIR}/mms-agent/${OPENSHIFT_GEAR_UUID}_agent.py &> $LOGPIPE &
       echo $! > ${OPENSHIFT_10GENMMSAGENT_DIR}/run/mms-agent.pid
     elif [ -d ${OPENSHIFT_MMS_BASE_DIR} ]
     then
@@ -53,7 +57,11 @@ function start() {
       then
         pushd ${OPENSHIFT_MMS_BASE_DIR} >/dev/null
         sed -i "s/^mmsApiKey\s*=.*/mmsApiKey=${OPENSHIFT_MMS_API_KEY}/g" monitoring-agent.config
-        nohup ${OPENSHIFT_MMS_BASE_DIR}/mongodb-mms-monitoring-agent &> >(/usr/bin/logshifter -tag 10gen-mms-agent) &
+        LOGPIPE=${OPENSHIFT_HOMEDIR}/app-root/runtime/logshifter-10gen-mms-agent
+        rm -f $LOGPIPE && mkfifo $LOGPIPE
+
+        /usr/bin/logshifter -tag 10gen-mms-agent < $LOGPIPE &
+        nohup ${OPENSHIFT_MMS_BASE_DIR}/mongodb-mms-monitoring-agent &> $LOGPIPE &
         echo $! > ${OPENSHIFT_10GENMMSAGENT_DIR}/run/mms-agent.pid
         popd >/dev/null
       else

--- a/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
+++ b/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
@@ -81,6 +81,10 @@ if [ -d "$SCRIPTS_DIR" ]; then
               mv -f "$OPENSHIFT_CRON_DIR/log/cron.$freq.log" "$OPENSHIFT_CRON_DIR/log/cron.$freq.log.1"
           fi
 
+          LOGPIPE=${OPENSHIFT_HOMEDIR}/app-root/runtime/logshifter-cron-${freq}
+          rm -f $LOGPIPE && mkfifo $LOGPIPE
+          /usr/bin/logshifter -tag cron_${freq} < $LOGPIPE &
+
           separator=$(seq -s_ 75 | tr -d '[:digit:]')
           {
               echo $separator
@@ -99,7 +103,7 @@ if [ -d "$SCRIPTS_DIR" ]; then
               echo $separator
               echo "`date`: END $freq cron run - status=$status"
               echo $separator
-          } &> >(/usr/bin/logshifter -tag cron_${freq})
+          } &> $LOGPIPE
 
       ) 9>&-
 

--- a/cartridges/openshift-origin-cartridge-haproxy/bin/control
+++ b/cartridges/openshift-origin-cartridge-haproxy/bin/control
@@ -69,7 +69,11 @@ function _start_haproxy_ctld() {
 function _launch_haproxy_bg() {
     [ -n "$1" ]  &&  zopts="-sf $1"
     ping_server_gears
-    nohup /usr/sbin/haproxy -f $OPENSHIFT_HAPROXY_DIR/conf/haproxy.cfg ${zopts} &> >(/usr/bin/logshifter -tag haproxy) &
+    LOGPIPE=${OPENSHIFT_HOMEDIR}/app-root/runtime/logshifter-haproxy
+    rm -f $LOGPIPE && mkfifo $LOGPIPE
+
+    /usr/bin/logshifter -tag haproxy < $LOGPIPE &
+    nohup /usr/sbin/haproxy -f $OPENSHIFT_HAPROXY_DIR/conf/haproxy.cfg ${zopts} &> $LOGPIPE &
     echo $! > $HAPROXY_PID
 }
 

--- a/cartridges/openshift-origin-cartridge-jbossas/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/control
@@ -304,7 +304,11 @@ function start() {
   if isrunning; then
       echo "Application is already running"
   else
-    ${JBOSSAS_BIN_DIR}/standalone.sh &> >(/usr/bin/logshifter -tag jbossas) &
+    LOGPIPE=${OPENSHIFT_HOMEDIR}/app-root/runtime/logshifter-jbossas
+    rm -f $LOGPIPE && mkfifo $LOGPIPE
+
+    /usr/bin/logshifter -tag jbossas < $LOGPIPE &
+    ${JBOSSAS_BIN_DIR}/standalone.sh &> $LOGPIPE &
     echo $! > ${JBOSSAS_PID_FILE}
 
     rc=0

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/control
@@ -303,7 +303,11 @@ function start() {
   else
     echo "Starting $cartridge_type cartridge"
 
-    ${JBOSSEAP_BIN_DIR}/standalone.sh &> >(/usr/bin/logshifter -tag jbosseap) &
+    LOGPIPE=${OPENSHIFT_HOMEDIR}/app-root/runtime/logshifter-jbosseap
+    rm -f $LOGPIPE && mkfifo $LOGPIPE
+
+    /usr/bin/logshifter -tag jbosseap < $LOGPIPE &
+    ${JBOSSEAP_BIN_DIR}/standalone.sh &> $LOGPIPE &
     echo $! > ${JBOSSEAP_PID_FILE}
 
     rc=0

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/control
@@ -87,7 +87,11 @@ function start_app() {
         export CATALINA_BASE=$OPENSHIFT_JBOSSEWS_DIR
         export CATALINA_TMPDIR=${OPENSHIFT_JBOSSEWS_DIR}/tmp
 
-        ${OPENSHIFT_JBOSSEWS_DIR}/bin/tomcat start &> >(/usr/bin/logshifter -tag jbossews) &
+        LOGPIPE=${OPENSHIFT_HOMEDIR}/app-root/runtime/logshifter-jbossews
+        rm -f $LOGPIPE && mkfifo $LOGPIPE
+
+        /usr/bin/logshifter -tag jbossews < $LOGPIPE &
+        ${OPENSHIFT_JBOSSEWS_DIR}/bin/tomcat start &> $LOGPIPE &
         echo $! > $JBOSS_PID_FILE
 
         rc=0

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
@@ -22,7 +22,13 @@ export APPDIR=$OPENSHIFT_PYTHON_DIR
 function start_app() {
     echo "Starting Python ${OPENSHIFT_PYTHON_VERSION} cartridge (app.py server)"
     cd "$OPENSHIFT_REPO_DIR"
-    nohup python -u app.py &> >(/usr/bin/logshifter -tag python) &
+
+    LOGPIPE=${OPENSHIFT_HOMEDIR}/app-root/runtime/logshifter-python
+    rm -f $LOGPIPE && mkfifo $LOGPIPE
+
+    /usr/bin/logshifter -tag python < $LOGPIPE &
+    nohup python -u app.py &> $LOGPIPE &
+
     if [ "$?" == "0" ]; then
       echo $! > $OPENSHIFT_PYTHON_DIR/run/appserver.pid
     else


### PR DESCRIPTION
Use named rather than anonymous pipes for cartridges whose processes
can't do internal pidfile management. When using process substitution,
the intermediate Bash interpreter which drives the anonymous pipes
results in dangling file descriptors in the intermediate Bash, causing
readers (such as oo_spawn) to block on IO select calls.

Using named pipes manually removes the unnecessary intermediate Bash.
