### PR TITLE
BZ1047469 - PHP cart: fixes pear package upgrade and downgrade messages

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -110,12 +110,21 @@ function build() {
     fi
     if [ -f ${OPENSHIFT_REPO_DIR}${pear_file} ]; then
         echo "Checking ${pear_file} for PEAR dependency..."
+        local show_cleanbuild_msg=0
+
         for f in $(cat ${OPENSHIFT_REPO_DIR}${pear_file}); do
             echo -e "Checking PEAR: $f\n"
-            if ! php_context "pear info '$f' &>/dev/null"; then
-                php_context "pear install --alldeps '$f'"
+
+            if php_context "pear info '$f' &>/dev/null"; then # package is already installed
+
+                local current_version=$(pear info "$f" | awk '$0$1 ~/Release Version/ {print $3;}')
+                local desired_version=$(echo "$f" | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
+
+                if [ "$current_version" != "$desired_version" ]; then
+                    php_context "pear upgrade --alldeps '$f'" || show_cleanbuild_msg=1
+                fi
             else
-                php_context "pear upgrade --alldeps '$f'" || :
+                php_context "pear install --alldeps '$f'"
             fi
             echo
             # Remove gear-specific absolute paths from the generated PEAR
@@ -123,6 +132,10 @@ function build() {
             find ${OPENSHIFT_PHP_DIR}phplib/pear/pear/ -type f \( ! -regex '.*/\..*' \) \
               -exec sed -i "s|${OPENSHIFT_HOMEDIR}|~/|g" {} \;
         done
+
+        if [ $show_cleanbuild_msg -eq 1 ]; then
+            echo -e "Tip: Use the .openshift/markers/force_clean_build marker file to do a clean build.\n"
+        fi
     fi
 
     # Composer

--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -135,6 +135,7 @@ function build() {
 
         if [ $show_cleanbuild_msg -eq 1 ]; then
             echo -e "Tip: Use the .openshift/markers/force_clean_build marker file to do a clean build.\n"
+            exit 1
         fi
     fi
 


### PR DESCRIPTION
It checks the versions of currently installed and desired packages. It prints a helpful message about clean build if the user would like to downgrade a package.

For more information please check this bug: [Bug 1047469](https://bugzilla.redhat.com/show_bug.cgi?id=1047469)
My  comment about [test cases](https://bugzilla.redhat.com/show_bug.cgi?id=1047469#c9). Should I implement them somewhere?

@VojtechVitek  : could you review this please? Please also look for bash and project specific conventions.
