### PR TITLE
Bug 1101836: Apache shouldn't disable backend when it can't connect to it

### DIFF
--- a/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
+++ b/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
@@ -184,7 +184,7 @@ module OpenShift
                     if gen_default_rule
                       tpath = path.empty? ? "/" : path
 
-                      f.puts("ProxyPass #{tpath} #{proxy_proto}://#{uri}/")
+                      f.puts("ProxyPass #{tpath} #{proxy_proto}://#{uri}/ retry=0")
 
                       if uri.empty?
                         turi = "127.0.0.1:80"


### PR DESCRIPTION
apache with vhost plugin disables a backend for a minute when it can't connect to it --

[Wed May 28 17:00:35 2014] [error](111)Connection refused: proxy: HTTP: attempt to connect to 127.1.244.129:8080 (127.1.244.129) failed
[Wed May 28 17:00:35 2014] [error] ap_proxy_connect_backend disabling worker for (127.1.244.129)
[Wed May 28 17:00:35 2014] [error] proxy: HTTP: disabled connection for (127.1.244.129)

This fix prevents apache from doing that.
