### PR TITLE
util-scl/oo-mco: Added error message when scl mco does not exist.

### DIFF
--- a/util-scl/oo-mco
+++ b/util-scl/oo-mco
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-exec oo-exec-ruby /opt/rh/ruby193/root/usr/sbin/mco "$@"
+if [ -e /opt/rh/ruby193/root/usr/sbin/mco ]; then
+  exec oo-exec-ruby /opt/rh/ruby193/root/usr/sbin/mco "$@"
+else
+  echo "/opt/rh/ruby193/root/usr/sbin/mco does not exist."
+  echo "mco client is likely not installed from scl."
+  exit 1
+fi


### PR DESCRIPTION
Bug 1131139
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1131139
oo-mco is installed on nodes due to rpm configuration, however the scl mco executable is not. Added error message to avoid confusion for newer administrators.

Unsure if error message fits with standards. Please advise.
