### PR TITLE
Bug 1150736 - Add timestamp to postgresql logs

### DIFF
--- a/cartridges/openshift-origin-cartridge-postgresql/versions/8.4/conf/postgresql.conf.erb
+++ b/cartridges/openshift-origin-cartridge-postgresql/versions/8.4/conf/postgresql.conf.erb
@@ -70,3 +70,7 @@ lc_monetary = '<%= ENV['OPENSHIFT_POSTGRESQL_LOCALE'] || 'en_US.utf8'%>'
 lc_numeric = '<%= ENV['OPENSHIFT_POSTGRESQL_LOCALE'] || 'en_US.utf8'%>'
 lc_time = '<%= ENV['OPENSHIFT_POSTGRESQL_LOCALE'] || 'en_US.utf8'%>'
 default_text_search_config = 'pg_catalog.english'
+
+# Logging
+
+log_line_prefix = '%t '

--- a/cartridges/openshift-origin-cartridge-postgresql/versions/9.2/conf/postgresql.conf.erb
+++ b/cartridges/openshift-origin-cartridge-postgresql/versions/9.2/conf/postgresql.conf.erb
@@ -76,3 +76,7 @@ lc_monetary = '<%= ENV['OPENSHIFT_POSTGRESQL_LOCALE'] || 'en_US.utf8'%>'
 lc_numeric = '<%= ENV['OPENSHIFT_POSTGRESQL_LOCALE'] || 'en_US.utf8'%>'
 lc_time = '<%= ENV['OPENSHIFT_POSTGRESQL_LOCALE'] || 'en_US.utf8'%>'
 default_text_search_config = 'pg_catalog.english'
+
+# Logging
+
+log_line_prefix = '%t '


### PR DESCRIPTION
This will prefix postgresql logs with timestamp:

```
 ~/sandbox/rubyapp/rubyapp2 → rhc tail
==> app-root/logs/postgresql.log <==
2014-10-09 16:17:08 GMT LOG:  could not bind socket for statistics collector: Permission denied
2014-10-09 16:17:08 GMT LOG:  disabling statistics collector for lack of working socket
2014-10-09 16:17:08 GMT WARNING:  autovacuum not started because of misconfiguration

```
