### PR TITLE
Bug 1116135 - Add -u to bash sdk pgrep calls

### DIFF
--- a/node/misc/usr/lib/cartridge_sdk/bash/sdk
+++ b/node/misc/usr/lib/cartridge_sdk/bash/sdk
@@ -249,10 +249,10 @@ function process_running {
   # Check the pidfile for a running process
   {
     if [ -f $pidfile ]; then
-      local error=$(pgrep -F $pidfile 2>&1)
+      local error=$(pgrep -u $uid -F $pidfile 2>&1)
       # pgrep returns 0 with an invalid pidfile, so we need to check the output
       # run it again to get the return code of the pgrep, not the assignment
-      pgrep -F $pidfile >& /dev/null
+      pgrep -u $uid -F $pidfile >& /dev/null
       [ $? -eq 0 ] && ! [[ "${error}" =~ 'pidfile not valid' ]] && return 0
     fi
   }


### PR DESCRIPTION
- Since gears can "see" another gears pid files in the /proc filesystem,
  a stale pid file could block a cartridge from starting via the check
  in sdk#process_running()
