### PR TITLE
More fixes for the routing daemon

### DIFF
--- a/routing-daemon/bin/oo-admin-ctl-routing
+++ b/routing-daemon/bin/oo-admin-ctl-routing
@@ -150,7 +150,7 @@ argvs.each do |argv|
       lb.create_route *argv
 
     when 'delete-route'
-      raise ArgumentError.new "Requires a pool name." unless 2 == argv.length
+      raise ArgumentError.new "Requires a pool name and a route name." unless 2 == argv.length
       puts "Deleting route #{argv[1]} from pool #{argv[0]}."
       lb.delete_route *argv
 
@@ -198,9 +198,9 @@ argvs.each do |argv|
       pool_name = argv[0]
       aliases = lb.pools[pool_name].get_aliases
       if aliases.count > 0
-        puts "pool #{pool_name} has #{aliases.count} aliases:\n" + aliases.map {|m| "  "+m+"\n"}.join
+        puts "Pool #{pool_name} has #{aliases.count} aliases:\n" + aliases.map {|m| "  "+m+"\n"}.join
       else
-        puts "pool #{pool_name} has 0 aliases.\n"
+        puts "Pool #{pool_name} has 0 aliases.\n"
       end
 
     when 'add-alias'
@@ -214,7 +214,7 @@ argvs.each do |argv|
       lb.pools[argv[0]].delete_alias argv[1]
 
     else
-      raise ArgumentError.new "Usage: #{$0} {list-pools|add-pool <name> [<monitor-name>]|delete-pool <name>|list-routes|add-route <pool> <name> <path>|delete-route <pool> <route_name>|list-monitors|create-monitor <name> <path> <up-code>|delete-monitor <name>list-pool-members <pool>|add-pool-member <pool> <host>:<port>|delete-pool-member <pool> <host>:<port>}"
+      raise ArgumentError.new "Usage: #{$0} {list-pools|add-pool <name> [<monitor-name>]|delete-pool <name>|list-routes|add-alias <pool> <name>|delete-alias <pool> <name>|add-route <pool> <name> <path>|delete-route <pool> <route_name>|list-monitors|create-monitor <name> <path> <up-code>|delete-monitor <name>list-pool-members <pool>|add-pool-member <pool> <host>:<port>|delete-pool-member <pool> <host>:<port>}"
     end
 
   rescue => e

--- a/routing-daemon/conf/routing-daemon.conf
+++ b/routing-daemon/conf/routing-daemon.conf
@@ -21,6 +21,7 @@ ACTIVEMQ_DESTINATION=/topic/routinginfo
 VIRTUAL_SERVER=ose-vserver
 
 ENDPOINT_TYPES=load_balancer
+CLOUD_DOMAIN=example.com
 POOL_NAME=pool_ose_%a_%n_80
 ROUTE_NAME=route_ose_%a_%n
 #MONITOR_NAME=monitor_ose_%a_%n

--- a/routing-daemon/conf/routing-daemon.conf
+++ b/routing-daemon/conf/routing-daemon.conf
@@ -20,6 +20,7 @@ ACTIVEMQ_DESTINATION=/topic/routinginfo
 
 VIRTUAL_SERVER=ose-vserver
 
+ENDPOINT_TYPES=load_balancer
 POOL_NAME=pool_ose_%a_%n_80
 ROUTE_NAME=route_ose_%a_%n
 #MONITOR_NAME=monitor_ose_%a_%n

--- a/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
@@ -82,6 +82,10 @@ module OpenShift
         members.delete member
       end
 
+      def get_aliases
+        @aliases
+      end
+
       def add_alias alias_str
         raise LBControllerException.new "Adding alias #{alias_str} to pool #{@name}, which already has the alias" if @aliases.include? alias_str
 

--- a/routing-daemon/lib/openshift/routing/controllers/batched.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/batched.rb
@@ -47,6 +47,10 @@ module OpenShift
         @lb_controller.pending_delete_member_ops.push pending unless @lb_controller.pending_add_member_ops.delete pending
       end
 
+      def get_aliases
+        @aliases
+      end
+
       def add_alias alias_str
         raise LBControllerException.new "Adding alias #{alias_str} to pool #{@name}, which already has the alias" if @aliases.include? alias_str
         @aliases.push alias_str

--- a/routing-daemon/lib/openshift/routing/controllers/load_balancer.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/load_balancer.rb
@@ -41,6 +41,9 @@ module OpenShift
       def delete_member address, port
       end
 
+      def get_aliases
+      end
+
       # Add an alias to the object's internal list of aliases.
       #
       # The argument should be a String representing the hostname of the alias.
