### PR TITLE
Fix reducing of multi platform group overrides 

### DIFF
--- a/broker/test/unit/group_override_test.rb
+++ b/broker/test/unit/group_override_test.rb
@@ -5,8 +5,7 @@ class GroupOverrideTest < ActiveSupport::TestCase
   test "remove empty specs" do
     assert_equal [], GroupOverride.reduce([
       nil,
-      GroupOverride.new([ComponentSpec.new('a', 'a')]),
-      GroupOverride.new([ComponentSpec.new('a', 'a')]),
+      GroupOverride.new([]),
     ])
   end
 

--- a/broker/test/unit/subscription_test.rb
+++ b/broker/test/unit/subscription_test.rb
@@ -80,6 +80,7 @@ class SubscriptionTest < ActiveSupport::TestCase
     embed_cart_categories = ['service', 'database', 'embedded']
     embed_cart.stubs(:categories).returns(embed_cart_categories)
     embed_cart.stubs(:is_external?).returns(false)
+    embed_cart.stubs(:platform).returns('linux')
 
     embed_publishes_array = []
 
@@ -149,6 +150,7 @@ class SubscriptionTest < ActiveSupport::TestCase
     web_cart_categories = ['service', 'webcart', 'web_framework']
     web_cart.stubs(:categories).returns(web_cart_categories)
     web_cart.stubs(:is_external?).returns(false)
+    web_cart.stubs(:platform).returns('linux')
 
     web_publishes_array = []
     web_component.stubs(:publishes).returns(web_publishes_array)

--- a/controller/app/models/group_override.rb
+++ b/controller/app/models/group_override.rb
@@ -132,7 +132,7 @@ class GroupOverride
 
   def empty?
     @min_gears.nil? && @max_gears.nil? && @gear_size.blank? && @additional_filesystem_gb.blank? &&
-      (@components.blank? || (@components.all?{ |s| s.nil? || s.default? } && @components.length < 2))
+      (@components.blank? || (@components.all?{ |s| s.nil? || s.default? } && @components.length < 1))
   end
 
   def inspect


### PR DESCRIPTION
Change GroupOverride.empty? so group overrides with 1 component is not considered empty.
Change logic that splits group overrides up if their component don't belong to the same platform.
