### PR TITLE
Add -v option to restorecon to see the result

### DIFF
--- a/node-util/sbin/oo-restorecon
+++ b/node-util/sbin/oo-restorecon
@@ -38,10 +38,16 @@ if ARGV.empty? and options[:all] == false
 end
 
 def restore_con(dir, label, verbose = False)
-    puts "restorecon -R #{dir}" if verbose
-    %x[restorecon -R #{dir} ]
+    puts "restorecon -R -v #{dir}" if verbose
+    result = %x[restorecon -R -v #{dir} ]
+    unless result.empty? && verbose
+        puts result if verbose
+    end
     puts "chcon -l #{label} -R #{dir}*" if verbose
-    %x[chcon -l #{label} -R #{dir}* ]
+    result = %x[chcon -l #{label} -R #{dir}* ]
+    unless result.empty? && verbose
+        puts result if verbose
+    end
 end
 
 SelinuxContext = OpenShift::Runtime::Utils::SelinuxContext


### PR DESCRIPTION
Please check the result current result and after this patch applied. Now oo-restorecon -v option is just show the command only.

(  Current  )
[root@node1 ~]#  /usr/sbin/oo-restorecon -av
restorecon -R -v /var/lib/openshift/5399bb133a0fb2fd24000001/
chcon -l s0:c1,c1022 -R /var/lib/openshift/5399bb133a0fb2fd24000001/*

(After this patch applied)
[root@node1 ~]#  /usr/sbin/oo-restorecon -av
restorecon -R -v /var/lib/openshift/5399bb133a0fb2fd24000001/
restorecon reset /var/lib/openshift/5399bb133a0fb2fd24000001/hoge context unconfined_u:object_r:usr_t:s0:c1,c1022->unconfined_u:object_r:openshift_var_lib_t:s0:c1,c1022
chcon -l s0:c1,c1022 -R /var/lib/openshift/5399bb133a0fb2fd24000001/*
