### PR TITLE
Bug 1153889 - Use /usr/bin/ruby to determine the system ruby version instead of rpm

### DIFF
--- a/util-scl/oo-exec-ruby
+++ b/util-scl/oo-exec-ruby
@@ -5,7 +5,7 @@
 orig_lang=$LANG
 export LANG=C
 
-ruby_ver=$(rpm -q ruby --qf "%{version}")
+ruby_ver=$(/usr/bin/ruby --version | cut -d ' ' -f 2)
 
 # If ruby193 scl installed, us it by default, otherwise use system ruby if it's
 # a recent enough version. Otherwise throw an error.


### PR DESCRIPTION
@maxamillion fyi
