### PR TITLE
Fix generated property for scaling model.

### DIFF
--- a/common/lib/openshift-origin-common/models/scaling.rb
+++ b/common/lib/openshift-origin-common/models/scaling.rb
@@ -18,7 +18,7 @@ module OpenShift
 #    end
 
     def generated
-      self.min == 1 && self.max == -1 && self.min_managed == 1 && self.multiplier == 1
+      self.min == 1 && self.max == -1 && self.min_managed == 1 && self.multiplier == 1 && self.required == false
     end
 
     def from_descriptor(spec_hash = {})


### PR DESCRIPTION
Scaling object is not persisted properly in MongoDB for cartridges that are required to be scalable because of this.
