### PR TITLE
sni-proxy: have restart re-create conf

### DIFF
--- a/plugins/frontend/haproxy-sni-proxy/scripts/openshift-sni-proxy
+++ b/plugins/frontend/haproxy-sni-proxy/scripts/openshift-sni-proxy
@@ -38,6 +38,8 @@ check() {
 }
 
 start() {
+    # Fix the IP address and config params if they changed.
+    oo-rebuild-haproxy-sni-proxy || :
     $exec -c -q -f $cfgfile
     if [ $? -ne 0 ]; then
         echo "Errors in configuration file, check with $prog check."
@@ -89,12 +91,7 @@ fdr_status() {
 }
 
 case "$1" in
-    start)
-        # Fix the IP address and config params if they changed.
-        oo-rebuild-haproxy-sni-proxy || :
-        start
-        ;;
-    stop|restart|reload)
+    start|stop|restart|reload)
         $1
         ;;
     force-reload)


### PR DESCRIPTION
"service openshift-sni-proxy start" caused haproxy conf to be re-created
according to the plugin conf file, but not a restart. This change causes
oo-rebuild-haproxy-sni-proxy to be run either way.

Bug 1161135 - openshift-sni-proxy restart command needs call
'oo-rebuild-haproxy-sni-proxy' function
https://bugzilla.redhat.com/show_bug.cgi?id=1161135
