### PR TITLE
Jenkins cart: Add "unzip" dependency

### DIFF
--- a/cartridges/openshift-origin-cartridge-jenkins/openshift-origin-cartridge-jenkins.spec
+++ b/cartridges/openshift-origin-cartridge-jenkins/openshift-origin-cartridge-jenkins.spec
@@ -14,6 +14,7 @@ Requires:      java >= 1.6
 Requires:      jenkins
 Requires:      jenkins-plugin-openshift
 Requires:      openshift-origin-node-util
+Requires:      unzip
 Provides:      openshift-origin-cartridge-jenkins-1.4 = 2.0.0
 Obsoletes:     openshift-origin-cartridge-jenkins-1.4 <= 1.99.9
 BuildArch:     noarch


### PR DESCRIPTION
The `bin/install` script depends on `unzip` being in the path, so the
specfile for this package should Require the `unzip` package.

Enterprise bug 1136706
https://bugzilla.redhat.com/show_bug.cgi?id=1136706
