### PR TITLE
oo-accept-systems: Fix check_nodes_cartridges

### DIFF
--- a/broker-util/oo-accept-systems
+++ b/broker-util/oo-accept-systems
@@ -144,14 +144,15 @@ def check_nodes_cartridges
     [node,
      OpenShift::ApplicationContainerProxy.instance(node)
     .get_available_cartridges
-    .map {|cart| cart.name}]
+    .map {|cart| cart.name}
+    .sort]
   end.instance_eval {|ary| Hash[*ary.flatten(1)]}
 
   carts_for.each do |node, carts|
     if carts.empty?
       do_fail "host #{node} does not have any cartridges installed"
     else
-      verbose "cartridges for #{node}: #{carts}"
+      verbose "cartridges for #{node}: #{carts.join ', '}"
     end
   end
 
@@ -169,7 +170,7 @@ def check_nodes_cartridges
   any_missing = false
   carts_for.each do |node,carts|
     missing = all_carts - carts
-    missing.empty? or do_fail "node #{node} cartridge list is missing #{missing.join ','}"
+    missing.empty? or do_fail "node #{node} cartridge list is missing #{missing.join ', '}"
     any_missing ||= !missing.empty?
   end
   #
@@ -182,15 +183,15 @@ def check_nodes_cartridges
   begin
     require 'json'
     api_carts = JSON.parse(RestClient.get('http://localhost:8080/broker/rest/cartridges.json'))
-    api_carts = api_carts["data"].map {|cart| cart["name"]}
-    verbose "API reports carts: #{api_carts.join '|'}"
+    api_carts = api_carts["data"].map {|cart| cart["name"]}.sort
+    verbose "API reports carts: #{api_carts.join ', '}"
 
-    do_fail <<-"MISMATCH" unless api_carts.sort == all_carts.sort
+    do_fail <<-"MISMATCH" unless api_carts == all_carts
       The broker's list of cartridges does not match what is available on
       the node hosts.
 
-      Broker is missing: #{(all_carts - api_carts).join ", "}
-      Broker has extra: #{(api_carts - all_carts).join ", "}
+      Broker is missing: #{(all_carts - api_carts).join ', '}
+      Broker has extra: #{(api_carts - all_carts).join ', '}
 
       You can instruct the broker to pull an updated list of cartridges from a node
       and clear the management console's cache using the following commands:

--- a/broker-util/oo-accept-systems
+++ b/broker-util/oo-accept-systems
@@ -136,25 +136,32 @@ end
 
 def check_nodes_cartridges
   verbose "checking that all node hosts have cartridges installed"
-  carts_for = Hash.new
-  all_carts = []
   #
   # get the list of cartridges from every node
   #
-  OpenShift::MCollectiveApplicationContainerProxy.rpc_get_fact("cart_list") do |node,carts|
-    all_carts << ( carts_for[node] = carts.split('|').sort )
+  nodes = OpenShift::MCollectiveApplicationContainerProxy.known_server_identities
+  carts_for = nodes.map do |node|
+    [node,
+     OpenShift::ApplicationContainerProxy.instance(node)
+    .get_available_cartridges
+    .map {|cart| cart.name}]
+  end.instance_eval {|ary| Hash[*ary.flatten(1)]}
+
+  carts_for.each do |node, carts|
     if carts.empty?
       do_fail "host #{node} does not have any cartridges installed"
     else
       verbose "cartridges for #{node}: #{carts}"
     end
   end
+
   carts_for.empty? and return #nothing to do...
+
   #
   # check it's the same on every node
   #
   verbose "checking that same cartridges are installed on all node hosts"
-  all_carts = all_carts.flatten.uniq.sort
+  all_carts = carts_for.values.flatten.uniq.sort
   if all_carts.empty?
     do_fail "no cartridges are installed; please install cartridges on your node hosts"
     return
@@ -166,12 +173,12 @@ def check_nodes_cartridges
     any_missing ||= !missing.empty?
   end
   #
-  # check against broker's probably-cached list of carts
+  # check against broker's list of carts
   #
   # This gets /broker/rest/cartridges API doc. API versions 1.2 and 1.3 seem OK,
   # may need to revisit for future versions.
   return if any_missing # would likely get false positive
-  verbose "checking that broker's cache is not stale"
+  verbose "checking that broker's list of cartridges is not stale"
   begin
     require 'json'
     api_carts = JSON.parse(RestClient.get('http://localhost:8080/broker/rest/cartridges.json'))
@@ -181,10 +188,14 @@ def check_nodes_cartridges
     do_fail <<-"MISMATCH" unless api_carts.sort == all_carts.sort
       The broker's list of cartridges does not match what is available on
       the node hosts.
+
       Broker is missing: #{(all_carts - api_carts).join ", "}
       Broker has extra: #{(api_carts - all_carts).join ", "}
-      The broker may have cached an old list. Clear the cache by executing:
-        # oo-admin-broker-cache --clear
+
+      You can instruct the broker to pull an updated list of cartridges from a node
+      and clear the management console's cache using the following commands:
+
+        # oo-admin-ctl-cartridge -c import-node --activate --obsolete
         # oo-admin-console-cache --clear
     MISMATCH
   rescue StandardError => e


### PR DESCRIPTION
Fix the `check_nodes_cartridges` test in `oo-accept-systems` to get the list of cartridges the correct way rather than trying to use the `cart_list` fact, which has been deprecated for several releases.

With commit 4e94c47a381f3cfd168e9add0383414202aa96e5, the `cart_list` fact is no longer updated, so the check was essentially a no-op (no nodes would respond with the fact, so the `carts_for` Hash would remain empty, which would cause the test to terminate silently).

This commit fixes bug 1118908.
