### PR TITLE
broker: require v8 (SCLized in RHEL 6)

### DIFF
--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -3,6 +3,7 @@
 %if 0%{?fedora}%{?rhel} <= 6
     %global scl ruby193
     %global scl_prefix ruby193-
+    %global v8_prefix v8314-
 %endif
 %{!?scl:%global pkg_name %{name}}
 
@@ -36,6 +37,8 @@ Requires:      openshift-origin-util
 Requires:      policycoreutils-python
 Requires:      rubygem-openshift-origin-controller
 Requires:      %{?scl:%scl_prefix}mod_passenger
+# Install v8 from its own collection
+Requires:      %{?v8_prefix:%v8_prefix}v8
 Requires:      %{?scl:%scl_prefix}rubygem-bson_ext
 Requires:      %{?scl:%scl_prefix}rubygem-json
 Requires:      %{?scl:%scl_prefix}rubygem-json_pure


### PR DESCRIPTION
Bug 1108762 - Need to install v8314 package to start openshift-broker service
https://bugzilla.redhat.com/show_bug.cgi?id=1108762

openshift-broker requires v8 at startup, but the packaging did not
express this requirement. Modified so it does.
