### PR TITLE
Bug 1122020: Fix syntax error in oo-diagnostics

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -1303,7 +1303,7 @@ class OODiag
     end
   end
 
-  test_node_clock_in_synch_with_broker
+  def test_node_clock_in_synch_with_broker
     skip_test unless @is_node
     require 'time'
     warning_threshold = 5


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1122020
