### PR TITLE
oo-accept-systems:  Fixes for obsolete and downloaded carts

### DIFF
--- a/broker-util/oo-accept-systems
+++ b/broker-util/oo-accept-systems
@@ -140,13 +140,12 @@ def check_nodes_cartridges
   # get the list of cartridges from every node
   #
   nodes = OpenShift::MCollectiveApplicationContainerProxy.known_server_identities
+  obsolete_carts = []
   carts_for = nodes.map do |node|
-    [node,
-     OpenShift::ApplicationContainerProxy.instance(node)
-    .get_available_cartridges
-    .reject {|cart| cart.is_obsolete?}
-    .map {|cart| cart.name}
-    .sort]
+    carts = OpenShift::ApplicationContainerProxy.instance(node).get_available_cartridges
+    obs_carts, non_obs_carts = carts.partition {|cart| cart.is_obsolete?}
+    obsolete_carts |= obs_carts.map {|cart| cart.name}
+    [node, non_obs_carts.map {|cart| cart.name}.sort]
   end.instance_eval {|ary| Hash[*ary.flatten(1)]}
 
   carts_for.each do |node, carts|
@@ -156,6 +155,8 @@ def check_nodes_cartridges
       verbose "cartridges for #{node}: #{carts.join ', '}"
     end
   end
+
+  verbose "In addition, some nodes have obsolete cartridges installed: #{obsolete_carts.uniq.sort.join(', ')}" if obsolete_carts.present?
 
   carts_for.empty? and return #nothing to do...
 

--- a/broker-util/oo-accept-systems
+++ b/broker-util/oo-accept-systems
@@ -144,6 +144,7 @@ def check_nodes_cartridges
     [node,
      OpenShift::ApplicationContainerProxy.instance(node)
     .get_available_cartridges
+    .reject {|cart| cart.is_obsolete?}
     .map {|cart| cart.name}
     .sort]
   end.instance_eval {|ary| Hash[*ary.flatten(1)]}
@@ -183,7 +184,9 @@ def check_nodes_cartridges
   begin
     require 'json'
     api_carts = JSON.parse(RestClient.get('http://localhost:8080/broker/rest/cartridges.json'))
-    api_carts = api_carts["data"].map {|cart| cart["name"]}.sort
+    api_carts = api_carts["data"].reject {|cart| cart["url"].present?}
+                                 .map {|cart| cart["name"]}
+                                 .sort
     verbose "API reports carts: #{api_carts.join ', '}"
 
     do_fail <<-"MISMATCH" unless api_carts == all_carts


### PR DESCRIPTION
Fix the `check_nodes_cartridges` test in `oo-accept-systems` to ignore obsolete cartridges returned by the node hosts, because the broker will not list obsolete cartridges, and to ignore downloaded cartridges returned by the by the broker, because a node will not have downloaded cartridges in its cartridge repository.

This commit fixes bug 1124938.

Modify the `check_nodes_cartridges` test in `oo-accept-systems` to warn about obsolete cartridges returned by the node hosts.
