### PR TITLE
Bug 1147946 - Do not snapshot jboss*/standalone/tmp

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-jbossas/metadata/managed_files.yml
@@ -20,3 +20,5 @@ dependency_dirs:
 - standalone/deployments: deployments
 build_dependency_dirs:
 - ~/.m2
+snapshot_exclusions:
+- standalone/tmp

--- a/cartridges/openshift-origin-cartridge-jbosseap/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-jbosseap/metadata/managed_files.yml
@@ -21,3 +21,5 @@ dependency_dirs:
 - standalone/deployments: deployments
 build_dependency_dirs:
 - ~/.m2
+snapshot_exclusions:
+- standalone/tmp

--- a/cartridges/openshift-origin-cartridge-jbossews/metadata/managed_files.yml
+++ b/cartridges/openshift-origin-cartridge-jbossews/metadata/managed_files.yml
@@ -16,3 +16,5 @@ dependency_dirs:
 - webapps
 build_dependency_dirs:
 - ~/.m2
+snapshot_exclusions:
+- standalone/tmp


### PR DESCRIPTION
- Save time and diskspace by not snapshot'ing standalone/tmp.  Content
  will be recreated when cartridge started during restore.
