### PR TITLE
Fix bug 1104228 - missing php-5.4 scl in PATH

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-php/bin/upgrade
@@ -35,9 +35,12 @@ if [[ $curr == 0.0.14 ]]; then
     chcon -u unconfined_u ${OPENSHIFT_PHP_DIR}configuration/etc/php.ini
 fi
 
-if [[ $curr == 0.0.16 ]]; then
+if [[ $curr == 0.0.17 ]]; then
     source ${OPENSHIFT_PHP_DIR}usr/lib/php_module_scan
     rm -f ${OPENSHIFT_PHP_DIR}configuration/etc/php.d/locked-*.ini
     OPENSHIFT_PHP_VERSION=$php_version
     scan_for_php_modules
+    source $OPENSHIFT_CARTRIDGE_SDK_BASH
+    source ${OPENSHIFT_PHP_DIR}usr/lib/php_context
+    update_configuration
 fi


### PR DESCRIPTION
Make sure all PHP 5.4 apps have "/opt/rh/php54/root/usr/bin" path
in OPENSHIFT_PHP_PATH_ELEMENT env var.

https://bugzilla.redhat.com/show_bug.cgi?id=1104228
