### PR TITLE
nodejs cartridge: use npm install --production

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/bin/control
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/control
@@ -213,7 +213,7 @@ function build() {
 
     nodejs_context /bin/bash
     if [ -f "${OPENSHIFT_REPO_DIR}"/package.json ]; then
-        (cd "${OPENSHIFT_REPO_DIR}"; nodejs_context "npm install -d")
+        (cd "${OPENSHIFT_REPO_DIR}"; nodejs_context "npm install --production --loglevel info")
     fi
 }
 


### PR DESCRIPTION
In the [npm config doc](https://www.npmjs.org/doc/misc/npm-config.html)  it's explained that `-d` means `--loglevel info`.

Moreover,

> By default, npm install will install all modules listed as dependencies. With the --production flag, npm will not install modules listed in devDependencies.

https://www.npmjs.org/doc/cli/npm-install.html

`devDependencies` are used for tests. We don't want to download tests dependencies when we deploy to openshift. It will make build faster for nodejs projects.
