### PR TITLE
remote-user auth plugin: Rely on 'user_action_log_identity_id' for username when trusted header is missing until BZ 1086910 is fixed

### DIFF
--- a/plugins/auth/remote-user/lib/openshift/remote_user_auth_service.rb
+++ b/plugins/auth/remote-user/lib/openshift/remote_user_auth_service.rb
@@ -4,7 +4,10 @@ module OpenShift
     # trusted.  The trusted must only be set if the web server has verified the
     # password.
     def authenticate_request(controller)
-      username = controller.request.env[trusted_header]
+      # FIXME: trusted_header i.e. 'REMOTE_USER' env var is missing for REST apis with singular resource format
+      # Work-around is to rely on Thread.current[:user_action_log_identity_id] when trusted_header is not set
+      # until we fix https://bugzilla.redhat.com/show_bug.cgi?id=1086910
+      username = controller.request.env[trusted_header] || Thread.current[:user_action_log_identity_id]
       raise OpenShift::AccessDeniedException if username.blank?
       {:username => username}
     end


### PR DESCRIPTION
[merge]
