### PR TITLE
Fix JBoss installation issue (metrics)

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/openshift-origin-cartridge-jbossas.spec
+++ b/cartridges/openshift-origin-cartridge-jbossas/openshift-origin-cartridge-jbossas.spec
@@ -16,7 +16,6 @@ Requires:      lsof
 Requires:      java-1.7.0-openjdk
 Requires:      java-1.7.0-openjdk-devel
 Requires:      jboss-as7-modules >= %{jbossver}
-Requires:      jboss-openshift-metrics-module
 Requires:      bc
 %if 0%{?rhel}
 Requires:      jboss-as7 >= %{jbossver}

--- a/cartridges/openshift-origin-cartridge-jbosseap/openshift-origin-cartridge-jbosseap.spec
+++ b/cartridges/openshift-origin-cartridge-jbosseap/openshift-origin-cartridge-jbosseap.spec
@@ -27,7 +27,6 @@ Requires:      jbossas-standalone
 Requires:      jbossas-welcome-content-eap
 Requires:      jboss-eap6-modules
 Requires:      jboss-eap6-index
-Requires:      jboss-openshift-metrics-module
 Requires:      bc
 %if 0%{?rhel}
 Requires:      maven3


### PR DESCRIPTION
Fix JBoss installation issue caused by having the JBoss cartridges
depend on the jboss-openshift-metrics-module package. Installing the
metrics module first causes /etc/alternatives/jboss{as-7,eap-6} to be
created as a real directory, instead of as a symlink, which results in
the cartridge failing to start.
