### PR TITLE
node.conf: comments for external port range

### DIFF
--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -16,22 +16,35 @@ CLOUD_DOMAIN="example.com"                                  # Domain suffix to u
 # should be an existing group.
 #GEAR_SUPPLEMENTARY_GROUPS="another_group"  # Supplementary groups for gear UIDs (comma separated list)
 
+# Gear external proxy ports.
+# These settings can only be changed safely prior to using the node, should be consistent
+# across all nodes in a profile, and typically require adjustments of the district at creation.
+# And then, only if you are sure you know what you are doing.
+#
+# Number of proxy ports available per gear. Increasing the ports per gear requires reducing
+# the number of UIDs the district has so that the ports allocated to all UIDs fit in the
+# proxy port range. 
+PORTS_PER_USER=5                                             # typically, 6000 UIDs * 5 ports each = 30,000 ports
+# Lower bound of port numbers used to proxy ports externally. Do not lower without also reducing
+# the ephemeral port range.
+PORT_BEGIN=35531                                             # (maximum port is hardcoded to 65535)
+
 # Generally the following should not be changed:
 ENABLE_CGROUPS=1                                             # constrain gears in cgroups (1=yes, 0=no)
 GEAR_BASE_DIR="/var/lib/openshift"                           # gear root directory
 GEAR_SKEL_DIR="/etc/openshift/skel"                          # skel files to use when building a gear
 GEAR_SHELL="/usr/bin/oo-trap-user"                           # shell to use for the gear
 GEAR_GECOS="OpenShift guest"                                 # Gecos information to populate for the gear user
-GEAR_MIN_UID=1000                                            # Lower bound of UID used to create gears
-GEAR_MAX_UID=6999                                            # Upper bound of UID used to create gears
 OPENSHIFT_NODE_PLUGINS=""                                    # Extensions to load when customize/observe openshift-origin-node models
 CARTRIDGE_BASE_PATH="/usr/libexec/openshift/cartridges"      # Locations where cartridges are installed
 LAST_ACCESS_DIR="/var/lib/openshift/.last_access"            # Location to maintain last accessed time for gears
-APACHE_ACCESS_LOG="/var/log/httpd/openshift_log"             # Localion of httpd for node
-PROXY_MIN_PORT_NUM=35531                                     # Lower bound of port numbers used to proxy ports externally
-PROXY_PORTS_PER_GEAR=5                                       # Number of proxy ports available per gear
+APACHE_ACCESS_LOG="/var/log/httpd/openshift_log"             # Location of httpd gear access log
 CREATE_APP_SYMLINKS=0                                        # If set to 1, creates gear-name symlinks to the UUID directories (debugging only)
 OPENSHIFT_HTTP_CONF_DIR="/etc/httpd/conf.d/openshift"
+# The following are basically vestigial. Normally UIDs are prescribed by the broker. In the case
+# where districts are disabled and nodes can choose their own UIDs, this is the range chosen.
+GEAR_MIN_UID=1000                                            # Lower bound of UID used to create gears
+GEAR_MAX_UID=6999                                            # Upper bound of UID used to create gears
 
 PLATFORM_LOG_FILE=/var/log/openshift/node/platform.log
 PLATFORM_LOG_LEVEL=DEBUG


### PR DESCRIPTION
With xpaas comes an important use case for adjusting port proxy settings. This clarifies those settings.
