### PR TITLE
Bug 1088405 - oo-admin-ctl-domain: Allow addition of ssh key to domain

### DIFF
--- a/broker-util/oo-admin-ctl-domain
+++ b/broker-util/oo-admin-ctl-domain
@@ -190,8 +190,8 @@ when "create"
   reply.resultIO << "Successfully created domain.\n"
 
 when "update"
-  if namespace.blank? || login.blank? ||  (allowed_gear_sizes.nil? && new_namespace.blank?)
-    print "Please provide login, namespace, and either a new namespace (rename), or a set of allowed gear sizes, to update the domain\n"
+  if namespace.blank? || login.blank? ||  (allowed_gear_sizes.nil? && new_namespace.blank? && ssh_key.nil?)
+    print "Please provide login, namespace, and either a new namespace (rename), new ssh key, or a set of allowed gear sizes, to update the domain\n"
     exit 1
   end
   user = nil


### PR DESCRIPTION
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1088405
The update action will now check to see if a ssh key has been provided before providing the error that not enough parameters were provided. This allows us to use the already-written ssh key addition code.
