### PR TITLE
Let broker run as ruby, not root

### DIFF
--- a/.sti/bin/assemble
+++ b/.sti/bin/assemble
@@ -1,24 +1,23 @@
 #!/bin/sh -e
 
-cp /opt/ruby/.bashrc ~/.bashrc
-
-# Copy puma.cfg
-cp -r /opt/ruby/etc /root/etc
 source ~/.bashrc
-mkdir -p /root/run
 
 mkdir -p ~/.openshift
 cp /tmp/src/broker/misc/docker_broker_plugins.rb ~/.openshift/broker_plugins.rb
-mkdir -p /etc/openshift
 cp -r /tmp/src/broker/conf/* /etc/openshift/
 cp /tmp/src/plugins/dns/bind/conf/openshift-origin-dns-bind.conf.example /etc/openshift/plugins.d/openshift-origin-dns-bind.conf
 cp /tmp/src/plugins/msg-broker/mcollective/conf/openshift-origin-msg-broker-mcollective.conf.example /etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf
 
 # Install broker oo-* scripts
-cp /tmp/src/util-scl/oo-* /usr/sbin/
-cp /tmp/src/broker-util/oo-* /usr/sbin/
-chmod 750 /usr/sbin/oo-*
-cp /tmp/src/broker-util/lib/* /opt/rh/ruby193/root/usr/share/ruby/
+cp /tmp/src/util-scl/oo-* /opt/ruby/bin
+cp /tmp/src/broker-util/oo-* /opt/ruby/bin
+chmod 750 /opt/ruby/bin/oo-*
+
+# TODO fix oo-app-info
+# it looks like this is currently just app_info.rb
+# it looks like it's only used by oo-app-info
+# would be nice not to have this installed into the SCL system
+#cp /tmp/src/broker-util/lib/* /opt/rh/ruby193/root/usr/share/ruby/
 
 # Imported from ruby-19-centos assemble
 

--- a/broker/docker/origin-broker-builder/Dockerfile
+++ b/broker/docker/origin-broker-builder/Dockerfile
@@ -31,11 +31,15 @@ RUN yum install --enablerepo=openshift-deps-rhel6 --assumeyes \
      ruby193 \
      && yum update -y && yum clean all # Clean up yum cache at the end.
 
-# TODO switch back to default "ruby" user
-# currently the assemble script needs root so we can't set the default user to non-root
-# or the sti build will fail.
-#USER ruby
-ENV HOME /root
+# These are necessary so we can run as the ruby user
+# TODO fix logging to not user /var/log/openshift
+RUN mkdir -p /etc/openshift && \
+    chown ruby:ruby /etc/openshift && \
+    echo 'export PATH=$PATH:/opt/ruby/bin' >> /opt/ruby/.bashrc && \
+    mkdir -p /var/log/openshift/broker && \
+    chown -R ruby:ruby /var/log/openshift
+
+USER ruby
 
 # BROKER_SOURCE tells the broker to include gems based on source locations
 ENV BROKER_SOURCE 1
@@ -44,7 +48,7 @@ ENV BROKER_SOURCE 1
 ENV OPENSHIFT_ENABLE_ENV_CONFIG 1
 
 # Broker is not installed in the previous default location
-ENV OPENSHIFT_BROKER_DIR /root/src/broker
+ENV OPENSHIFT_BROKER_DIR /opt/ruby/src/broker
 
 # APP_ROOT tells the prepare and run scripts where the Gemfile is located for bundler to install/exec
 ENV APP_ROOT broker


### PR DESCRIPTION
Various fixes so the broker can run as the ruby user.

oo-app-info and anything else that depends on app_info.rb is temporarily
broken with this change, until we figure out a better way to install
app_info.rb instead of putting it in /opt/rh/ruby193/...
