### PR TITLE
Support unidling scalable apps

### DIFF
--- a/broker/test/functional/access_controlled_test.rb
+++ b/broker/test/functional/access_controlled_test.rb
@@ -455,6 +455,7 @@ class AccessControlledTest < ActiveSupport::TestCase
         :change_gear_quota => [false, false, true],
         :ssh_to_gears      => [false, false, true],
         :scale_cartridge   => [false, true,  true],
+        :change_state      => [false, true,  true]
       }
       allows.each_pair do |p, expect|
         apps.zip(expect).each do |(a, bool)|
@@ -469,6 +470,7 @@ class AccessControlledTest < ActiveSupport::TestCase
         :change_gear_quota => [true, true, true],
         :ssh_to_gears      => [true, true, true],
         :scale_cartridge   => [true, true, true],
+        :change_state      => [true, true, true]
       }
       allows.each_pair do |p, expect|
         apps.zip(expect).each do |(a, bool)|

--- a/controller/app/models/scope/application.rb
+++ b/controller/app/models/scope/application.rb
@@ -64,7 +64,10 @@ class Scope::Application < Scope::Parameterized
           #:change_members,
         ].include?(permission)
     when :scale
-      resource === Application && resource._id === app_id && :scale_cartridge == permission
+      resource === Application && resource._id === app_id && [
+        :scale_cartridge,
+        :change_state
+      ].include?(permission)
     when :report_deployments
       resource === Application && resource._id === app_id && :update_deployments == permission
     end


### PR DESCRIPTION
Use a broker REST call to start the entire app up during unidle
rather than a local gear start.

Adjust the 'scale' auth scope to include explicit state changes.
This allows the node to start the app via the broker API, and is
consistent with the previous scope in that it already includes
scaling (which itself involves an implicit state change).

Resolve bug: https://bugzilla.redhat.com/show_bug.cgi?id=1093776
