### PR TITLE
Set java minimum heap size to 40megs to reduce EAP/AS/EWS footprint.

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/versions/7/bin/standalone.conf
+++ b/cartridges/openshift-origin-cartridge-jbossas/versions/7/bin/standalone.conf
@@ -95,9 +95,9 @@ fi
 
 if [ $max_heap -lt 1024 ]
 then
-	memory_options="-Xmx${max_heap}m -XX:MaxPermSize=${max_permgen}m -XX:+AggressiveOpts -Dorg.apache.tomcat.util.LOW_MEMORY=true" 
+	memory_options="-XX:+UseSerialGC -Xms40m -Xmx${max_heap}m -XX:MaxPermSize=${max_permgen}m -XX:+AggressiveOpts -Dorg.apache.tomcat.util.LOW_MEMORY=true" 
 else
-	memory_options="-Xmx${max_heap}m -XX:MaxPermSize=${max_permgen}m -XX:+AggressiveOpts"
+	memory_options="-XX:+UseSerialGC -Xms40m -Xmx${max_heap}m -XX:MaxPermSize=${max_permgen}m -XX:+AggressiveOpts"
 fi
 
 if [ -z "${OPENSHIFT_JBOSSAS_CLUSTER_PROXY_PORT}" ]; then

--- a/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/bin/standalone.conf
+++ b/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/bin/standalone.conf
@@ -96,9 +96,9 @@ fi
 
 if [ $max_heap -lt 1024 ]
 then
-	memory_options="-Xmx${max_heap}m -XX:MaxPermSize=${max_permgen}m -XX:+AggressiveOpts -Dorg.apache.tomcat.util.LOW_MEMORY=true" 
+	memory_options="-XX:+UseSerialGC -Xms40m -Xmx${max_heap}m -XX:MaxPermSize=${max_permgen}m -XX:+AggressiveOpts -Dorg.apache.tomcat.util.LOW_MEMORY=true" 
 else
-	memory_options="-Xmx${max_heap}m -XX:MaxPermSize=${max_permgen}m -XX:+AggressiveOpts"
+	memory_options="-XX:+UseSerialGC -Xms40m -Xmx${max_heap}m -XX:MaxPermSize=${max_permgen}m -XX:+AggressiveOpts"
 fi
 
 if [ -z "${OPENSHIFT_JBOSSEAP_CLUSTER_PROXY_PORT}" ]; then

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/tomcat
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/tomcat
@@ -26,7 +26,7 @@ if [ $max_permgen -gt 256 ]; then
 	max_permgen=256
 fi
 
-memory_options="-Xmx${max_heap}m -XX:MaxPermSize=${max_permgen}m -XX:+AggressiveOpts" 
+memory_options="-XX:+UseSerialGC -Xms40m -Xmx${max_heap}m -XX:MaxPermSize=${max_permgen}m -XX:+AggressiveOpts" 
 
 #
 # Specify options to pass to the Java VM.

--- a/cartridges/openshift-origin-cartridge-jenkins/bin/control
+++ b/cartridges/openshift-origin-cartridge-jenkins/bin/control
@@ -47,6 +47,8 @@ function start() {
     exit 0
   fi
   JENKINS_CMD="/etc/alternatives/jre/bin/java \
+      -XX:+UseSerialGC \
+      -Xms20m \
       -Xmx168m \
       -XX:MaxPermSize=100m \
       -Djava.awt.headless=true"


### PR DESCRIPTION
also sets jenkins min heap to 20megs and uses serial gc policy instead of
parallel
