### PR TITLE
Modified URL match rule for remote user auth configurations

### DIFF
--- a/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-basic.conf.sample
+++ b/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-basic.conf.sample
@@ -53,7 +53,7 @@ LoadModule authz_user_module modules/mod_authz_user.so
 # But not:
 #
 # /api_with_auth
-<LocationMatch ^/broker/rest/(api|environment|cartridges|quickstarts)(\.\w+|/?)$>
+<LocationMatch ^/broker/rest/(api|environment|cartridges|quickstarts)(\.\w+|/?|/.*)$>
   <IfVersion >= 2.4>
     Require all granted
   </IfVersion>

--- a/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-kerberos.conf.sample
+++ b/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-kerberos.conf.sample
@@ -61,7 +61,7 @@ LoadModule auth_kerb_module modules/mod_auth_kerb.so
 # But not:
 #
 # /api_with_auth
-<LocationMatch ^/broker/rest/(api|environment|cartridges|quickstarts)(\.\w+|/?)$>
+<LocationMatch ^/broker/rest/(api|environment|cartridges|quickstarts)(\.\w+|/?|/.*)$>
   <IfVersion >= 2.4>
     Require all granted
   </IfVersion>

--- a/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-ldap.conf.sample
+++ b/plugins/auth/remote-user/conf/openshift-origin-auth-remote-user-ldap.conf.sample
@@ -62,7 +62,7 @@ LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
 # But not:
 #
 # /api_with_auth
-<LocationMatch ^/broker/rest/(api|environment|cartridges|quickstarts)(\.\w+|/?)$>
+<LocationMatch ^/broker/rest/(api|environment|cartridges|quickstarts)(\.\w+|/?|/.*)$>
   <IfVersion >= 2.4>
     Require all granted
   </IfVersion>


### PR DESCRIPTION
The existing configurations were preventing URLs like
`https://<server>/broker/rest/quickstarts/<uuid>`
from succeeding.
