### PR TITLE
Allow "/" in branch name for initial_git_url

### DIFF
--- a/common/lib/openshift-origin-common/utils/git.rb
+++ b/common/lib/openshift-origin-common/utils/git.rb
@@ -49,7 +49,7 @@ module OpenShift
     # (commit/branch/treeish/relative) or nil otherwise.
     #
     def self.safe_clone_ref_spec(ref)
-      ref && !ref.empty? && ref =~ %r(\A[\w\d\-_\.\^~]+\Z) ? ref : nil
+      ref && !ref.empty? && ref =~ %r(\A[\w\d\/\-_\.\^~]+\Z) ? ref : nil
     end
 
     #

--- a/controller/app/controllers/emb_cart_controller.rb
+++ b/controller/app/controllers/emb_cart_controller.rb
@@ -212,6 +212,6 @@ class EmbCartController < BaseController
       @application.group_instances_with_overrides.detect{ |i| i.instance == instance.group_instance }
     )
 
-    render_success(:ok, "cartridge", cartridge, "Showing cartridge #{id} for application #{@application.name} under domain #{@application.domain_namespace}", result)
+    render_success(:ok, "cartridge", cartridge, "Updated cartridge #{id} for application #{@application.name} under domain #{@application.domain_namespace}", result)
   end
 end


### PR DESCRIPTION
OpenShift::Git.safe_clone_ref_spec was returning nil for ref if ref contained "/" character.  Modified the regex to allow "/" in ref.

@smarterclayton - please review
