### PR TITLE
Clean up & unify upgrade scripts

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-haproxy/bin/upgrade
@@ -1,3 +1,5 @@
 #!/bin/bash -eu
 
-sed -i '/server\s*filler/d' $OPENSHIFT_HAPROXY_DIR/conf/haproxy.cfg
+haproxy_version="$1"
+curr="$2"
+next="$3"

--- a/cartridges/openshift-origin-cartridge-jbossas/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/upgrade
@@ -1,23 +1,5 @@
-#!/bin/bash
-
-source $OPENSHIFT_CARTRIDGE_SDK_BASH
+#!/bin/bash -eu
 
 jboss_version="$1"
-old_cart_version="$2"
-new_cart_version="$3"
-
-# Needed for version 0.0.1 -> 0.1.10.  This can be removed after the upgrade
-# has been deployed.
-if [ -e $OPENSHIFT_HOMEDIR/jbossas/metadata/jenkins_shell_command ]; then
-  rm -f $OPENSHIFT_HOMEDIR/jbossas/metadata/jenkins_shell_command
-fi
-
-# For migration, if the user repo does not contain a standalone.xml, populate the "backup" from
-# the current config file used by the cartridge.
-mkdir -p $OPENSHIFT_JBOSSAS_DIR/jboss_cfg_backup
-if [ ! -f ${OPENSHIFT_REPO_DIR}/.openshift/config/standalone.xml ]
-then
-  cp -n ${OPENSHIFT_JBOSSAS_DIR}/standalone/configuration/standalone.xml $OPENSHIFT_JBOSSAS_DIR/jboss_cfg_backup
-else
-  cp -n ${OPENSHIFT_REPO_DIR}/.openshift/config/standalone.xml $OPENSHIFT_JBOSSAS_DIR/jboss_cfg_backup
-fi
+curr="$2"
+next="$3"

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/upgrade
@@ -1,23 +1,5 @@
-#!/bin/bash
-
-source $OPENSHIFT_CARTRIDGE_SDK_BASH
+#!/bin/bash -eu
 
 jboss_version="$1"
-old_cart_version="$2"
-new_cart_version="$3"
-
-# Needed for version 0.0.1 -> 0.1.9.  This can be removed after the upgrade
-# has been deployed.
-if [ -e $OPENSHIFT_HOMEDIR/jbosseap/metadata/jenkins_shell_command ]; then
-  rm -f $OPENSHIFT_HOMEDIR/jbosseap/metadata/jenkins_shell_command
-fi
-
-# For migration, if the user repo does not contain a standalone.xml, populate the "backup" from
-# the current config file used by the cartridge.
-mkdir -p $OPENSHIFT_JBOSSEAP_DIR/jboss_cfg_backup
-if [ ! -f ${OPENSHIFT_REPO_DIR}/.openshift/config/standalone.xml ]
-then
-  cp -n ${OPENSHIFT_JBOSSEAP_DIR}/standalone/configuration/standalone.xml $OPENSHIFT_JBOSSEAP_DIR/jboss_cfg_backup
-else
-  cp -n ${OPENSHIFT_REPO_DIR}/.openshift/config/standalone.xml $OPENSHIFT_JBOSSEAP_DIR/jboss_cfg_backup
-fi
+curr="$2"
+next="$3"

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/upgrade
@@ -1,18 +1,5 @@
-#!/bin/bash
-
-source $OPENSHIFT_CARTRIDGE_SDK_BASH
+#!/bin/bash -eu
 
 jboss_version="$1"
-old_cart_version="$2"
-new_cart_version="$3"
-
-# Needed for version 0.0.1 -> 0.1.10.  This can be removed after the upgrade
-# has been deployed.
-if [ -e $OPENSHIFT_HOMEDIR/jbossews/metadata/jenkins_shell_command ]; then
-  rm -f $OPENSHIFT_HOMEDIR/jbossews/metadata/jenkins_shell_command
-fi
-
-# Needed for upgrade from versions [0.0.1-0.0.11].  This can be removed after the upgrade has been deployed
-if [ -d $OPENSHIFT_HOMEDIR/jbossews/versions ]; then
-  rm -rf $OPENSHIFT_HOMEDIR/jbossews/versions
-fi
+curr="$2"
+next="$3"

--- a/cartridges/openshift-origin-cartridge-jenkins/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-jenkins/bin/upgrade
@@ -1,1 +1,5 @@
-#!/bin/bash
+#!/bin/bash -eu
+
+jenkins_version="$1"
+curr="$2"
+next="$3"

