### PR TITLE
v2_cart_model: allow archiving of destroyed gears

### DIFF
--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1889,7 +1889,7 @@ class Application
 
       reserve_uid_op = ReserveGearUidOp.new(gear_id: gear_id, gear_size: gear_size, region_id: region_id, prereq: maybe_notify_app_create_op + [init_gear_op._id.to_s])
 
-      create_gear_op = CreateGearOp.new(gear_id: gear_id, prereq: [reserve_uid_op._id.to_s], retry_rollback_op: reserve_uid_op._id.to_s)
+      create_gear_op = CreateGearOp.new(gear_id: gear_id, prereq: [reserve_uid_op._id.to_s], retry_rollback_op: reserve_uid_op._id.to_s, is_group_creation: !is_scale_up)
       # this flag is passed to the node to indicate that an sshkey is required to be generated for this gear
       # currently the sshkey is being generated on the app dns gear if the application is scalable
       # we are assuming that haproxy will also be added to this gear

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1937,19 +1937,20 @@ class Application
     # Add and/or push user env vars when this is not an app create or user_env_vars are specified
     user_vars_op_id = nil
     # FIXME this condition should be stronger (only fired when env vars are specified OR other gears already exist)
+    # If this is a new group instance creation (gear creation and not a scale up), we can skip rollback
     if maybe_notify_app_create_op.empty? || user_env_vars.present?
       prereq = gear_id_prereqs[app_dns_gear_id].nil? ? [ops.last._id.to_s] : [gear_id_prereqs[app_dns_gear_id]]
-      op = PatchUserEnvVarsOp.new(group_instance_id: ginst_id, user_env_vars: user_env_vars, push_vars: true, prereq: prereq)
+      op = PatchUserEnvVarsOp.new(group_instance_id: ginst_id, user_env_vars: user_env_vars, push_vars: true, 
+                                  skip_rollback: !is_scale_up, prereq: prereq)
       ops << op
       user_vars_op_id = op._id.to_s
     end
 
+    # Since this is a new gear creation, we can skip rollback for some operations
     prereq_op_id = prereq_op._id.to_s rescue nil
-    # since this component add operation is part of a new gear creation, we can skip rollback for everything other that gear creation
-    is_gear_creation = true
     add, usage = calculate_add_component_ops(gear_comp_specs, comp_spec_gears, ginst_id, deploy_gear_id, gear_id_prereqs, component_ops,
                                              is_scale_up, (user_vars_op_id || prereq_op_id), init_git_url,
-                                             app_dns_gear_id, is_gear_creation)
+                                             app_dns_gear_id, true)
     ops.concat(add)
     track_usage_ops.concat(usage)
 

--- a/controller/app/models/gear.rb
+++ b/controller/app/models/gear.rb
@@ -116,8 +116,8 @@ class Gear
     result_io
   end
 
-  def destroy_gear(keep_uid=false)
-    result_io = get_proxy.destroy(self, keep_uid)
+  def destroy_gear(keep_uid=false, is_group_creation=false)
+    result_io = get_proxy.destroy(self, keep_uid, is_group_creation)
     application.process_commands(result_io, nil, self)
     result_io
   end

--- a/controller/app/models/gear.rb
+++ b/controller/app/models/gear.rb
@@ -116,8 +116,8 @@ class Gear
     result_io
   end
 
-  def destroy_gear(keep_uid=false, is_group_creation=false)
-    result_io = get_proxy.destroy(self, keep_uid, is_group_creation)
+  def destroy_gear(keep_uid=false, is_group_rollback=false)
+    result_io = get_proxy.destroy(self, keep_uid, is_group_rollback)
     application.process_commands(result_io, nil, self)
     result_io
   end

--- a/controller/app/models/pending_app_op.rb
+++ b/controller/app/models/pending_app_op.rb
@@ -12,6 +12,7 @@ class PendingAppOp
   field :prereq,            type: Array
   field :retry_count,       type: Integer,  default: 0
   field :retry_rollback_op, type: Moped::BSON::ObjectId
+  field :skip_rollback,     type: Boolean
 
   def prereq
     self.attributes["prereq"] || []

