### PR TITLE
diagnostics: fix errant warning on httpd conf

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -1271,17 +1271,23 @@ class OODiag
     unreadable = []
     broker_unreadable = node_unreadable = []
     if @is_broker
-      dirs = "/etc/openshift /etc/httpd/conf.d /var/www/openshift/{broker,console}/httpd/"
+      # many files in /etc/openshift are read by apache, others are not
+      dirs = "/etc/openshift"
       names = %w[*.conf *.pem htpasswd quickstarts.json].map {|n| "-name '#{n}'" }
       names = '\( ' +  names * ' -o ' + ' \)'
-      broker_ok = %w[express node resource_limits].map {|f| "/etc/openshift/#{f}.conf" }
-      broker_unreadable = %x[find #{dirs} #{names} #{query} 2> /dev/null].split(/\n/) - broker_ok
-      dirs = "/etc/httpd/conf.d"
-      broker_unreadable += %x[find #{dirs} #{query}].split(/\n/)
+      broker_unreadable = %x[find #{dirs} #{names} #{query} 2> /dev/null].split(/\n/) -
+               # ignore these, broker/console do not read them
+               %w[express node resource_limits].map {|f| "/etc/openshift/#{f}.conf" }
+
+      # basically everything under broker/console should be apache-readable
+      # except httpd config (which is read by root)
+      dirs = "/var/www/openshift/broker"
+      dirs += " /var/www/openshift/console" if Dir.exists? "/var/www/openshift/console"
+      broker_unreadable += %x[find #{dirs} #{query} ! -wholename '*/httpd/*' ].split(/\n/)
     end
     if @is_node
-      dirs = "/etc/httpd/conf.d /var/lib/openshift/.httpd.d "
-      node_unreadable = %x[find #{dirs} #{query}].split(/\n/)
+      dirs = "/var/lib/openshift/.httpd.d/*.db" # only present for mod-rewrite frontend
+      node_unreadable = %x[find #{dirs} #{query}].split(/\n/) unless Dir.glob(dirs).empty?
     end
     unreadable = (broker_unreadable + node_unreadable).uniq
     unless unreadable.empty?


### PR DESCRIPTION
Bug 1100169 - oo-diagnostics tools throw warning message when user add
alias cert to app
https://bugzilla.redhat.com/show_bug.cgi?id=1100169

also:
Bug 1002559 - oo-diagnostics should check the mode on important files
https://bugzilla.redhat.com/show_bug.cgi?id=1002559

test_apache_can_read_conf_files is intended to warn when the apache user
cannot read files it needs to. The files being checked are overly broad;
since httpd reads all of its configuration as root before switching to
apache user, none of that needs to be apache-readable. Instead, just
check files that apache will actually be reading at runtime. Everything
related to Rails apps falls into this category.