--- a/cartridges/openshift-origin-cartridge-mariadb/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-mariadb/bin/upgrade
@@ -1,19 +1,14 @@
-#!/bin/bash -e
-$OPENSHIFT_MARIADB_DIR/bin/control start
+#!/bin/bash -eu
 
-next=$3
+mariadb_version="$1"
+curr="$2"
+next="$3"
 
-echo "
-grant all on *.* to '$OPENSHIFT_MARIADB_DB_USERNAME'@'%' identified by '$OPENSHIFT_MARIADB_DB_PASSWORD' with grant option;
-flush privileges; " | /usr/bin/mysql -h $OPENSHIFT_MARIADB_DB_HOST -P $OPENSHIFT_MARIADB_DB_PORT -u $OPENSHIFT_MARIADB_DB_USERNAME --password="$OPENSHIFT_MARIADB_DB_PASSWORD" --skip-column-names
-
-# The LD_LIBRARY_PATH is now handled by the Node itself
-# and constructed using LD_LIBRARY_PATH_ELEMENT. This will
-# remove the existing LD_LIBRARY_PATH so the Node one can
-# take the precedence.
-#
-
-if [[ $next == "0.2.6" ]]; then
+if [[ "$next" == "0.2.6" ]]; then
+  # The LD_LIBRARY_PATH is now handled by the Node itself
+  # and constructed using LD_LIBRARY_PATH_ELEMENT. This will
+  # remove the existing LD_LIBRARY_PATH so the Node one can
+  # take the precedence.
   if [ -f ${OPENSHIFT_MARIADB_DIR}env/LD_LIBRARY_PATH ]; then
     rm -f ${OPENSHIFT_MARIADB_DIR}env/LD_LIBRARY_PATH
   fi

--- a/cartridges/openshift-origin-cartridge-mongodb/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/upgrade
@@ -1,13 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
-source "${OPENSHIFT_MONGODB_DIR}/lib/mongodb_context"
-source $OPENSHIFT_CARTRIDGE_SDK_BASH
-
-mongo_version=$1
-curr=$2
-next=$3
-
-# Fix the missing $OPENSHIFT_MONGODB_(LD_LIBRARY)PATH_ELEMENT variables
-if [ -z "${OPENSHIFT_MONGODB_PATH_ELEMENT}" ] || [ -z "${OPENSHIFT_MONGODB_LD_LIBRARY_PATH_ELEMENT}" ]; then
-  update_configuration
-fi
+mongo_version="$1"
+curr="$2"
+next="$3"

--- a/cartridges/openshift-origin-cartridge-mysql/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-mysql/bin/upgrade
@@ -1,33 +1,30 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 mysql_version="$1"
-old_cart_version="$2"
-new_cart_version="$3"
+curr="$2"
+next="$3"
 
