### PR TITLE
Admiller/oo exec ruby

### DIFF
--- a/util-scl/oo-exec-ruby
+++ b/util-scl/oo-exec-ruby
@@ -6,7 +6,10 @@ orig_lang=$LANG
 export LANG=C
 
 ruby_ver=$(rpm -q ruby --qf "%{version}")
-if [[ $ruby_ver < "1.9" ]]; then
+
+# If ruby193 scl installed, us it by default, otherwise use system ruby if it's
+# a recent enough version. Otherwise throw an error.
+if scl -l | grep ruby193 &> /dev/null; then
     # Ensure that the ruby193 SCL's directories come first in the PATH,
     # LD_LIBRARY_PATH, PKG_CONFIG_PATH, and MANPATH variables.
 
@@ -25,7 +28,11 @@ if [[ $ruby_ver < "1.9" ]]; then
     # If it did we would use:  exec scl enable ruby193 "$@"
     #COMMAND="$(printf "%q " "$@")"
     #exec scl enable ruby193 "$COMMAND"
-else
+elif [[ $ruby_ver < "1.9" ]]; then
     export LANG=$orig_lang
     exec "$@"
+else
+    export LANG=$orig_lang
+    printf "ERROR: scl ruby193 not found and ruby version too old.\n" >&2
+    exit 1
 fi

--- a/util-scl/oo-exec-ruby
+++ b/util-scl/oo-exec-ruby
@@ -1,18 +1,31 @@
 #!/bin/bash
 
-# Ensure that the ruby193 SCL's directories come first in the PATH,
-# LD_LIBRARY_PATH, PKG_CONFIG_PATH, and MANPATH variables.
-dir=/opt/rh/ruby193/root/usr/bin
-[[ ${PATH}: =~ ^$dir: ]] || export PATH="$dir:${PATH/:$dir}"
-dir=/opt/rh/ruby193/root/usr/lib64:/opt/rh/v8314/root/usr/lib64
-[[ ${LD_LIBRARY_PATH}: =~ ^$dir: ]] || export LD_LIBRARY_PATH="$dir:${LD_LIBRARY_PATH/:$dir}"
+# We are kind of abusing string evaluation of equality, so set LANG for the
+# specific check for version
+orig_lang=$LANG
+export LANG=C
 
-exec "$@"
+ruby_ver=$(rpm -q ruby --qf "%{version}")
+if [[ $ruby_ver < "1.9" ]]; then
+    # Ensure that the ruby193 SCL's directories come first in the PATH,
+    # LD_LIBRARY_PATH, PKG_CONFIG_PATH, and MANPATH variables.
 
-# We use the above implementation instead of the following because we want to
-# avoid using the scl command.
-#
-# scl <action> <collection1>...<collectionN> <command> doesn't handle multiple params for command.
-# If it did we would use:  exec scl enable ruby193 "$@"
-#COMMAND="$(printf "%q " "$@")"
-#exec scl enable ruby193 "$COMMAND"
+    export LANG=$orig_lang
+    dir=/opt/rh/ruby193/root/usr/bin
+    [[ ${PATH}: =~ ^$dir: ]] || export PATH="$dir:${PATH/:$dir}"
+    dir=/opt/rh/ruby193/root/usr/lib64:/opt/rh/v8314/root/usr/lib64
+    [[ ${LD_LIBRARY_PATH}: =~ ^$dir: ]] || export LD_LIBRARY_PATH="$dir:${LD_LIBRARY_PATH/:$dir}"
+
+    exec "$@"
+
+    # We use the above implementation instead of the following because we want to
+    # avoid using the scl command.
+    #
+    # scl <action> <collection1>...<collectionN> <command> doesn't handle multiple params for command.
+    # If it did we would use:  exec scl enable ruby193 "$@"
+    #COMMAND="$(printf "%q " "$@")"
+    #exec scl enable ruby193 "$COMMAND"
+else
+    export LANG=$orig_lang
+    exec "$@"
+fi

--- a/util-scl/oo-mco
+++ b/util-scl/oo-mco
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -e /opt/rh/ruby193/root/usr/sbin/mco ]; then
-  scl enable ruby193 "/opt/rh/ruby193/root/usr/sbin/mco $@"
+  exec oo-exec-ruby /opt/rh/ruby193/root/usr/sbin/mco "$@"
 else
   echo "/opt/rh/ruby193/root/usr/sbin/mco does not exist."
   echo "mco client is likely not installed from scl."

--- a/util-scl/oo-mco
+++ b/util-scl/oo-mco
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -e /opt/rh/ruby193/root/usr/sbin/mco ]; then
-  exec oo-exec-ruby /opt/rh/ruby193/root/usr/sbin/mco "$@"
+  scl enable ruby193 "/opt/rh/ruby193/root/usr/sbin/mco $@"
 else
   echo "/opt/rh/ruby193/root/usr/sbin/mco does not exist."
   echo "mco client is likely not installed from scl."


### PR DESCRIPTION
I updated oo-exec-ruby to handle multiple versions of ruby, this should work for all scenarios that I believe us to support. I also changed oo-mco since that invocation of oo-exec-ruby seemed unnecessary because it relies upon RHSCL ruby193 anyways.

@sosiouxme @detiber - please review

[test]
