### PR TITLE
cart => cartridge

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -61,7 +61,7 @@ function stop() {
 }
 
 function restart() {
-    echo "${1}ing Ruby cart"
+    echo "${1}ing Ruby cartridge"
     mkdir -p ${OPENSHIFT_REPO_DIR}public
     write_httpd_passenv $HTTPD_PASSENV_FILE
     oo-erb ${OPENSHIFT_RUBY_DIR}conf/performance.conf.erb.hidden > $HTTPD_CFG_DIR/performance.conf


### PR DESCRIPTION
Since this is output to the user, it should be consistant, for clarity's
sake. In other cartridges and in other methods, output specifies
"cartridge" instead of "cart".
