### PR TITLE
[TO_STAGE] Check haproxyctld pid when trying to stop it

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/bin/control
+++ b/cartridges/openshift-origin-cartridge-haproxy/bin/control
@@ -49,7 +49,7 @@ function wait_to_start() {
 function _stop_haproxy_ctld() {
   if [ -f ${HAPROXY_CTLD_PID} ]; then
     pid=$( /bin/cat "${HAPROXY_CTLD_PID}" )
-    if isrunning; then
+    if ps --no-headers --pid ${pid} > /dev/null 2>&1; then
       kill -TERM $pid
     else
       rm -f ${HAPROXY_CTLD_PID}

--- a/cartridges/openshift-origin-cartridge-haproxy/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-haproxy/metadata/manifest.yml
@@ -10,7 +10,7 @@ Version: '1.4'
 License: GPLv2+
 License-Url: http://www.gnu.org/licenses/gpl-2.0.html
 Vendor: http://haproxy.1wt.eu/
-Cartridge-Version: 0.0.14
+Cartridge-Version: 0.0.15
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:


### PR DESCRIPTION
Check the haproxy_ctld pidfile during stop rather than relying on
isrunning, which checks haproxy's pidfile; otherwise, haproxy_ctld
will never be signalled.
