### PR TITLE
Update get_quota to handle grace values

### DIFF
--- a/node/lib/openshift-origin-node/model/node.rb
+++ b/node/lib/openshift-origin-node/model/node.rb
@@ -113,7 +113,7 @@ module OpenShift
         end
 
         resolve_opt      = resolve ? "--always-resolve" : ""
-        stdout, _, _ = Utils.oo_spawn("quota #{resolve_opt} -w #{uuid}")
+        stdout, _, _ = Utils.oo_spawn("quota -p #{resolve_opt} -w #{uuid}")
         results      = stdout.split("\n").grep(%r(^.*/dev/))
         if results.empty?
           raise NodeCommandException.new(
@@ -125,7 +125,7 @@ module OpenShift
 
         {device:      results[0],
          blocks_used: results[1].to_i, blocks_quota: results[2].to_i, blocks_limit: results[3].to_i,
-         inodes_used: results[4].to_i, inodes_quota: results[5].to_i, inodes_limit: results[6].to_i
+         inodes_used: results[5].to_i, inodes_quota: results[6].to_i, inodes_limit: results[7].to_i
         }
       end
 

--- a/node/test/node_functional/node_func_test.rb
+++ b/node/test/node_functional/node_func_test.rb
@@ -82,12 +82,23 @@ module OpenShift
           OpenShift::Runtime::Node.set_quota(@uuid, results[:blocks_used], results[:inodes_used] - 1)
         end
       end
-    end
 
-    def test_get_quota_pass
-      results = OpenShift::Runtime::Node.get_quota(@uuid)
-      refute_nil results
-      refute_empty results
+      def test_get_quota_pass
+        tests = [
+          {blocks_limit: '300000', inodes_limit: '80000'},
+          {blocks_limit: '500000', inodes_limit: '60000'},
+          {blocks_limit: '400000', inodes_limit: '70000'}
+        ]
+        tests.each do |expected|
+          OpenShift::Runtime::Node.set_quota(@uuid, expected[:blocks_limit], expected[:inodes_limit])
+
+          results = OpenShift::Runtime::Node.get_quota(@uuid)
+          refute_nil results
+          refute_empty results
+          assert_equal expected[:blocks_limit].to_i, results[:blocks_limit]
+          assert_equal expected[:inodes_limit].to_i, results[:inodes_limit]
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Update get_quota to support output from the `quota` command that
includes values in the grace columns. These columns have been empty for
ext4 volumes, but with xfs volumes, they can have a value, and that was
causing get_quota to return incorrect values for certain fields. Add the
-p flag to the quota call so the grace columns always have a value.

Fix bug 1129394.
