### PR TITLE
Kill out-of-memory gears more aggressively to reduce downtime

### DIFF
--- a/node-util/conf/watchman/plugins.d/oom_plugin.rb
+++ b/node-util/conf/watchman/plugins.d/oom_plugin.rb
@@ -44,6 +44,29 @@ class OomPlugin < OpenShift::Runtime::WatchmanPlugin
     @stop_wait_seconds = stop_wait_seconds
   end
 
+  def try_cgstore(cg, attr, value, retries=3)
+    1.upto(retries) do
+      begin
+        cg.store(attr, value)
+        return true
+      rescue
+        sleep 1
+      end
+    end
+    return false
+  end
+
+  def try_cgfetch(cg, attr, retries=3)
+    1.upto(retries) do
+      begin
+        return cg.fetch(attr)
+      rescue
+        sleep 1
+      end
+    end
+    return nil
+  end
+
   # Search for gears under_oom
   # @param [OpenShift::Runtime::WatchmanPluginTemplate::Iteration] iteration timestamps of given events
   # @return void
@@ -55,7 +78,7 @@ class OomPlugin < OpenShift::Runtime::WatchmanPlugin
     @gears.ids.each do |uuid|
       cgroup = OpenShift::Runtime::Utils::Cgroups::Libcgroup.new(uuid)
       begin
-        oom_control = cgroup.fetch('memory.oom_control')['memory.oom_control']
+        oom_control = try_cgfetch(cgroup, 'memory.oom_control')['memory.oom_control']
       rescue
         # Usually means the user has been deleted
         next
@@ -71,65 +94,42 @@ class OomPlugin < OpenShift::Runtime::WatchmanPlugin
       # Should we infer the template from the current values?
       cg = OpenShift::Runtime::Utils::Cgroups.new(uuid)
       restore_memsw_limit = cg.templates[:default][MEMSW_LIMIT].to_i
