### PR TITLE
Fix bug 1061400: POST /broker/analytics Status Code 500 on release 3

### DIFF
--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -45,7 +45,9 @@ LIBVIRT_PRIVATE_IP_GW=172.16.0.1
 CONTAINERIZATION_PLUGIN=openshift-origin-container-selinux
 QUOTA_WARNING_PERCENT=90.0
 
-# MOTD_FILE=" /etc/openshift/welcome.rhcsh"                   # Change the default rhcs welcome message
+REPORT_BUILD_ANALYTICS=true
+
+# MOTD_FILE="/etc/openshift/welcome.rhcsh"                   # Change the default rhcs welcome message
 
 # Gems for managing the frontend http server
 # NOTE: Steps must be taken both before and after these values are changed.

--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -612,6 +612,8 @@ module OpenShift
       # Send a fire-and-forget request to the broker to report build analytics.
       #
       def report_build_analytics
+        return unless @config.get_bool('REPORT_BUILD_ANALYTICS', true)
+
         broker_addr = @config.get('BROKER_HOST')
         url         = "https://#{broker_addr}/broker/analytics"
 

--- a/node/test/cart_functional/application_repository_func_test.rb
+++ b/node/test/cart_functional/application_repository_func_test.rb
@@ -39,6 +39,7 @@ class ApplicationRepositoryFuncTest < OpenShift::NodeTestCase
     @config.stubs(:get).with("UID_BEGIN").returns(@uid)
     @config.stubs(:get).with("BROKER_HOST").returns('localhost')
     @config.stubs(:get).with("CARTRIDGE_BASE_PATH").returns('.')
+    @config.stubs(:get).with('REPORT_BUILD_ANALYTICS').returns(false)
 
     @uuid = SecureRandom.uuid.gsub(/-/, '')
 

--- a/node/test/cart_functional/v2_cart_model_func_test.rb
+++ b/node/test/cart_functional/v2_cart_model_func_test.rb
@@ -38,6 +38,7 @@ module OpenShift
       @config.stubs(:get).with("PORTS_PER_USER").returns(5)
       @config.stubs(:get).with("UID_BEGIN").returns(@uid)
       @config.stubs(:get).with("BROKER_HOST").returns('localhost')
+      @config.stubs(:get).with('REPORT_BUILD_ANALYTICS').returns(false)
 
       script_dir     = File.expand_path(File.dirname(__FILE__))
       cart_base_path = File.join(script_dir, '..', '..', '..', 'cartridges')

--- a/node/test/node_functional/application_container_func_test.rb
+++ b/node/test/node_functional/application_container_func_test.rb
@@ -37,6 +37,7 @@ class ApplicationContainerFuncTest < OpenShift::NodeTestCase
     @config.stubs(:get).with("PORTS_PER_USER").returns(5)
     @config.stubs(:get).with("UID_BEGIN").returns(@uid)
     @config.stubs(:get).with("BROKER_HOST").returns('localhost')
