### PR TITLE
Bug 1122166 - Preserve sparse files during rsync operations

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/control
@@ -288,7 +288,7 @@ function deploy() {
   # and delete any files in $JBOSSAS_DEPLOYMENTS_DIR that don't exist in
   # repo/deployments
   if [ "$(ls ${OPENSHIFT_REPO_DIR}/deployments 2>/dev/null)" ]; then
-    rsync -r --delete --exclude ".*" ${OPENSHIFT_REPO_DIR}/deployments/ $JBOSSAS_DEPLOYMENTS_DIR
+    rsync -rS --delete --exclude ".*" ${OPENSHIFT_REPO_DIR}/deployments/ $JBOSSAS_DEPLOYMENTS_DIR
   fi
 }
 

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/control
@@ -288,7 +288,7 @@ function deploy() {
   # and delete any files in $JBOSSEAP_DEPLOYMENTS_DIR that don't exist in
   # repo/deployments
   if [ "$(ls ${OPENSHIFT_REPO_DIR}/deployments 2>/dev/null)" ]; then
-    rsync -r --delete --exclude ".*" ${OPENSHIFT_REPO_DIR}/deployments/ $JBOSSEAP_DEPLOYMENTS_DIR
+    rsync -rS --delete --exclude ".*" ${OPENSHIFT_REPO_DIR}/deployments/ $JBOSSEAP_DEPLOYMENTS_DIR
   fi
 }
 

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/deploy
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/deploy
@@ -22,5 +22,5 @@ fi
 # and delete any files in $OPENSHIFT_JBOSSEWS_DIR/webapps that don't exist in
 # repo/webapps
 if [ "$(ls ${OPENSHIFT_REPO_DIR}/webapps 2>/dev/null)" ]; then
-  rsync -r --delete ${OPENSHIFT_REPO_DIR}/webapps/ ${OPENSHIFT_JBOSSEWS_DIR}/webapps/
+  rsync -rS --delete ${OPENSHIFT_REPO_DIR}/webapps/ ${OPENSHIFT_JBOSSEWS_DIR}/webapps/
 fi

--- a/cartridges/openshift-origin-cartridge-jenkins-client/metadata/jenkins_shell_command
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/metadata/jenkins_shell_command
@@ -1,6 +1,6 @@
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
-alias rsync="rsync --delete-after -az -e '$GIT_SSH'"
+alias rsync="rsync --delete-after -azS -e '$GIT_SSH'"
 
 upstream_ssh="UPSTREAM_SSH"
 

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-scl/metadata/jenkins_shell_command.erb
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-scl/metadata/jenkins_shell_command.erb
@@ -1,6 +1,6 @@
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
-alias rsync="rsync --exclude-from='${OPENSHIFT_PYTHON_DIR}/metadata/rsync.excludes' --delete-after -az -e '$GIT_SSH'"
+alias rsync="rsync --exclude-from='${OPENSHIFT_PYTHON_DIR}/metadata/rsync.excludes' --delete-after -azS -e '$GIT_SSH'"
 
 upstream_ssh="<%= ENV['OPENSHIFT_GEAR_UUID'] %>@<%= ENV['OPENSHIFT_APP_NAME'] %>-${OPENSHIFT_NAMESPACE}.<%= ENV['OPENSHIFT_CLOUD_DOMAIN'] %>"
 

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/metadata/jenkins_shell_command.erb
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/metadata/jenkins_shell_command.erb
@@ -1,6 +1,6 @@
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
-alias rsync="rsync --delete-after -azO -e '$GIT_SSH'"
+alias rsync="rsync --delete-after -azOS -e '$GIT_SSH'"
 
 upstream_ssh="<%= ENV['OPENSHIFT_GEAR_UUID'] %>@<%= ENV['OPENSHIFT_APP_NAME'] %>-${OPENSHIFT_NAMESPACE}.<%= ENV['OPENSHIFT_CLOUD_DOMAIN'] %>"
 

--- a/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/cartridge_actions.rb
@@ -1487,7 +1487,7 @@ module OpenShift
           ssh_dir        = PathUtils.join(container_dir, '.openshift_ssh')
           ssh_key        = PathUtils.join(ssh_dir, 'id_rsa')
           OpenShift::Runtime::Threads::Parallel.map(ssh_urls, :in_threads => MAX_THREADS) do |gear|
