### PR TITLE
oo-accept-node: check_user: use configured quotas

### DIFF
--- a/node-util/sbin/oo-accept-node
+++ b/node-util/sbin/oo-accept-node
@@ -568,7 +568,7 @@ def check_users
     if results.length == 0 ||
         results[0].split[4].to_i == 0 ||
         results[0].split[7].to_i == 0
-      user_fail(user.name, "user #{user.name} does not have quotas imposed. This can be addressed by running: oo-devel-node set-quota --with-container-uuid #{user.name} --blocks 1048576 --inodes 80000")
+      user_fail(user.name, "user #{user.name} does not have quotas imposed. This can be addressed by running: oo-devel-node set-quota --with-container-uuid #{user.name} --blocks #{$RESOURCE_LIMITS.get('quota_blocks', 1048576)} --inodes #{$RESOURCE_LIMITS.get('quota_files', 80000)}")
     end
   end
 end


### PR DESCRIPTION
Update 'oo-accept-node' to point the administrator to the 'oo-devel-node'
set-quota command using quota values fetched from resources_limit.conf.
