### PR TITLE
[TO_STAGE] Bug 1097959 - Add THROTTLER_CHECK_PERIOD to detune Throttler

### DIFF
--- a/node-util/conf/sysconfig/watchman
+++ b/node-util/conf/sysconfig/watchman
@@ -12,5 +12,9 @@
 #STATE_CHANGE_DELAY=900
 
 # Wait at least this number of seconds since last check before checking gear state on the Node.
-# Use this to reduce Watchman's GearStatePlugin's impact on the system.
+# Increase this to reduce Watchman's GearStatePlugin's impact on the system.
 #STATE_CHECK_PERIOD=0
+
+# Wait at least this number of seconds before checking gears' cgroup state on the Node.
+# Increase this to reduce Watchman's Throttler's impact on the system.
+#THROTTLER_CHECK_PERIOD=5

--- a/node-util/conf/watchman/plugins.d/throttler_plugin.rb
+++ b/node-util/conf/watchman/plugins.d/throttler_plugin.rb
@@ -72,13 +72,15 @@ module OpenShift
             @restore_percent  = resource('restore_percent') { |x| Float(x) }
 
             MonitoredGear.intervals = [@interval]
-            MonitoredGear.delay     = 5
+
+            MonitoredGear.delay = 5
+            MonitoredGear.delay = ENV['THROTTLER_CHECK_PERIOD'].to_i unless ENV['THROTTLER_CHECK_PERIOD'].nil?
 
             # Allow us to lazy initialize MonitoredGears
-            @running_apps           = Hash.new { |h, uuid| h[uuid] = MonitoredGear.new(uuid) }
+            @running_apps       = Hash.new { |h, uuid| h[uuid] = MonitoredGear.new(uuid) }
 
             # Need to "escape" the percents here for use in Syslog.info
-            str                     = 'throttle at: %0.2f%%%%, restore at: %0.2f%%%%, period: %d, check_interval: %0.2f' %
+            str                 = 'throttle at: %0.2f%%%%, restore at: %0.2f%%%%, period: %d, check_interval: %0.2fs' %
                 [@throttle_percent, @restore_percent, @interval, MonitoredGear.delay]
             Syslog.info("Starting throttler => #{str}")
 

--- a/node-util/man8/oo-watchman.8
+++ b/node-util/man8/oo-watchman.8
@@ -43,8 +43,12 @@ Watchman attempts to reset state. Default: 900 seconds (15 minutes)
 .TP
 .B  STATE_CHECK_PERIOD
 Wait at least this number of seconds since last check before checking gear state on the Node.
-Use this to reduce \fBWatchman\fR's impact on the system.
+Increase this to reduce \fBWatchman\fR's impact on the system.
 Default: 0 seconds
+.B  THROTTLER_CHECK_PERIOD
+Wait at least this number of seconds before checking gears' cgroup state on the Node.
+Increase this to reduce \fBWatchman\fR's impact on the system.
+Default: 5 seconds
 .SH FILES
 .TP
 .FN /etc/sysconfig/watchman


### PR DESCRIPTION
- Add THROTTLER_CHECK_PERIOD element to /etc/sysconfig/watchman to
  allow Operator to set period for checking cgroup counters
