### PR TITLE
Changed documentation to install rubygem-rhc by yum command

### DIFF
--- a/documentation/oo_client_tools_installation_guide.adoc
+++ b/documentation/oo_client_tools_installation_guide.adoc
@@ -92,16 +92,10 @@ $ rhc -v
 ----
 
 == Fedora
-To install on Fedora 16 or above, the most reliable solution is to use RubyGems.
+To install on Fedora 19 or above, you can install by yum command.
 
 ----
-$ sudo yum install rubygems
-----
-
-After installing RubyGems, use it to install the OpenShift Origin client tools:
-
-----
-$ sudo gem install rhc
+$ sudo yum install rubygem-rhc
 ----
 
 You will also need to install Git if it is not already installed:


### PR DESCRIPTION
According to Fedora package repository[1], rhc can be installed by yum command.

[1] https://admin.fedoraproject.org/pkgdb/acls/name/rubygem-rhc
