### PR TITLE
added Servlet 3 dependency

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossews/template/pom.xml
+++ b/cartridges/openshift-origin-cartridge-jbossews/template/pom.xml
@@ -45,7 +45,13 @@
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 			<version>5.1.25</version>
-		</dependency>           
+		</dependency>     
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.0.1</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 	<profiles>
 		<profile>


### PR DESCRIPTION
Importing this template application in Eclipse or other IDE shows error as the snoop.jsp depends on the Servlet API. It will improve user experience.
