### PR TITLE
Console: Improve grouping of application types

### DIFF
--- a/console/app/helpers/console/model_helper.rb
+++ b/console/app/helpers/console/model_helper.rb
@@ -254,25 +254,20 @@ module Console::ModelHelper
     end
   end
 
-  def in_groups_by_tag(ary, tags)
-    groups = {}
-    other = ary.reject do |t|
-      tags.any? do |tag|
-        (groups[tag] ||= []) << t if t.tags.include?(tag)
+  def in_groups_by_tag(types, tags)
+    categorized = []
+    uncategorized = types
+
+    tags.each do |tag|
+      matches, uncategorized = uncategorized.partition {|type| type.tags.include?(tag)}
+      if matches.length > 1
+        categorized << [tag, matches]
+      else
+        uncategorized.concat matches
       end
     end
-    groups = tags.map do |tag|
-      types = groups[tag]
-      if types
-        if types.length < 2
-          other.concat(types)
-          nil
-        else
-          [tag, types]
-        end
-      end
-    end.compact
-    [groups, other]
+
+    [categorized, uncategorized]
   end
 
   def common_tags_for(ary)

--- a/console/test/unit/helpers/model_helper_test.rb
+++ b/console/test/unit/helpers/model_helper_test.rb
@@ -53,6 +53,7 @@ class Console::ModelHelperTest < ActionView::TestCase
   def test_in_groups_by_tag
     t1 = Tagged.new([:ruby, :php])
     t2 = Tagged.new([:ruby])
+    t3 = Tagged.new([:ruby, :php, :java])
 
     groups, others = in_groups_by_tag([t1], [:ruby])
     assert_equal [t1], others
@@ -60,6 +61,10 @@ class Console::ModelHelperTest < ActionView::TestCase
 
     groups, others = in_groups_by_tag([t1, t2], [:ruby])
     assert_equal [[:ruby, [t1, t2]]], groups
+    assert others.empty?
+
+    groups, others = in_groups_by_tag([t1, t3], [:java, :php, :ruby])
+    assert_equal [[:php, [t1, t3]]], groups
     assert others.empty?
   end
 end

--- a/console/test/unit/helpers/model_helper_test.rb
+++ b/console/test/unit/helpers/model_helper_test.rb
@@ -55,14 +55,19 @@ class Console::ModelHelperTest < ActionView::TestCase
     t2 = Tagged.new([:ruby])
     t3 = Tagged.new([:ruby, :php, :java])
 
+    # If only one type matches a given tag, the type should go under others.
     groups, others = in_groups_by_tag([t1], [:ruby])
     assert_equal [t1], others
     assert groups.empty?
 
+    # If two types match a given tag, the types should be grouped together.
     groups, others = in_groups_by_tag([t1, t2], [:ruby])
     assert_equal [[:ruby, [t1, t2]]], groups
     assert others.empty?
 
+    # If a type matches more than one tag, but it is the only type that matches
+    # the first matching tag, and multiple types match a subsequent tag, then
+    # the type should be grouped under the first such subsequent tag.
     groups, others = in_groups_by_tag([t1, t3], [:java, :php, :ruby])
     assert_equal [[:php, [t1, t3]]], groups
     assert others.empty?


### PR DESCRIPTION
Improve the algorithm `Console::ModelHelper#in_groups_by_tag` to consider application types for grouping under a tag even for a type that has previously matched a tag that had only one match.

`in_groups_by_tag` takes a list of application types and tags and returns two arrays: One with the application types grouped tags that they match and one with application types that have no tags that more than one application type matches.

The algorithm iterates over the array of tags that is passed into it.  For each tag in this array, the algorithm pulls out each type that matches the tag.  After iterating over the array of types while matching them against the iterator tag, the algorithm either creates a new grouping of all types that matched the tag if there were more than one, or else the algorithm puts any matching type in the "other" group.

The problem is that jbosseap-6 has the "xpaas" tag, which comes before the "java" tag in the array of tags provided to `in_groups_by_tag`.  Thus the jbosseap-6 cartridge is found to match the "xpaas" tag before the "java" tag is considered.  However, jbosseap-6 is the only cartridge with the "xpaas" tag, so it is placed on the "other" group before the "java" tag is considered.  Thus by the time the "java" tag is considered, jbosseap-6 has already been pulled into the "others" group and is not in the array considered for consideration when matching types against the "java" tag.

This commit changes the algorithm instead to leave types in the array of types for consideration for matching against tags until that type is found to be one of multiple types that match some tag.

This commit fixes bug 1100508.
