### PR TITLE
feat(fog_plugin): implement fog plugin

### DIFF
--- a/plugins/dns/fog/Gemfile
+++ b/plugins/dns/fog/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/plugins/dns/fog/LICENSE
+++ b/plugins/dns/fog/LICENSE
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/plugins/dns/fog/README.md
+++ b/plugins/dns/fog/README.md
@@ -1,0 +1,29 @@
+# Openshift Origin Dynamic DNS plugin using Fog
+
+This package is a Dynamic DNS plugin for OpenShift Origin.
+
+It allows OpenShift Origin to use cloud DNS services to publish
+applications
+
+## Installation and Configuration
+
+* Install package *rubygem-openshift-origin-dns-fog*
+* Install package *rubygem-fog* (version >= 1.7.0)
+* Add gem *fog* to broker <code>Gemfile</code>
+
+  */var/www/openshift/broker/Gemfile*
+
+     <code>gem 'fog' >= 1.7.0</code>
+
+* Create and update config file:
+
+  *cp /etc/openshift/plugins.d/openshift-origin-dns-fog.conf.example /etc/openshift/plugins.d/openshift-origin-dns-fog.conf*
+
+
+* Restart broker
+  *systemctl restart openshift-broker.service*
+
+## References:
+
+* Fog
+  http://fog.io/

--- a/plugins/dns/fog/Rakefile
+++ b/plugins/dns/fog/Rakefile
@@ -1,0 +1,21 @@
+require "bundler/gem_tasks"
+require 'rake'
+require 'rake/testtask'
+require 'rspec/core/rake_task'
+require 'rdoc/task'
+
+task :default => [:rdoc]
+
+desc "Run RSpec unit tests"
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = "./spec/*/*_spec.rb" # don't need this, it's default.
+  # make sure ruby can find the superclass and dependencies
+  t.ruby_opts = "-I spec/lib -I ../../../common/lib -I ../../../controller/lib -I lib"
+end
+
+desc "Generate RDoc output"
+Rake::RDocTask.new do |rd|
+  rd.main = "README.rdoc"
+  rd.rdoc_dir = "doc"
+  rd.rdoc_files.include("README.rdoc", "lib/**/*.rb")
+end

--- a/plugins/dns/fog/conf/openshift-origin-dns-fog.conf.example
+++ b/plugins/dns/fog/conf/openshift-origin-dns-fog.conf.example
@@ -1,0 +1,12 @@
+# Settings related to the Fog DNS service
+
+# Provider
+FOG_PROVIDER="rackspace"
+
+# Zone
+FOG_ZONE="oo.example.com"
+
+# Rackspace Provider Keys
+FOG_RACKSPACE_USERNAME="racker"
+FOG_RACKSPACE_API_KEY="apikey"
+FOG_RACKSPACE_REGION="ord"

--- a/plugins/dns/fog/config/initializers/openshift-origin-dns-fog.rb
+++ b/plugins/dns/fog/config/initializers/openshift-origin-dns-fog.rb
@@ -1,0 +1,23 @@
+require 'openshift-origin-common'
+
+Broker::Application.configure do
+  conf_file = File.join(OpenShift::Config::PLUGINS_DIR, File.basename(__FILE__, '.rb') + '.conf')
+  if Rails.env.development?
+    dev_conf_file = File.join(OpenShift::Config::PLUGINS_DIR, File.basename(__FILE__, '.rb') + '-dev.conf')
+    if File.exist? dev_conf_file
+      conf_file = dev_conf_file
+    else
+      Rails.logger.info "Development configuration for #{File.basename(__FILE__, '.rb')} not found. Using production configuration."
+    end
+  end
+  conf = OpenShift::Config.new(conf_file)
+
+  config.dns = {
+    :provider => conf.get("FOG_PROVIDER", "unset"),
+    :zone => conf.get("FOG_ZONE", "unset"),
+    # Rackspace
+    :rackspace_username => conf.get("FOG_RACKSPACE_USERNAME", "unset"),
+    :rackspace_api_key => conf.get("FOG_RACKSPACE_API_KEY", "unset"),
+    :rackspace_region => conf.get("FOG_RACKSPACE_REGION", "unset")
+  }
+end

--- a/plugins/dns/fog/lib/fog_dns_engine.rb
+++ b/plugins/dns/fog/lib/fog_dns_engine.rb
@@ -1,0 +1,7 @@
+require 'openshift-origin-controller'
+require 'rails'
+
+module OpenShift
+  class FogDnsEngine < Rails::Engine
+  end
+end

