### PR TITLE
<mongodb cart> adapt to use SCL-provided mongodb

### DIFF
--- a/cartridges/openshift-origin-cartridge-mongodb/bin/control
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/control
@@ -1,4 +1,5 @@
 #!/bin/bash -e
+source "${OPENSHIFT_MONGODB_DIR}/lib/mongodb_context"
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 export STOPTIMEOUT=20
 
@@ -18,7 +19,7 @@ function isrunning() {
 
 function _wait_for_mongod_to_startup() {
     i=0
-    while (! echo "exit" | mongo $OPENSHIFT_MONGODB_DB_HOST > /dev/null 2>&1) \
+    while (! echo "exit" | mongodb_context "mongo ${OPENSHIFT_MONGODB_DB_HOST}" > /dev/null 2>&1) \
              && [ $i -lt 60 ]; do
         sleep 1
         i=$(($i + 1))
@@ -31,8 +32,7 @@ function _repair_mongod() {
         client_result "Attempting to repair MongoDB ..."
         tmp_config="/tmp/mongodb.repair.conf"
         grep -ve "fork\s*=\s*true" $OPENSHIFT_MONGODB_DIR/conf/mongodb.conf > $tmp_config
-        /usr/bin/mongod $authopts -f $tmp_config  \
-                                  --repair
+        mongodb_context "mongod ${authopts} -f ${tmp_config} --repair"
         client_result "MongoDB repair status = $?"
         rm -f $tmp_config
     else
@@ -42,13 +42,13 @@ function _repair_mongod() {
 
 function _start_mongod() {
     authopts=${1:-"--auth"}
-    nohup /usr/bin/mongod $authopts \
-                    -f $OPENSHIFT_MONGODB_DIR/conf/mongodb.conf run |& /usr/bin/logshifter -tag mongodb &
+     mongodb_context "nohup mongod ${authopts} \
+                    -f ${OPENSHIFT_MONGODB_DIR}/conf/mongodb.conf run" |& /usr/bin/logshifter -tag mongodb &
     _wait_for_mongod_to_startup
     if ! isrunning; then
        _repair_mongod "$authopts"
-       nohup /usr/bin/mongod $authopts \
-                       -f $OPENSHIFT_MONGODB_DIR/conf/mongodb.conf run |& /usr/bin/logshifter -tag mongodb &
+       mongodb_context "nohup mongod ${authopts} \
+                       -f ${OPENSHIFT_MONGODB_DIR}/conf/mongodb.conf run" |& /usr/bin/logshifter -tag mongodb &
        _wait_for_mongod_to_startup
     fi
 }
@@ -124,7 +124,7 @@ function pre_snapshot {
 
    #  Take a "dump".
    creds="-u $OPENSHIFT_MONGODB_DB_USERNAME -p \"$OPENSHIFT_MONGODB_DB_PASSWORD\" --port $OPENSHIFT_MONGODB_DB_PORT"
-   if mongodump -h $OPENSHIFT_MONGODB_DB_HOST $creds --directoryperdb > /dev/null 2>&1; then
+   if mongodb_context "mongodump -h ${OPENSHIFT_MONGODB_DB_HOST} ${creds} --directoryperdb" > /dev/null 2>&1; then
       #  Dump ok - now create a gzipped tarball.
       echo "$OPENSHIFT_APP_NAME" > $OPENSHIFT_DATA_DIR/mongodb_dump_old_db_name.txt
       if tar -zcf $OPENSHIFT_DATA_DIR/mongodb_dump_snapshot.tar.gz . ; then
@@ -199,9 +199,9 @@ function restore_from_mongodb_snapshot {
    #        See  https://jira.mongodb.org/browse/SERVER-7262 for details.
    #[ -z "$HAVE_MONGODB_221_RC1" ]  &&  creds=""
 
-   if ! mongorestore -h $OPENSHIFT_MONGODB_DB_HOST              \
-                     --port $OPENSHIFT_MONGODB_DB_PORT $creds   \
-                     --directoryperdb --drop  1>&2; then
+   if ! mongodb_context "mongorestore -h ${OPENSHIFT_MONGODB_DB_HOST} \
+                         --port ${OPENSHIFT_MONGODB_DB_PORT} ${creds} \
+                         --directoryperdb --drop" 1>&2; then
        print_mongo_jira_warnings
        popd > /dev/null
        /bin/rm -rf $dumpdir
@@ -222,9 +222,9 @@ function restore_from_mongodb_snapshot {
                    { application: \"$OPENSHIFT_APP_NAME\", dbhost: \"$OPENSHIFT_MONGODB_DB_HOST\" })
                  use $old_name
                  db.dropDatabase() " | \
-                     mongo --username $OPENSHIFT_MONGODB_DB_USERNAME \
-                     --password "$OPENSHIFT_MONGODB_DB_PASSWORD" \
-                     "${OPENSHIFT_MONGODB_DB_HOST}:${OPENSHIFT_MONGODB_DB_PORT}/admin"
+                     mongodb_context "mongo --username ${OPENSHIFT_MONGODB_DB_USERNAME} \
+                     --password \"${OPENSHIFT_MONGODB_DB_PASSWORD}\" \
+                     \"${OPENSHIFT_MONGODB_DB_HOST}:${OPENSHIFT_MONGODB_DB_PORT}/admin\""
        fi
    fi
 

--- a/cartridges/openshift-origin-cartridge-mongodb/bin/mkjournal
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/mkjournal
@@ -23,14 +23,14 @@ tmpdir=$(mktemp -d)
 trap "rm -rf $tmpdir $tmpfile" EXIT
 
 touch $tmpdir/mongodb.conf
-scl enable mongodb24 "mongod \
+mongod \
     --dbpath ${tmpdir} \
     --journal \
     --noprealloc \
     --smallfiles \
     --bind_ip 127.0.0.2 \
     --port 27017 \
-    -f ${tmpdir}/mongodb.conf" 2>&1 > ${tmpdir}/mongodb.log &
+    -f ${tmpdir}/mongodb.conf 2>&1 > ${tmpdir}/mongodb.log &
 
 mongopid=$!
 

--- a/cartridges/openshift-origin-cartridge-mongodb/bin/mkjournal
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/mkjournal
@@ -23,14 +23,14 @@ tmpdir=$(mktemp -d)
 trap "rm -rf $tmpdir $tmpfile" EXIT
 
 touch $tmpdir/mongodb.conf
-/usr/bin/mongod \
-    --dbpath $tmpdir \
+scl enable mongodb24 "mongod \
+    --dbpath ${tmpdir} \
     --journal \
     --noprealloc \
     --smallfiles \
     --bind_ip 127.0.0.2 \
     --port 27017 \
-    -f $tmpdir/mongodb.conf 2>&1 > $tmpdir/mongodb.log &
+    -f ${tmpdir}/mongodb.conf" 2>&1 > ${tmpdir}/mongodb.log &
 
 mongopid=$!
 

--- a/cartridges/openshift-origin-cartridge-mongodb/bin/post_install
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/post_install
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
+source "${OPENSHIFT_MONGODB_DIR}/lib/mongodb_context"
 
 password=$OPENSHIFT_MONGODB_DB_PASSWORD
 echo "use admin
@@ -11,7 +12,7 @@ echo "use admin
       db.openshift.save({application: \"$OPENSHIFT_APP_NAME\", dbhost: \"$OPENSHIFT_MONGODB_DB_HOST\" })
       db.addUser(\"admin\", \"${password}\")
       exit
-     "  | mongo $OPENSHIFT_MONGODB_DB_HOST
+     "  | mongodb_context "mongo ${OPENSHIFT_MONGODB_DB_HOST}"
 rm -f /tmp/.dbshell
 
 cart_props "connection_url=mongodb://\$OPENSHIFT_MONGODB_DB_HOST:\$OPENSHIFT_MONGODB_DB_PORT/"

--- a/cartridges/openshift-origin-cartridge-mongodb/bin/setup
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/setup
@@ -1,3 +1,6 @@
 #!/bin/bash -e
+source "${OPENSHIFT_MONGODB_DIR}/lib/mongodb_context"
 
 mkdir -p $OPENSHIFT_MONGODB_DIR/{pid,socket,data,run}
+
+update_configuration

--- a/cartridges/openshift-origin-cartridge-mongodb/hooks/publish-ld-library-path-info
+++ b/cartridges/openshift-origin-cartridge-mongodb/hooks/publish-ld-library-path-info
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# For SCL based carts we need publish LD_LIBRARY_PATH
+# to web framework, so application can find the correct versions
+# of client libraries.
+#
+#
+source "${OPENSHIFT_MONGODB_DIR}/lib/mongodb_context"
+
+ld_path=$(LD_LIBRARY_PATH="" mongodb_context "printenv LD_LIBRARY_PATH")
+echo "OPENSHIFT_MONGODB_LD_LIBRARY_PATH_ELEMENT=${ld_path}"
+

--- a/cartridges/openshift-origin-cartridge-mongodb/hooks/publish-ld-library-path-info
+++ b/cartridges/openshift-origin-cartridge-mongodb/hooks/publish-ld-library-path-info
@@ -8,5 +8,5 @@
 source "${OPENSHIFT_MONGODB_DIR}/lib/mongodb_context"
 
 ld_path=$(LD_LIBRARY_PATH="" mongodb_context "printenv LD_LIBRARY_PATH")
-echo "OPENSHIFT_MONGODB_LD_LIBRARY_PATH_ELEMENT=${ld_path}"
-
+[[ -n "${ld_path}" ]] && echo "OPENSHIFT_MONGODB_LD_LIBRARY_PATH_ELEMENT=${ld_path}"
+[[ -n "${OPENSHIFT_MONGODB_PATH_ELEMENT}" ]] && echo "OPENSHIFT_MONGODB_PATH_ELEMENT=${OPENSHIFT_MONGODB_PATH_ELEMENT}"

--- a/cartridges/openshift-origin-cartridge-mongodb/hooks/publish-ld-library-path-info
+++ b/cartridges/openshift-origin-cartridge-mongodb/hooks/publish-ld-library-path-info
@@ -7,6 +7,7 @@
 #
 source "${OPENSHIFT_MONGODB_DIR}/lib/mongodb_context"
 
-ld_path=$(LD_LIBRARY_PATH="" mongodb_context "printenv LD_LIBRARY_PATH")
-[[ -n "${ld_path}" ]] && echo "OPENSHIFT_MONGODB_LD_LIBRARY_PATH_ELEMENT=${ld_path}"
-[[ -n "${OPENSHIFT_MONGODB_PATH_ELEMENT}" ]] && echo "OPENSHIFT_MONGODB_PATH_ELEMENT=${OPENSHIFT_MONGODB_PATH_ELEMENT}"
+ld_library_path_element="$(get_ld_library_path_element)"
+[[ -n "${ld_library_path_element}" ]] && echo "OPENSHIFT_MONGODB_LD_LIBRARY_PATH_ELEMENT=${ld_library_path_element}"
+path_element="$(get_path_element)"
+[[ -n "${path_element}" ]] && echo "OPENSHIFT_MONGODB_PATH_ELEMENT=${path_element}"

--- a/cartridges/openshift-origin-cartridge-mongodb/lib/mongodb_context
+++ b/cartridges/openshift-origin-cartridge-mongodb/lib/mongodb_context
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+source $OPENSHIFT_CARTRIDGE_SDK_BASH
+
+function update_configuration {
+    set +u
+    local path_tail="/root/usr/bin"
+    local pe=""
+    local scls=( $(mongodb_context "printenv X_SCLS") )
+    local env_dir="${OPENSHIFT_MONGODB_DIR}/env"
+
+    for collection in ${scls[*]}
+    do
+        pe+="$(cat /etc/scl/prefixes/${collection})/${collection}${path_tail}"
+        if [[ $collection != ${scls[${#scls[@]}-1]} ]]
+        then
+            pe+=":"
+        fi
+    done
+    set_env_var 'OPENSHIFT_MONGODB_PATH_ELEMENT' $pe $env_dir
+
+    local ld_path=$(LD_LIBRARY_PATH="" scl enable mongodb24 "printenv LD_LIBRARY_PATH")
+    set_env_var 'OPENSHIFT_MONGODB_LD_LIBRARY_PATH_ELEMENT' ${ld_path:-:} $env_dir
+
+    local man_path=$(MANPATH="" scl enable mongodb24 "printenv MANPATH")
+    path_append ${MANPATH:-:} ${man_path:-:} > ${env_dir}/MANPATH
+
+}
+
+function mongodb_context {
+    /usr/bin/scl enable mongodb24 "$1"
+}

--- a/cartridges/openshift-origin-cartridge-mongodb/lib/mongodb_context
+++ b/cartridges/openshift-origin-cartridge-mongodb/lib/mongodb_context
@@ -4,29 +4,36 @@ source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 function update_configuration {
     set +u
-    local path_tail="/root/usr/bin"
-    local pe=""
-    local scls=( $(mongodb_context "printenv X_SCLS") )
-    local env_dir="${OPENSHIFT_MONGODB_DIR}/env"
+    if [[ -f /usr/bin/scl ]] && /usr/bin/scl -l | grep -q 'mongodb24'
+    then
+        local path_tail="/root/usr/bin"
+        local pe=""
+        local scls=( $(/usr/bin/scl enable mongodb24 "printenv X_SCLS") )
+        local env_dir="${OPENSHIFT_MONGODB_DIR}/env"
 
-    for collection in ${scls[*]}
-    do
-        pe+="$(cat /etc/scl/prefixes/${collection})/${collection}${path_tail}"
-        if [[ $collection != ${scls[${#scls[@]}-1]} ]]
-        then
-            pe+=":"
-        fi
-    done
-    set_env_var 'OPENSHIFT_MONGODB_PATH_ELEMENT' $pe $env_dir
+        for collection in ${scls[*]}
+        do
+            pe+="$(cat /etc/scl/prefixes/${collection})/${collection}${path_tail}"
+            if [[ $collection != ${scls[${#scls[@]}-1]} ]]
+            then
+                pe+=":"
+            fi
+        done
+        set_env_var 'OPENSHIFT_MONGODB_PATH_ELEMENT' $pe $env_dir
 
-    local ld_path=$(LD_LIBRARY_PATH="" scl enable mongodb24 "printenv LD_LIBRARY_PATH")
-    set_env_var 'OPENSHIFT_MONGODB_LD_LIBRARY_PATH_ELEMENT' ${ld_path:-:} $env_dir
+        local ld_path=$(LD_LIBRARY_PATH="" /usr/bin/scl enable mongodb24 "printenv LD_LIBRARY_PATH")
+        set_env_var 'OPENSHIFT_MONGODB_LD_LIBRARY_PATH_ELEMENT' ${ld_path:-:} $env_dir
 
-    local man_path=$(MANPATH="" scl enable mongodb24 "printenv MANPATH")
-    path_append ${MANPATH:-:} ${man_path:-:} > ${env_dir}/MANPATH
-
+        local man_path=$(MANPATH="" /usr/bin/scl enable mongodb24 "printenv MANPATH")
+        path_append ${MANPATH:-:} ${man_path:-:} > ${env_dir}/MANPATH
+    fi
 }
 
 function mongodb_context {
-    /usr/bin/scl enable mongodb24 "$1"
+    if [[ -n "${OPENSHIFT_MONGODB_PATH_ELEMENT}" ]] # SCL mongo is installed
+    then
+        /usr/bin/scl enable mongodb24 "$1"
+    else
+        eval $1
+    fi
 }

--- a/cartridges/openshift-origin-cartridge-mongodb/lib/mongodb_context
+++ b/cartridges/openshift-origin-cartridge-mongodb/lib/mongodb_context
@@ -2,35 +2,44 @@
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
+function using_scl_mongo {
+    [[ -n "${OPENSHIFT_MONGODB_PATH_ELEMENT}" ]] ||
+    [[ -f /usr/bin/scl ]] && [[ $(/usr/bin/scl -l) =~ mongodb24 ]]
+}
+
+function get_path_element {
+    using_scl_mongo && echo -n $(PATH= /usr/bin/scl enable mongodb24 'echo $PATH')
+}
+
+function get_ld_library_path_element {
+    if using_scl_mongo
+    then
+        echo -n $(LD_LIBRARY_PATH="" /usr/bin/scl enable mongodb24 "printenv LD_LIBRARY_PATH")
+    fi
+}
+
 function update_configuration {
     set +u
-    if [[ -f /usr/bin/scl ]] && /usr/bin/scl -l | grep -q 'mongodb24'
+    local env_dir="${OPENSHIFT_MONGODB_DIR}/env"
+    if using_scl_mongo
     then
-        local path_tail="/root/usr/bin"
-        local pe=""
-        local scls=( $(/usr/bin/scl enable mongodb24 "printenv X_SCLS") )
-        local env_dir="${OPENSHIFT_MONGODB_DIR}/env"
-
-        for collection in ${scls[*]}
-        do
-            pe+="$(cat /etc/scl/prefixes/${collection})/${collection}${path_tail}"
-            if [[ $collection != ${scls[${#scls[@]}-1]} ]]
-            then
-                pe+=":"
-            fi
-        done
-        set_env_var 'OPENSHIFT_MONGODB_PATH_ELEMENT' $pe $env_dir
-
-        local ld_path=$(LD_LIBRARY_PATH="" /usr/bin/scl enable mongodb24 "printenv LD_LIBRARY_PATH")
-        set_env_var 'OPENSHIFT_MONGODB_LD_LIBRARY_PATH_ELEMENT' ${ld_path:-:} $env_dir
-
+        local pe="$(get_path_element)"
+        if [[ -n "${pe}" ]]
+        then
+            set_env_var 'OPENSHIFT_MONGODB_PATH_ELEMENT' "${pe}" $env_dir
+        fi
+        local ld_path="$(get_ld_library_path_element)"
+        if [[ -n "${ld_path}" ]]
+        then
+            set_env_var 'OPENSHIFT_MONGODB_LD_LIBRARY_PATH_ELEMENT' "${ld_path}" $env_dir
+        fi
         local man_path=$(MANPATH="" /usr/bin/scl enable mongodb24 "printenv MANPATH")
         path_append ${MANPATH:-:} ${man_path:-:} > ${env_dir}/MANPATH
     fi
 }
 
 function mongodb_context {
-    if [[ -n "${OPENSHIFT_MONGODB_PATH_ELEMENT}" ]] # SCL mongo is installed
+    if using_scl_mongo
     then
         /usr/bin/scl enable mongodb24 "$1"
     else

--- a/cartridges/openshift-origin-cartridge-mongodb/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-mongodb/metadata/managed_files.yml
@@ -4,6 +4,8 @@ snapshot_exclusions:
 locked_files:
 - bin/
 - bin/*
+- lib/
+- lib/*
 - env/
 - env/*
 - metadata/

--- a/cartridges/openshift-origin-cartridge-mongodb/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mongodb/metadata/manifest.yml
@@ -46,6 +46,8 @@ Provides:
 Publishes:
   publish-nosql-db-connection-info:
     Type: ENV:NET_TCP:nosqldb:connection-info
+  publish-ld-library-path-info:
+    Type: ENV:NET_TCP:db:ld-library-path-info
 Scaling:
   Min: 1
   Max: 1

--- a/cartridges/openshift-origin-cartridge-mongodb/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mongodb/metadata/manifest.yml
@@ -47,7 +47,7 @@ Publishes:
   publish-nosql-db-connection-info:
     Type: ENV:NET_TCP:nosqldb:connection-info
   publish-ld-library-path-info:
-    Type: ENV:NET_TCP:db:ld-library-path-info
+    Type: ENV:NET_TCP:nosqldb:ld-library-path-info
 Scaling:
   Min: 1
   Max: 1

--- a/cartridges/openshift-origin-cartridge-mongodb/openshift-origin-cartridge-mongodb.spec
+++ b/cartridges/openshift-origin-cartridge-mongodb/openshift-origin-cartridge-mongodb.spec
@@ -8,10 +8,10 @@ Group:         Network/Daemons
 License:       ASL 2.0
 URL:           http://www.openshift.com
 Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-Requires:      mongodb-server
-Requires:      mongodb-devel
-Requires:      libmongodb
-Requires:      mongodb
+Requires:      mongodb24-mongodb-server
+Requires:      mongodb24-mongodb-devel
+Requires:      mongodb24-libmongodb
+Requires:      mongodb24-mongodb
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
 Provides:      openshift-origin-cartridge-mongodb-2.2 = 2.0.0
@@ -47,6 +47,7 @@ fi
 %files
 %dir %{cartridgedir}
 %attr(0755,-,-) %{cartridgedir}/bin/
+%attr(0755,-,-) %{cartridgedir}/lib/
 %attr(0755,-,-) %{cartridgedir}/hooks/
 %{cartridgedir}/conf
 %{cartridgedir}/metadata

--- a/cartridges/openshift-origin-cartridge-mongodb/openshift-origin-cartridge-mongodb.spec
+++ b/cartridges/openshift-origin-cartridge-mongodb/openshift-origin-cartridge-mongodb.spec
@@ -1,3 +1,11 @@
+%if 0%{?rhel} <= 6
+    %global scl mongodb24
+    %global scl_prefix mongodb24-
+    %global scl_context /usr/bin/scl enable %{scl}
+%else
+    %global scl_context eval
+%endif
+
 %global cartridgedir %{_libexecdir}/openshift/cartridges/mongodb
 
 Summary:       Embedded mongodb support for OpenShift
@@ -8,10 +16,10 @@ Group:         Network/Daemons
 License:       ASL 2.0
 URL:           http://www.openshift.com
 Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-Requires:      mongodb24-mongodb-server
-Requires:      mongodb24-mongodb-devel
-Requires:      mongodb24-libmongodb
-Requires:      mongodb24-mongodb
+Requires:      %{?scl:%scl_prefix}mongodb-server
+Requires:      %{?scl:%scl_prefix}mongodb-devel
+Requires:      %{?scl:%scl_prefix}libmongodb
+Requires:      %{?scl:%scl_prefix}mongodb
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
 Provides:      openshift-origin-cartridge-mongodb-2.2 = 2.0.0
@@ -35,7 +43,7 @@ Provides mongodb cartridge support to OpenShift
 
 
 %post
-%{cartridgedir}/bin/mkjournal %{cartridgedir}/usr/journal-cache/journal.tar.gz
+%{?scl_context} "%{cartridgedir}/bin/mkjournal %{cartridgedir}/usr/journal-cache/journal.tar.gz"
 
 
 %preun

--- a/node/misc/bin/rhcsh
+++ b/node/misc/bin/rhcsh
@@ -197,7 +197,6 @@ function psql() {
 }
 
 function mongo() {
-   local mongo_bin=$(which mongo)
    if test $# -gt 0; then
       uopt=""
       popt=""
@@ -216,7 +215,7 @@ function mongo() {
       fi
    fi
 
-   ${mongo_bin} ${hopt} ${uopt} ${popt} "$@"
+   scl enable mongodb24 "mongo ${hopt} ${uopt} ${popt} $@"
 }
 
 # The mco command shouldn't be run by gears

--- a/node/misc/bin/rhcsh
+++ b/node/misc/bin/rhcsh
@@ -196,26 +196,33 @@ function psql() {
   return $CMD_RC
 }
 
-function mongo() {
-   if test $# -gt 0; then
-      uopt=""
-      popt=""
-   else
-      uopt="--username ${OPENSHIFT_MONGODB_DB_USERNAME:-'admin'}"
-      [ -n "$OPENSHIFT_MONGODB_DB_PASSWORD" ]  &&  popt="--password $OPENSHIFT_MONGODB_DB_PASSWORD"
-   fi
-
-   if echo "$@" | egrep "\-\-host|$OPENSHIFT_MONGODB_DB_HOST" > /dev/null; then
-      hopt=""  #  Do not override if --host is passed.
-   else
-      if [ -n "$OPENSHIFT_MONGODB_DB_GEAR_DNS" ]; then
-         hopt="${OPENSHIFT_MONGODB_DB_GEAR_DNS:-'127.0.0.1'}:${OPENSHIFT_MONGODB_DB_PORT:-27017}/admin"
-      else
-         hopt="${OPENSHIFT_MONGODB_DB_HOST:-'127.0.0.1'}:${OPENSHIFT_MONGODB_DB_PORT:-27017}/admin"
-      fi
-   fi
-
-   scl enable mongodb24 "mongo ${hopt} ${uopt} ${popt} $@"
+function mongo () {
+    local -a cmdline=("mongo");
+    if [[ $# -eq 0 ]]
+    then
+        cmdline+=("--username" "${OPENSHIFT_MONGODB_DB_USERNAME:-'admin'}")
+        [[ -n "$OPENSHIFT_MONGODB_DB_PASSWORD" ]] && cmdline+=("--password" "$OPENSHIFT_MONGODB_DB_PASSWORD")
+    fi
+    if ! [[ "$@" =~ --host|"$OPENSHIFT_MONGODB_DB_HOST" ]]
+    then
+        local port_db="${OPENSHIFT_MONGODB_DB_PORT:-27017}/admin"
+        if [[ -n "$OPENSHIFT_MONGODB_DB_GEAR_DNS" ]]
+        then
+            cmdline+=("${OPENSHIFT_MONGODB_DB_GEAR_DNS:-'127.0.0.1'}:${port_db}")
+        else
+            cmdline+=("${OPENSHIFT_MONGODB_DB_HOST:-'127.0.0.1'}:${port_db}")
+        fi
+    fi
+    cmdline+=("$@")
+    # If scl mongo is installed and the app uses mongo, assume scl
+    # mongo. If scl mongo is installed but the app doesn't have a mongo
+    # cart, assume "system" mongo
+    if [[ -n "${OPENSHIFT_MONGODB_DB_GEAR_DNS}" ]] && scl -l | grep -q mongodb24
+    then
+        scl enable mongodb24 "$(printf %q\  "${cmdline[@]}")"
+    else
+        command "${cmdline[@]}"
+    fi
 }
 
 # The mco command shouldn't be run by gears

--- a/node/misc/bin/rhcsh
+++ b/node/misc/bin/rhcsh
@@ -197,6 +197,7 @@ function psql() {
 }
 
 function mongo() {
+   local mongo_bin=$(which mongo)
    if test $# -gt 0; then
       uopt=""
       popt=""
@@ -215,7 +216,7 @@ function mongo() {
       fi
    fi
 
-   ( unset LD_LIBRARY_PATH; /usr/bin/mongo ${hopt} ${uopt} ${popt} "$@" )
+   ${mongo_bin} ${hopt} ${uopt} ${popt} "$@"
 }
 
 # The mco command shouldn't be run by gears

--- a/node/misc/bin/rhcsh
+++ b/node/misc/bin/rhcsh
@@ -217,7 +217,7 @@ function mongo () {
     # If scl mongo is installed and the app uses mongo, assume scl
     # mongo. If scl mongo is installed but the app doesn't have a mongo
     # cart, assume "system" mongo
-    if [[ -n "${OPENSHIFT_MONGODB_DB_GEAR_DNS}" ]] && scl -l | grep -q mongodb24
+    if [[ -n "${OPENSHIFT_MONGODB_DB_GEAR_DNS}" ]] && [[ $(/usr/bin/scl -l) =~ mongodb24 ]]
     then
         scl enable mongodb24 "$(printf %q\  "${cmdline[@]}")"
     else


### PR DESCRIPTION
Bug 1073126
https://bugzilla.redhat.com/show_bug.cgi?id=1073126

Adds `lib/mongodb_context`, which wraps MongoDB executables with
appropriate SCL context

Adds `update_configuration` function: sets up `PATH`, `MANPATH`, and
`LD_LIBRARY_PATH` for shell env

Update `mongo` shell function in `rhcsh`: don't clear `LD_LIBRARY_PATH`
before calling `mongo`, trust the `PATH` variable to find the right
`mongo`, and resolve `mongo` path into var `mongo_bin`

---

mongodb cart: address bugs with scaled carts

Bug 1073126
https://bugzilla.redhat.com/show_bug.cgi?id=1073126#c8

Add `publish-ld-library-path-info` hook, lock `mongodb/lib` directory

Also addresses issue with `rhcsh` where correct `mongo` bin isn't
necessarily on the `PATH`

---

mongodb cart: Support non-SCL systems

Bug 1104072
https://bugzilla.redhat.com/show_bug.cgi?id=1104072

This commit updates the cart spec file to conditionally call the
`mkjournal` script with or without SCL mongo, updates `mongodb_context`
to support non-scl mongo and tweaks `rhcsh` in a similar manner.

Additional fixes include:
- modify the `mongo` function in `rhcsh` to properly quote
  user-specified parameters for passing to `scl enable mongodb24`
- conditionally publish path elements so the correct `mongo*` binaries
  are preferred in scaled and non-scaled environments
- defensively quote user-specified parameters in function `mongo` in
  `rhcsh` so that things like exotic passwords that contain spaces are
  passed to the `mongo` binary without being erroneously split into
  multiple arguments

---

 mongodb cart: clean up `mongodb_context`

Integrating Miciah's suggestions to simplify `update_configuration` -
smarter path element generation and more correct handling for empty
`ld_path` variables
