### PR TITLE
Bug 1039356 - Skip the failed CPAN modules to allow build to finish

### DIFF
--- a/cartridges/openshift-origin-cartridge-perl/bin/build
+++ b/cartridges/openshift-origin-cartridge-perl/bin/build
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -ue
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
@@ -72,7 +72,12 @@ then
         DISABLE_TEST=""
     fi
 
+    # Do not error the build when the CPAN module failed to install, but report
+    # it to user. This will allow modules that are not local, nor CPAN to pass
+    # the build.
+    set +e
     cpanm $DISABLE_TEST $MIRROR -L ${OPENSHIFT_PERL_DIR}perl5lib "$f"
+    set -e
   done
 fi
 


### PR DESCRIPTION
@jhadvig fyi.

This will allow to skip the failed CPAN modules installation, which will make the build finish even if some modules are not available. The user will get the error message during the `git push`.