@@ -48,7 +51,7 @@ module OpenShift
       # This method does not necessarily update the load balancer itself; use
       # the update method of the corresponding LoadBalancerController object to
       # force an immediate update.
-      def add_member alias_str
+      def add_alias alias_str
       end
 
       # Remove an alias from the object's internal list of aliases.
@@ -58,7 +61,7 @@ module OpenShift
       # This method does not necessarily update the load balancer itself; use
       # the update method of the corresponding LoadBalancerController object to
       # force an immediate update.
-      def delete_member alias_str
+      def delete_alias alias_str
       end
     end
 

--- a/routing-daemon/lib/openshift/routing/controllers/simple.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/simple.rb
@@ -38,6 +38,10 @@ module OpenShift
         @lb_model.delete_pool_member @name, address, port
       end
 
+      def get_aliases
+        @aliases
+      end
+
       def add_alias alias_str
         @aliases.push alias_str
         @lb_model.add_pool_alias @name, alias_str

--- a/routing-daemon/lib/openshift/routing/daemon.rb
+++ b/routing-daemon/lib/openshift/routing/daemon.rb
@@ -34,6 +34,7 @@ module OpenShift
       end
       @destination = cfg['ACTIVEMQ_DESTINATION'] || cfg['ACTIVEMQ_TOPIC'] || '/topic/routinginfo'
       @endpoint_types = (cfg['ENDPOINT_TYPES'] || 'load_balancer').split(',')
+      @cloud_domain = (cfg['CLOUD_DOMAIN'] || 'example.com')
       @pool_name_format = cfg['POOL_NAME'] || 'pool_ose_%a_%n_80'
       @route_name_format = cfg['ROUTE_NAME'] || 'route_ose_%a_%n'
       @monitor_name_format = cfg['MONITOR_NAME']
@@ -257,6 +258,10 @@ module OpenShift
       route = '/' + app_name
       @logger.info "Creating new routing rule #{route_name} for route #{route} to pool #{pool_name}"
       @lb_controller.create_route pool_name, route_name, route
+
+      alias_str = "ha-#{app_name}-#{namespace}.#{@cloud_domain}"
+      @logger.info "Adding new alias #{alias_str} to pool #{pool_name}"
+      @lb_controller.pools[pool_name].add_alias alias_str
     end
 
     def delete_application app_name, namespace

--- a/routing-daemon/lib/openshift/routing/daemon.rb
+++ b/routing-daemon/lib/openshift/routing/daemon.rb
@@ -33,6 +33,7 @@ module OpenShift
         end
       end
       @destination = cfg['ACTIVEMQ_DESTINATION'] || cfg['ACTIVEMQ_TOPIC'] || '/topic/routinginfo'
+      @endpoint_types = (cfg['ENDPOINT_TYPES'] || 'load_balancer').split(',')
       @pool_name_format = cfg['POOL_NAME'] || 'pool_ose_%a_%n_80'
       @route_name_format = cfg['ROUTE_NAME'] || 'route_ose_%a_%n'
       @monitor_name_format = cfg['MONITOR_NAME']
@@ -193,7 +194,7 @@ module OpenShift
         when :delete_application
           delete_application event[:app_name], event[:namespace]
         when :add_public_endpoint
-          add_endpoint event[:app_name], event[:namespace], event[:public_address], event[:public_port]
+          add_endpoint event[:app_name], event[:namespace], event[:public_address], event[:public_port], event[:types]
         when :remove_public_endpoint
           remove_endpoint event[:app_name], event[:namespace], event[:public_address], event[:public_port]
         when :add_alias
@@ -284,16 +285,31 @@ module OpenShift
       end
     end
 
-    def add_endpoint app_name, namespace, gear_host, gear_port
+    def add_endpoint app_name, namespace, gear_host, gear_port, types
       pool_name = generate_pool_name app_name, namespace
-      @logger.info "Adding new member #{gear_host}:#{gear_port} to pool #{pool_name}"
-      @lb_controller.pools[pool_name].add_member gear_host, gear_port.to_i
+      unless (types & @endpoint_types).empty?
+        @logger.info "Adding new member #{gear_host}:#{gear_port} to pool #{pool_name}"
+        @lb_controller.pools[pool_name].add_member gear_host, gear_port.to_i
+      else
+        @logger.info "Ignoring endpoint with types #{types.join(',')}"
+      end
     end
 
     def remove_endpoint app_name, namespace, gear_host, gear_port
       pool_name = generate_pool_name app_name, namespace
