### PR TITLE
Delete users plan_id users after admin-console functional tests

### DIFF
--- a/admin-console/test/functional/admin_console/api/search/users_controller_test.rb
+++ b/admin-console/test/functional/admin_console/api/search/users_controller_test.rb
@@ -22,7 +22,7 @@ module AdminConsole
           end unless @domain
         end
 
-        MiniTest::Unit.after_tests do
+        def teardown
           begin
             @user.force_delete
           rescue


### PR DESCRIPTION
- Change from MiniTest::Unit.after_tests to teardown since the
  after_tests weren't being triggered properly, and users were getting
  created after every test run.  The 'unless @domain' doesn't skip the
  user creation on subsequent tests, so after the
  admin-console/test/functional/admin_console/api/search/users_contorller_test.rb
  script is run there are 7 users in the openshift_broker_test db with
  plan_id: "free".
