### PR TITLE
Generate and display ssh public key fingerprints instead of key contents

### DIFF
--- a/console/app/models/key.rb
+++ b/console/app/models/key.rb
@@ -64,13 +64,24 @@ class Key < RestApi::Base
   end
 
   def display_content
-    if content.length > 20
-      "#{content[1..8]}..#{content[-8..-1]}"
+    if (is_ssh?)
+      Digest::MD5.hexdigest(Base64.decode64(content)).gsub(/(.{2})(?=.)/, '\1:\2')
     else
-      content
+      if content.length > 32
+        "#{content[1..16]}..#{content[-16..-1]}"
+      else
+        content
+      end
     end
+    
   end
-
+  
+  #
+  # Determine if the key is an ssh key or kerberos principal
+  #
+  def is_ssh?
+    self.type != 'krb5-principal'
+  end
   #
   # Until the empty default key is attached from domain, ignore in lists
   #

--- a/console/app/views/settings/_keys.html.haml
+++ b/console/app/views/settings/_keys.html.haml
@@ -7,17 +7,12 @@
   = link_to "Learn more about SSH keys.", ssh_keys_help_path
 
 %table.table.table-condensed.table-fixed
-  %thead
-    %tr
-      %th.nowrap{:scope => 'col'} Key name
-      %th.nowrap{:scope => 'col'} Type
-      %th.nowrap{:scope => 'col'} Contents
-      %th
   - keys.each do |key|
     %tr{:id => "#{key.name}_sshkey"}
-      %td.sshkey-name{:scope => 'row'}= key.name
-      %td.sshkey-type= key.type
-      %td.code.sshkey= key.display_content
+      %td.nowrap{:scope => 'row'}
+        %div
+          %strong= key.name
+        %div= key.display_content + " (#{key.type})"
       %td= link_to 'Delete', key_path(key), :class => 'btn btn-mini btn-delete nowrap', :method => :delete, :confirm => "Are you sure you want to delete your key '#{key.name}'?"
 .btn-toolbar
   = link_to "Add a new key...", new_key_path, :class => 'btn btn-small'


### PR DESCRIPTION
Trello Card: https://trello.com/c/iB213gUS/8-show-individual-ssh-key-fingerprints-in-the-console

Updated files:
modified:   console/app/models/key.rb
modified:   console/app/views/settings/_keys.html.haml

Updated to generate ssh key fingerprint in the model, and display that fingerprint in the view instead of the content of the key
