### PR TITLE
ctl-team: allow anonymous or encrypted LDAP access

### DIFF
--- a/broker-util/man/oo-admin-ctl-team.8
+++ b/broker-util/man/oo-admin-ctl-team.8
@@ -94,10 +94,6 @@ Host: openldap-server.example.com
 .br
 Port: 389
 .br
-Username: cn=admin,dc=example,dc=com
-.br
-Password: passw0rd
-.br
 Get-Group: 
   Base: dc=example,dc=com
   Filter: (cn=<group_name>)
@@ -160,10 +156,6 @@ Host: directory-server.example.com
 .br
 Port: 389
 .br
-Username: cn=admin,dc=example,dc=com
-.br
-Password: passw0rd
-.br
 Get-Group: 
   Base: dc=example,dc=com
   Filter: (cn=<group_cn>)
@@ -178,6 +170,19 @@ Openshift-Username: emailAddress
 .PP
 .B 
 Note: The placeholders <group_cn>, <group_dn> and <user_id> will be replaced by actual values at the time of the script execution.
+.PP
+An encrypted connection and authentication may be specified in the configuration as well:
+.PP
+Host: directory-server.example.com
+.br
+Port: 636
+.br
+Encryption: true
+.br
+Username: cn=admin,dc=example,dc=com
+.br
+Password: passw0rd
+.br
 
 .SH EXAMPLE
 $ oo-admin-ctl-team \fB-c\fP list

--- a/broker-util/man/oo-admin-ctl-team.txt2man
+++ b/broker-util/man/oo-admin-ctl-team.txt2man
@@ -71,8 +71,6 @@ CONFIGURATION
 
        Host: openldap-server.example.com
        Port: 389
-       Username: cn=admin,dc=example,dc=com
-       Password: passw0rd
        Get-Group:
          Base: dc=example,dc=com
          Filter: (cn=<group_cn>)
@@ -115,8 +113,6 @@ CONFIGURATION
 
        Host: directory-server.example.com
        Port: 389
-       Username: cn=admin,dc=example,dc=com
-       Password: passw0rd
        Get-Group:
          Base: dc=example,dc=com
          Filter: (cn=<group_cn>)
@@ -129,6 +125,13 @@ CONFIGURATION
 
 Note: The placeholders <group_cn>, <group_dn> and <user_id> will be replaced by actual values at the time of the script execution.
 
+       An encrypted connection and authentication may be specified in the configuration as well:
+
+       Host: directory-server.example.com
+       Port: 636
+       Encryption: true
+       Username: cn=admin,dc=example,dc=com
+       Password: passw0rd
 
 EXAMPLE
        $ oo-admin-ctl-team -c list

--- a/broker-util/oo-admin-ctl-team
+++ b/broker-util/oo-admin-ctl-team
@@ -311,10 +311,11 @@ class Command
       require options.broker || PATH
       if options.config_file
         @ldap_config = YAML.load_file(options.config_file)
-        @ldap = Net::LDAP.new
-        @ldap.host = @ldap_config["Host"]
-        @ldap.port = @ldap_config["Port"]
-        @ldap.auth @ldap_config["Username"], @ldap_config["Password"]
+        @ldap = Net::LDAP.new( host: @ldap_config["Host"],
+                               port: @ldap_config["Port"],
+                               encryption: @ldap_config["Encryption"] ? :simple_tls : nil )
+        # if user name given for auth, use it; otherwise anonymous access is used.
+        @ldap.auth @ldap_config["Username"], @ldap_config["Password"] if @ldap_config["Username"]
         unless @ldap.bind
           puts "Could not connect to LDAP server \"#{@ldap.host}\": #{@ldap.get_operation_result.message}" 
           exit 1


### PR DESCRIPTION
bug 1087984
https://bugzilla.redhat.com/show_bug.cgi?id=1087984

Introduces the "Encryption: true" conf setting. Also, username/password
auth can be omitted from the conf file.
