### PR TITLE
apache-vhost: fix BZ 1090358 on moving custom certs

### DIFF
--- a/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
+++ b/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
@@ -357,7 +357,11 @@ module OpenShift
               with_lock_and_reload do
                 if not File.exists?(alias_path(server_alias))
                   raise PluginException.new("Specified alias #{server_alias} does not exist for the app",
-                                            @container_uuid, @fqdn)
+                                            @container_uuid, @fqdn
+                    # BZ 1090358 in the case of reconstructing the frontend for a moved gear,
+                    # the alias_path is already removed in favor of the vhost ssl_conf_path,
+                    # so just proceed if that is already there:
+                                           ) unless File.exists?(ssl_conf_path(server_alias))
                 end
 
                 ssl_certificate_file = ssl_certificate_path(server_alias)
@@ -386,7 +390,7 @@ module OpenShift
                   f.fsync
                 end
 
-                FileUtils.rm_f(alias_path(server_alias))
+                FileUtils.rm_f(alias_path(server_alias)) if File.exists?(alias_path(server_alias))
               end
             end
 


### PR DESCRIPTION
Bug 1090358 - Can't move gear of app with alias ssl cert between nodes
with vhost frontend
https://bugzilla.redhat.com/show_bug.cgi?id=1090358

When oo-admin-move copies a gear over from one node to another, it
copies over the frontend config files too. Then it reconstructs the
frontend from JSON anyway. This causes a problem with apache-vhost if a
gear alias has a custom cert.

The frontend construction first creates the aliases. Each gets a simple
config file. Crucially, this is only created if there is not already a
custom cert and vhost for the same alias. In the case of a move, since
the custom cert vhost conf is moved over, it already exists, so alias
conf is not created.

Then it creates the custom cert vhosts. This first checks that the alias
config file already exists and throws an exception if not. In the case
of a move, it doesn't exist and isn't recreated, so the frontend
reconstruction fails and the entire move is rolled back.

The fix simply skips raising that exception in the case that the custom
cert vhost conf file already exists, which should only be the case for
gear moves.
