### PR TITLE
Spec file fix for gear-placement plugin

### DIFF
--- a/plugins/gear-placement/rubygem-openshift-origin-gear-placement.spec
+++ b/plugins/gear-placement/rubygem-openshift-origin-gear-placement.spec
@@ -67,7 +67,7 @@ cp conf/openshift-origin-gear-placement.conf.pin-user-to-host-example %{buildroo
 %files
 %dir %{gem_instdir}
 %dir %{gem_dir}
-%doc Gemfile LICENSE README
+%doc %{gem_docdir}
 %{gem_dir}/doc/%{gem_name}-%{version}
 %{gem_dir}/gems/%{gem_name}-%{version}
 %{gem_dir}/cache/%{gem_name}-%{version}.gem


### PR DESCRIPTION
Docs are actually in the gemfile docs directory, no need to include them a second time.
