### PR TITLE
Add the ability to adjust when haproxy shutsdown the app cart in the lead gear

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/update-cluster
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/update-cluster
@@ -123,7 +123,7 @@ ratio=${info[0]}
 unset info[0]
 
 echo "Web/Proxy gears ratio $ratio"
-if [ "$ratio" -ge 3 ]; then
+if [ "$ratio" -ge ${OPENSHIFT_HAPROXY_GEAR_RATIO-"3"} ]; then
     echo "Disabling colocated gears ${info[@]}"
     nohup $OPENSHIFT_HAPROXY_DIR/usr/bin/disable-colocated-gears ${info[@]} &
 else

--- a/node/test/gear_functional/multi_ha_func_test.rb
+++ b/node/test/gear_functional/multi_ha_func_test.rb
@@ -22,7 +22,7 @@ class MultiHaFuncTest < OpenShift::NodeBareTestCase
     @api = FunctionalApi.new
     @namespace = @api.create_domain
 
-    @api.up_gears
+    @api.up_gears(10)
     @api.enable_ha
 
     @framework_cartridge = ENV['CART_TO_TEST'] || 'mock-0.1'
@@ -77,6 +77,13 @@ class MultiHaFuncTest < OpenShift::NodeBareTestCase
     @api.restart_cartridge(app_name, @framework_cartridge)
     assert_proxies_disabled(proxy_entries)
 
+    @api.add_env_vars(app_name,[{name:"OPENSHIFT_HAPROXY_GEAR_RATIO",value:"4"}])
+    @api.assert_scales_to(app_name, @framework_cartridge, 6)
+    assert_proxies_not_disabled(proxy_entries)
+    @api.assert_scales_to(app_name, @framework_cartridge, 7)
+    assert_proxies_disabled(proxy_entries)    
+    
+
   end
 
   def assert_proxies_disabled(proxy_entries)
@@ -84,6 +91,15 @@ class MultiHaFuncTest < OpenShift::NodeBareTestCase
       proxy_entries.values.each do |proxy|
         logger.info "Checking target gear #{target_gear.dns} status from proxy #{proxy.dns}"
         @api.assert_gear_status_in_proxy(proxy, target_gear, 'MAINT')
+      end
+    end
+  end
+
+  def assert_proxies_not_disabled(proxy_entries)
+    proxy_entries.values.each do |target_gear|
+      proxy_entries.values.each do |proxy|
+        logger.info "Checking target gear #{target_gear.dns} status from proxy #{proxy.dns}"
+        @api.assert_gear_status_in_proxy(proxy, target_gear, 'UP')
       end
     end
   end

--- a/node/test/support/functional_api.rb
+++ b/node/test/support/functional_api.rb
@@ -186,9 +186,9 @@ EOFZ
     end
   end
 
-  def up_gears
+  def up_gears(num=5)
     logger.info "Upping gears for #{@login}"
-    logger.info `oo-broker --non-interactive oo-admin-ctl-user -l #{@login} --setmaxgears 5`
+    logger.info `oo-broker --non-interactive oo-admin-ctl-user -l #{@login} --setmaxgears #{num}`
   end
 
   def enable_ha


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1013166

Currently, haproxy, when scaled to 3 or more gears, will shutdown the 
application cartridge (i.e. ruby, python, php, etc) in the gear that also
houses haproxy so that haproxy has access to the entire gear's resources. It
is requested that the number of gears required to shutdown the application
cartridge be adjustable.

The goal of this is to allow the application creator to have one haproxy gear
and just one application gear or , if load permits, have 3 total gears and
still have the application cartridge running on the haproxy gear.
