### PR TITLE
The output message about TLS URLs is not clear when creating jboss-amq cartridge

### DIFF
--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -1106,7 +1106,7 @@ module OpenShift
               end
               if reported_urls
                 reported_urls.each do |url|
-                  outstr = "Cartridge #{cartridge.name} exposed URL #{url}"
+                  outstr = "Cartridge #{cartridge.name} endpoint #{endpoint.private_port_name} is exposed at URL #{url}"
                   if endpoint.description
                     outstr << " for #{endpoint.description}"
                   end

--- a/plugins/frontend/haproxy-sni-proxy/README.haproxy-sni-proxy.md
+++ b/plugins/frontend/haproxy-sni-proxy/README.haproxy-sni-proxy.md
@@ -80,7 +80,7 @@ Endpoints:
 
 The exposed port will be reported back as a client result.
 ```
-  Cartridge mock exposed URL tls:foo.example.com:2303
+  Cartridge mock endpoint AMQPS_PORT is exposed at URL tls:foo.example.com:2303
 ```
 
 The reported URL reports the protocol as "tls" instead of the


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1128083

Jboss-AMQ provides 4 ways to connect. They are openwire, stomp,amqp and mqtt.
But when creating jboss-amq app, the output message is not clear which one is
for stomp, which one is for amqp. There's no information related with these
ports in app's gear env variables. (Who will generate these variables? 
Openshift Framework or Cartridge) User only have one way to guess which port
is for openwire. 'TLS_PORT_1' which is defined in manifest.yml is for
"OPENWIRE_SSL_PROXY_PORT". It will use the smallest port 2303. And
'TLS_PORT_4' uses the biggest port 2306.
