### PR TITLE
Test improvements that were affecting enterprise/origin test scenarios

### DIFF
--- a/admin-console/test/functional/admin_console/api/search/users_controller_test.rb
+++ b/admin-console/test/functional/admin_console/api/search/users_controller_test.rb
@@ -22,6 +22,13 @@ module AdminConsole
           end unless @domain
         end
 
+        MiniTest::Unit.after_tests do
+          begin
+            @user.force_delete
+          rescue
+          end
+        end
+
         test "should search users by id" do
           get :index, :id => @user.id, :format => :json
           assert_response :success

--- a/broker/test/functional_ext/removed_nodes_app_fixup_test.rb
+++ b/broker/test/functional_ext/removed_nodes_app_fixup_test.rb
@@ -16,7 +16,6 @@ class RemovedNodesAppFixupTest < ActionDispatch::IntegrationTest
 
     @domain = Domain.new(namespace: @namespace, owner: @cu)
     @domain.save!
-    Rails.configuration.msg_broker[:districts][:enabled] = false
     Rails.configuration.openshift[:allow_ha_applications] = true
     @appnames = []
     for i in 0..20

--- a/controller/test/cucumber/runtime-cartridge-mongodb.feature
+++ b/controller/test/cucumber/runtime-cartridge-mongodb.feature
@@ -1,5 +1,4 @@
 @cartridge_extended3
-@not-enterprise
 Feature: MongoDB Application Sub-Cartridge
 
   Scenario: Create Delete one application with a MongoDB database


### PR DESCRIPTION
- Remove hardcoding of disabling districts for
  broker/test/functional_ext/removed_nodes_app_fixup_test.rb
- Delete test user on teardown for
  admin-console/test/functional/admin_console/api/search/users_controller_test.rb
- Remove the not-enterprise tag from
  controller/test/cucumber/runtime-cartridge-mongodb.feature
