### PR TITLE
Speed up chcon calls

### DIFF
--- a/node/lib/openshift-origin-node/utils/selinux_context.rb
+++ b/node/lib/openshift-origin-node/utils/selinux_context.rb
@@ -130,7 +130,10 @@ module OpenShift
               @context_mutex.synchronize do
 
                 # @note false wake ups are possible so we sleep until we know there is work queued up
-                while @context.empty?
+                # Also, @context may not be empty, but all the requests may have been handled and we're
+                # just waiting for the callers to pick them up, so make sure we wait if every value's
+                # .context is filled in
+                while @context.empty? or @context.values.all? { |v| not v.context.nil? }
                   # Wait for a +signal+ from a #matchpathcon call if there is no work queued up for us
                   @query.wait(@context_mutex)
                 end


### PR DESCRIPTION
Fix matchpathcon_worker thread so it truly waits when it has no requests
to process, instead of accidentally running a busy loop similar to a
spin lock. It previously was only checking to see if the @context Hash
used for matchpathcon requests and replies was empty, but it's possible
that it's not empty but all the requests have been handled. In this
case, the worker thread is really just waiting for all the callers to
pick up their replies, but instead of waiting to be signaled, it was
looping over and over without broadcasting anything.
