### PR TITLE
Replacing the short app name on the delete application page with the ful...

### DIFF
--- a/console/app/controllers/applications_controller.rb
+++ b/console/app/controllers/applications_controller.rb
@@ -106,7 +106,6 @@ class ApplicationsController < ConsoleController
 
   def delete
     @application = Application.find(params[:id], :as => current_user)
-
     @referer = application_path(@application)
   end
 

--- a/console/app/views/applications/delete.html.haml
+++ b/console/app/views/applications/delete.html.haml
@@ -5,7 +5,7 @@
 = semantic_form_for @application, :html => {:method => :delete, :class => 'form'} do |f|
   %p 
     Are you sure you want to delete the application 
-    <strong>'#{@application.name}'?</strong>
+    <strong>'#{@application.name}'</strong> from domain <strong>'#{@application.domain_name}'</strong>?
 
   %p 
     This will delete all the code and data associated with 


### PR DESCRIPTION
Replacing the short app name on the delete application page with the full application url to help negate confusion when deleting applications when you have access to multiple domains.  
php-testing.example.com instead of just php  
Similar to how github does it when you delete a repository, they show the user or organization name plus the repo name.  if this format is not appropriate, let me know what format would make more sense maybe domain/app_name?
