### PR TITLE
Bug 1105660 - ActiveModel::Obserservs moved out from rails > 4.0

### DIFF
--- a/common/openshift-origin-common.gemspec
+++ b/common/openshift-origin-common.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency("json")
   s.add_dependency('safe_yaml')
   s.add_dependency("activemodel")
+  s.add_dependency("rails-observers")
 
   s.add_development_dependency('rspec', "1.1.12")
   s.add_development_dependency('mocha', "0.9.8")

--- a/common/rubygem-openshift-origin-common.spec
+++ b/common/rubygem-openshift-origin-common.spec
@@ -22,6 +22,7 @@ Requires:      %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
 %endif
 Requires:      %{?scl:%scl_prefix}rubygems
 Requires:      %{?scl:%scl_prefix}rubygem(activemodel)
+Requires:      %{?scl:%scl_prefix}rubygem(rails-observers)
 Requires:      %{?scl:%scl_prefix}rubygem(json)
 Requires:      %{?scl:%scl_prefix}rubygem(safe_yaml)
 Requires:      %{?scl:%scl_prefix}rubygem(bundler)


### PR DESCRIPTION
Bug 1105660
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1105660
From rails > 4.0, ActiveModel::Observers has moved out as a gem
`rails-observers` https://github.com/rails/rails-observers.
And having a project using rails > 4.0 will broke the `ctl_app`.
