### PR TITLE
Bug 1120467: Fixing wrong grep format for threaddump in ruby-2.0

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -234,7 +234,7 @@ function _threaddump() {
       exit 1
   fi
 
-  PID=$(ps -u $(id -u $1) -o pid,command | grep -v grep | grep 'Rack:.*'$1 | awk 'BEGIN {FS=" "}{print $1}')
+  PID=$(ps -u $(id -u $1) -o pid,command | grep -v grep | grep 'Rack.*'$1 | awk 'BEGIN {FS=" "}{print $1}')
 
   if [ -z "$PID" ]; then
     echo "Unable to detect application PID. Check the application's availability by accessing http://${OPENSHIFT_GEAR_DNS}"


### PR DESCRIPTION
Problem was that ruby-1.8 and 1.9 Rack processes which are grepped upon the threaddump action look like:
`Rack: /var/lib/openshift/53c910b204a1bbc98f00001d/app-root/runtime/repo`,
whereas the ruby-2.0 process looks like:
`Passenger RackApp: /var/lib/openshift/53c911e304a1bbfca7000001/app-root/runtime/repo`

Just modified the grepped string
