### PR TITLE
Install JBoss metrics RPM and provide sample configuration

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/openshift-origin-cartridge-jbossas.spec
+++ b/cartridges/openshift-origin-cartridge-jbossas/openshift-origin-cartridge-jbossas.spec
@@ -16,6 +16,7 @@ Requires:      lsof
 Requires:      java-1.7.0-openjdk
 Requires:      java-1.7.0-openjdk-devel
 Requires:      jboss-as7-modules >= %{jbossver}
+Requires:      jboss-openshift-metrics-module
 Requires:      bc
 %if 0%{?rhel}
 Requires:      jboss-as7 >= %{jbossver}

--- a/cartridges/openshift-origin-cartridge-jbossas/versions/7/standalone/configuration/standalone.xml
+++ b/cartridges/openshift-origin-cartridge-jbossas/versions/7/standalone/configuration/standalone.xml
@@ -31,6 +31,11 @@
         <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
+
+        <!-- OpenShift metrics module - disabled by default -->
+        <!--
+        <extension module="com.openshift.metrics"/>
+        -->
     </extensions>
     
     <system-properties>
@@ -502,6 +507,21 @@
             </endpoint-config>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:weld:1.0"/>
+        <!-- OpenShift metrics - disabled by default -->
+        <!--
+        <subsystem xmlns="urn:redhat:openshift:metrics:1.0">
+          <metrics-group cron="*/15 * * * * ?">
+            <source type="jboss" path="core-service=platform-mbean/type=memory-pool/name=Tenured_Gen">
+              <metric source-key="usage.used" publish-key="oldgen.used" />
+              <metric source-key="usage.max" publish-key="oldgen.max" />
+              <metric source-key="usage.committed" publish-key="oldgen.committed" />
+            </source>
+            <source type="mbean" path="java.lang:type=Memory">
+              <metric source-key="HeapMemoryUsage.used" publish-key="jmx.heap.used"/>
+            </source>
+          </metrics-group>
+        </subsystem>
+        -->
     </profile>
 
     <interfaces>

--- a/cartridges/openshift-origin-cartridge-jbosseap/openshift-origin-cartridge-jbosseap.spec
+++ b/cartridges/openshift-origin-cartridge-jbosseap/openshift-origin-cartridge-jbosseap.spec
@@ -27,6 +27,7 @@ Requires:      jbossas-standalone
 Requires:      jbossas-welcome-content-eap
 Requires:      jboss-eap6-modules
 Requires:      jboss-eap6-index
+Requires:      jboss-openshift-metrics-module
 Requires:      bc
 %if 0%{?rhel}
 Requires:      maven3

--- a/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/standalone/configuration/standalone.xml
+++ b/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/standalone/configuration/standalone.xml
@@ -32,6 +32,11 @@
 		<extension module="org.jboss.as.web" />
 		<extension module="org.jboss.as.webservices" />
 		<extension module="org.jboss.as.weld" />
+
+		<!-- OpenShift metrics module - disabled by default -->
+		<!--
+		<extension module="com.openshift.metrics"/>
+		-->
 	</extensions>
 	
 	<system-properties>
@@ -505,6 +510,21 @@
 			</endpoint-config>
 		</subsystem>
 		<subsystem xmlns="urn:jboss:domain:weld:1.0" />
+		<!-- OpenShift metrics - disabled by default -->
+		<!--
+		<subsystem xmlns="urn:redhat:openshift:metrics:1.0">
+			<metrics-group cron="*/15 * * * * ?">
+				<source type="jboss" path="core-service=platform-mbean/type=memory-pool/name=Tenured_Gen">
+					<metric source-key="usage.used" publish-key="oldgen.used" />
+					<metric source-key="usage.max" publish-key="oldgen.max" />
+					<metric source-key="usage.committed" publish-key="oldgen.committed" />
+				</source>
+				<source type="mbean" path="java.lang:type=Memory">
+					<metric source-key="HeapMemoryUsage.used" publish-key="jmx.heap.used"/>
+				</source>
+			</metrics-group>
+		</subsystem>
+		-->
 	</profile>
 
 	<interfaces>


### PR DESCRIPTION
Add dependency on JBoss metrics module so it will be installed with the
JBoss cartridges.

Add sample (disabled) metrics configuration to standalone.xml.
