### PR TITLE
node.conf: correct IP_ADDRESS_WRAPAROUND_OFFSET param

### DIFF
--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -205,7 +205,7 @@ OPENSHIFT_FRONTEND_HTTP_PLUGINS=openshift-origin-frontend-apache-mod-rewrite,ope
 # Defaults:
 #
 # WRAPAROUND_UID=65536
-# WRAPAROUND_IP_ADDRESS_OFFSET=1
+# IP_ADDRESS_WRAPAROUND_OFFSET=1
 
 # Enable archiving gears on gear destroy due to failure during
 # app-create; requires ARCHIVE_DESTROYED_GEARS_DIR to be set


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1150186
Bug 1150186 - node.conf incorrectly indicates
WRAPAROUND_IP_ADDRESS_OFFSET

The default node.conf had a long section explaining what
IP_ADDRESS_WRAPAROUND_OFFSET is for and then provided
WRAPAROUND_IP_ADDRESS_OFFSET. The actual container looks at
IP_ADDRESS_WRAPAROUND_OFFSET. Correct node.conf.