--- a/plugins/dns/fog/lib/openshift-origin-dns-fog.rb
+++ b/plugins/dns/fog/lib/openshift-origin-dns-fog.rb
@@ -1,0 +1,10 @@
+require "openshift-origin-common"
+
+module OpenShift
+  module FogDnsModule
+    require 'fog_dns_engine' if defined?(Rails) && Rails::VERSION::MAJOR == 3
+  end
+end
+
+require "openshift/fog_plugin.rb"
+OpenShift::DnsService.provider=OpenShift::FogPlugin

--- a/plugins/dns/fog/lib/openshift/fog_plugin.rb
+++ b/plugins/dns/fog/lib/openshift/fog_plugin.rb
@@ -1,0 +1,61 @@
+#
+# Make OpenShift DNS updates using Fog
+#
+require 'rubygems'
+require 'fog'
+
+module OpenShift
+
+  class FogPlugin < OpenShift::DnsService
+    @oo_dns_provider = OpenShift::FogPlugin
+
+    attr_reader :config, :zone
+
+    def initialize(access_info = nil)
+      access_info = Rails.application.config.dns unless !access_info.nil?
+      @zone = access_info[:zone]
+      @config = access_info.clone
+      @config.delete(:zone)
+    end
+
+    def register_application(app_name, namespace, public_hostname)
+      fqdn = "#{app_name}-#{namespace}.#{@zone}"
+      zone = fog.zones.find {|zone| zone.domain == @zone}
+      zone.records.create({
+        :name => fqdn,
+        :type => 'CNAME',
+        :value => public_hostname
+      })
+    end
+
+    def deregister_application(app_name, namespace)
+      fqdn = "#{app_name}-#{namespace}.#{@zone}"
+      zone = fog.zones.find {|zone| zone.domain == @zone}
+      record = zone.records.find {|record| record.name == fqdn}
+      record.destroy unless record.nil?
+    end
+
+    def modify_application(app_name, namespace, new_public_hostname)
+      fqdn = "#{app_name}-#{namespace}.#{@zone}"
+      zone = fog.zones.find {|zone| zone.domain == @zone}
+      record = zone.records.find {|record| record.name == fqdn}
+      record.name = fqdn
+      record.value = new_public_hostname
+      record.save
+    end
+
+    def publish
+    end
+
+    def close
+    end
+
+    private
+
+    def fog
+      Fog::DNS.new(@config)
+    end
+
+  end
+end
+

--- a/plugins/dns/fog/openshift-origin-dns-fog.gemspec
+++ b/plugins/dns/fog/openshift-origin-dns-fog.gemspec
@@ -1,0 +1,34 @@
+# -*- encoding: utf-8 -*-
+config_dir  = File.join(File.join("config", "**"), "*")
+$:.push File.expand_path("../lib", __FILE__)
+lib_dir  = File.join(File.join("lib", "**"), "*")
+test_dir  = File.join(File.join("test", "**"), "*")
+bin_dir  = File.join("bin", "*")
+doc_dir  = File.join(File.join("doc", "**"), "*")
+conf_dir  = File.join(File.join("conf", "**"), "*")
+spec_file = "rubygem-openshift-origin-dns-fog.spec"
+
+Gem::Specification.new do |s|
+  spec_file = IO.read(File.expand_path("../rubygem-#{File.basename(__FILE__, '.gemspec')}.spec", __FILE__))
+
+  s.name        = "openshift-origin-dns-fog"
+  s.version     = spec_file.match(/^Version:\s*(.*?)$/mi)[1].chomp
+  s.authors     = ["David Porter", "John Lozano"]
+  s.email       = ["anomalous20@gmail.com", "johnbobsexipants@gmail.com"]
+  s.homepage    = 'https://github.com/openshift/origin-server'
+  s.summary     = 'OpenShift Origin DNS Fog plugin'
+
+  s.files       = Dir[lib_dir] + Dir[doc_dir] + Dir[conf_dir] + Dir[config_dir]
+  s.test_files  = Dir[test_dir]
+  s.executables   = Dir[bin_dir]
+  s.files       += %w(README.md Rakefile Gemfile rubygem-openshift-origin-dns-fog.spec openshift-origin-dns-fog.gemspec LICENSE)
+  s.require_paths = ["lib"]
+
+  s.add_dependency('fog')
+  s.add_dependency('openshift-origin-controller')
+  s.add_dependency('openshift-origin-common')
+  s.add_development_dependency('rake', '>= 0.8.7', '<= 0.9.6')  
+  s.add_development_dependency('bundler')
+  s.add_development_dependency('mocha')
+
+end

