### PR TITLE
Bug 1086094: Multiple changes for cartridge colocation

### DIFF
--- a/common/lib/openshift-origin-common/models/cartridge.rb
+++ b/common/lib/openshift-origin-common/models/cartridge.rb
@@ -36,6 +36,10 @@ module OpenShift
       categories.include?('ci_builder')
     end
 
+    def has_scalable_categories?
+      is_web_framework? || is_service?
+    end
+
     alias_method :is_deployable?, :is_web_framework?
     alias_method :is_buildable?, :is_web_framework?
   end

--- a/controller/app/models/component_instance.rb
+++ b/controller/app/models/component_instance.rb
@@ -52,7 +52,7 @@ class ComponentInstance
     name
   end
 
-  delegate :is_plugin?, :is_embeddable?, :is_web_proxy?, :is_external?, :is_web_framework?, to: :cartridge
+  delegate :is_plugin?, :is_embeddable?, :is_web_proxy?, :is_external?, :is_web_framework?, :has_scalable_categories?, to: :cartridge
   delegate :is_sparse?, to: :component
 
   def min


### PR DESCRIPTION
We are:
- taking into account the app's complete group overrides
- allowing only plugin carts to colocate with web/service carts
- blocking plugin (except sparse) carts from responding to scaling min/max changes
