### PR TITLE
Add support for multiple platforms to Jenkins builds

### DIFF
--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/install
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/install
@@ -16,12 +16,23 @@ mv ${OPENSHIFT_JENKINS_CLIENT_DIR}/configuration/jenkins_job_template.xml.erb.hi
 
 echo $JENKINS_PASSWORD > "$OPENSHIFT_JENKINS_CLIENT_DIR/.password"
 
+PLATFORM=`oo-gear-registry web|head -n 1|rev|cut -f 1 -d \,|rev`
+if [ -z "$PLATFORM" ]
+then
+    PLATFORM="linux"
+fi
+
 # Maybe allow cartridges to create their own jenkins job
 if [ -f "${OPENSHIFT_PRIMARY_CARTRIDGE_DIR}/metadata/jenkins_shell_command" ]
 then
     SHELL_COMMAND="${OPENSHIFT_PRIMARY_CARTRIDGE_DIR}/metadata/jenkins_shell_command"
 else
-    SHELL_COMMAND="$OPENSHIFT_JENKINS_CLIENT_DIR/metadata/jenkins_shell_command"
+    if [ $PLATFORM == "windows" ]
+    then
+        SHELL_COMMAND="$OPENSHIFT_JENKINS_CLIENT_DIR/metadata/jenkins_shell_command_windows"
+    else
+        SHELL_COMMAND="$OPENSHIFT_JENKINS_CLIENT_DIR/metadata/jenkins_shell_command"
+    fi
 fi
 
 if [ -f "${OPENSHIFT_PRIMARY_CARTRIDGE_DIR}/metadata/jenkins_artifacts_glob" ]
@@ -35,7 +46,7 @@ JOB_NAME=${OPENSHIFT_APP_NAME}-build
 
 BUILDER_TYPE=$(primary_cartridge_name)
 
-if out=$(${OPENSHIFT_JENKINS_CLIENT_DIR}/bin/jenkins_create_job "${OPENSHIFT_CLOUD_DOMAIN}" "$BUILDER_TYPE" "$SHELL_COMMAND" "$ARTIFACTS_GLOB" 2>&1)
+if out=$(${OPENSHIFT_JENKINS_CLIENT_DIR}/bin/jenkins_create_job "${OPENSHIFT_CLOUD_DOMAIN}" "$BUILDER_TYPE" "$SHELL_COMMAND" "$ARTIFACTS_GLOB" "$PLATFORM" 2>&1)
 then
     # Embedding success
     client_result ""

--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_create_job
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_create_job
@@ -19,6 +19,7 @@ STDERR.sync = true
 @openshift_domain = ARGV[0]
 @job_erb = "#{ENV['OPENSHIFT_JENKINS_CLIENT_DIR']}/configuration/jenkins_job_template.xml.erb"
 @builder_type = ARGV[1]
+@platform = ARGV[4]
 @application_uuid = ENV['OPENSHIFT_APP_UUID']
 ## https://bugzilla.redhat.com/show_bug.cgi?id=952161
 # Encode XML entites in jenkins_shell_command.erb template *after*

--- a/cartridges/openshift-origin-cartridge-jenkins-client/configuration/jenkins_job_template.xml.erb.hidden
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/configuration/jenkins_job_template.xml.erb.hidden
@@ -16,6 +16,9 @@
     <hudson.plugins.openshift.OpenShiftBuilderTypeJobProperty>
       <builderType><%= @builder_type %></builderType>
     </hudson.plugins.openshift.OpenShiftBuilderTypeJobProperty>
+    <hudson.plugins.openshift.OpenShiftPlatformJobProperty>
+      <platform><%= @platform %></platform>
+    </hudson.plugins.openshift.OpenShiftPlatformJobProperty>
     <hudson.plugins.openshift.OpenShiftApplicationUUIDJobProperty>
       <applicationUUID><%= @application_uuid %></applicationUUID>
     </hudson.plugins.openshift.OpenShiftApplicationUUIDJobProperty>

--- a/cartridges/openshift-origin-cartridge-jenkins-client/metadata/jenkins_shell_command_windows
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/metadata/jenkins_shell_command_windows
@@ -1,0 +1,44 @@
+source $OPENSHIFT_CARTRIDGE_SDK_BASH
+
+alias rsync="rsync --delete-after -az -e '$GIT_SSH'"
+
+upstream_ssh="UPSTREAM_SSH"
+
+# Need to use cygpath for rsync on windows
+homedir=`cygpath $OPENSHIFT_HOMEDIR`
+build_dependencies_dir=`cygpath $OPENSHIFT_BUILD_DEPENDENCIES_DIR`
+dependencies_dir=`cygpath $OPENSHIFT_DEPENDENCIES_DIR`
+cygworkspace=`cygpath $WORKSPACE`
+
+# remove previous metadata, if any
+rm -f $OPENSHIFT_HOMEDIR/app-deployments/current/metadata.json
+
+if ! marker_present "force_clean_build"; then
+  # don't fail if these rsyncs fail
+  set +e
+  # Need to use cygpath for rsync on windows
+  rsync $upstream_ssh:'$OPENSHIFT_BUILD_DEPENDENCIES_DIR' $build_dependencies_dir
+  rsync $upstream_ssh:'$OPENSHIFT_DEPENDENCIES_DIR' $dependencies_dir
+  set -e
+fi
+
+# Build/update libs and run user pre_build and build
+gear build
+
+# Run tests here
+
+# Deploy new build
+
+# Stop app
+$GIT_SSH $upstream_ssh "gear stop --conditional --exclude-web-proxy --git-ref $GIT_COMMIT"
+
+deployment_dir=`$GIT_SSH $upstream_ssh 'gear create-deployment-dir'`
+
+# Push content back to application
+rsync $homedir/app-deployments/current/metadata.json $upstream_ssh:app-deployments/$deployment_dir/metadata.json
+rsync --exclude .git $cygworkspace/ $upstream_ssh:app-root/runtime/repo/
+rsync $build_dependencies_dir $upstream_ssh:app-root/runtime/build-dependencies/
+rsync $dependencies_dir $upstream_ssh:app-root/runtime/dependencies/
+
+# Configure / start app
+$GIT_SSH $upstream_ssh "gear remotedeploy --deployment-datetime $deployment_dir"

--- a/node-util/bin/oo-gear-registry
+++ b/node-util/bin/oo-gear-registry
@@ -33,7 +33,6 @@ STDERR.sync = true
 OpenShift::Runtime::NodeLogger.disable
 
 @container = OpenShift::Runtime::ApplicationContainer.from_uuid(ENV['OPENSHIFT_GEAR_UUID'])
-@gear_registry = OpenShift::Runtime::GearRegistry.new(@container)
 
 command :read do |c|
   c.syntax = "#{name} read [options]"
@@ -47,11 +46,18 @@ command :read do |c|
       exit! 3
     end
 
+    unless @container.cartridge_model.web_proxy
+      $stderr.puts "application is not scalable"
+      exit! 4
+    end
+
+    gear_registry = OpenShift::Runtime::GearRegistry.new(@container)
+
     if type != 'all'
-      requested_gears = @gear_registry.entries[type.to_sym]
+      requested_gears = gear_registry.entries[type.to_sym]
     else
       requested_gears = {}
-      @gear_registry.entries.each do |type, gears|
+      gear_registry.entries.each do |type, gears|
         requested_gears.merge!(gears)
       end
     end


### PR DESCRIPTION
support cygwin in jenkins client shell command
detect application platform in jenkins client and use it to determine if builder should be scalable
update bash sdk with function to determine node platform
