### PR TITLE
Bug 1070173 - Add '-v' option for oo-admin-ctl-tc to turn verbose output

### DIFF
--- a/node/misc/sbin/oo-admin-ctl-tc
+++ b/node/misc/sbin/oo-admin-ctl-tc
@@ -27,6 +27,10 @@ traffic_control_enabled = config.get_bool("TRAFFIC_CONTROL_ENABLED", "true")
 
 tc = OpenShift::Runtime::Utils::TC.new
 
+verbose = false
+verbose = true if ARGV[1] && ARGV[1] == '-v'
+verbose = true if ARGV[2] && ARGV[2] == '-v'
+
 begin
   unless traffic_control_enabled
     unless ARGV[0] == "stop" || ARGV[0] == "show" || ARGV[0] == "status"
@@ -70,13 +74,13 @@ begin
     tc.deluser(ARGV[1])
 
   when "status"
-    tc.status(ARGV[1])
+    tc.status(ARGV[1], verbose)
 
   when "show"
     tc.show(ARGV[1])
 
   else
-    $stderr.puts "Usage: #{__FILE__} {start|stop|restart|status [username]|startuser <username>|stopuser <username>|restartuser <username>|throttleuser <username>|nothrottleuser <username>|deluser <username>}"
+    $stderr.puts "Usage: #{__FILE__} {start|stop|restart|status [username]|startuser <username>|stopuser <username>|restartuser <username>|throttleuser <username>|nothrottleuser <username>|deluser <username> [-v]}"
     exit(1)
   end
 


### PR DESCRIPTION
This will change the output in this way:

```
# oo-admin-ctl-tc status 5347ce3cb60aa6709f000001
Bandwidth shaping status: 
tc is active for the user 5347ce3cb60aa6709f000001 [OK]
```

```
# oo-admin-ctl-tc status 5347ce3cb60aa6709f000001 -v
Bandwidth shaping status: 
tc is active for the user 5347ce3cb60aa6709f000001
class htb 1:3e8 parent 1:1 leaf 3e8: prio 0 rate 2000Kbit ceil 800000Kbit burst 1600b cburst 1600b 
 Sent 3526 bytes 11 pkt (dropped 0, overlimits 0 requeues 0) 
 rate 0bit 0pps backlog 0b 0p requeues 0 
 lended: 10 borrowed: 1 giants: 0
 tokens: 95500 ctokens: 250

 [OK]
```

The verbose option is optional and it can be used in other commands as well (if we would need to).
