### PR TITLE
rhcsh: Fix quota check if quotas disabled

### DIFF
--- a/node/misc/bin/rhcsh
+++ b/node/misc/bin/rhcsh
@@ -86,13 +86,13 @@ function welcome {
     if quota >/dev/null 2>&1
     then
       local usage=$(quota -w 2>/dev/null| grep '^.*/dev/' | awk '{printf "%3.1f", ($2 / $4 * 100)}')
-      if float_test "$usage > 90.0"
+      if float_test "${usage:-0} > 90.0"
       then
         echo "Warning: Gear ${OPENSHIFT_GEAR_UUID} is using ${usage}% of disk quota"
       fi
 
       local usage=$(quota -w 2>/dev/null| grep '^.*/dev/' | awk '{printf "%3.1f",  ($5 / $7 * 100)}')
-      if float_test "$usage > 90.0"
+      if float_test "${usage:-0} > 90.0"
       then
         echo "Warning: Gear ${OPENSHIFT_GEAR_UUID} is using ${usage}% of inodes allowed"
       fi


### PR DESCRIPTION
When testing whether the gear's quota usage is close to its quota limit, substitute 0 for the empty string in case there was an error reading the current usage.

This changes fixes a problem that shows up, for example,  if quotas are disabled:

```
> quota
Disk quotas for user [uuid] (uid [uid]): none
```

Previously, in this situation, the following error message would appear when the application developer tried to log into the gear using ssh:

```
awk: END { exit ( !(  > 90.0)); }
awk:                  ^ syntax error
awk: END { exit ( !(  > 90.0)); }
awk:                         ^ syntax error
awk: END { exit ( !(  > 90.0)); }
awk:                          ^ syntax error
awk: END { exit ( !(  > 90.0)); }
awk:                  ^ syntax error
awk: END { exit ( !(  > 90.0)); }
awk:                         ^ syntax error
awk: END { exit ( !(  > 90.0)); }
awk:                          ^ syntax error
```

This commit fixes bug 1092722.
