### PR TITLE
BZ#1159392 - Add HTTPS configuration for all applications with NGINX

### DIFF
--- a/routing-daemon/conf/routing-daemon.conf
+++ b/routing-daemon/conf/routing-daemon.conf
@@ -49,6 +49,10 @@ LBAAS_KEYSTONE_TENANT=lbms
 
 NGINX_CONFDIR=/opt/rh/nginx16/root/etc/nginx/conf.d
 NGINX_SERVICE=nginx16-nginx
+# To enable HTTPS access to applications, SSL Certificate and Key must be
+# copied from one of the OpenShift Node hosts.
+NGINX_SSL_CERTIFICATE=/etc/pki/tls/certs/node.example.com.crt
+NGINX_SSL_KEY=/etc/pki/tls/private/node.example.com.key
 #NGINX_PLUS=true
 #NGINX_PLUS_HEALTH_CHECK_INTERVAL=2s
 #NGINX_PLUS_HEALTH_CHECK_FAILS=1


### PR DESCRIPTION
This patch adds:
- Config settings for the location of the SSL
  certificate and key.
- Sets up a common certificate and key that all applications can use
  to access HA apps over HTTPS without having to set up an alias
  and adding an app specific cert/key
