### PR TITLE
Fix scalable platform snapshot test

### DIFF
--- a/controller/test/cucumber/platform-scalable-snapshot.feature
+++ b/controller/test/cucumber/platform-scalable-snapshot.feature
@@ -6,6 +6,15 @@ Feature: Scalable snapshot and restore
     And a new client created scalable mock-0.1 application
     And the embedded mock-plugin-0.1 cartridge is added
 
+    # FIXME there is an issue with the haproxy cartridge where attempting to reload haproxy
+    # with a new configuration (e.g. after update-cluster), followed quickly by attempts to
+    # stop and then start haproxy, can fail. The issue is that the reload is still trying
+    # to gracefully stop the previous haproxy process instance, and then the attempts to
+    # stop and start the haproxy cartridge don't produce the intended results, resulting
+    # in a test failure. In the long term, we should try to fix the haproxy cartridge's
+    # control script to address these issues.
+    And I sleep 10 seconds
+
     When I snapshot the application
     Then the mock control_pre_snapshot marker will exist in the gear
     And the mock control_post_snapshot marker will exist in the gear
@@ -13,7 +22,7 @@ Feature: Scalable snapshot and restore
     And the mock-plugin control_post_snapshot marker will exist in the plugin gear
     And the plugin gear state will be started
     And the gear state will be started
-    
+
     When a new file is added and pushed to the client-created application repo
     Then the new file will be present in the gear app-root repo
 
@@ -23,13 +32,12 @@ Feature: Scalable snapshot and restore
     And the mock-plugin control_post_restore marker will exist in the plugin gear
     Then the plugin gear state will be started
     And the gear state will be started
-    
+
     When the application is stopped
     And I snapshot the application
     Then the plugin gear state will be stopped
     And the gear state will be stopped
-    
+
     When I restore the application
     Then the plugin gear state will be stopped
     And the gear state will be stopped
-    

--- a/controller/test/cucumber/step_definitions/application_steps.rb
+++ b/controller/test/cucumber/step_definitions/application_steps.rb
@@ -118,7 +118,7 @@ Given /^an additional client created( scalable)? (.+) application named "([^\"]*
      rhc_create_app(@app, true, '-s')
   else
      rhc_create_app(@app)
-  end 
+  end
  end
 
  raise "Could not create application #{@app.create_app_code}" unless @app.create_app_code == 0
@@ -489,4 +489,8 @@ end
 When /^the jvm is using JAVA_OPTS_EXT$/ do
   %x(pgrep -fl 'java.*Dcucumber=true')
   assert_equal(0, $?.exitstatus, 'JAVA_OPTS_EXT is not being used')
+end
+
+And /^I sleep (.+) seconds/ do |seconds|
+  sleep seconds.to_i
 end


### PR DESCRIPTION
Add a wait in between when the mock-plugin cartridge is added and when
the snapshot command is issued. The addition of the plugin causes
haproxy to reload, but it does it gracefully, which means that the
previous haproxy process instance may still be running while a new one
is running. Attempts to rapidly add a cartridge and then snapshot the
application (which stops haproxy, does some snapshot work, and then
starts haproxy again) currently may fail due to the way the haproxy
cartridge's control script checks to see if haproxy is running.
