### PR TITLE
Bug 1105324 - <node-proxy> add setsid to startup

### DIFF
--- a/node-proxy/scripts/init.d/openshift-node-web-proxy
+++ b/node-proxy/scripts/init.d/openshift-node-web-proxy
@@ -39,7 +39,7 @@ start() {
     echo -n $"Starting node-web-proxy: "
     chown apache.apache /var/log/openshift/node/node-web-proxy/*.log >/dev/null 2>&1 || :
     export NODE_PATH="$nodesysmodulespath"
-    scl enable nodejs010 "nohup $cmd &>> $logfile &"
+    setsid scl enable nodejs010 "nohup $cmd &>> $logfile &"
 
     for i in {1..30}; do
       pgrep -u 0 -f bin/node-supervisor > $pidfile


### PR DESCRIPTION
Finally fixes the issue of restarting openshift-node-web-proxy over an ssh connection with pty.

It turns out that ssh -t does not invoke the shell (bash) with job control, so even though the process is backgrounded and initiated with nohup, there is still a way that the process would receive a sighup.

I'm still not 100% on why the SIGHUP is sent, but it looks to be sending a SIGHUP to the entire process group, which without job control, the supervisor process is still a member of.  This only appears to happen if another command is invoked after the service restart command.

This is a problem because nodejs supervisor has a handler for SIGHUP that invokes process.exit.  By adding setsid, we are invoking the command within it's own process group.