-            out, err, rc = run_in_container_context("rsync -aAX --rsh=/usr/bin/oo-ssh #{ssh_key}{,.pub} #{gear}:.openshift_ssh/",
+            out, err, rc = run_in_container_context("rsync -aAXS --rsh=/usr/bin/oo-ssh #{ssh_key}{,.pub} #{gear}:.openshift_ssh/",
                                                     env: gear_env,
                                                     chdir: container_dir,
                                                     expected_exitstatus: 0)
@@ -1712,7 +1712,7 @@ module OpenShift
             when 'windows'
               '-rltgoDOv'
             else
-              '-avz'
+              '-avzS'
           end
         end
       end

--- a/node/lib/openshift-origin-node/model/application_container_ext/deployments.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/deployments.rb
@@ -200,7 +200,7 @@ module OpenShift
         end
 
         def sync_files(from, to)
-          out, err, rc = run_in_container_context("/usr/bin/rsync -av --delete #{from}/ #{to}/",
+          out, err, rc = run_in_container_context("/usr/bin/rsync -avS --delete #{from}/ #{to}/",
                                                   expected_exitstatus: 0)
         end
 

--- a/node/lib/openshift-origin-node/model/application_container_ext/environment.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/environment.rb
@@ -346,7 +346,7 @@ module OpenShift
                 gear_dns = fqdn
                 retries  = 2
                 begin
-                  command = "/usr/bin/rsync -rp0 --delete -e '/usr/bin/oo-ssh' #{source}/ #{fqdn}:#{target}"
+                  command = "/usr/bin/rsync -rp0S --delete -e '/usr/bin/oo-ssh' #{source}/ #{fqdn}:#{target}"
                   env = OpenShift::Runtime::Utils::Environ.for_gear(@container_dir)
                   ::OpenShift::Runtime::Utils::oo_spawn(command, expected_exitstatus: 0, uid: @uid, env: env)
                 rescue Exception => e

--- a/node/lib/openshift-origin-node/model/application_repository.rb
+++ b/node/lib/openshift-origin-node/model/application_repository.rb
@@ -100,7 +100,7 @@ module OpenShift
 
           gear_env = ::OpenShift::Runtime::Utils::Environ::for_gear(@container.container_dir)
 
-          out, err, rc = @container.run_in_container_context("mkdir -p #{locations.first} ; rsync -rOv --exclude '.git' --delete --rsh=/usr/bin/oo-ssh #{ssh_url}:git/template/ #{locations.first}",
+          out, err, rc = @container.run_in_container_context("mkdir -p #{locations.first} ; rsync -rOvS --exclude '.git' --delete --rsh=/usr/bin/oo-ssh #{ssh_url}:git/template/ #{locations.first}",
                                                              env: gear_env,
                                                              chdir: @container.container_dir,
                                                              expected_exitstatus: 0)

--- a/node/test/unit/application_container_test.rb
+++ b/node/test/unit/application_container_test.rb
@@ -447,7 +447,7 @@
       ssh_url = "#{entry1[:uuid]}@#{entry1[:proxy_hostname]}"
       location = PathUtils.join(@container.container_dir, 'mock', 'template')
 
-      @container.expects(:run_in_container_context).with("mkdir -p #{location} ; rsync -rOv --exclude '.git' --delete --rsh=/usr/bin/oo-ssh #{ssh_url}:git/template/ #{location}",
+      @container.expects(:run_in_container_context).with("mkdir -p #{location} ; rsync -rOvS --exclude '.git' --delete --rsh=/usr/bin/oo-ssh #{ssh_url}:git/template/ #{location}",
                                                          env: gear_env,
                                                          chdir: @container.container_dir,
                                                          expected_exitstatus: 0)
@@ -495,7 +495,7 @@
       @container.expects(:gear_registry).times(2).returns(gear_registry)
 
       rsync_options = @container.send(:remote_rsync_options, uuid1)
-      assert_equal '-avz', rsync_options
+      assert_equal '-avzS', rsync_options
 
       rsync_options = @container.send(:remote_rsync_options, uuid2)
       assert_equal '-rltgoDOv', rsync_options
@@ -561,7 +561,7 @@
 
       @container.expects(:gear_registry).returns(gear_registry).at_least_once
 
-      @container.expects(:run_in_container_context).with("rsync -aAX --rsh=/usr/bin/oo-ssh /var/lib/openshift/#{@gear_uuid}/.openshift_ssh/id_rsa{,.pub} #{@gear_uuid.to_i + 2}@node1.example.com:.openshift_ssh/",
+      @container.expects(:run_in_container_context).with("rsync -aAXS --rsh=/usr/bin/oo-ssh /var/lib/openshift/#{@gear_uuid}/.openshift_ssh/id_rsa{,.pub} #{@gear_uuid.to_i + 2}@node1.example.com:.openshift_ssh/",
                                                               env: gear_env,
                                                               chdir: @container.container_dir,
                                                               expected_exitstatus: 0)
@@ -657,7 +657,7 @@
       gear_registry.expects(:save)
 
       [web_entry2, web_entry3].each do |new_entry|
-        @container.expects(:run_in_container_context).with("rsync -avz --delete --rsh=/usr/bin/oo-ssh app-deployments/ #{new_entry.uuid}@#{new_entry.proxy_hostname}:app-deployments/",
+        @container.expects(:run_in_container_context).with("rsync -avzS --delete --rsh=/usr/bin/oo-ssh app-deployments/ #{new_entry.uuid}@#{new_entry.proxy_hostname}:app-deployments/",
                                                           env: gear_env,
                                                           chdir: @container.container_dir,
                                                           expected_exitstatus: 0)
@@ -676,7 +676,7 @@
                                          rotate: false)
                                    .returns(status: 'success')
 
-      @container.expects(:run_in_container_context).with("rsync -avz --delete --exclude hooks --rsh=/usr/bin/oo-ssh git/#{@app_name}.git/ #{proxy_entry3.uuid}@#{proxy_entry3.proxy_hostname}:git/#{@app_name}.git/",
+      @container.expects(:run_in_container_context).with("rsync -avzS --delete --exclude hooks --rsh=/usr/bin/oo-ssh git/#{@app_name}.git/ #{proxy_entry3.uuid}@#{proxy_entry3.proxy_hostname}:git/#{@app_name}.git/",
                                                           env: gear_env,
                                                           chdir: @container.container_dir,
                                                           expected_exitstatus: 0)
@@ -725,7 +725,7 @@
       location = PathUtils.join(@container.container_dir, 'foo', 'template')
       ssh_url = "#{uuid1}@#{gear1[:proxy_hostname]}"
 
-      @container.expects(:run_in_container_context).with("mkdir -p #{location} ; rsync -rOv --exclude '.git' --delete --rsh=/usr/bin/oo-ssh #{ssh_url}:git/template/ #{location}",
+      @container.expects(:run_in_container_context).with("mkdir -p #{location} ; rsync -rOvS --exclude '.git' --delete --rsh=/usr/bin/oo-ssh #{ssh_url}:git/template/ #{location}",
                                                          env: gear_env,
                                                          chdir: @container.container_dir,
                                                          expected_exitstatus: 0)
@@ -883,7 +883,7 @@
       gear_registry.expects(:save)
 
       [web_entry2, web_entry3].each do |new_entry|
-        @container.expects(:run_in_container_context).with("rsync -avz --delete --rsh=/usr/bin/oo-ssh app-deployments/ #{new_entry.uuid}@#{new_entry.proxy_hostname}:app-deployments/",
+        @container.expects(:run_in_container_context).with("rsync -avzS --delete --rsh=/usr/bin/oo-ssh app-deployments/ #{new_entry.uuid}@#{new_entry.proxy_hostname}:app-deployments/",
                                                           env: gear_env,
                                                           chdir: @container.container_dir,
                                                           expected_exitstatus: 0)

--- a/node/test/unit/deployments_test.rb
+++ b/node/test/unit/deployments_test.rb
@@ -151,7 +151,7 @@ class DeploymentsTest < OpenShift::NodeTestCase
       deployment_datetime = 'now'
       from = PathUtils.join(@container.container_dir, 'app-root', 'runtime', dir)
       to = PathUtils.join(@container.container_dir, 'app-deployments', deployment_datetime, dir)
-      command = "/usr/bin/rsync -av --delete #{from}/ #{to}/"
+      command = "/usr/bin/rsync -avS --delete #{from}/ #{to}/"
       @container.expects(:run_in_container_context).with(command, expected_exitstatus: 0)
 
       @container.send("sync_runtime_#{dir.gsub(/-/, '_')}_dir_to_deployment".to_sym, deployment_datetime)
@@ -163,7 +163,7 @@ class DeploymentsTest < OpenShift::NodeTestCase
       deployment_datetime = 'now'
       from = PathUtils.join(@container.container_dir, 'app-deployments', deployment_datetime, dir)
       to = PathUtils.join(@container.container_dir, 'app-root', 'runtime', dir)
-      command = "/usr/bin/rsync -av --delete #{from}/ #{to}/"
+      command = "/usr/bin/rsync -avS --delete #{from}/ #{to}/"
       @container.expects(:run_in_container_context).with(command, expected_exitstatus: 0)
 
       @container.send("sync_deployment_#{dir.gsub(/-/, '_')}_dir_to_runtime".to_sym, deployment_datetime)

--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -2255,7 +2255,7 @@ module OpenShift
           #Rsync arguments had to be changed for windows to move the gear with full rights and reset them correctly in the post move method
           log_debug `eval \`ssh-agent\`; ssh-add #{rsync_keyfile}; ssh -o StrictHostKeyChecking=no -A root@#{source_container.get_ip_address} "rsync --perms -rltgoD0v --chmod=Du=rwx,Dg=rwx,Do=rwx,Fu=rww,Fg=rwx,Fo=rwx -p --exclude 'profile' -e 'ssh -o StrictHostKeyChecking=no' /cygdrive/c/openshift/gears/#{gear.uuid}/ root@#{destination_container.get_ip_address}:/cygdrive/c/openshift/gears/#{gear.uuid}/"; exit_code=$?; ssh-agent -k;exit $exit_code`
         else
-          log_debug `eval \`ssh-agent\`; ssh-add #{rsync_keyfile}; ssh -o StrictHostKeyChecking=no -A root@#{source_container.get_ip_address} "rsync -aAX -e 'ssh -o StrictHostKeyChecking=no' /var/lib/openshift/#{gear.uuid}/ root@#{destination_container.get_ip_address}:/var/lib/openshift/#{gear.uuid}/"; exit_code=$?; ssh-agent -k; exit $exit_code`
+          log_debug `eval \`ssh-agent\`; ssh-add #{rsync_keyfile}; ssh -o StrictHostKeyChecking=no -A root@#{source_container.get_ip_address} "rsync -aAXS -e 'ssh -o StrictHostKeyChecking=no' /var/lib/openshift/#{gear.uuid}/ root@#{destination_container.get_ip_address}:/var/lib/openshift/#{gear.uuid}/"; exit_code=$?; ssh-agent -k; exit $exit_code`
       end
 
       if $?.exitstatus != 0
@@ -2268,7 +2268,7 @@ module OpenShift
           #Rsync arguments changed, preserving extended attributes and ACLs cannot be used on windows
           log_debug `eval \`ssh-agent\`; ssh-add #{rsync_keyfile}; ssh -o StrictHostKeyChecking=no -A root@#{source_container.get_ip_address} "rsync -rltgoD0v -e 'ssh -o StrictHostKeyChecking=no' --include '.httpd.d/' --include '.httpd.d/#{gear.uuid}_***' --include '#{gear.name}-#{app.domain.namespace}' --include '.last_access/' --include '.last_access/#{gear.uuid}' --exclude '*' /cygdrive/c/openshift/gears/ root@#{destination_container.get_ip_address}:/cygdrive/c/openshift/gears/"; exit_code=$?; ssh-agent -k; exit $exit_code`
         else
-          log_debug `eval \`ssh-agent\`; ssh-add #{rsync_keyfile}; ssh -o StrictHostKeyChecking=no -A root@#{source_container.get_ip_address} "rsync -aAX -e 'ssh -o StrictHostKeyChecking=no' --include '.httpd.d/' --include '.httpd.d/#{gear.uuid}_***' --include '#{gear.name}-#{app.domain_namespace}' --include '.last_access/' --include '.last_access/#{gear.uuid}' --exclude '*' /var/lib/openshift/ root@#{destination_container.get_ip_address}:/var/lib/openshift/"; exit_code=$?; ssh-agent -k; exit $exit_code`
+          log_debug `eval \`ssh-agent\`; ssh-add #{rsync_keyfile}; ssh -o StrictHostKeyChecking=no -A root@#{source_container.get_ip_address} "rsync -aAXS -e 'ssh -o StrictHostKeyChecking=no' --include '.httpd.d/' --include '.httpd.d/#{gear.uuid}_***' --include '#{gear.name}-#{app.domain_namespace}' --include '.last_access/' --include '.last_access/#{gear.uuid}' --exclude '*' /var/lib/openshift/ root@#{destination_container.get_ip_address}:/var/lib/openshift/"; exit_code=$?; ssh-agent -k; exit $exit_code`
       end
 
       if $?.exitstatus != 0
@@ -3106,7 +3106,7 @@ module OpenShift
           if district.servers.where(name: server_identity).exists?
             server = district.servers.find_by(name: server_identity)
             if (gear_exists_in_district || district.available_capacity > 0) &&
-                server.active && (!require_zone || server.zone_id) 
+                server.active && (!require_zone || server.zone_id)
               server_infos << NodeProperties.new(server_identity, capacity.to_f, district, server) unless (region_id and server.region_id != region_id)
             end
             found_district = true


### PR DESCRIPTION
I have added the "-S" option to all of the non-windows-specific rsync operations I found, as well as any corresponding tests.  I think it is appropriate in all cases, but please review to be sure.
