### PR TITLE
Bug 1086609 - Adding $OPENSHIFT_REPO_DIR/libs back into $PERL5LIB for backward compatibility

### DIFF
--- a/cartridges/openshift-origin-cartridge-perl/env/PERL5LIB.erb
+++ b/cartridges/openshift-origin-cartridge-perl/env/PERL5LIB.erb
@@ -1,1 +1,1 @@
-<%= ENV['OPENSHIFT_PERL_DIR'] %>perl5lib/lib/perl5/
+<%= ENV['OPENSHIFT_REPO_DIR'] %>libs:<%= ENV['OPENSHIFT_PERL_DIR'] %>perl5lib/lib/perl5/


### PR DESCRIPTION
Returning $OPENSHIFT_REPO_DIR/libs path into $PERL5LIB variable, so users are able to use thier own libraries.
@mfojtik could you please review.