-      orig_memsw_limit = cgroup.fetch(MEMSW_LIMIT)[MEMSW_LIMIT].to_i
-
-      # Increase limit by 10% in order to clean up processes. Trying to
-      # restart a gear already at its memory limit is treacherous.
-      increased = (orig_memsw_limit * @memsw_multiplier).round(0)
-      Syslog.info %Q(#{PLUGIN_NAME}: Increasing memory for gear #{uuid} to #{increased} and restarting)
-      begin
-        cgroup.store(MEMSW_LIMIT, increased)
-      rescue
-        # This is not fatal; it just makes things less likely to work
-        Syslog.info %Q(#{PLUGIN_NAME}: Failed to increase memory limit for gear #{uuid})
+      orig_memsw_limit = try_cgfetch(cgroup, MEMSW_LIMIT)[MEMSW_LIMIT].to_i
+      if orig_memsw_limit == 0
+        # Assume it is currently at the templated limit
+        orig_memsw_limit = restore_memsw_limit
       end
 
       begin
-        # If gear is under OOM and OOM kill is enabled, skip this and go
-        # straight to kill_procs / restart, since the gear has already
-        # received kill signals, and if it's wedged, spawning more
-        # processes for stop action will just make the kernel do more work.
-        if oom_control['oom_kill_disable'] == '1'
-          begin
-            out, err, rc = ::OpenShift::Runtime::Utils.oo_spawn("oo-admin-ctl-gears forcestopgear #{uuid}", timeout: OP_TIMEOUT)
-            # Does rc == 0 here indicate success when forcestop is used?
-            # Also, does forcestop actually get to its "pkill -9" if
-            # the gear is under OOM?
-            # NB: memory reset and gear restart happen in the "ensure" block
-            next unless rc != 0
-            Syslog.info %Q(#{PLUGIN_NAME}: Force stop failed for gear #{uuid} , rc=#{rc}, stderr=#{err}")
-          rescue ::OpenShift::Runtime::Utils::ShellExecutionException => e
-            Syslog.info %Q(#{PLUGIN_NAME}: Force stop failed for gear #{uuid}: #{e.message}")
-            # This is primarily to catch timeouts
-          end
-        end
-
-        sleep @stop_wait_seconds
-
         # Verify that we are ready to reset to the old limit
         retries = 3
-        current = cgroup.fetch(MEMSW_USAGE)[MEMSW_USAGE].to_i
+        current = try_cgfetch(cgroup, MEMSW_USAGE)[MEMSW_USAGE].to_i
+        increased = orig_memsw_limit
         app = OpenShift::Runtime::ApplicationContainer.from_uuid(uuid)
-        while current > restore_memsw_limit && retries > 0
+        while (current >= restore_memsw_limit or current == 0) && retries > 0
+          # Increase limit by 10% in order to clean up processes. Trying to
+          # restart a gear already at its memory limit is treacherous.
           increased = (increased * @memsw_multiplier).round(0)
           Syslog.info %Q(#{PLUGIN_NAME}: Increasing memory for gear #{uuid} to #{increased} and killing processes)
-          cgroup.store(MEMSW_LIMIT, increased)
           app.kill_procs()
+          if not try_cgstore(cgroup, MEMSW_LIMIT, increased)
+            Syslog.warning %Q(#{PLUGIN_NAME}: Failed to increase memsw limit for gear #{uuid})
+          end
           sleep 5
           retries -= 1
-          current = cgroup.fetch(MEMSW_USAGE)[MEMSW_USAGE].to_i
+          current = try_cgfetch(cgroup, MEMSW_USAGE)[MEMSW_USAGE].to_i
         end
+      rescue Exception => e
+        Syslog.warning %Q(#{PLUGIN_NAME}: exception in OOM handling: #{e})
       ensure
         # Reset memory limit
-        begin
-          cgroup.store(MEMSW_LIMIT, restore_memsw_limit)
-        rescue
+        if not try_cgstore(cgroup, MEMSW_LIMIT, restore_memsw_limit)
           Syslog.warning %Q(#{PLUGIN_NAME}: Failed to lower memsw limit for gear #{uuid} from #{increased} to #{orig_memsw_limit})
         end
 
         # Finally, restart
         begin
-          start(uuid)
+          restart(uuid)
         rescue ::OpenShift::Runtime::Utils::ShellExecutionException => e
           Syslog.info %Q(#{PLUGIN_NAME}: Start failed for gear #{uuid}: #{e.message}")
         end

--- a/node/test/unit/oom_plugin_test.rb
+++ b/node/test/unit/oom_plugin_test.rb
@@ -24,7 +24,7 @@ class OomPluginTest < OpenShift::NodeBareTestCase
   def setup
     Syslog.open(File.basename($0), Syslog::LOG_PID, Syslog::LOG_DAEMON) unless Syslog.opened?
 
-    @uuids = %w(52cc244091aa71fac4000007 52cc244091aa71fac4000008 52cc244091aa71fac4000009)
+    @uuids = %w(52cc244091aa71fac4000007 52cc244091aa71fac4000008 52cc244091aa71fac4000009 52cc244091aa71fac400000a)
     @gears = mock
     @gears.stubs(:ids).returns @uuids
     @gears.stubs(:empty?).returns @uuids.empty?
@@ -39,6 +39,10 @@ class OomPluginTest < OpenShift::NodeBareTestCase
 
     @libcgroup_mock = mock('OpenShift::Runtime::Utils::Cgroups::Libcgroup')
     @libcgroup_mock.stubs(:parameters).returns(parameters)
+
+    @appcontainer_mock = mock('OpenShift::Runtime::ApplicationContainer')
+    @appcontainer_mock.stubs(:kill_procs).returns(nil)
+    
   end
 
   def test_no_oom_control
@@ -62,19 +66,19 @@ class OomPluginTest < OpenShift::NodeBareTestCase
                      {'under_oom'        => '1',
                       'oom_kill_disable' => '0'}}).
         times(@uuids.length)
-    @libcgroup_mock.expects(:fetch).with(OomPlugin::MEMSW_LIMIT).returns({OomPlugin::MEMSW_LIMIT => 1024}).times(3)
-    @libcgroup_mock.expects(:fetch).with(OomPlugin::MEMSW_USAGE).returns({OomPlugin::MEMSW_LIMIT => 1024}).times(3)
-    @libcgroup_mock.expects(:store).with(OomPlugin::MEMSW_LIMIT, kind_of(Fixnum)).times(@uuids.length * 2)
+    @libcgroup_mock.expects(:fetch).with(OomPlugin::MEMSW_LIMIT).returns({OomPlugin::MEMSW_LIMIT => 1024}).times(@uuids.length)
+    @libcgroup_mock.expects(:fetch).with(OomPlugin::MEMSW_USAGE).returns({OomPlugin::MEMSW_USAGE => 1024}).times(@uuids.length * (OomPlugin::BUMP_RETRIES + 1))
+    @libcgroup_mock.expects(:store).with(OomPlugin::MEMSW_LIMIT, kind_of(Fixnum)).times(@uuids.length * (OomPlugin::BUMP_RETRIES + 1))
 
     OpenShift::Runtime::ApplicationContainer.stubs(:from_uuid).
         with(any_of(*@uuids)).
-        returns(nil)
+        returns(@appcontainer_mock)
 
     OpenShift::Runtime::Utils::Cgroups::Libcgroup.stubs(:new).
         with(any_of(*@uuids)).
         returns(@libcgroup_mock)
 
-    @operation.expects(:call).with(:start, any_of(*@uuids)).times(3)
+    @operation.expects(:call).with(:restart, any_of(*@uuids)).times(@uuids.length)
 
     OomPlugin.new(nil, nil, @gears, @operation, 0).apply(nil)
   end


### PR DESCRIPTION
This change does a few things differently:
- Make multiple attempts when reading or writing cgroup
  data, to get around lock contention.  Also, handle
  exceptions better in this process
- Avoid calling force stop on the gear, because this
  involves other possible locking problems, and almost
  never works on an OOM gear, even when we bump the memory
  limit.  This also eliminates the time window between
  stopped and started states where someone/something could
  execute a conflicting state change.
- Send kill signals before we bump memory, so that the
  existing processes should immediately start cleaning
  up when the memory limit is bumped, without doing
  anything else like accepting more connections.
