### PR TITLE
Region bugfixes: 1115321, 1115244, 1115238, 1115274, 1115309

### DIFF
--- a/broker/conf/broker.conf
+++ b/broker/conf/broker.conf
@@ -184,3 +184,6 @@ DEFAULT_APP_TEMPLATES=
 # All node platforms must be present in the node network.
 # In the case of conflicting cartridges, priority is given to the platforms with a lower index.
 # NODE_PLATFORMS=linux
+
+# Default region for new applications
+DEFAULT_REGION_NAME=""

--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -112,7 +112,7 @@ Broker::Application.configure do
     :node_platforms => OpenShift::Controller::Configuration.parse_list(conf.get('NODE_PLATFORMS', 'linux')).map { |platform| platform.downcase },
     :default_max_untracked_addtl_storage_per_gear => (conf.get("DEFAULT_MAX_UNTRACKED_ADDTL_STORAGE_PER_GEAR", "0")).to_i,
     :default_max_tracked_addtl_storage_per_gear => (conf.get("DEFAULT_MAX_TRACKED_ADDTL_STORAGE_PER_GEAR", "0")).to_i,
-    :default_region_id => conf.get("DEFAULT_REGION_ID", nil)
+    :default_region_name => conf.get("DEFAULT_REGION_NAME", "")
   }
 
   config.auth = {

--- a/broker/config/environments/production.rb
+++ b/broker/config/environments/production.rb
@@ -101,7 +101,7 @@ Broker::Application.configure do
     :node_platforms => OpenShift::Controller::Configuration.parse_list(conf.get('NODE_PLATFORMS', 'linux')).map { |platform| platform.downcase },
     :default_max_untracked_addtl_storage_per_gear => (conf.get("DEFAULT_MAX_UNTRACKED_ADDTL_STORAGE_PER_GEAR", "0")).to_i,
     :default_max_tracked_addtl_storage_per_gear => (conf.get("DEFAULT_MAX_TRACKED_ADDTL_STORAGE_PER_GEAR", "0")).to_i,
-    :default_region_id => conf.get("DEFAULT_REGION_ID", nil)
+    :default_region_name => conf.get("DEFAULT_REGION_NAME", "")
   }
 
   config.auth = {

--- a/broker/config/environments/test.rb
+++ b/broker/config/environments/test.rb
@@ -110,7 +110,7 @@ Broker::Application.configure do
     :node_platforms => OpenShift::Controller::Configuration.parse_list(conf.get('NODE_PLATFORMS', 'linux')).map { |platform| platform.downcase },
     :default_max_untracked_addtl_storage_per_gear => (conf.get("DEFAULT_MAX_UNTRACKED_ADDTL_STORAGE_PER_GEAR", "0")).to_i,
     :default_max_tracked_addtl_storage_per_gear => (conf.get("DEFAULT_MAX_TRACKED_ADDTL_STORAGE_PER_GEAR", "0")).to_i,
-    :default_region_id => conf.get("DEFAULT_REGION_ID", nil)
+    :default_region_name => conf.get("DEFAULT_REGION_NAME", "")
   }
 
   config.auth = {

--- a/controller/app/controllers/applications_controller.rb
+++ b/controller/app/controllers/applications_controller.rb
@@ -66,15 +66,15 @@ class ApplicationsController < BaseController
     if region_name
       region = Region.find_by(name: region_name) rescue nil
       raise OpenShift::UserException.new("Could not find region '#{region_name}'.  Available regions are #{Region.where({}).collect{|r| r.name}.join(",")}") if region.nil?
-    elsif Rails.application.config.openshift[:default_region_id]
-      region = Region.find(Rails.application.config.openshift[:default_region_id]) rescue nil
-      Rails.logger.warn "The default region ID #{Rails.application.config.openshift[:default_region_id]} does not exist.  Proceeding to create app without specific region" if region.nil?
+    elsif Rails.application.config.openshift[:default_region_name].present?
+      region = Region.find_by(name: Rails.application.config.openshift[:default_region_name]) rescue nil
+      Rails.logger.warn "The default region #{Rails.application.config.openshift[:default_region_name]} does not exist. Proceeding to create app without specific region" if region.nil?
     end
     
     region_id = region ? region.id : nil
     
     if OpenShift::ApplicationContainerProxy.blacklisted? app_name
-      return render_error(:forbidden, "Application name is not allowed.  Please choose another.", 105)
+      return render_error(:forbidden, "Application name is not allowed. Please choose another.", 105)
     end
 
     if init_git_url = String(params[:initial_git_url]).presence

--- a/controller/app/rest_models/rest_domain.rb
+++ b/controller/app/rest_models/rest_domain.rb
@@ -48,7 +48,7 @@ class RestDomain < OpenShift::Model
       self.links = {
         "GET" => Link.new("Get domain", "GET", URI::join(url, "domain/#{name}")),
         "ADD_APPLICATION" => Link.new("Create new application", "POST", URI::join(url, "domain/#{name}/applications"),
-          [Param.new("name", "string", "Name of the application",nil,blacklisted_words)],
+          [Param.new("name", "string", "Name of the application", nil, blacklisted_words)],
           [OptionalParam.new("cartridges", "array", "Array of one or more cartridge names"),
           OptionalParam.new("scale", "boolean", "Mark application as scalable", [true, false], false),
           OptionalParam.new("gear_size", "string", "The size of the gear", allowed_gear_sizes, allowed_gear_sizes[0]),
@@ -56,7 +56,8 @@ class RestDomain < OpenShift::Model
           OptionalParam.new("cartridges[][name]", "string", "Name of a cartridge."),
           OptionalParam.new("cartridges[][gear_size]", "string", "Gear size for the cartridge.", allowed_gear_sizes, allowed_gear_sizes[0]),
           (OptionalParam.new("cartridges[][url]", "string", "A URL to a downloadable cartridge. You may specify an multiple urls via {'cartridges' : [{'url':'http://...'}, ...]}") if Rails.application.config.openshift[:download_cartridges_enabled]),
-          OptionalParam.new("environment_variables", "array", "Add or Update application environment variables, e.g.:[{'name':'FOO', 'value':'123'}, {'name':'BAR', 'value':'abc'}]")
+          OptionalParam.new("environment_variables", "array", "Add or Update application environment variables, e.g.:[{'name':'FOO', 'value':'123'}, {'name':'BAR', 'value':'abc'}]"),
+          OptionalParam.new("region", "string", "Restrict application to the given region")
         ].compact),
         "LIST_APPLICATIONS" => Link.new("List applications for a domain", "GET", URI::join(url, "domain/#{name}/applications")),
         "LIST_MEMBERS" => Link.new("List members of this domain", "GET", URI::join(url, "domain/#{name}/members")),

--- a/controller/app/rest_models/rest_gear_group.rb
+++ b/controller/app/rest_models/rest_gear_group.rb
@@ -83,7 +83,7 @@ class RestGearGroup < OpenShift::Model
 
       if servers
         ghash[:region] = servers[gear.server_identity].region_name rescue nil
-        ghash[:zone] = servers[gear.server_identity].region_name rescue nil
+        ghash[:zone] = servers[gear.server_identity].zone_name rescue nil
       end
       ghash
     }

--- a/controller/app/rest_models/rest_region.rb
+++ b/controller/app/rest_models/rest_region.rb
@@ -3,7 +3,7 @@ class RestRegion < OpenShift::Model
 
   def initialize(region)
     [:id, :name, :zones].each{ |sym| self.send("#{sym}=", region.send(sym)) }
-    self.default = region.name ==  Rails.configuration.openshift[:default_region_name] ? true : false
+    self.default = (region.name == Rails.configuration.openshift[:default_region_name])
   end
 
   def to_xml(options={})


### PR DESCRIPTION
Bug 1115321 - Fix zone name in gear_groups rest api response
Bug 1115244 - Add 'region' as optional param to ADD_APPLICATION link
Bug 1115238 - Add DEFAULT_REGION_NAME param to the broker configuration.
Bug 1115274 - Fix 'default' field in /regions REST api
Bug 1115309 - Default region will be selected when optional param 'region' is not set during app creation.
