### PR TITLE
move env var guard for all http plugins and not just the vhost plugin

### DIFF
--- a/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
+++ b/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
@@ -424,7 +424,7 @@ module OpenShift
                   end
                 end
               end
-              ::OpenShift::Runtime::Frontend::Http::Plugins::reload_httpd unless ENV['APACHE_VHOST_DO_NOT_RELOAD']
+              ::OpenShift::Runtime::Frontend::Http::Plugins::reload_httpd
             end
 
             def with_lock_and_reload(&block)

--- a/plugins/frontend/apachedb/lib/openshift/runtime/frontend/http/plugins/apachedb.rb
+++ b/plugins/frontend/apachedb/lib/openshift/runtime/frontend/http/plugins/apachedb.rb
@@ -39,7 +39,7 @@ module OpenShift
           def self.reload_httpd(async=false)
             async_opt="-b" if async
             begin
-              ::OpenShift::Runtime::Utils::oo_spawn("/usr/sbin/oo-httpd-singular #{async_opt} graceful", :expected_exitstatus=> 0)
+              ::OpenShift::Runtime::Utils::oo_spawn("/usr/sbin/oo-httpd-singular #{async_opt} graceful", :expected_exitstatus=> 0) unless ENV['APACHE_HTTPD_DO_NOT_RELOAD']
             rescue ::OpenShift::Runtime::Utils::ShellExecutionException => e
               NodeLogger.logger.error("ERROR: failure from oo-httpd-singular(#{e.rc}): #{@container_uuid}: stdout: #{e.stdout} stderr:#{e.stderr}")
             end


### PR DESCRIPTION
The env var name has also been changed from 'APACHE_VHOST_DO_NOT_RELOAD' to 'APACHE_HTTPD_DO_NOT_RELOAD'
