### PR TITLE
Cron job is missing cart vars

### DIFF
--- a/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
+++ b/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
@@ -23,7 +23,7 @@ function load_env {
     export $key=$(< $1)
 }
 
-for f in ~/.env/* ~/.env/user_vars/* ~/*/env/*
+for f in `find ~/.env/ -type f` ~/*/env/*
 do
     load_env $f
 done


### PR DESCRIPTION
On scalable apps, database cartridges won't have it's vars exported during cron jobs.