-      @logger.info "Deleting member #{gear_host}:#{gear_port} from pool #{pool_name}"
-      @lb_controller.pools[pool_name].delete_member gear_host, gear_port.to_i
+      member = gear_host + ':' + gear_port.to_s
+      # The remove_endpoint notification does not include a "types" field, so we
+      # cannot simply filter out endpoint types that we don't care about.
+      # Furthermore, the daemon by design does not store state itself, so we
+      # cannot check keep track of endpoints that we did not add to the load
+      # balancer.  All we can do is check whether the endpoint exists and delete
+      # it if it does.
+      if @lb_controller.pools[pool_name].members.include?(member)
+        @logger.info "Deleting member #{member} from pool #{pool_name}"
+        @lb_controller.pools[pool_name].delete_member gear_host, gear_port.to_i
+      else
+        @logger.info "No member #{member} exists in pool #{pool_name}; ignoring"
+      end
     end
 
     def add_alias app_name, namespace, alias_str

--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -1,6 +1,7 @@
 require 'openshift/routing/models/load_balancer'
 require 'json'
 require 'parseconfig'
+require 'uri'
 require 'restclient'
 
 module OpenShift
@@ -60,9 +61,16 @@ module OpenShift
       rest_request({ method: :put }.merge(options))
     end
 
+    # Send a PATCH request to the given URL with the given payload and
+    # return the response.
+    # patch :: Hash -> Net::HTTPResponse
+    def patch options
+      rest_request({ method: :patch }.merge(options))
+    end
+
     # Send a DELETE request to the given URL and return the response.
-    # put :: Hash -> Net::HTTPResponse
-    def put options
+    # delete :: Hash -> Net::HTTPResponse
+    def delete options
       rest_request({ method: :delete }.merge(options))
     end
 
@@ -75,7 +83,7 @@ module OpenShift
       post(url: "https://#{@host}/mgmt/tm/ltm/pool",
            payload: {
              "loadBalancingMode" => "round-robin",
-             "monitor" => "/Common/#{monitor_name}",
+             "monitor" => ("/Common/#{monitor_name}" if monitor_name),
              "name" => "#{pool_name}",
            }.to_json)
     end
@@ -85,22 +93,21 @@ module OpenShift
     end
 
     def get_route_names
