### PR TITLE
Bug 1135941 - Finish setup for 10gen cartridge when the agent code is missing

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/control
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/control
@@ -1,8 +1,7 @@
 #!/bin/bash -e
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
-
-export OPENSHIFT_MMS_BASE_DIR=${OPENSHIFT_DATA_DIR}mms-agent
+source "${OPENSHIFT_10GENMMSAGENT_DIR}lib/util"
 
 cartridge_type="10gen-mms-agent"
 
@@ -26,6 +25,7 @@ function get_process() {
 }
 
 function start() {
+    ! is_agent_installed && install_agent_sources
     echo "Starting $cartridge_type cartridge"
     running_process=$(get_process)
     if ps -ef | grep ${running_process} | grep -qv grep > /dev/null 2>&1

--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/setup
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/setup
@@ -1,8 +1,7 @@
 #!/bin/bash -e
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
-
-OPENSHIFT_MMS_BASE_DIR=${OPENSHIFT_DATA_DIR}mms-agent
+source "${OPENSHIFT_10GENMMSAGENT_DIR}lib/util"
 
 rm -rf $OPENSHIFT_10GENMMSAGENT_DIR/mms-agent
 mkdir -p $OPENSHIFT_10GENMMSAGENT_DIR/{logs,run,mms-agent}
@@ -12,27 +11,7 @@ mkdir -p ${OPENSHIFT_MMS_BASE_DIR}
 
 if [ ! -f "${OPENSHIFT_REPO_DIR}/.openshift/mms/settings.py" ]
 then
-  if [ ! -f ${OPENSHIFT_REPO_DIR}/.openshift/mms/mongodb-mms-monitoring-agent*.tar.gz ]
-  then
-    client_error ""
-    client_error "Missing mongodb-mms-monitoring-agent.tar.gz, which needs to be git pushed in the .openshift/mms/ directory in your repository."
-    client_error "The tarball is available after registration at https://mms.mongodb.com, in the Settings -> Monitoring Agent section."
-    exit 137
-  else
-    pushd $OPENSHIFT_MMS_BASE_DIR >/dev/null
-    tar --strip-components=1 -xzvf ${OPENSHIFT_REPO_DIR}/.openshift/mms/mongodb-mms-monitoring-agent*.tar.gz -C ${OPENSHIFT_MMS_BASE_DIR}
-    if [ $? -gt 0 ]
-    then
-      client_error "Error during extracting the mongodb mms agent archive."
-      exit 137
-    elif [ ! -f "${OPENSHIFT_MMS_BASE_DIR}/monitoring-agent.config" ]
-    then
-      client_error "Extracted archive doesn't contain monitoring-agent.config file."
-      client_error "Please download the tarball at the https://mms.mongodb.com, in the Settings -> Monitoring Agent section."
-      exit 137
-    fi
-    popd >/dev/null
-  fi
+  install_agent_sources
 else
   if ! grep -q "secret_key" "${OPENSHIFT_REPO_DIR}/.openshift/mms/settings.py"
   then

--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/lib/util
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/lib/util
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Utility functions for 10gen cartridge installation
+
+export OPENSHIFT_MMS_BASE_DIR=${OPENSHIFT_DATA_DIR}mms-agent
+export OPENSHIFT_MMS_SOURCES_DIR=${OPENSHIFT_REPO_DIR}/.openshift/mms
+
+function agent_sources_exists {
+  stat -t ${OPENSHIFT_MMS_SOURCES_DIR}/mongodb-mms-monitoring-agent*.tar.gz &>/dev/null
+}
+
+function is_agent_installed {
+  [ -f "${OPENSHIFT_MMS_BASE_DIR}/monitoring-agent.config" ]
+}
+
+function install_agent_sources {
+  if ! agent_sources_exists; then
+    client_error ""
+    client_error "Missing mongodb-mms-monitoring-agent.tar.gz, which needs to be git pushed in the .openshift/mms/ directory in your repository."
+    client_error "The tarball is available after registration at https://mms.mongodb.com, in the Settings -> Monitoring Agent section."
+    exit 0
+  fi
+  pushd $OPENSHIFT_MMS_BASE_DIR >/dev/null
+  echo "Installing MMS agent sources..."
+  tar --strip-components=1 -xzvf \
+    ${OPENSHIFT_MMS_SOURCES_DIR}/mongodb-mms-monitoring-agent*.tar.gz \
+    -C ${OPENSHIFT_MMS_BASE_DIR}
+  if [ $? -gt 0 ]; then
+    client_error "Error during extracting the mongodb mms agent archive."
+    return 1
+  fi
+  if ! is_agent_installed; then
+    client_error "Extracted archive doesn't contain monitoring-agent.config file."
+    client_error "Please download the tarball at the https://mms.mongodb.com, in the Settings -> Monitoring Agent section."
+    return 1
+  fi
+  popd >/dev/null
+  return 0
+}

--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/metadata/managed_files.yml
@@ -5,5 +5,6 @@ locked_files:
 - metadata/
 - env/
 - env/*
+- lib/util
 processed_templates:
 - '**/*.erb'

--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/openshift-origin-cartridge-10gen-mms-agent.spec
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/openshift-origin-cartridge-10gen-mms-agent.spec
@@ -32,6 +32,7 @@ Provides 10gen MMS agent cartridge support. (Cartridge Format V2)
 %files
 %dir %{cartridgedir}
 %{cartridgedir}/metadata
+%{cartridgedir}/lib
 %attr(0755,-,-) %{cartridgedir}/bin/
 %doc %{cartridgedir}/README.md
 %doc %{cartridgedir}/COPYRIGHT


### PR DESCRIPTION
This will allow 10gen to be installed regardless the 10gen agent sources (tar.gz) exists in the GIT repository. It will print error to user, but it will not break the installation.

This allows to add the MMS agent sources later, without breaking the snapshot/restore/from-app workflow.