--- a/controller/app/pending_ops_models/add_comp_op.rb
+++ b/controller/app/pending_ops_models/add_comp_op.rb
@@ -3,7 +3,6 @@ class AddCompOp < PendingAppOp
   field :gear_id, type: String
   field :comp_spec, type: ComponentSpec
   field :init_git_url, type: String
-  field :skip_rollback, type: Boolean
 
   def execute
     gear = get_gear

--- a/controller/app/pending_ops_models/create_gear_op.rb
+++ b/controller/app/pending_ops_models/create_gear_op.rb
@@ -2,6 +2,7 @@ class CreateGearOp < PendingAppOp
 
   field :gear_id, type: String
   field :sshkey_required, type: Boolean, default: false
+  field :is_group_creation, type: Boolean, default: false
 
   def execute
     result_io = ResultIO.new
@@ -15,7 +16,7 @@ class CreateGearOp < PendingAppOp
   def rollback
     result_io = ResultIO.new
     gear = get_gear()
-    result_io = gear.destroy_gear(true) unless gear.removed
+    result_io = gear.destroy_gear(true, is_group_creation) unless gear.removed
     pending_app_op_group.inc(:num_gears_rolled_back, 1) if state == :completed
     result_io
   end

--- a/controller/app/pending_ops_models/resend_aliases_op.rb
+++ b/controller/app/pending_ops_models/resend_aliases_op.rb
@@ -2,7 +2,6 @@ class ResendAliasesOp < PendingAppOp
 
   field :gear_id, type: String
   field :fqdns, type: Array
-  field :skip_rollback, type: Boolean
 
   def execute
     result_io = ResultIO.new 

--- a/controller/app/pending_ops_models/resend_ssl_certs_op.rb
+++ b/controller/app/pending_ops_models/resend_ssl_certs_op.rb
@@ -2,7 +2,6 @@ class ResendSslCertsOp < PendingAppOp
 
   field :gear_id, type: String
   field :ssl_certs, type: Array
-  field :skip_rollback, type: Boolean
 
   def execute
     result_io = ResultIO.new

--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -207,8 +207,32 @@ OPENSHIFT_FRONTEND_HTTP_PLUGINS=openshift-origin-frontend-apache-mod-rewrite,ope
 # WRAPAROUND_UID=65536
 # WRAPAROUND_IP_ADDRESS_OFFSET=1
 
-# Enable archiving gears on gear destroy
-# ARCHIVE_DESTROYED_GEARS="true"
+# Enable archiving gears on gear destroy due to failure during
+# app-create; requires ARCHIVE_DESTROYED_GEARS_DIR to be set
+# appropriately
+#
+# Defaults:
+#
+# ARCHIVE_DESTROYED_GEARS="false"
 
-# Specify directory for storing archived gears. Must not be world-readable or writable.
+# Directory for storing gear directory archives (see:
+# ARCHIVE_DESTROYED_GEARS). The archive directory must meet these
+# conditions:
+#
+# * must be writable by the ruby193-mcollective service user (root)
+# * must not be world-readable
+# * must not be world-writable
+#
+# For example, a suitable directory can be created by setting the node
+# option:
+#
 # ARCHIVE_DESTROYED_GEARS_DIR="/cartout"
+#
+# ... and running the following as root:
+#
+# mkdir /cartout ; chmod 750 /cartout
+#
+# Defaults:
+#
+# ARCHIVE_DESTROYED_GEARS_DIR=
+

--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -206,3 +206,9 @@ OPENSHIFT_FRONTEND_HTTP_PLUGINS=openshift-origin-frontend-apache-mod-rewrite,ope
 #
 # WRAPAROUND_UID=65536
 # WRAPAROUND_IP_ADDRESS_OFFSET=1
+
+# Enable archiving gears on gear destroy
+# ARCHIVE_DESTROYED_GEARS="true"
+
+# Specify directory for storing archived gears. Must not be world-readable or writable.
+# ARCHIVE_DESTROYED_GEARS_DIR="/cartout"

--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -233,7 +233,8 @@ module OpenShift
       # - model/unix_user.rb
       # context: root
       # @param skip_hooks should destroy call the gear's hooks before destroying the gear
