### PR TITLE
Bug 1106413: psql wrapper always return zero even if psql command is already failed

### DIFF
--- a/node/misc/bin/rhcsh
+++ b/node/misc/bin/rhcsh
@@ -183,7 +183,9 @@ function psql() {
     PGDATABASE=$pgdatabase \
     $CMD $extra_args "$@"
 
-  if [ $? -eq 2 ]; then
+  CMD_RC=$?
+
+  if [ $CMD_RC -eq 2 ]; then
     lines=(
       "psql: could not connect to server: Connection refused",
       "        Is the server running on host \"${pghost}\" and accepting",
@@ -191,6 +193,7 @@ function psql() {
     )
     errmsg=$(printf -- '%s\n' "${lines[@]}")
   fi
+  return $CMD_RC
 }
 
 function mongo() {


### PR DESCRIPTION
Update psql wrapper, to return actual psql return code
