### PR TITLE
vhost frontend: fix annotation logging

### DIFF
--- a/plugins/frontend/apache-vhost/httpd/frontend-vhost-http-template.erb
+++ b/plugins/frontend/apache-vhost/httpd/frontend-vhost-http-template.erb
@@ -17,6 +17,8 @@
   RequestHeader set X-Client-IP %{X_CLIENT_IP}e
 
   # Log configuration for gear access logs
+  SetEnv APP_UUID <%= app_uuid %>
+  SetEnv GEAR_UUID <%= gear_uuid %>
   Include conf.d/openshift-vhost-logconf.include
 
   # Create this file to customize configuration for all gear vhosts:

--- a/plugins/frontend/apache-vhost/httpd/frontend-vhost-https-template.erb
+++ b/plugins/frontend/apache-vhost/httpd/frontend-vhost-https-template.erb
@@ -27,6 +27,8 @@
   RequestHeader set X-Client-IP %{X_CLIENT_IP}e
 
   # Log configuration for gear access logs
+  SetEnv APP_UUID <%= app_uuid %>
+  SetEnv GEAR_UUID <%= gear_uuid %>
   Include conf.d/openshift-vhost-logconf.include
 
   # Create this file to customize configuration for all gear vhosts:

--- a/plugins/frontend/apache-vhost/httpd/openshift-vhost-logconf.include
+++ b/plugins/frontend/apache-vhost/httpd/openshift-vhost-logconf.include
@@ -3,7 +3,7 @@
 LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X" openshift
 # If the `OpenShiftAnnotateFrontendAccessLog` option is defined, add the app/gear UUIDs to the log msg
 <IfDefine OpenShiftAnnotateFrontendAccessLog>
-  LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X <%= app_uuid %> <%= gear_uuid %>" openshift
+  LogFormat "%h %v %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" (%Dus) %X %{APP_UUID}e %{GEAR_UUID}e" openshift
 </IfDefine>
 
 # Log file is used by the autoidler to assess gear (in)activity.


### PR DESCRIPTION
Bug 1092426 - "-DOpenShiftAnnotateFrontendAccessLog" option does NOT
work with vhost frontend plugin.
https://bugzilla.redhat.com/show_bug.cgi?id=1092426

A dynamic part of the template was moved to a static include. It fails
when the annotation option is set. The fix is to set env vars in the
dynamic template and log them in the include.
