### PR TITLE
Bug 1087701 - The remote-user sample configs were incorrectly using rege...

### DIFF
--- a/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-basic.conf.sample
+++ b/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-basic.conf.sample
@@ -38,7 +38,22 @@ LoadModule authz_user_module modules/mod_authz_user.so
 </Location>
 
 # The following APIs do not require auth:
-<LocationMatch /broker/rest/(api*|environment*|cartridges*|cartridges/*|cartridge/*|quickstarts*|quickstarts/*|quickstart/*)>
+#
+# /api
+# /environment
+# /cartridges
+# /quickstarts
+#
+# We want to match requests in the form of:
+#
+# /api
+# /api.json
+# /api/
+#
+# But not:
+#
+# /api_with_auth
+<LocationMatch ^/broker/rest/(api|environment|cartridges|quickstarts)(\.\w+|/?)$>
   <IfVersion >= 2.4>
     Require all granted
   </IfVersion>

--- a/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-kerberos.conf.sample
+++ b/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-kerberos.conf.sample
@@ -46,7 +46,22 @@ LoadModule auth_kerb_module modules/mod_auth_kerb.so
 </Location>
 
 # The following APIs do not require auth:
-<LocationMatch /broker/rest/(api*|environment*|cartridges*|cartridges/*|cartridge/*|quickstarts*|quickstarts/*|quickstart/*)>
+#
+# /api
+# /environment
+# /cartridges
+# /quickstarts
+#
+# We want to match requests in the form of:
+#
+# /api
+# /api.json
+# /api/
+#
+# But not:
+#
+# /api_with_auth
+<LocationMatch ^/broker/rest/(api|environment|cartridges|quickstarts)(\.\w+|/?)$>
   <IfVersion >= 2.4>
     Require all granted
   </IfVersion>

--- a/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-ldap.conf.sample
+++ b/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-ldap.conf.sample
@@ -47,7 +47,22 @@ LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
 </Location>
 
 # The following APIs do not require auth:
-<LocationMatch /broker/rest/(api*|environment*|cartridges*|cartridges/*|cartridge/*|quickstarts*|quickstarts/*|quickstart/*)>
+#
+# /api
+# /environment
+# /cartridges
+# /quickstarts
+#
+# We want to match requests in the form of:
+#
+# /api
+# /api.json
+# /api/
+#
+# But not:
+#
+# /api_with_auth
+<LocationMatch ^/broker/rest/(api|environment|cartridges|quickstarts)(\.\w+|/?)$>
   <IfVersion >= 2.4>
     Require all granted
   </IfVersion>


### PR DESCRIPTION
...xes

Location directives use globs.  LocationMatch uses regexes.
