### PR TITLE
Bug 1089697: nsupdate_plugin: Exception logging now includes error output from nsupda...

### DIFF
--- a/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
+++ b/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
@@ -193,9 +193,10 @@ EOF
       
       cmd = add_cmd(fqdn, public_hostname)
 
-      success = system cmd
-      if not success
-        raise DNSException.new("error adding app record #{fqdn}")
+      output = `#{cmd} 2>&1`
+      exit_code = $?.exitstatus
+      if exit_code != 0
+        raise DNSException.new("error adding app record #{fqdn} - #{exit_code} - #{output}")
       end
     end
 
@@ -214,10 +215,11 @@ EOF
 
       cmd = del_cmd(fqdn)
 
-      success = system cmd
-      if not success
-        raise DNSException.new("error deleting app record #{fqdn}")
-      end  
+      output = `#{cmd} 2>&1`
+      exit_code = $?.exitstatus
+      if exit_code != 0
+        raise DNSException.new("error adding app record #{fqdn} - #{exit_code} - #{output}")
+      end
     end
 
    # Change the published location of an application - Modify DNS record

--- a/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
+++ b/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
@@ -179,16 +179,14 @@ EOF
     #
     # @param cmd [String] 
     #   An nsupdate command sequence
-    # @param addition [Boolean]
-    #   True if adding a record, false if removing a record.
-    #   Default: true
+    # @param addition [String]
+    #   Action to be reported in log message ("adding" or "removing")
     #
-    def modify_dns(cmd, addition=true)
+    def modify_dns(cmd, action)
       output = `#{cmd} 2>&1`
       exit_code = $?.exitstatus
 
       if exit_code != 0
-        addition ? action = "adding" : action = "removing"
         raise DNSException.new("error #{action} app record #{fqdn} rc=#{exit_code}")
         Rails.logger.error "Error #{action} DNS application record #{fqdn}: #{output}"
       end
@@ -211,7 +209,7 @@ EOF
       fqdn = "#{app_name}-#{namespace}.#{@domain_suffix}"
       
       cmd = add_cmd(fqdn, public_hostname)
-      modify_dns(cmd, true)
+      modify_dns(cmd, "adding")
     end
 
     # Unpublish an application - remove DNS record
@@ -228,7 +226,7 @@ EOF
       fqdn = "#{app_name}-#{namespace}.#{@domain_suffix}"
 
       cmd = del_cmd(fqdn)
-      modify_dns(cmd, false)
+      modify_dns(cmd, "removing")
     end
 
    # Change the published location of an application - Modify DNS record

--- a/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
+++ b/plugins/dns/nsupdate/lib/openshift/nsupdate_plugin.rb
@@ -196,7 +196,8 @@ EOF
       output = `#{cmd} 2>&1`
       exit_code = $?.exitstatus
       if exit_code != 0
-        raise DNSException.new("error adding app record #{fqdn} - #{exit_code} - #{output}")
+        raise DNSException.new("error adding app record #{fqdn} rc=#{exit_code}")
+        Rails.logger.error "Error adding DNS application record #{fqdn}: #{output}"
       end
     end
 
@@ -218,7 +219,8 @@ EOF
       output = `#{cmd} 2>&1`
       exit_code = $?.exitstatus
       if exit_code != 0
-        raise DNSException.new("error adding app record #{fqdn} - #{exit_code} - #{output}")
+        raise DNSException.new("error adding app record #{fqdn} rc=#{exit_code}")
+        Rails.logger.error "Error adding DNS application record #{fqdn}: #{output}"
       end
     end
 


### PR DESCRIPTION
...te command

Bug 1089697
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1089697
When troubleshooting DNS record addition/removal errors, it is helpful to have the error output from the nsupdate command. Specifically in scenarios where record changes only fail <1% of the time.
