### PR TITLE
Bug 1065047 - changed exception raised to NodeUnavailableException to in...

### DIFF
--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -3428,12 +3428,12 @@ module OpenShift
         flags = { :options => options, :exit_on_failure => false }
         begin
           rpc_client = rpcclient(agent, flags)
+          return rpc_client
         rescue Exception => e
           Rails.logger.error "Exception raised by rpcclient:#{e.message}"
           Rails.logger.error (e.backtrace)
-          raise OpenShift::NodeException.new(e)
+          raise OpenShift::NodeUnavailableException.new(e)
         end
-        return rpc_client
       end
 
       #
@@ -3563,9 +3563,9 @@ module OpenShift
         return unless handle.present?
 
         start_time = Time.new
+        options = MCollectiveApplicationContainerProxy.rpc_options.merge(custom_options)
+        rpc_client = MCollectiveApplicationContainerProxy.get_rpc_client('openshift', options)
         begin
-          options = MCollectiveApplicationContainerProxy.rpc_options.merge(custom_options)
-          rpc_client = MCollectiveApplicationContainerProxy.get_rpc_client('openshift', options)
           identities = handle.keys
           rpc_client.custom_request('execute_parallel', mc_args, identities, {'identity' => identities}).each { |mcoll_reply|
             if mcoll_reply.results[:statuscode] == 0


### PR DESCRIPTION
...dicate retry advisable (503)
- Changed exception raised by rpcclient to NodeUnavailableException to indicate that retry is advisable. i.e. results in HTTP status code 503
- nil checking on rpc_client before calling disconnect to prevent runtime exception being thrown when connection is unsuccessful. i.e. undefined method `disconnect' for nil:NilClass 

Not really dependent but related pull request

https://github.com/openshift/li/pull/2609