-      (JSON.parse(get(url: "https://#{@host}/mgmt/tm/ltm/policy")) || [])['items'].map {|item| item['name']}
+      (JSON.parse(get(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_application_routes/rules")) || [])['items'].map {|item| item['name']}
     end
 
-    def get_active_route_names
-      (JSON.parse(get(url: "https://#{@host}/mgmt/tm/ltm/virtual/~Common~ose-vlan/policies")) || [])['items'].map {|item| item['name']}
-    end
+    alias_method :get_active_route_names, :get_route_names
 
     def create_route pool_name, route_name, path
-      post(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_applications/rules/#{route_name}",
+      post(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_application_routes/rules",
            payload: {
-             "controls" => ["forwarding"],
-             "requires" => ["http"],
-             "strategy" => "/Common/first-match",
+             "kind" => "tm:ltm:policy:rules:rulesstate",
+             "name" => route_name,
            }.to_json)
-      post(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_applications/rules/#{route_name}/conditions/0",
+      post(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_application_routes/rules/#{route_name}/conditions",
            payload: {
+             "kind" => "tm:ltm:policy:rules:actions:conditionsstate",
+             "name" => "0",
              "caseInsensitive" => true,
              "external" => true,
              "httpUri" => true,
@@ -112,12 +119,14 @@ module OpenShift
              "startsWith" => true,
              "values" => [path]
            }.to_json)
-      post(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_applications/rules/#{route_name}/actions/0",
+      post(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_application_routes/rules/#{route_name}/actions",
            payload: {
+             "kind" => "tm:ltm:policy:rules:actions:actionsstate",
+             "name" => "0",
              "code" => 0,
              "forward" => true,
              "pool" => "/Common/#{pool_name}",
-             "port" => 80,
+             "port" => 0,
              "request" => true,
              "select" => true,
              "status" => 0,
@@ -134,7 +143,7 @@ module OpenShift
     end
 
     def delete_route pool_name, route_name
-      delete(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_applications/rules/#{route_name}")
+      delete(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_application_routes/rules/#{route_name}")
     end
 
     def get_monitor_names
@@ -167,11 +176,62 @@ module OpenShift
     alias_method :get_active_pool_members, :get_pool_members
 
     def add_pool_member pool_name, address, port
-      post(url: "https://#{@host}/mgmt/tm/ltm/pool/#{pool_name}/members/#{address + ':' + port.to_s}")
+      member = address + ':' + port.to_s
+      post(url: "https://#{@host}/mgmt/tm/ltm/pool/#{pool_name}/members",
+            payload: {
+                "kind" => "ltm:pool:members",
+                "name" => member,
+            }.to_json)
     end
 
     def delete_pool_member pool_name, address, port
       delete(url: "https://#{@host}/mgmt/tm/ltm/pool/#{pool_name}/members/#{address + ':' + port.to_s}")
+    end
+
+    def get_pool_aliases pool_name
+      alias_name_regex = Regexp.new("\\Aalias_#{pool_name}_(.*)\\Z")
+      (JSON.parse(get(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_application_aliases/rules")) || [])['items'].map {|item| item['name']}.grep(alias_name_regex) {$1}
+    end
+
+    def add_pool_alias pool_name, alias_str
+      alias_name = "alias_#{URI.escape(pool_name)}_#{URI.escape(alias_str)}"
+      post(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_application_aliases/rules",
+           payload: {
+             "kind" => "tm:ltm:policy:rules:rulesstate",
+             "name" => alias_name,
+           }.to_json)
+      post(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_application_aliases/rules/#{alias_name}/conditions",
+           payload: {
+             "kind" => "tm:ltm:policy:rules:actions:conditionsstate",
+             "name" => "0",
+             "caseInsensitive" => true,
+             "external" => true,
+             "httpHost" => true,
+             "index" => 0,
+             "equals" => true,
+             "present" => true,
+             "remote" => true,
+             "request" => true,
+             "values" => [alias_str]
+           }.to_json)
+      post(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_application_aliases/rules/#{alias_name}/actions",
+           payload: {
+             "kind" => "tm:ltm:policy:rules:actions:actionsstate",
+             "name" => "0",
+             "code" => 0,
+             "forward" => true,
+             "pool" => "/Common/#{pool_name}",
+             "port" => 0,
+             "request" => true,
+             "select" => true,
+             "status" => 0,
+             "vlanId" => 0,
+           }.to_json)
+    end
+
+    def delete_pool_alias pool_name, alias_str
+      alias_name = "alias_#{URI.escape(pool_name)}_#{URI.escape(alias_str)}"
+      delete(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_application_aliases/rules/#{alias_name}")
     end
 
     def initialize logger, cfgfile
@@ -181,15 +241,27 @@ module OpenShift
 
       read_config cfgfile
 
-      # TODO: Create the openshift_applications policy if it does not
-      # already exist.  The create_route and delete_route methods add
-      # the application-specific rules to this policy.
-      #post(url: "https://#{@host}/mgmt/tm/ltm/policy/openshift_applications",
-      #     payload: {
-      #       "controls" => ["forwarding"],
-      #       "requires" => ["http"],
-      #       "strategy" => "/Common/first-match",
-      #     }.to_json)
+      # Create the openshift_application_routes an openshift_application_aliases
+      # policies if they do not already exist.  The create_route and
+      # delete_route methods add and delete the application-specific rules to
+      # and from the former, and the add_pool_alias and delete_pool_alias
+      # methods add and delete the application-specific rules to and from the
+      # latter.
+      ["openshift_application_routes","openshift_application_aliases"].each do |policy|
+        begin
+          get(url: "https://#{@host}/mgmt/tm/ltm/policy/#{policy}")
+        rescue RestClient::ResourceNotFound
+          @logger.info "No #{policy} policy exists.  Creating..."
+          post(url: "https://#{@host}/mgmt/tm/ltm/policy",
+               payload: {
+                 "kind" => "tm:ltm:policy:policystate",
+                 "name" => policy,
+                 "controls" => ["forwarding"],
+                 "requires" => ["http"],
+                 "strategy" => "first-match",
+               }.to_json)
+        end
+      end
     end
 
   end


### PR DESCRIPTION
The PR has the following changes:

• Improve `oo-admin-ctl-routing` output.

• Fix the F5 iControl REST model so it configures F5 BIG-IP as intended (I tested it against F5 BIG-IP to make sure it was performing the expected configuration, but the BIG-IP system has other configuration problems unrelated to the daemon, so I have not been able to confirm that the daemon's configuration works).

• Fix alias code in the controllers.

• Filter on endpoint type in the daemon  so that it only adds endpoints with the `load_balancer` type.

• Add an implicit `ha-#{app_name}-#{namespace}.#{@cloud_domain}` alias for each application.  This is a workaround until the broker sends the information to create these aliases.
