### PR TITLE
Add journal cache dir to %files

### DIFF
--- a/cartridges/openshift-origin-cartridge-mongodb/openshift-origin-cartridge-mongodb.spec
+++ b/cartridges/openshift-origin-cartridge-mongodb/openshift-origin-cartridge-mongodb.spec
@@ -51,6 +51,7 @@ fi
 %{cartridgedir}/conf
 %{cartridgedir}/metadata
 %{cartridgedir}/env
+%dir %{cartridgedir}/usr/journal-cache/
 %doc %{cartridgedir}/README.md
 %doc %{cartridgedir}/COPYRIGHT
 %doc %{cartridgedir}/LICENSE


### PR DESCRIPTION
Add the mongodb journal cache dir to the %files list to ensure
the directory sticks around.

Resolve bug: https://bugzilla.redhat.com/show_bug.cgi?id=1092159
