### PR TITLE
Added v8341-runtime RPM to Node.JS cartridge RPM requirements

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/openshift-origin-cartridge-nodejs.spec
+++ b/cartridges/openshift-origin-cartridge-nodejs/openshift-origin-cartridge-nodejs.spec
@@ -40,6 +40,7 @@ Requires:      nodejs-node-static
 Requires:      nodejs-pg
 Requires:      nodejs-supervisor
 Requires:      nodejs-options
+Requires:      v8341-runtime
 Provides:      openshift-origin-cartridge-nodejs-0.6 = 2.0.0
 Obsoletes:     openshift-origin-cartridge-nodejs-0.6 <= 1.99.9
 BuildArch:     noarch


### PR DESCRIPTION
@maxamillion please review (v4 branch); do not merge until `v8341-runtime` is available in our deps repos.
