### PR TITLE
oo-diagnostics test_broker_certificate fixes

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -1135,7 +1135,6 @@ class OODiag
 
   def test_broker_certificate
     skip_test unless @is_broker
-    require 'socket'
 
     # Retrieve the SSL cert from Apache
     response = `curl -k -s -v https://localhost/ -o /dev/null 2>&1`

--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -1138,6 +1138,16 @@ class OODiag
 
     # Retrieve the SSL cert from Apache
     response = `curl -k -s -v https://localhost/ -o /dev/null 2>&1`
+    if $? != 0
+      do_fail <<-CANNOTCONNECT
+        An error arose while trying to connect to the SSL reverse proxy.  curl returned with
+        #{response.strip.empty? ? "no output." : "the following output:\n" + response}
+
+        Please check whether the httpd service is running.
+      CANNOTCONNECT
+      return
+    end
+
     issuer = response.slice(/^\*\s*issuer: .*$/).gsub(/^\*\s*issuer: /,"")
     subject = response.slice(/^\*\s*subject: .*$/).gsub(/^\*\s*subject: /,"")
     commonname = response.slice(/^\*\s*common name: .*$/).gsub(/^\*\s*common name: /,"")


### PR DESCRIPTION
Drop a "require 'socket'" statement in the test_broker_certificate check.

This require statement was obviated in commit 9b72939f28a6d35354db74cc7464d879bbd3a81e.

Catch and report if curl returns an error in the test_broker_certificate check.

Previously, test_broker_certificate would ignore curl's return code, and so errors connecting to the broker would turn up as backtraces when test_broker_certificate would try to parse the output from curl.

Let me know if we should do more error checking, for example rescuing from exceptions when parsing the response from the broker.  It is probably a more common problem that the broker fails to start, so it is nice to identify the problem quickly.  It is probably a less common problem that curl succeeds but the response cannot be parsed, so it may not be worth rescuing from such errors to return a nicer error message.
