### PR TITLE
Fix websockets in jbossas cartridge

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jbossas/metadata/manifest.yml
@@ -52,8 +52,6 @@ Endpoints:
   Private-Port-Name: HTTP_PORT
   Private-Port: 8080
   Public-Port-Name: HTTP_PROXY_PORT
-  WebSocket-Port-Name: WEBSOCKET_PORT
-  WebSocket-Port: 8676
   Protocols:
   - http
   - ws


### PR DESCRIPTION
Remove WebSocket-\* lines from jbossas cartridge manifest, as nothing is
currently using them. Their existence causes the node web proxy to try
to route websocket connections to port 8676, which isn't being used.

Bug 1133823
