### PR TITLE
NodeLogger: add attrs to log, parse execute_parallel actions

### DIFF
--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -53,8 +53,8 @@ PLATFORM_TRACE_LOG_LEVEL=DEBUG
 
 # Uncomment and use the following lines if you want platform log entries to contain
 # parsable attributes associated with a given MCollective request. Possible values
-# are request_id, app_uuid, container_uuid. The entries will appear in the order
-# specified.
+# are request_id, app_uuid, container_uuid, app_name, app_namespace, cart_name.
+# The entries will appear in the order specified.
 # PLATFORM_LOG_CONTEXT_ENABLED=1
 # PLATFORM_LOG_CONTEXT_ATTRS=request_id,app_uuid
 


### PR DESCRIPTION
Bug 1139359 - node platform logs do not provide context attributes consistently
https://bugzilla.redhat.com/show_bug.cgi?id=1139359

This fixes platform context logging such that it works for
execute_parallel agent requests.

Additionally, the available context attributes are expanded to include
app_name, app_namespace, and (where applicable) cart_name.
