### PR TITLE
Fix bug 1108951: correct nodejs update-configuration function

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/lib/nodejs_context
+++ b/cartridges/openshift-origin-cartridge-nodejs/lib/nodejs_context
@@ -13,6 +13,6 @@ function nodejs_context {
 function update-configuration {
   case "$1" in
     0.6) set-configuration $1 native ;;
-    0.10) set-configuration $1 scl v8314 nodejs010 ;;
+    0.10) set-configuration $1 scl "v8314 nodejs010";;
   esac
 }

--- a/node/misc/bin/rhcsh
+++ b/node/misc/bin/rhcsh
@@ -196,13 +196,6 @@ function psql() {
   return $CMD_RC
 }
 
-function node() {
-  case "$OPENSHIFT_NODEJS_VERSION" in
-    0.6)  `which node` $@ ;;
-    0.10) /usr/bin/scl enable nodejs010 "node $@" ;;
-  esac
-}
-
 function mongo() {
    if test $# -gt 0; then
       uopt=""
@@ -281,7 +274,6 @@ ps              list running applications
 kill            kill running applications
 mysql           interactive MySQL shell
 mongo           interactive MongoDB shell
-node            interactive NodeJS shell
 psql            interactive PostgreSQL shell
 quota           list disk usage
 


### PR DESCRIPTION
Remove rhcsh 'node' wrapper introduced in earlier work for this bug and fix the nodejs path element.
