### PR TITLE
Fix bug 1102428

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/managed_files.yml
@@ -18,3 +18,7 @@ locked_files:
 - env/PASSENGER_TEMP_DIR
 processed_templates:
 - 'etc/conf.d/*.erb'
+setup_rewritten:
+# This can be safely removed in Sprint 46+
+- versions/1.8/template/.openshift
+- versions/1.9/template/.openshift

--- a/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-ruby/metadata/manifest.yml
@@ -12,9 +12,7 @@ License: Ruby BSDL
 License-Url: http://www.ruby-lang.org/en/about/license.txt
 Vendor: ruby.org
 Cartridge-Version: 0.0.18
-Compatible-Versions:
-- 0.0.16
-- 0.0.17
+Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:
 - service


### PR DESCRIPTION
Remove directories that are to be replaced by symlinks
when the new version of cartridge is overlaid into gear.

Note: Mark ruby for incompatible upgrade.

https://bugzilla.redhat.com/show_bug.cgi?id=1102428

[test]
