### PR TITLE
mgmt console: describe SYSLOG_ENABLED option

### DIFF
--- a/openshift-console/etc/openshift/console.conf
+++ b/openshift-console/etc/openshift/console.conf
@@ -143,3 +143,7 @@ REMOTE_USER_COPY_HEADERS=X-Remote-User
 
 #Openshift instance name, change it if you want a custom name.
 #PRODUCT_TITLE=OpenShift Origin
+
+# Direct logs to syslog rather than log files:
+#SYSLOG_ENABLED="true"
+


### PR DESCRIPTION
bug 1112838
https://bugzilla.redhat.com/show_bug.cgi?id=1112838

console.conf should include a description of the (commented-out) option
SYSLOG_ENABLED that's mentioned in the admin guide.
