### PR TITLE
haproxy_ctld.log not tidy after run the command rhc tidy-app app_name

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/bin/control
+++ b/cartridges/openshift-origin-cartridge-haproxy/bin/control
@@ -306,6 +306,7 @@ function tidy() {
     client_message "Emptying haproxy logs in dir: $OPENSHIFT_LOG_DIR"
     shopt -s dotglob
     rm -rf $OPENSHIFT_LOG_DIR/haproxy.log*
+    rm -rf $OPENSHIFT_LOG_DIR/haproxy_ctld.log*
 }
 
 #

--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/haproxy_ctld.rb
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/haproxy_ctld.rb
@@ -169,6 +169,9 @@ class Haproxy
         @stats_sock=stats_sock
         @gear_namespace = ENV['OPENSHIFT_GEAR_DNS'].split('.')[0].split('-')[1]
 
+        # don't buffer log output or it may never make it to logshifter
+        STDOUT.sync=true
+        STDERR.sync=true
         @log = Logger.new(STDOUT)
         if log_debug
           @log.level = Logger::DEBUG


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1086649

The log haproxy_ctld.log in app-root/logs is not tidied after run the command
"rhc tidy-app scalable_app_name"
