### PR TITLE
plugins/routing/activemq: s/TOPIC/DESTINATION/

### DIFF
--- a/plugins/routing/activemq/conf/openshift-origin-routing-activemq.conf.example
+++ b/plugins/routing/activemq/conf/openshift-origin-routing-activemq.conf.example
@@ -1,4 +1,4 @@
-ACTIVEMQ_TOPIC='/topic/routinginfo'
+ACTIVEMQ_DESTINATION='/topic/routinginfo'
 ACTIVEMQ_USERNAME='routinginfo'
 ACTIVEMQ_PASSWORD='routinginfopasswd'
 ACTIVEMQ_HOST='127.0.0.1'

--- a/plugins/routing/activemq/config/initializers/openshift-origin-routing-activemq.rb
+++ b/plugins/routing/activemq/config/initializers/openshift-origin-routing-activemq.rb
@@ -13,7 +13,7 @@ Broker::Application.configure do
   conf = OpenShift::Config.new(conf_file)
 
   config.routing_activemq = {
-    :topic => conf.get("ACTIVEMQ_TOPIC", "/topic/routing"),
+    :destination => conf.get("ACTIVEMQ_DESTINATION", conf.get("ACTIVEMQ_TOPIC", "/topic/routing")),
     :hosts => conf.get("ACTIVEMQ_HOST", "127.0.0.1").split(',').map do |hp|
       hp.split(":").instance_eval do |h,p|
         {

--- a/plugins/routing/activemq/lib/openshift/activemq_routing_plugin.rb
+++ b/plugins/routing/activemq/lib/openshift/activemq_routing_plugin.rb
@@ -8,11 +8,11 @@ module OpenShift
   class ActiveMQPlugin < OpenShift::RoutingService
     def initialize
       Rails.logger.debug("Listening for routing events")
-      @topic = Rails.application.config.routing_activemq[:topic]
+      @dest = Rails.application.config.routing_activemq[:destination]
       if Rails.application.config.routing_activemq[:debug]
         @conn = Class.new(Object) do
-          def publish(topic, msg)
-            Rails.logger.debug("Topic #{topic} gets message:\n#{msg}")
+          def publish(dest, msg)
+            Rails.logger.debug("Destination #{dest} gets message:\n#{msg}")
           end
         end.new
       else
@@ -29,7 +29,7 @@ module OpenShift
     end
 
     def send_msg(msg)
-      @conn.publish @topic, msg
+      @conn.publish @dest, msg
     end
 
     def notify_ssl_cert_add(app, fqdn, ssl_cert, pvt_key, passphrase)


### PR DESCRIPTION
In the ActiveMQ routing plug-in, change the `ACTIVEMQ_TOPIC` setting to be `ACTIVEMQ_DESTINATION` as the value may be either a topic or a queue.

For compatibility, `ACTIVEMQ_TOPIC` is used if`ACTIVEMQ_DESTINATION` is not specified.

This commit fixes bug 1110454.