+    @config.stubs(:get).with('REPORT_BUILD_ANALYTICS').returns(false)
 
     begin
       %x(userdel -f #{Etc.getpwuid(@uid).name})

--- a/node/test/node_functional/node_func_test.rb
+++ b/node/test/node_functional/node_func_test.rb
@@ -39,6 +39,8 @@ module OpenShift
         @config.stubs(:get).with("PORTS_PER_USER").returns(5)
         @config.stubs(:get).with("UID_BEGIN").returns(@uid)
         @config.stubs(:get).with("BROKER_HOST").returns('localhost')
+        @config.stubs(:get).with('REPORT_BUILD_ANALYTICS').returns(false)
+
 
         script_dir     = File.expand_path(File.dirname(__FILE__))
         cart_base_path = File.join(script_dir, '..', '..', '..', 'cartridges')


### PR DESCRIPTION
Hi,

OpenShift Release 3 logs are filled by stack trace, due to this bug : 
https://bugzilla.redhat.com/show_bug.cgi?id=1061400

```
2014-04-23 17:12:55.520 [INFO ] Started POST "/broker/analytics" for 127.0.0.1 at 2014-04-23 17:12:55 +0200 (pid:8212)

==> /var/log/openshift/broker/httpd/error_log <==
[ pid=8212 thr=5212300 file=utils.rb:176 time=2014-04-23 17:12:55.521 ]: *** Exception ActionController::RoutingError in Rack application object (No route matches [POST] "/broker/analytics") (process 8212, thread #<Thread:0x000000009f1118>):
        from /opt/rh/ruby193/root/usr/share/gems/gems/actionpack-3.2.8/lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
        from /opt/rh/ruby193/root/usr/share/gems/gems/actionpack-3.2.8/lib/action_dispatch/middleware/show_exceptions.rb:56:in `call'
        from /opt/rh/ruby193/root/usr/share/gems/gems/railties-3.2.8/lib/rails/rack/logger.rb:26:in `call_app'
        from /opt/rh/ruby193/root/usr/share/gems/gems/railties-3.2.8/lib/rails/rack/logger.rb:16:in `call'
        from /opt/rh/ruby193/root/usr/share/gems/gems/actionpack-3.2.8/lib/action_dispatch/middleware/request_id.rb:22:in `call'
        from /opt/rh/ruby193/root/usr/share/gems/gems/rack-1.4.1/lib/rack/methodoverride.rb:21:in `call'
        from /opt/rh/ruby193/root/usr/share/gems/gems/rack-1.4.1/lib/rack/runtime.rb:17:in `call'
        from /opt/rh/ruby193/root/usr/share/gems/gems/activesupport-3.2.8/lib/active_support/cache/strategy/local_cache.rb:72:in `call'
        from /opt/rh/ruby193/root/usr/share/gems/gems/rack-1.4.1/lib/rack/lock.rb:15:in `call'
        from /opt/rh/ruby193/root/usr/share/gems/gems/actionpack-3.2.8/lib/action_dispatch/middleware/static.rb:62:in `call'
        from /opt/rh/ruby193/root/usr/share/gems/gems/rack-cache-1.2/lib/rack/cache/context.rb:136:in `forward'
        from /opt/rh/ruby193/root/usr/share/gems/gems/rack-cache-1.2/lib/rack/cache/context.rb:143:in `pass'
        from /opt/rh/ruby193/root/usr/share/gems/gems/rack-cache-1.2/lib/rack/cache/context.rb:155:in `invalidate'
        from /opt/rh/ruby193/root/usr/share/gems/gems/rack-cache-1.2/lib/rack/cache/context.rb:71:in `call!'
        from /opt/rh/ruby193/root/usr/share/gems/gems/rack-cache-1.2/lib/rack/cache/context.rb:51:in `call'
        from /opt/rh/ruby193/root/usr/share/gems/gems/railties-3.2.8/lib/rails/engine.rb:479:in `call'
        from /opt/rh/ruby193/root/usr/share/gems/gems/railties-3.2.8/lib/rails/application.rb:223:in `call'
        from /opt/rh/ruby193/root/usr/share/gems/gems/railties-3.2.8/lib/rails/railtie/configurable.rb:30:in `method_missing'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/rack/request_handler.rb:97:in `process_request'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/abstract_request_handler.rb:521:in `accept_and_process_next_request'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/abstract_request_handler.rb:274:in `main_loop'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/rack/application_spawner.rb:206:in `start_request_handler'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/rack/application_spawner.rb:171:in `block in handle_spawn_application'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/utils.rb:470:in `safe_fork'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/rack/application_spawner.rb:166:in `handle_spawn_application'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/abstract_server.rb:357:in `server_main_loop'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/abstract_server.rb:206:in `start_synchronously'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/abstract_server.rb:180:in `start'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/rack/application_spawner.rb:129:in `start'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/spawn_manager.rb:253:in `block (2 levels) in spawn_rack_application'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/abstract_server_collection.rb:132:in `lookup_or_add'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/spawn_manager.rb:246:in `block in spawn_rack_application'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/abstract_server_collection.rb:82:in `block in synchronize'
        from <internal:prelude>:10:in `synchronize'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/abstract_server_collection.rb:79:in `synchronize'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/spawn_manager.rb:244:in `spawn_rack_application'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/spawn_manager.rb:137:in `spawn_application'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/spawn_manager.rb:275:in `handle_spawn_application'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/abstract_server.rb:357:in `server_main_loop'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/lib/phusion_passenger/abstract_server.rb:206:in `start_synchronously'
        from /opt/rh/ruby193/root/usr/share/gems/gems/passenger-3.0.21/helper-scripts/passenger-spawn-server:102:in `<main>'
[Wed Apr 23 17:12:55 2014] [error] [client 127.0.0.1] Premature end of script headers: broker
[ pid=32211 thr=139658144016352 file=ext/apache2/Hooks.cpp:841 time=2014-04-23 17:12:55.521 ]: The backend application (process 8212) did not send a valid HTTP response; instead, it sent nothing at all. It is possible that it has crashed; please check whether there are crashing bugs in this application.

==> /var/log/openshift/broker/httpd/access_log <==
- otvmi110s.priv.atos.fr - - [23/Apr/2014:17:12:55 +0200] "POST /broker/analytics HTTP/1.1" 500 622 "-" "OpenShift" "-" "1" "-" "-"
```

I cherry picked https://github.com/openshift/origin-server/commit/c02133325e877abcaff316e8e3bf07534583f113
