### PR TITLE
oo-admin-ctl-app: show app/gear UUID with status

### DIFF
--- a/broker-util/oo-admin-ctl-app
+++ b/broker-util/oo-admin-ctl-app
@@ -112,6 +112,10 @@ begin
   when "restart"
     reply.append app.restart  
   when "status"
+    puts "Application UUID is #{app._id}"
+    app.gears.each do |gear|
+      puts "GEAR UUID is #{gear.uuid}"
+    end
     app.cartridges.each do |cart|
       reply.append app.status(cart.name)
     end


### PR DESCRIPTION
Make oo-admin-ctl-app  -l username@EXAMPLE.COM -a test -c status display the application's and its gear's UUIDs.
