### PR TITLE
Add support for SSLv2 when downloading cartridges

### DIFF
--- a/controller/app/helpers/cartridge_cache.rb
+++ b/controller/app/helpers/cartridge_cache.rb
@@ -305,6 +305,11 @@ class CartridgeCache
     client.receive_timeout =        cartridge_conf[:max_download_time] || 10
     client.follow_redirect_count =  cartridge_conf[:max_download_redirects] || 2
 
+    # Fix the case when SSL certificate does not support SSLv3 which is default
+    # for HTTPClient.
+    #
+    client.ssl_config.ssl_version = 'SSLv23'
+
     manifest = ""
 
     if URI.parse(url).kind_of? URI::HTTP


### PR DESCRIPTION
Before:

```
irb(main):008:0> client.get_content('https://cert.startcom.org/'
irb(main):009:1> )
OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 read server hello A: sslv3 alert handshake failure
```

After:

```
irb(main):021:0> client.get_content('https://cert.startcom.org/')
=> "\t\t\t\n\t\t\t\r\n\r\n\r\n\r\n\n<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n<html dir=\"ltr\">\n<!-- Creation date: 01/25/2005  -->\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\n<title>StartCom Free SSL Cert...
```

This is affecting users in PROD if they run their own Git hosted repositories, they are unable to add their cartridges to OpenShift.