-      def destroy(skip_hooks=false, is_group_creation = false)
+      # @param is_group_rollback destroy is being called as part of a failed app deployment
+      def destroy(skip_hooks=false, is_group_rollback = false)
         notify_observers(:before_container_destroy)
 
         if @uid.nil? or (@container_plugin.nil? or !File.directory?(@container_dir.to_s))
@@ -259,7 +260,7 @@ module OpenShift
               end
             end
             # possible mismatch across cart model versions
-            out, errout, retcode = @cartridge_model.destroy(skip_hooks, is_group_creation)
+            out, errout, retcode = @cartridge_model.destroy(skip_hooks, is_group_rollback)
             output << out unless out.nil?
           rescue => e
             logger.warn %Q(Failure while deleting gear #@uuid: #{e.message})

--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -233,7 +233,7 @@ module OpenShift
       # - model/unix_user.rb
       # context: root
       # @param skip_hooks should destroy call the gear's hooks before destroying the gear
-      def destroy(skip_hooks=false)
+      def destroy(skip_hooks=false, is_group_creation = false)
         notify_observers(:before_container_destroy)
 
         if @uid.nil? or (@container_plugin.nil? or !File.directory?(@container_dir.to_s))
@@ -259,7 +259,7 @@ module OpenShift
               end
             end
             # possible mismatch across cart model versions
-            out, errout, retcode = @cartridge_model.destroy(skip_hooks)
+            out, errout, retcode = @cartridge_model.destroy(skip_hooks, is_group_creation)
             output << out unless out.nil?
           rescue => e
             logger.warn %Q(Failure while deleting gear #@uuid: #{e.message})

--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -199,10 +199,16 @@ module OpenShift
         Manifest.new(manifest_path, version, :file, @container.container_dir)
       end
 
+      # Optionally back up the gear directory contents to a
+      # user-specified "dump site" if a gear is rolled back due to
+      # failure during app create
       def archive_gear()
-        archive_dir = @config.get("ARCHIVE_DESTROYED_GEARS_DIR")
-        if @config.get_bool("ARCHIVE_DESTROYED_GEARS")
-          if not File.directory? archive_dir
+        archive_dir = @config.get("ARCHIVE_DESTROYED_GEARS_DIR", nil)
+        if @config.get_bool("ARCHIVE_DESTROYED_GEARS", false)
+          if not archive_dir
+            logger.warn "Cannot archive destroyed gears; ARCHIVE_DESTROYED_GEARS_DIR is not set in node.conf"
+            return
+          elsif not File.directory? archive_dir
             logger.warn "Cannot archive destroyed gears; #{archive_dir} is not a directory"
             return
           elsif not File.writable? archive_dir
@@ -225,19 +231,20 @@ module OpenShift
         end
       end
 
-      # destroy(skip_hooks = false, is_group_creation = false) -> [buffer, '', 0]
+      # destroy(skip_hooks = false, is_group_rollback = false) -> [buffer, '', 0]
       #
       # Remove all cartridges from a gear and delete the gear.  Accepts
       # and discards any parameters to comply with the signature of V1
       # require, which accepted a single argument.
       #
       # destroy() => ['', '', 0]
-      def destroy(skip_hooks = false, is_group_creation = false)
+      def destroy(skip_hooks = false, is_group_rollback = false)
         logger.info('V2 destroy')
 
         buffer = ''
         begin
-          archive_gear if is_group_creation
+          # only archive if app create failed
+          archive_gear if is_group_rollback
           unless skip_hooks
             each_cartridge do |cartridge|
               unlock_gear(cartridge, false) do |c|

--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -225,19 +225,19 @@ module OpenShift
         end
       end
 
-      # destroy(skip_hooks = false) -> [buffer, '', 0]
+      # destroy(skip_hooks = false, is_group_creation = false) -> [buffer, '', 0]
       #
       # Remove all cartridges from a gear and delete the gear.  Accepts
       # and discards any parameters to comply with the signature of V1
       # require, which accepted a single argument.
       #
       # destroy() => ['', '', 0]
-      def destroy(skip_hooks = false)
+      def destroy(skip_hooks = false, is_group_creation = false)
         logger.info('V2 destroy')
 
         buffer = ''
         begin
-          archive_gear
+          archive_gear if is_group_creation
           unless skip_hooks
             each_cartridge do |cartridge|
               unlock_gear(cartridge, false) do |c|

--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -226,6 +226,7 @@ module OpenShift
             tarout, tarerr, rc = Utils.oo_spawn(command)
             unless rc == 0
               logger.warn "Error occurred running \"#{command}\"; rc=#{rc}, stdout=#{tarout}, stderr=#{tarerr}"
+              FileUtils.rm_f archive_filespec
             end
           end
         end

--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -401,7 +401,7 @@ module OpenShift
     # INPUTS:
     # * gear: a Gear object
     # * keep_uid: boolean
-    # * is_group_creation: boolean - flag for optional archive on rollback
+    # * is_group_rollback: boolean - flag for optional archive on rollback
     # * uid: Integer: reserved UID
     # * skip_hooks: boolean
     #
@@ -411,10 +411,10 @@ module OpenShift
     # NOTES:
     # * uses execute_direct
     #
-    def destroy(gear, keep_uid=false, is_group_creation=false, uid=nil, skip_hooks=false)
+    def destroy(gear, keep_uid=false, is_group_rollback=false, uid=nil, skip_hooks=false)
       args = build_base_gear_args(gear)
       args['--skip-hooks'] = true if skip_hooks
-      args['--is-gear-creation'] = true if is_group_creation
+      args['--is-group-rollback'] = true if is_group_rollback
       begin
         result = execute_direct(@@C_CONTROLLER, 'app-destroy', args)
         result_io = parse_result(result, gear)

--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -401,6 +401,7 @@ module OpenShift
     # INPUTS:
     # * gear: a Gear object
     # * keep_uid: boolean
+    # * is_group_creation: boolean - flag for optional archive on rollback
     # * uid: Integer: reserved UID
     # * skip_hooks: boolean
     #
@@ -410,9 +411,10 @@ module OpenShift
     # NOTES:
     # * uses execute_direct
     #
-    def destroy(gear, keep_uid=false, uid=nil, skip_hooks=false)
+    def destroy(gear, keep_uid=false, is_group_creation=false, uid=nil, skip_hooks=false)
       args = build_base_gear_args(gear)
       args['--skip-hooks'] = true if skip_hooks
+      args['--is-gear-creation'] = true if is_group_creation
       begin
         result = execute_direct(@@C_CONTROLLER, 'app-destroy', args)
         result_io = parse_result(result, gear)

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -393,10 +393,11 @@ module MCollective
 
       def oo_app_destroy(args)
         skip_hooks = args['--skip-hooks'] ? args['--skip-hooks'] : false
+        is_group_creation = args['--is-gear-creation'] ? args['--is-gear-creation'] : false
         output     = ""
         begin
           container    = get_app_container_from_args(args)
-          out, err, rc = container.destroy(skip_hooks)
+          out, err, rc = container.destroy(skip_hooks, is_group_creation)
 
           output << out
           output << err

--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -393,11 +393,11 @@ module MCollective
 
       def oo_app_destroy(args)
         skip_hooks = args['--skip-hooks'] ? args['--skip-hooks'] : false
-        is_group_creation = args['--is-gear-creation'] ? args['--is-gear-creation'] : false
+        is_group_rollback = args['--is-group-rollback'] ? args['--is-group-rollback'] : false
         output     = ""
         begin
           container    = get_app_container_from_args(args)
-          out, err, rc = container.destroy(skip_hooks, is_group_creation)
+          out, err, rc = container.destroy(skip_hooks, is_group_rollback)
 
           output << out
           output << err


### PR DESCRIPTION
Adds cart model logic and two node config options to allow admins to
enable archiving of gears as they are destroyed, and to specify the
directory for archiving the gears.

Note that this doesn't archive the user env vars
(`GEAR_DIR/.env/user_vars`) as they are un-set before
`V2CartridgeModel#destroy` gets called. The user env vars can be
determined from looking at the node logs.

Enterprise bug: 1092045
https://bugzilla.redhat.com/show_bug.cgi?id=1092045