--- a/plugins/dns/fog/rubygem-openshift-origin-dns-fog.spec
+++ b/plugins/dns/fog/rubygem-openshift-origin-dns-fog.spec
@@ -1,0 +1,85 @@
+%if 0%{?fedora}%{?rhel} <= 6
+    %global scl ruby193
+    %global scl_prefix ruby193-
+%endif
+%{!?scl:%global pkg_name %{name}}
+%{?scl:%scl_package rubygem-%{gem_name}}
+%global gem_name openshift-origin-dns-fog
+%global rubyabi 1.9.1
+
+Summary:       OpenShift plugin for Fog cloud services library
+Name:          rubygem-%{gem_name}
+Version:       1.0.0
+Release:       1%{?dist}
+Group:         Development/Languages
+License:       ASL 2.0
+URL:           http://www.openshift.com
+Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{gem_name}/rubygem-%{gem_name}-%{version}.tar.gz
+%if 0%{?fedora} >= 19
+Requires:      ruby(release)
+%else
+Requires:      %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
+%endif
+Requires:      %{?scl:%scl_prefix}rubygems
+Requires:      rubygem(openshift-origin-common)
+Requires:      openshift-origin-broker
+Requires:      %{?scl:%scl_prefix}rubygem-fog >= 1.7.0
+%if 0%{?fedora}%{?rhel} <= 6
+BuildRequires: ruby193-build
+BuildRequires: scl-utils-build
+%endif
+%if 0%{?fedora} >= 19
+BuildRequires: ruby(release)
+%else
+BuildRequires: %{?scl:%scl_prefix}ruby(abi) >= %{rubyabi}
+%endif
+BuildRequires: %{?scl:%scl_prefix}rubygems
+BuildRequires: %{?scl:%scl_prefix}rubygems-devel
+BuildArch:     noarch
+Provides:      rubygem(%{gem_name}) = %version
+
+%description
+Provides an Fog cloud DNS service plugin
+
+%prep
+%setup -q
+
+%build
+%{?scl:scl enable %scl - << \EOF}
+mkdir -p ./%{gem_dir}
+# Create the gem as gem install only works on a gem file
+gem build %{gem_name}.gemspec
+rdoc
+export CONFIGURE_ARGS="--with-cflags='%{optflags}'"
+# gem install compiles any C extensions and installs into a directory
+# We set that to be a local directory so that we can move it into the
+# buildroot in %%install
+gem install -V \
+        --local \
+        --install-dir ./%{gem_dir} \
+        --force \
+        --rdoc \
+        %{gem_name}-%{version}.gem
+%{?scl:EOF}
+
+%install
+mkdir -p %{buildroot}%{gem_dir}
+cp -a ./%{gem_dir}/* %{buildroot}%{gem_dir}/
+
+# Add documents/examples
+mkdir -p %{buildroot}%{_docdir}/%{name}-%{version}/
+cp -r doc/* %{buildroot}%{_docdir}/%{name}-%{version}/
+
+#Config file
+mkdir -p %{buildroot}/etc/openshift/plugins.d
+cp %{buildroot}/%{gem_dir}/gems/%{gem_name}-%{version}/conf/openshift-origin-dns-fog.conf.example %{buildroot}/etc/openshift/plugins.d/openshift-origin-dns-fog.conf.example
+
+
+%files
+%doc %{gem_docdir}
+%doc %{_docdir}/%{name}-%{version}
+%{gem_instdir}
+%{gem_spec}
+%{gem_cache}
+/etc/openshift/plugins.d/openshift-origin-dns-fog.conf.example
+

--- a/plugins/dns/fog/spec/unit/fog_spec.rb
+++ b/plugins/dns/fog/spec/unit/fog_spec.rb
@@ -1,0 +1,135 @@
+require 'parseconfig'
+require 'openshift/dns_service'
+require 'openshift/fog_plugin'
+
+# Mock up the rails application configuration object
+module Rails
+  def self.application()
+    Application.new
+  end
+
+  class Application
+
+    class Configuration
+      attr_accessor :dns
+      
+      def initialize()
+        conf_file = File.expand_path('../../../conf/openshift-origin-dns-fog.conf.example', __FILE__);
+        conf = ParseConfig.new(conf_file)
+
+        @dns = {
+          :provider => conf["FOG_PROVIDER"],
+          :zone => conf["FOG_ZONE"],
+          :rackspace_username => conf["FOG_RACKSPACE_USERNAME"],
+          :rackspace_api_key => conf["FOG_RACKSPACE_API_KEY"],
+          :rackspace_region => conf["FOG_RACKSPACE_REGION"],
+        }
+      end
+    end
+
+    def config()
+     Configuration.new
+    end
+  end
+end
+
+module OpenShift
+
+  describe FogPlugin do
+
+    def mock_fog
+
+    end
+
+    before(:all) do
+      $test_appname = "testapp"
+      $test_namespace = "ns"
+      $test_hostname = "test.com"
+      $fqdn = "#{$test_appname}-#{$test_namespace}.#{Rails.application.config.dns[:zone]}"
+    end
+
+    it "can be initialized with arguments" do
+      
+      fog_options = {
+        provider: 'fogProvider',
+        zone: 'fogZone',
+        rackspace_username: 'username',
+        rackspace_api_key: 'apikey',
+        rackspace_region: 'region'
+      };
+
+      dns_service = FogPlugin.new(fog_options)
+      expect(dns_service.zone).to eql('fogZone')
+      expect(dns_service.config).to include(
+        :provider => 'fogProvider',
+        :rackspace_username => 'username',
+        :rackspace_api_key => 'apikey',
+        :rackspace_region => 'region' )
+    end
+
+    it "can be initialized from the Rails Application configuration" do
+      dns_service = FogPlugin.new()
+
+      expected_config = Rails.application.config.dns
+      expect(dns_service.zone).to eql(expected_config[:zone])
+      expect(dns_service.config).to include(
+        :provider => expected_config[:provider],
+        :rackspace_username => expected_config[:rackspace_username],
+        :rackspace_api_key => expected_config[:rackspace_api_key],
+        :rackspace_region => expected_config[:rackspace_region] )
+    end
+
+    it "can add application records to fog" do
+      record = double( :destroy => {}, :save => {} )
+      records = double( :records => double( :create => {}, :find => record  ) ) 
+      zone = double("zone", :find => records )
+      fog = double("fog", :zones => zone)
+      allow(Fog::DNS).to receive(:new) { fog }
+
+      dns_service = FogPlugin.new()
+      reply = dns_service.register_application($test_appname, 
+                                               $test_namespace,
+                                               $test_hostname)
+
+      expectedCreatePayload = {
+        :name => $fqdn,
+        :type => 'CNAME',
+        :value => $test_hostname
+      }
+      expect(zone.find.records).to have_received(:create).with(expectedCreatePayload)
+                                       
+    end
+
+    it "can delete application records from fog" do
+      record = double( :destroy => {}, :save => {} )
+      records = double( :records => double( :create => {}, :find => record  ) ) 
+      zone = double("zone", :find => records )
+      fog = double("fog", :zones => zone)
+      allow(Fog::DNS).to receive(:new) { fog }
+
+      dns_service = FogPlugin.new()
+      reply = dns_service.deregister_application($test_appname, 
+                                                 $test_namespace)
+
+      expect(record).to have_received(:destroy)
+    end
+
+    it "can modify application records from fog" do
+      record = double( :destroy => {}, :save => {}, :name= => '', :value= => '')
+      records = double( :records => double( :create => {}, :find => record  ) ) 
+      zone = double("zone", :find => records )
+      fog = double("fog", :zones => zone)
+      allow(Fog::DNS).to receive(:new) { fog }
+
+      dns_service = FogPlugin.new()
+      new_name = $test_hostname + 'new'
+      reply = dns_service.modify_application($test_appname, 
+                                             $test_namespace,
+                                             new_name)
+
+      expect(record).to have_received(:name=).with($fqdn)
+      expect(record).to have_received(:value=).with(new_name)
+      expect(record).to have_received(:save)
+    end
+  end
+end


### PR DESCRIPTION
This contribution introduces a DNS plugin using Fog, the ruby cloud services library.

http://fog.io

Initially, only the Rackspace provider credentials are mapped; however, credentials for AWS and other providers can be easily mapped as necessary.
