### PR TITLE
Python cartridge suddenly stopped installing dependencies

### DIFF
--- a/cartridges/openshift-origin-cartridge-python/openshift-origin-cartridge-python.spec
+++ b/cartridges/openshift-origin-cartridge-python/openshift-origin-cartridge-python.spec
@@ -11,6 +11,7 @@ URL:           https://www.openshift.com
 Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
+Requires:      libyaml-devel
 %if 0%{?fedora}%{?rhel} <= 6
 Requires:      python >= 2.6
 Requires:      python < 2.7


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1085783

When i push to my Python cartridge, it fails to install dependencies from
setup.py.

Need to add libyaml-devel dependency so python dependencies can build.
