### PR TITLE
 Specify additional gems to be loaded in the broker and console

### DIFF
--- a/broker/Gemfile
+++ b/broker/Gemfile
@@ -62,6 +62,21 @@ else
   end
 end
 
+# Load extra gems specified in the broker configuration file
+conf_file_path = (ENV['OPENSHIFT_CONF_DIR'] || "/etc/openshift/") + 'broker.conf'
+if File.exists?(conf_file_path)
+  conf_file = File.open(conf_file_path)
+  additional_gems = conf_file.read[/^ADDITIONAL_RUBYGEMS\s*=\s*(.+)/, 1]
+  if additional_gems
+    gem_list = additional_gems.split(" ").uniq
+    gem_list.each do |name|
+      gem name.gsub(/["']/, "")
+    end
+  end
+else
+  puts "Could not find broker configuration file at #{conf_file_path}. Skipping loading additional gems."
+end
+
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
 

--- a/broker/conf/broker.conf
+++ b/broker/conf/broker.conf
@@ -220,3 +220,5 @@ ALLOW_REGION_SELECTION="true"
 # (set to 26 to leave 2 chars for hyphens and 4 chars for up to 9999 gears.)
 #LIMIT_APP_NAME_CHARS=26
 
+# Additional rubygems (space seperated) that will be loaded in the broker's Gemfile.
+# ADDITIONAL_RUBYGEMS=""

--- a/console/Gemfile
+++ b/console/Gemfile
@@ -42,3 +42,17 @@ group :assets do
   gem 'sass-twitter-bootstrap',  '2.0.1'
 end
 
+# Load extra gems specified in the console configuration file
+conf_file_path = (ENV['OPENSHIFT_CONF_DIR'] || "/etc/openshift/") + 'console.conf'
+if File.exists?(conf_file_path)
+  conf_file = File.open(conf_file_path)
+  additional_gems = conf_file.read[/^ADDITIONAL_RUBYGEMS\s*=\s*(.+)/, 1]
+  if additional_gems
+    gem_list = additional_gems.split(" ").uniq
+    gem_list.each do |name|
+      gem name.gsub(/["']/, "")
+    end
+  end
+else
+  puts "Could not find console configuration file at #{conf_file_path}. Skipping loading additional gems."
+end

--- a/openshift-console/etc/openshift/console.conf
+++ b/openshift-console/etc/openshift/console.conf
@@ -148,3 +148,5 @@ REMOTE_USER_COPY_HEADERS=X-Remote-User
 # Direct logs to syslog rather than log files:
 #SYSLOG_ENABLED="true"
 
+# Additional rubygems (space seperated) that will be loaded in the broker's Gemfile.
+# ADDITIONAL_RUBYGEMS=""


### PR DESCRIPTION
 Specify additional gems to be loaded in the broker and console

Bug <1094454>
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1094454
Added ability to specify additional gems to be loaded in the broker and console Gemfiles.
