### PR TITLE
fix bug 993561 on openshift-release 3

### DIFF
--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_build
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/jenkins_build
@@ -46,7 +46,7 @@ end
 
 def schedule_build
   status_code = `curl -s -w %{http_code} --output /dev/null -X POST --insecure https://${JENKINS_USERNAME}:${JENKINS_PASSWORD}@#{@hostname}#{@job_url}/build`
-  if status_code != '302' && status_code != '200'
+  if status_code != '302' && status_code != '200' && status_code !='201'
     puts "ERROR - Couldn't schedule job"
     exit 292
   end

--- a/cartridges/openshift-origin-cartridge-jenkins/bin/control
+++ b/cartridges/openshift-origin-cartridge-jenkins/bin/control
@@ -54,10 +54,14 @@ function start() {
       -Dcom.sun.akuma.Daemon=daemonized \
       -Djava.awt.headless=true"
 
-  if [ -f "${OPENSHIFT_REPO_DIR}/.openshift/markers/enable_debugging" ]; then
-      JENKINS_CMD="${JENKINS_CMD} -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${OPENSHIFT_JENKINS_IP}:7600,suspend=n"
+  if marker_present "disable_jenkins_udp_broadcast"; then
+      JENKINS_CMD="${JENKINS_CMD} -Dhudson.udp=-1"
   fi
 
+  if marker_present "enable_debugging"; then
+      JENKINS_CMD="${JENKINS_CMD} -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${OPENSHIFT_JENKINS_IP}:7600,suspend=n"
+  fi
+  
   if [ -z "$JENKINS_WAR_PATH" ]; then
     JENKINS_WAR_PATH=/usr/lib/jenkins/jenkins.war
   fi


### PR DESCRIPTION
The bug [993561](https://bugzilla.redhat.com/show_bug.cgi?id=993561) breaks the jenkins client cartridge on release 3.

I cherry picked https://github.com/openshift/origin-server/commit/48f66cdf01510560bbf4bfda1313813da405987a to fix this issue.
