### PR TITLE
Downloadable cartridges are improperly described as getting updates

### DIFF
--- a/console/app/views/application_types/index.html.haml
+++ b/console/app/views/application_types/index.html.haml
@@ -36,7 +36,7 @@
       %dt
         %span.font-icon{"aria-hidden" => "true", "data-icon" => "\uee51", "title" => 'Cartridge icon'}
       %dd 
-        <b>Cartridge</b> &ndash; A managed runtime that receives security updates and upgrades automatically.
+        <b>Cartridge</b> &ndash; A managed runtime for your application.
       %dt
         %span.font-icon{"aria-hidden" => "true", "data-icon" => "\ue029", "title" => 'QuickStart icon'}
       %dd

--- a/console/app/views/application_types/search.html.haml
+++ b/console/app/views/application_types/search.html.haml
@@ -37,7 +37,7 @@
       %dt
         %span.font-icon{"aria-hidden" => "true", "data-icon" => "\uee51", "title" => 'Cartridge icon'}
       %dd 
-        <b>Cartridge</b> &ndash; A managed runtime that receives security updates and upgrades automatically.
+        <b>Cartridge</b> &ndash; A managed runtime for your application.
       %dt
         %span.font-icon{"aria-hidden" => "true", "data-icon" => "\ue029", "title" => 'QuickStart icon'}
       %dd


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1068797

The application types page tags imported downloadable cartridges with the
cartridge icon.  This icon is associated with the following text:
"A managed runtime that receives security updates and upgrades automatically."

However downloadable cartridges do not receive updates or automatic upgrades. 
This text should be changed, since we already have the shield icon to indicate
cartridges which receive updates.
