### PR TITLE
Update JBoss cart specs for new metrics location

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/openshift-origin-cartridge-jbossas.spec
+++ b/cartridges/openshift-origin-cartridge-jbossas/openshift-origin-cartridge-jbossas.spec
@@ -17,6 +17,7 @@ Requires:      java-1.7.0-openjdk
 Requires:      java-1.7.0-openjdk-devel
 Requires:      jboss-as7-modules >= %{jbossver}
 Requires:      bc
+Requires:      jboss-openshift-metrics-module
 %if 0%{?rhel}
 Requires:      jboss-as7 >= %{jbossver}
 Requires:      maven3
@@ -76,6 +77,10 @@ alternatives --set jbossas-7 /usr/share/jboss-as
 mkdir -p /etc/alternatives/jbossas-7/modules/org/postgresql/jdbc/main
 ln -fs /usr/share/java/postgresql-jdbc3.jar /etc/alternatives/jbossas-7/modules/org/postgresql/jdbc/main
 cp -p %{cartridgedir}/versions/7/modules/postgresql_module.xml /etc/alternatives/jbossas-7/modules/org/postgresql/jdbc/main/module.xml
+
+# link in the metrics module
+mkdir -p /etc/alternatives/jbossas-7/modules/com/openshift
+ln -fs /usr/share/openshift/jboss/modules/com/openshift/metrics /etc/alternatives/jbossas-7/modules/com/openshift/metrics
 
 %postun
 # Cleanup alternatives if uninstall only

--- a/cartridges/openshift-origin-cartridge-jbosseap/openshift-origin-cartridge-jbosseap.spec
+++ b/cartridges/openshift-origin-cartridge-jbosseap/openshift-origin-cartridge-jbosseap.spec
@@ -28,6 +28,7 @@ Requires:      jbossas-welcome-content-eap
 Requires:      jboss-eap6-modules
 Requires:      jboss-eap6-index
 Requires:      bc
+Requires:      jboss-openshift-metrics-module
 %if 0%{?rhel}
 Requires:      maven3
 %endif
@@ -79,6 +80,10 @@ cp -p %{cartridgedir}/versions/shared/modules/postgresql_module.xml /etc/alterna
 mkdir -p /etc/alternatives/jbosseap-6/modules/com/mysql/jdbc/main
 ln -fs /usr/share/java/mysql-connector-java.jar /etc/alternatives/jbosseap-6/modules/com/mysql/jdbc/main
 cp -p %{cartridgedir}/versions/shared/modules/mysql_module.xml /etc/alternatives/jbosseap-6/modules/com/mysql/jdbc/main/module.xml
+
+# link in the metrics module
+mkdir -p /etc/alternatives/jbosseap-6/modules/com/openshift
+ln -fs /usr/share/openshift/jboss/modules/com/openshift/metrics /etc/alternatives/jbosseap-6/modules/com/openshift/metrics
 
 %files
 %dir %{cartridgedir}


### PR DESCRIPTION
Add dependency on jboss-openshift-metrics-module to the jbossas and
jbosseap cartridges.

Create symlinks in /etc/alternatives/{jbossas-7,jbosseap-6} that point
to the shared JBoss metrics module location.
