### PR TITLE
Bug 1084427 - Stop JBossEws cartridge gracefully

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossews/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/control
@@ -20,8 +20,34 @@ killtree() {
     for _child in $(ps -o pid --no-headers --ppid ${_pid}); do
         killtree ${_child}
     done
-    echo kill -9 ${_pid}
-    kill -9 ${_pid} || :
+
+    local should_be_gone_pid=$(ps -o pid -p ${_pid} --no-headers)
+    if [ -z "$should_be_gone_pid" ]; then
+        return
+    else
+        # process might have finished stopping after the ps check above
+        # so prevent kill from throwing an error (which would exit the script due to bash -e)
+        # with || true
+        kill -TERM ${_pid} || true
+    fi
+
+    local count=0
+    while [ ${count} -lt 15 ]
+    do
+        local should_be_gone_pid=$(ps -o pid -p ${_pid} --no-headers)
+        if [ -z "$should_be_gone_pid" ]; then
+                return
+        else
+                sleep 2
+                let count=${count}+1
+        fi
+    done
+
+    local should_be_gone_pid=$(ps -o pid -p ${_pid} --no-headers)
+    if [ ! -z $should_be_gone_pid ]
+    then
+        kill -9 ${_pid}
+    fi
 }
 
 # Check if the jbossas process is running


### PR DESCRIPTION
Replace SIGKILL with SIGTERM and a fallback to force kill the
processes after a timeout.
See other jboss carts for reference.

https://bugzilla.redhat.com/show_bug.cgi?id=1084427
