### PR TITLE
Match specific php module filename

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml
@@ -21,7 +21,7 @@ Version-Overrides:
 License: The PHP License, version 3.0
 License-Url: http://www.php.net/license/3_0.txt
 Vendor: php.net
-Cartridge-Version: 0.0.18
+Cartridge-Version: 0.0.19
 Compatible-Versions: []
 Cartridge-Vendor: redhat
 Categories:

--- a/cartridges/openshift-origin-cartridge-php/usr/lib/php_config
+++ b/cartridges/openshift-origin-cartridge-php/usr/lib/php_config
@@ -41,7 +41,7 @@ function enable_modules {
         module=${module%.erb}
         module=${module%.ini}
         modvar="OPENSHIFT_PHP_${module^^}_ENABLED"
-        if [[ "${!modvar,,}" != "false" && $testcmd != *${module}\.so* ]]; then
+        if [[ "${!modvar,,}" != "false" && $testcmd != *\'${module}.so\'* ]]; then
             testcmd+="@dl('${module}.so') and printf(' ${file}');"
         fi
     done


### PR DESCRIPTION
Fix possible prefix/substring bug. Distinguish `foobar.so` vs. `bar.so`.

[test] [extended:cartridge]

Fyi, @dobbymoodge @Miciah .. Could you please review this?
