### PR TITLE
Fix frontend system_proxy_delete/system_proxy_set

### DIFF
--- a/node/lib/openshift-origin-node/model/frontend_proxy.rb
+++ b/node/lib/openshift-origin-node/model/frontend_proxy.rb
@@ -226,7 +226,7 @@ module OpenShift
           out, err, rc = ::OpenShift::Runtime::Utils::oo_spawn(cmd)
           return out, err, rc
         else
-          return 0, nil, nil
+          return nil, nil, 0
         end
       end
 
@@ -252,7 +252,7 @@ module OpenShift
           out, err, rc = ::OpenShift::Runtime::Utils::oo_spawn(cmd)
           return out, err, rc
         else
-          return 0, nil, nil
+          return nil, nil, 0
         end
       end
 

--- a/node/test/unit/frontend_proxy_test.rb
+++ b/node/test/unit/frontend_proxy_test.rb
@@ -236,7 +236,7 @@ class FrontendProxyTest < OpenShift::NodeTestCase
     proxy.system_proxy_delete(1, 2, 3)
 
     OpenShift::Runtime::Utils.expects(:oo_spawn).with(regexp_matches(/^oo-iptables-port-proxy/)).never
-    assert_equal [0,nil,nil], proxy.system_proxy_delete()
+    assert_equal [nil,nil,0], proxy.system_proxy_delete()
   end
 
   # Verify the command line constructed by the system proxy add command
@@ -258,7 +258,7 @@ class FrontendProxyTest < OpenShift::NodeTestCase
       )
 
     OpenShift::Runtime::Utils.expects(:oo_spawn).with(regexp_matches(/^oo-iptables-port-proxy/)).never
-    assert_equal [0,nil,nil], proxy.system_proxy_set()
+    assert_equal [nil,nil,0], proxy.system_proxy_set()
   end
 
   # Verify the command line constructed by the system proxy show


### PR DESCRIPTION
`OpenShift::Runtime::FrontendProxyServer#system_proxy_delete` and `OpenShift::Runtime::FrontendProxyServer#system_proxy_set`: Return values in
a consistent ordering (stdout, stderr, exit status) irrespective of whether
arguments were passed.

Previously, these methods returned the exit status as the first value instead of the last if no arguments were provided.

Fix the corresponding test cases to expect the correct ordering.

This commit fixes bug 1121238.
