### PR TITLE
scl build fixes

### DIFF
--- a/admin-console/rubygem-openshift-origin-admin-console.spec
+++ b/admin-console/rubygem-openshift-origin-admin-console.spec
@@ -1,5 +1,6 @@
 %if 0%{?fedora}%{?rhel} <= 6
     %global scl ruby193
+    %global v8_scl v8314
     %global scl_prefix ruby193-
 %endif
 %{!?scl:%global pkg_name %{name}}
@@ -72,7 +73,7 @@ OpenShift plugin that adds the administrative console as a Rails Engine for the 
 %setup -q
 
 %build
-%{?scl:scl enable %scl - << \EOF}
+%{?scl:scl enable %scl %v8_scl - << \EOF}
 
 set -ex
 mkdir -p .%{gem_dir}

--- a/console/rubygem-openshift-origin-console.spec
+++ b/console/rubygem-openshift-origin-console.spec
@@ -1,5 +1,6 @@
 %if 0%{?fedora}%{?rhel} <= 6
     %global scl ruby193
+    %global v8_scl v8314
     %global scl_prefix ruby193-
 %endif
 %{!?scl:%global pkg_name %{name}}
@@ -82,7 +83,7 @@ OpenShift Origin Management Console ri documentation
 %setup -q
 
 %build
-%{?scl:scl enable %scl - << \EOF}
+%{?scl:scl enable %scl %v8_scl - << \EOF}
 
 set -e
 mkdir -p .%{gem_dir}

--- a/openshift-console/openshift-origin-console.spec
+++ b/openshift-console/openshift-origin-console.spec
@@ -3,6 +3,7 @@
 %global consoledir %{_var}/www/openshift/console
 %if 0%{?fedora}%{?rhel} <= 6
     %global scl ruby193
+    %global v8_scl v8314
     %global scl_prefix ruby193-
     %global with_systemd 0
     %global gemdir /opt/rh/ruby193/root/usr/share/gems/gems
@@ -91,7 +92,7 @@ This includes the configuration necessary to run the console with mod_passenger.
 %setup -q
 
 %build
-%{?scl:scl enable %scl - << \EOF}
+%{?scl:scl enable %scl %v8_scl - << \EOF}
 
 set -e
 # Remove dependencies not needed at runtime


### PR DESCRIPTION
- add v8314 to scl enable for rubygem-openshift-origin-admin-console and
  rubygem-openshift-origin-console
