### PR TITLE
plugins/routing/activemq: Take array of hosts

### DIFF
--- a/plugins/routing/activemq/config/initializers/openshift-origin-routing-activemq.rb
+++ b/plugins/routing/activemq/config/initializers/openshift-origin-routing-activemq.rb
@@ -14,10 +14,18 @@ Broker::Application.configure do
 
   config.routing_activemq = {
     :topic => conf.get("ACTIVEMQ_TOPIC", "/topic/routing"),
+    :hosts => conf.get("ACTIVEMQ_HOST", "127.0.0.1").split(',').map do |hp|
+      hp.split(":").instance_eval do |h,p|
+        {
+          :host => h,
+          # Originally, ACTIVEMQ_HOST allowed specifying only one host, with
+          # the port specified separately in ACTIVEMQ_PORT.
+          :port => p || conf.get("ACTIVEMQ_PORT", "61613"),
+        }
+      end
+    end,
     :username => conf.get("ACTIVEMQ_USERNAME", "routinginfo"),
     :password => conf.get("ACTIVEMQ_PASSWORD", "routinginfopasswd"),
-    :host => conf.get("ACTIVEMQ_HOST", "127.0.0.1"),
-    :port => conf.get("ACTIVEMQ_PORT", "61613"),
     :debug => conf.get_bool("ACTIVEMQ_DEBUG", "false"),
   }
 end

--- a/plugins/routing/activemq/lib/openshift/activemq_routing_plugin.rb
+++ b/plugins/routing/activemq/lib/openshift/activemq_routing_plugin.rb
@@ -16,11 +16,15 @@ module OpenShift
           end
         end.new
       else
-        @conn = Stomp::Connection.open Rails.application.config.routing_activemq[:username],
-                                       Rails.application.config.routing_activemq[:password],
-                                       Rails.application.config.routing_activemq[:host],
-                                       Rails.application.config.routing_activemq[:port],
-                                       true
+        @conn = Stomp::Connection.open({
+          :hosts => Rails.application.config.routing_activemq[:hosts].map do |host|
+            host.merge({
+              :login => Rails.application.config.routing_activemq[:username],
+              :passcode => Rails.application.config.routing_activemq[:password],
+            })
+          end,
+          :reliable => true,
+        })
       end
     end
 


### PR DESCRIPTION
In the ActiveMQ routing plug-in, interpret `ACTIVEMQ_HOST` as a comma-separated list of host:port pairs, and use this list of hosts when connecting to ActiveMQ for redundancy.

This commit fixes bug 1102432.
