### PR TITLE
Bug 1085128 - Add warning message for the unsupported legacy version of the mms-agent

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/setup
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/setup
@@ -34,6 +34,13 @@ then
     popd >/dev/null
 	fi
 else
+  if ! grep -Fxq "secret_key" "${OPENSHIFT_REPO_DIR}/.openshift/mms/settings.py"
+  then
+    client_error ""
+    client_error "You are using using legacy version of the mms-agent, which is not supported."
+    client_error "Your settings.py file is missing the secter_key variable."
+    exit 137
+  fi
 	client_message "The settings.py was deprecated, please check your 10gen-mms-agent cartridge documentation at http://openshift.github.io/documentation/oo_cartridge_guide.html#10gen-mms-agent"
   shopt -s dotglob
   pushd "$OPENSHIFT_10GENMMSAGENT_DIR" > /dev/null


### PR DESCRIPTION
If the user is using the legacy version of the mms-agent he will be noticed that, this version is not supported and that his settings.py is missing secret_key variable.
