### PR TITLE
check for domain environment variable uniqueness on app create

### DIFF
--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1662,7 +1662,9 @@ class Application
       when "APP_ENV_VAR_REMOVE"
         remove_env_vars.push({"key" => command_item[:args][0]})
       when "ENV_VAR_ADD"
-        domain_env_vars_to_add.push({"key" => command_item[:args][0], "value" => command_item[:args][1], "component_id" => component_id})
+        domain_env_vars_to_add.push({"key" => command_item[:args][0], "value" => command_item[:args][1], "component_id" => component_id, "unique" => false})
+      when "ENV_VAR_ADD_UNIQUE"
+        domain_env_vars_to_add.push({"key" => command_item[:args][0], "value" => command_item[:args][1], "component_id" => component_id, "unique" => true})
       when "BROKER_KEY_ADD"
         op_group = AddBrokerAuthKeyOpGroup.new(user_agent: self.user_agent)
         op_group.set_created_at

--- a/controller/app/models/domain.rb
+++ b/controller/app/models/domain.rb
@@ -246,7 +246,13 @@ class Domain
     variables.each do |new_var|
       self.env_vars.each do |cur_var|
         if cur_var["key"] == new_var["key"]
-          env_vars_to_rm << cur_var.dup
+          if !(new_var["unique"] || cur_var["unique"])
+            env_vars_to_rm << cur_var.dup
+          else
+            raise OpenShift::UserException.new(
+              "This application attempted to create a unique domain environment variable #{new_var["key"]} which already exists in this domain (#{namespace}).",
+              134, nil, nil, :forbidden)
+          end
         end
       end
     end

--- a/controller/app/models/result_io.rb
+++ b/controller/app/models/result_io.rb
@@ -131,6 +131,9 @@ class ResultIO
           elsif line.start_with?('ENV_VAR_ADD: ')
             env_var = line['ENV_VAR_ADD: '.length..-1].chomp.split('=')
             self.cart_commands.push({:command => "ENV_VAR_ADD", :args => [env_var[0], env_var[1]]})
+          elsif line.start_with?('ENV_VAR_ADD_UNIQUE: ')
+            env_var = line['ENV_VAR_ADD_UNIQUE: '.length..-1].chomp.split('=')
+            self.cart_commands.push({:command => "ENV_VAR_ADD_UNIQUE", :args => [env_var[0], env_var[1]]})
           elsif line =~ /^BROKER_AUTH_KEY_(ADD): /
             if $1 == 'ADD'
               self.cart_commands.push({:command => "BROKER_KEY_ADD", :args => []})

--- a/node/misc/usr/lib/cartridge_sdk/bash/sdk
+++ b/node/misc/usr/lib/cartridge_sdk/bash/sdk
@@ -101,6 +101,16 @@ function add_domain_env_var {
     echo "ENV_VAR_ADD: $1"
 }
 
+# Add environment variable visible to all gears in a domain
+# Environment variable key will be checked for uniqueness
+# before being added, app creation will fail if it is not
+# unique.
+# Argument(s):
+# - name of environment variable to add plus value
+function add_domain_env_var_unique {
+    echo "ENV_VAR_ADD_UNIQUE: $1"
+}
+
 # remove environment variable visible to all gears in application
 # Argument(s):
 # - name of environment variable to remove


### PR DESCRIPTION
The fuse cartridge has some baked in logic where it uses the existence/non-existence of some domain env variables to determinte if a new fuse app should create itself as the master, or join an existing fabric.  That results in race conditions today if 2+ fuse apps are created in the same domain simultaneously (each check, do not find the env var defined, and then attempt to define it as part of their install script).  I'm proposing a new option to create domain env variables "uniquely" and fail the app creation if the race condition occurs (ie domain env var already exists).
