### PR TITLE
user system libyaml

### DIFF
--- a/cartridges/dependencies/openshift-origin-cartridge-dependencies.spec
+++ b/cartridges/dependencies/openshift-origin-cartridge-dependencies.spec
@@ -439,7 +439,6 @@ Requires:  rubygem-rugged
 Requires:  rubygem-nokogiri
 %endif
 Requires:  %{?scl_prefix}js-devel
-Requires:  %{?scl_prefix}libyaml-devel
 Requires:  %{?scl_prefix}ruby-tcltk
 Requires:  %{?scl_prefix}rubygem-actionmailer
 Requires:  %{?scl_prefix}rubygem-actionpack

--- a/cartridges/openshift-origin-cartridge-ruby/openshift-origin-cartridge-ruby.spec
+++ b/cartridges/openshift-origin-cartridge-ruby/openshift-origin-cartridge-ruby.spec
@@ -33,7 +33,6 @@ Requires:      %{?scl:%scl_prefix}rubygem-fastthread
 Requires:      %{?scl:%scl_prefix}runtime
 %endif
 Requires:      %{?scl:%scl_prefix}js
-Requires:      %{?scl:%scl_prefix}libyaml
 Requires:      %{?scl:%scl_prefix}mod_passenger
 Requires:      %{?scl:%scl_prefix}ruby
 Requires:      %{?scl:%scl_prefix}ruby-libs


### PR DESCRIPTION
There was no reason to have a ruby193-libyaml package.  It is going away with rhscl 1.1
