### PR TITLE
[TO_STAGE] oo-trap-user: preserve quoting on shell commands

### DIFF
--- a/node/misc/bin/oo-trap-user
+++ b/node/misc/bin/oo-trap-user
@@ -174,16 +174,19 @@ if __name__ == '__main__':
 
     # Determine the command source
     # Start with the command passed by the user through SSH
-    # be careful not to recurse (ssh adds $SHELL -c)
-    allargs = sys.argv
+    allargs = shell_args = sys.argv
+    # allargs are for the arguments split on whitespace (easy to reconstruct)
+    # shell_args are for the arguments as the shell would understand them
     #
+    # be careful not to recurse (ssh adds $SHELL -c)
     if allargs[:2] == ['/usr/bin/oo-trap-user', '-c']:
         # the final command is a SINGLE string
-        #syslog.syslog(syslog.LOG_DEBUG, "allargs: " + str(allargs))
-        allargs = shsplit(allargs[2])
+        #syslog.syslog(syslog.LOG_DEBUG, "shell_args: " + str(shell_args))
+        allargs = shell_args[2].split()
+        shell_args = shsplit(shell_args[2])
         # Provide for authorized_keys entries of form "NAME=value /usr/bin/oo-trap-user"
-        while allargs[0].find("=") > 0:
-             nv = allargs.pop(0)
+        while shell_args[0].find("=") > 0:
+             nv = shell_args.pop(0) #remove NAME=VALUE from beginning of command
              nv = nv.split("=",2)
              os.environ[nv[0]] = nv[1]
 
@@ -192,25 +195,25 @@ if __name__ == '__main__':
     if orig_cmd != None:
         # extract the command which was replaced by SSH auth key command
         #syslog.syslog(syslog.LOG_DEBUG, "orig_cmd: " + orig_cmd)
-        allargs = shsplit(orig_cmd) if orig_cmd else []
+        allargs = shell_args = orig_cmd.split() if orig_cmd else []
 
-    if allargs == ['/usr/bin/oo-trap-user'] or allargs == []:
+    if shell_args == ['/usr/bin/oo-trap-user'] or shell_args == []:
         # no command, avoid recursion, drop to shell
         #syslog.syslog(syslog.LOG_DEBUG, "no command: drop to rhcsh")
-        allargs = ['rhcsh']
+        allargs = shell_args = ['rhcsh']
 
     # Log OpenShift login if known, plus gear UUID
     if config.get('SYSLOG_GEAR_LOGIN') == 'true':
         syslog.syslog("oo_login: %s from: %s gearUuid=%s cmd=%s" %
                      (os.environ.get('OPENSHIFT_LOGIN'), os.environ.get('SSH_CLIENT').split()[0],
-                     os.environ.get('OPENSHIFT_GEAR_UUID'), '+'.join(allargs)))
+                     os.environ.get('OPENSHIFT_GEAR_UUID'), ' '.join(allargs)))
 
     # Determine the command to execute: use from command_map if provided
     try:
         # Check the commmand_map for special "trapped" commands
         #syslog.syslog(syslog.LOG_DEBUG,
         #              "trying trapped commands from: " + str(allargs))
-        basecmd = os.path.basename(allargs[0])
+        basecmd = os.path.basename(shell_args[0])
         #syslog.syslog(syslog.LOG_DEBUG, "basecmd = " + basecmd)
         cmd = commands_map[basecmd]
         #syslog.syslog(syslog.LOG_DEBUG, "cmd = " + cmd)


### PR DESCRIPTION
The new behavior of oo-trap-user stripped quoting and escaping from
incoming ssh commands, breaking certain functionality that depended on
commands running verbatim.

With the fix, the original command is preserved (with only whitespace
changes, same as previous behavior).

Bug 1156171 - oo-trap-user breaks ssh commands with quotes in them
https://bugzilla.redhat.com/show_bug.cgi?id=1156171
