### PR TITLE
Bug 1126888: oo-app-info is broken under docker

### DIFF
--- a/broker-util/openshift-origin-broker-util.spec
+++ b/broker-util/openshift-origin-broker-util.spec
@@ -2,6 +2,7 @@
     %global scl ruby193
     %global scl_prefix ruby193-
     %global scl_root /opt/rh/ruby193/root
+    %global ruby_libdir /usr/share/ruby
 %endif
 %global rubyabi 1.9.1
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1126888

The app_info.rb file was not getting placed because ruby_lib_dir was not defined.  As a result, script failed to execute.  With this change, validated things were working again.