-env_dir="${OPENSHIFT_MYSQL_DIR}/env"
-
-if [[ $new_cart_version == 0.2.5 ]]; then
+if [[ "$next" == "0.2.5" ]]; then
   files=$(shopt -s nullglob; shopt -s dotglob; echo data/ib_logfile*)
   if [ ${#files} -gt 0 ]; then
     mv data/ib_logfile* /tmp
   fi
 fi
 
-# The LD_LIBRARY_PATH is now handled by the Node itself
-# and constructed using LD_LIBRARY_PATH_ELEMENT. This will
-# remove the existing LD_LIBRARY_PATH so the Node one can
-# take the precedence.
-#
-if [[ $new_cart_version == "0.2.9" ]]; then
+if [[ "$next" == "0.2.9" ]]; then
+  # The LD_LIBRARY_PATH is now handled by the Node itself
+  # and constructed using LD_LIBRARY_PATH_ELEMENT. This will
+  # remove the existing LD_LIBRARY_PATH so the Node one can
+  # take the precedence.
   if [ -f ${OPENSHIFT_MYSQL_DIR}env/LD_LIBRARY_PATH ]; then
     rm -f ${OPENSHIFT_MYSQL_DIR}env/LD_LIBRARY_PATH
   fi
 fi
 
-# There is now a VERSION variable to allow the detection of 5.5
-# in rhcsh.
-if [[ $new_cart_version == "0.2.16" ]]; then
-  set_env_var 'OPENSHIFT_MYSQL_VERSION' $mysql_version $env_dir
+if [[ "$next" == "0.2.16" ]]; then
+  # There is now a VERSION variable to allow the detection of 5.5
+  # in rhcsh.
+  set_env_var 'OPENSHIFT_MYSQL_VERSION' $mysql_version "${OPENSHIFT_MYSQL_DIR}/env"
 fi

--- a/cartridges/openshift-origin-cartridge-nodejs/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/upgrade
@@ -1,49 +1,33 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_NODEJS_DIR}/lib/util"
 source "${OPENSHIFT_NODEJS_DIR}/lib/nodejs_context"
 
 nodejs_version="$1"
-old_cart_version="$2"
-new_cart_version="$3"
+curr="$2"
+next="$3"
 
-if [[ $old_cart_version =~ ^0.0.[0-4]$ ]]; then
+if [[ "$curr" =~ ^0\.0\.[0-4]$ ]]; then
   echo "$nodejs_version" > $OPENSHIFT_NODEJS_DIR/env/OPENSHIFT_NODEJS_VERSION
   update-configuration $nodejs_version
 fi
 
-if [ "${nodejs_version}" == "0.10" ]; then
-    express_path=$(readlink $OPENSHIFT_NODEJS_DIR/node_modules/express)
-    if [ "$express_path" != "/opt/rh/nodejs010/root/usr/lib/node_modules/express" ]; then
-        shopt -s dotglob
-        rm -rf $OPENSHIFT_NODEJS_DIR/node_modules/*
-        link_global_modules ${nodejs_version}
-    fi
-fi
-
-# Needed for version 0.0.1 -> 0.1.10.  This can be removed after the upgrade
-# has been deployed.
-if [ -e $OPENSHIFT_HOMEDIR/nodejs/metadata/jenkins_shell_command ]; then
-  rm -f $OPENSHIFT_HOMEDIR/nodejs/metadata/jenkins_shell_command
-fi
-
-# The LD_LIBRARY_PATH is now handled by the Node itself
-# and constructed using LD_LIBRARY_PATH_ELEMENT. This will
-# remove the existing LD_LIBRARY_PATH so the Node one can
-# take the precedence.
-#
-if [[ $new_cart_version == "0.0.14" ]]; then
+if [[ "$next" == "0.0.14" ]]; then
+  # The LD_LIBRARY_PATH is now handled by the Node itself
+  # and constructed using LD_LIBRARY_PATH_ELEMENT. This will
+  # remove the existing LD_LIBRARY_PATH so the Node one can
+  # take the precedence.
   if [ -f ${OPENSHIFT_NODEJS_DIR}env/LD_LIBRARY_PATH ]; then
     rm -f ${OPENSHIFT_NODEJS_DIR}env/LD_LIBRARY_PATH
   fi
   update-configuration $nodejs_version
 fi
 
-if [[ $new_cart_version == "0.0.19" ]]; then
+if [[ "$next" == "0.0.19" ]]; then
   update-configuration $nodejs_version
 fi
 
-if [[ $new_cart_version == "0.0.20" ]]; then
+if [[ "$next" == "0.0.20" ]]; then
   update-configuration $nodejs_version
 fi

--- a/cartridges/openshift-origin-cartridge-perl/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-perl/bin/upgrade
@@ -1,16 +1,10 @@
 #!/bin/bash -eu
 
-perl_version=$1
-curr=$2
-next=$3
+perl_version="$1"
+curr="$2"
+next="$3"
 
-# Needed for version 0.0.1 -> 0.1.8.  This can be removed after the upgrade
-# has been deployed.
-if [ -e $OPENSHIFT_HOMEDIR/perl/metadata/jenkins_shell_command ]; then
-  rm -f $OPENSHIFT_HOMEDIR/perl/metadata/jenkins_shell_command
-fi
-
-if [[ $next == "0.0.11" ]]; then
+if [[ "$next" == "0.0.11" ]]; then
 	chown $OPENSHIFT_GEAR_UUID:$OPENSHIFT_GEAR_UUID $OPENSHIFT_PERL_DIR/etc/conf.d/openshift.conf
 	chcon -u unconfined_u $OPENSHIFT_PERL_DIR/etc/conf.d/openshift.conf
 fi

--- a/cartridges/openshift-origin-cartridge-php/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-php/bin/upgrade
@@ -1,41 +1,37 @@
 #!/bin/bash -eu
 
-php_version=$1
-curr=$2
-next=$3
+php_version="$1"
+curr="$2"
+next="$3"
 
-if [[ $curr =~ ^0.0.[1-3]$ ]]; then
+case "$curr" in
+
+"0.0.1"|"0.0.2"|"0.0.3")
     pear -c "$OPENSHIFT_HOMEDIR"/.pearrc config-get bin_dir > "$OPENSHIFT_PHP_DIR/env/OPENSHIFT_PHP_PATH_ELEMENT"
-fi
+    ;;
 
-if [[ $curr == 0.0.4 ]]; then
+"0.0.4")
     mkdir -p $OPENSHIFT_HOMEDIR/.drush
-fi
+    ;;
 
-# Needed for version 0.0.1 -> 0.1.8.  This can be removed after the upgrade
-# has been deployed.
-if [ -e $OPENSHIFT_HOMEDIR/php/metadata/jenkins_shell_command ]; then
-    rm -f $OPENSHIFT_HOMEDIR/php/metadata/jenkins_shell_command
-fi
-
-if [[ $next == 0.0.12 ]]; then
+"0.0.11")
     chown $OPENSHIFT_GEAR_UUID:$OPENSHIFT_GEAR_UUID $OPENSHIFT_PHP_DIR/configuration/etc/conf.d/openshift.conf
     chcon -u unconfined_u $OPENSHIFT_PHP_DIR/configuration/etc/conf.d/openshift.conf
-fi
+    ;;
 
-if [[ $curr == 0.0.12 ]]; then
+"0.0.12")
     oo-erb ${OPENSHIFT_PHP_DIR}versions/shared/configuration/etc/php.ini.erb > ${OPENSHIFT_PHP_DIR}configuration/etc/php.ini
-fi
+    ;;
 
-if [[ $curr == 0.0.14 ]]; then
+"0.0.14")
     echo "${OPENSHIFT_PHP_DIR}configuration/etc/php.d" > ${OPENSHIFT_PHP_DIR}env/PHP_INI_SCAN_DIR
     # versions/ directory moved from user space (gear) to the shared usr/ directory (root)
     rm -rf ${OPENSHIFT_PHP_DIR}versions
     chown $OPENSHIFT_GEAR_UUID:$OPENSHIFT_GEAR_UUID ${OPENSHIFT_PHP_DIR}configuration/etc/php.ini
     chcon -u unconfined_u ${OPENSHIFT_PHP_DIR}configuration/etc/php.ini
-fi
+    ;;
 
-if [[ $curr == 0.0.17 ]]; then
+"0.0.17")
     source ${OPENSHIFT_PHP_DIR}usr/lib/php_config
     rm -f ${OPENSHIFT_PHP_DIR}configuration/etc/php.d/*
     echo > ${OPENSHIFT_PHP_DIR}configuration/etc/php.d/openshift.ini
@@ -45,4 +41,6 @@ if [[ $curr == 0.0.17 ]]; then
     mkdir -p ${OPENSHIFT_HOMEDIR}.composer
     chown $OPENSHIFT_GEAR_UUID:$OPENSHIFT_GEAR_UUID ${OPENSHIFT_HOMEDIR}.composer
     chcon -u unconfined_u ${OPENSHIFT_HOMEDIR}.composer
-fi
+    ;;
+
+esac

--- a/cartridges/openshift-origin-cartridge-postgresql/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/upgrade
@@ -1,30 +1,27 @@
-#!/bin/bash -ue
+#!/bin/bash -eu
 
-cart_version=$1
-curr=$2
-next=$3
+postgresql_version="$1"
+curr="$2"
+next="$3"
 
-# Allow upgrade to pass when the $OPENSHIFT_POSTGRESQL_DIR was deleted by user.
-if [ -f "${OPENSHIFT_POSTGRESQL_DIR}data/pg_hba.conf" ]; then
+if [[ "$next" == "0.3.15" ]]; then
+  # Allow upgrade to pass when the $OPENSHIFT_POSTGRESQL_DIR was deleted by user.
+  if [ -f "${OPENSHIFT_POSTGRESQL_DIR}data/pg_hba.conf" ]; then
 
-  if ! grep "0.0.0.0/0" $OPENSHIFT_POSTGRESQL_DIR/data/pg_hba.conf; then
-    echo "host    all         all           0.0.0.0/0             md5" >> $OPENSHIFT_POSTGRESQL_DIR/data/pg_hba.conf
-  fi
+    if ! grep "0.0.0.0/0" $OPENSHIFT_POSTGRESQL_DIR/data/pg_hba.conf; then
+      echo "host    all         all           0.0.0.0/0             md5" >> $OPENSHIFT_POSTGRESQL_DIR/data/pg_hba.conf
+    fi
 
-  if [[ $next == "0.3.15" ]]; then
     sed -ie "s#host\s\+all\s\+postgres\s\+0.0.0.0/8\s\+reject#host    all         postgres      0.0.0.0/0             reject#" $OPENSHIFT_POSTGRESQL_DIR/data/pg_hba.conf
     sed -ie "s#host\s\+all\s\+all\s\+::1/128\s\+md5#host    all         all           ::/0                  md5#" $OPENSHIFT_POSTGRESQL_DIR/data/pg_hba.conf
   fi
-
 fi
 
-# The LD_LIBRARY_PATH is now handled by the Node itself
-# and constructed using LD_LIBRARY_PATH_ELEMENT. This will
-# remove the existing LD_LIBRARY_PATH so the Node one can
-# take the precedence.
-#
-
-if [[ $next == "0.3.9" ]]; then
+if [[ "$next" == "0.3.9" ]]; then
+  # The LD_LIBRARY_PATH is now handled by the Node itself
+  # and constructed using LD_LIBRARY_PATH_ELEMENT. This will
+  # remove the existing LD_LIBRARY_PATH so the Node one can
+  # take the precedence.
   if [ -f ${OPENSHIFT_POSTGRESQL_DIR}env/LD_LIBRARY_PATH ]; then
     rm -f ${OPENSHIFT_POSTGRESQL_DIR}env/LD_LIBRARY_PATH
   fi

--- a/cartridges/openshift-origin-cartridge-python/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-python/bin/upgrade
@@ -1,12 +1,22 @@
 #!/bin/bash -eu
 
-python_version=$1
-curr=$2
-next=$3
+python_version="$1"
+curr="$2"
+next="$3"
 
-if [[ $curr =~ ^0.0.1[23]$ ]]; then
+if [[ "$curr" == "0.0.12" || "$curr" == "0.0.13" ]]; then
     chown $OPENSHIFT_GEAR_UUID:$OPENSHIFT_GEAR_UUID ${OPENSHIFT_PYTHON_DIR}etc/conf.d/openshift.conf
     chcon -u unconfined_u ${OPENSHIFT_PYTHON_DIR}etc/conf.d/openshift.conf
+fi
+
+if [[ "$next" == "0.0.13" ]]; then
+  # The LD_LIBRARY_PATH is now handled by the Node itself
+  # and constructed using LD_LIBRARY_PATH_ELEMENT. This will
+  # remove the existing LD_LIBRARY_PATH so the Node one can
+  # take the precedence.
+  if [ -f ${OPENSHIFT_PYTHON_DIR}env/LD_LIBRARY_PATH ]; then
+    rm -f ${OPENSHIFT_PYTHON_DIR}env/LD_LIBRARY_PATH
+  fi
 fi
 
 upgrade_script="${OPENSHIFT_PYTHON_DIR}usr/versions/${python_version}/bin/upgrade"
@@ -14,16 +24,3 @@ upgrade_script="${OPENSHIFT_PYTHON_DIR}usr/versions/${python_version}/bin/upgrad
 if [ -e "$upgrade_script" ]; then
     $upgrade_script "$@"
 fi
-
-# The LD_LIBRARY_PATH is now handled by the Node itself
-# and constructed using LD_LIBRARY_PATH_ELEMENT. This will
-# remove the existing LD_LIBRARY_PATH so the Node one can
-# take the precedence.
-#
-if [[ $next == "0.0.13" ]]; then
-  if [ -f ${OPENSHIFT_PYTHON_DIR}env/LD_LIBRARY_PATH ]; then
-    rm -f ${OPENSHIFT_PYTHON_DIR}env/LD_LIBRARY_PATH
-  fi
-fi
-
-exit 0

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/2.7-scl/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/2.7-scl/bin/upgrade
@@ -3,14 +3,14 @@
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 python_version="$1"
-old_cart_version="$2"
-new_cart_version="$3"
+curr="$2"
+next="$3"
 
 source $OPENSHIFT_PYTHON_DIR/usr/versions/$python_version/lib/update-configuration
 source $OPENSHIFT_PYTHON_DIR/usr/versions/$python_version/lib/python-context
 
 # Switch to SCL environment
-case "$old_cart_version" in
+case "$curr" in
     '0.0.0'|'0.0.1'|'0.0.2'|'0.0.3')
 
         # Construct a listing of the old virtual env as an aid in
@@ -25,10 +25,10 @@ case "$old_cart_version" in
 
         # Past this point, the application is not functional if there
         # is a failure but retry is possible.
-	rm -rf $OPENSHIFT_PYTHON_DIR/opt
-	rm -rf $OPENSHIFT_PYTHON_DIR/versions
+        rm -rf $OPENSHIFT_PYTHON_DIR/opt
+        rm -rf $OPENSHIFT_PYTHON_DIR/versions
         rm -rf $OPENSHIFT_PYTHON_DIR/upstream-repo
-	rm -rf $OPENSHIFT_PYTHON_DIR/virtenv/*
+        rm -rf $OPENSHIFT_PYTHON_DIR/virtenv/*
 
         # Need the environment ERBs rendered at this point
         for f in $OPENSHIFT_PYTHON_DIR/env/*.erb; do

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-scl/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-scl/bin/upgrade
@@ -3,14 +3,14 @@
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 python_version="$1"
-old_cart_version="$2"
-new_cart_version="$3"
+curr="$2"
+next="$3"
 
 source $OPENSHIFT_PYTHON_DIR/usr/versions/$python_version/lib/update-configuration
 source $OPENSHIFT_PYTHON_DIR/usr/versions/$python_version/lib/python-context
 
 # Switch to SCL environment
-case "$old_cart_version" in
+case "$curr" in
     '0.0.0'|'0.0.1'|'0.0.2'|'0.0.3'|'0.0.9')
 
         # Construct a listing of the old virtual env as an aid in

--- a/cartridges/openshift-origin-cartridge-ruby/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/upgrade
@@ -1,21 +1,14 @@
 #!/bin/bash -eu
 
-ruby_version=$1
-curr=$2
-next=$3
+ruby_version="$1"
+curr="$2"
+next="$3"
 
-# Needed for version 0.0.1 -> 0.1.11.  This can be removed after the upgrade
-# has been deployed.
-if [ -e $OPENSHIFT_HOMEDIR/ruby/metadata/jenkins_shell_command ]; then
-  rm -f $OPENSHIFT_HOMEDIR/ruby/metadata/jenkins_shell_command
-fi
-
-# The LD_LIBRARY_PATH is now handled by the Node itself
-# and constructed using LD_LIBRARY_PATH_ELEMENT. This will
-# remove the existing LD_LIBRARY_PATH so the Node one can
-# take the precedence.
-#
-if [[ $next == "0.0.14" ]]; then
+if [[ "$next" == "0.0.14" ]]; then
+  # The LD_LIBRARY_PATH is now handled by the Node itself
+  # and constructed using LD_LIBRARY_PATH_ELEMENT. This will
+  # remove the existing LD_LIBRARY_PATH so the Node one can
+  # take the precedence.
   if [ -f ${OPENSHIFT_RUBY_DIR}env/LD_LIBRARY_PATH ]; then
     rm -f ${OPENSHIFT_RUBY_DIR}env/LD_LIBRARY_PATH
   fi

--- a/cartridges/openshift-origin-cartridge-switchyard/bin/upgrade
+++ b/cartridges/openshift-origin-cartridge-switchyard/bin/upgrade
@@ -1,23 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
-switchyard_version=$1
-curr=$2
-next=$3
-
-# switchyard used to define variables for jbossas and eap, we can remove
-# the unneeded one.
-if [ -z "$OPENSHIFT_JBOSSAS_IP" ]
-then
-    if [ -f $OPENSHIFT_SWITCHYARD_DIR/env/OPENSHIFT_JBOSSAS_MODULE_PATH ]
-    then
-        rm -f $OPENSHIFT_SWITCHYARD_DIR/env/OPENSHIFT_JBOSSAS_MODULE_PATH
-    fi
-fi
-
-if [ -z "$OPENSHIFT_JBOSSEAP_IP" ]
-then
-    if [ -f $OPENSHIFT_SWITCHYARD_DIR/env/OPENSHIFT_JBOSSEAP_MODULE_PATH ]
-    then
-        rm -f $OPENSHIFT_SWITCHYARD_DIR/env/OPENSHIFT_JBOSSEAP_MODULE_PATH
-    fi
-fi
+switchyard_version="$1"
+curr="$2"
+next="$3"


### PR DESCRIPTION
- Remove all unversioned upgrade steps
- Strictly compare versions as strings, fix regexps
- Unify variables across upgrade scripts
