### PR TITLE
Customize openshift logo and name

### DIFF
--- a/console/app/helpers/console/console_helper.rb
+++ b/console/app/helpers/console/console_helper.rb
@@ -10,11 +10,11 @@ module Console::ConsoleHelper
 
   def product_branding
     [
-      image_tag('/assets/logo-origin.svg', :alt => 'OpenShift Origin')
+      image_tag(Console.config.env(:PRODUCT_LOGO, "/assets/logo-origin.svg"), :alt => Console.config.env(:PRODUCT_TITLE, "OpenShift Origin"))
     ].join.html_safe
   end
 
   def product_title
-    'OpenShift Origin'
+    Console.config.env(:PRODUCT_TITLE, 'OpenShift Origin')
   end
 end

--- a/openshift-console/etc/openshift/console.conf
+++ b/openshift-console/etc/openshift/console.conf
@@ -136,3 +136,10 @@ REMOTE_USER_COPY_HEADERS=X-Remote-User
 #RED_HAT_ACCOUNT_URL=https://www.redhat.com/wapps/ugc
 
 #CONTACT_MAIL=openshift@redhat.com
+
+
+#product logo, change it if you want a custom logo.
+#PRODUCT_LOGO=/assets/logo-origin.svg
+
+#Openshift instance name, change it if you want a custom name.
+#PRODUCT_TITLE=OpenShift Origin


### PR DESCRIPTION
We wanted to make openshift's logo and name settable via console.conf. Here are the changes:
console_helper.rb
    - replace hard-coded value of openshift logo and product title by dynamic values from   Console.config

configuration.rb:
    - add support of OPENSHIFT_LOGO and OPENSHIFT_INSTANCE_NAME parameters

console.conf:
    - add OPENSHIFT_LOGO and OPENSHIFT_INSTANCE_NAME parameters
