### PR TITLE
fix phpmyadmin PHP_INI_SCAN_DIR bug

### DIFF
--- a/cartridges/openshift-origin-cartridge-phpmyadmin/bin/control
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/bin/control
@@ -3,6 +3,7 @@
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 export PHPRC="${OPENSHIFT_PHPMYADMIN_DIR}conf/php.ini"
+export PHP_INI_SCAN_DIR="/etc/php.d"
 
 HTTPD_CFG_FILE=${OPENSHIFT_PHPMYADMIN_DIR}conf/httpd_nolog.conf
 HTTPD_PASSENV_FILE=${OPENSHIFT_PHPMYADMIN_DIR}conf.d/passenv.conf


### PR DESCRIPTION
PHPMyAdmin runs on PHP 5.3, even if it's attached to PHP 5.4 or Zend Server.

Bug 1086220 - https://bugzilla.redhat.com/show_bug.cgi?id=1086220
[test] [extended:cartridge]
