### PR TITLE
Bug 1094007 - PHP cart: update pear.php.net channel when install

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/bin/install
+++ b/cartridges/openshift-origin-cartridge-php/bin/install
@@ -35,5 +35,6 @@ rm -f $OPENSHIFT_HOMEDIR/.pearrc
 php_context "pear config-create ${OPENSHIFT_PHP_DIR}phplib/pear/ ${OPENSHIFT_HOMEDIR}.pearrc"
 php_context "pear -c ${OPENSHIFT_HOMEDIR}.pearrc config-set php_ini ${OPENSHIFT_PHP_DIR}configuration/etc/php.ini"
 php_context "pear -c ${OPENSHIFT_HOMEDIR}.pearrc config-set auto_discover 1"
+php_context "pear -c ${OPENSHIFT_HOMEDIR}.pearrc channel-update pear.php.net"
 
 update_configuration


### PR DESCRIPTION
This patch fixes the warning in PHP cart when installing dependencies: _channel "pear.php.net" has updated its protocols, use "pear channel-update pear.php.net" to update._

See [Bug 1094007](https://bugzilla.redhat.com/show_bug.cgi?id=1094007)
[Trello card](https://trello.com/c/RsENlXNV/257-5-fix-5-existing-bugs)
