### PR TITLE
NodeJS Cartridge Should Only Pull Production Modules

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/bin/control
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/control
@@ -213,7 +213,7 @@ function build() {
 
     nodejs_context /bin/bash
     if [ -f "${OPENSHIFT_REPO_DIR}"/package.json ]; then
-        (cd "${OPENSHIFT_REPO_DIR}"; nodejs_context "npm install -d")
+        (cd "${OPENSHIFT_REPO_DIR}"; nodejs_context "npm install -d --production")
     fi
 }
 


### PR DESCRIPTION
Issue #5627
