### PR TITLE
oo-iptables-port-proxy: getaddr: clean-up and add check

### DIFF
--- a/node/misc/bin/oo-iptables-port-proxy
+++ b/node/misc/bin/oo-iptables-port-proxy
@@ -11,7 +11,10 @@ function help() {
 
 function getaddr() {
     # External due to using DNS for gear->gear
-    ip -4 addr show dev ${EXTERNAL_ETH_DEV:-eth0} scope global | sed -r -n '/inet/ { s/^.*inet ([0-9\.]+).*/\1/; p }' | head -1
+    dev="${EXTERNAL_ETH_DEV:-eth0}"
+    read _ _ _ ipaddr _ < \
+      <(ip -o -f inet addr show dev $dev scope global)
+    echo -n "${ipaddr%/*}"
 }
 
 # Fix up the IP Address in the config if the assigned node IP Address has changed.

--- a/node/misc/bin/oo-iptables-port-proxy
+++ b/node/misc/bin/oo-iptables-port-proxy
@@ -14,7 +14,8 @@ function getaddr() {
     dev="${EXTERNAL_ETH_DEV:-eth0}"
     read _ _ _ ipaddr _ < \
       <(ip -o -f inet addr show dev $dev scope global)
-    echo -n "${ipaddr%/*}"
+    ipaddr="${ipaddr%/*}"
+    echo -n "${ipaddr:?$dev has no globally scoped IPv4 address}"
 }
 
 # Fix up the IP Address in the config if the assigned node IP Address has changed.


### PR DESCRIPTION
Clean up the `getaddr` command to use pure Bash with only one fork and simpler (and hopefully more reliable) parsing.

Check that the IP address is not empty in `getaddr` and report a helpful error message if it is.

This commit fixes bug 1121200.
