### PR TITLE
Register app dns vhost for secondary haproxy gears

### DIFF
--- a/node-util/conf/watchman/plugins.d/frontend_plugin.rb
+++ b/node-util/conf/watchman/plugins.d/frontend_plugin.rb
@@ -54,11 +54,17 @@ class FrontendPlugin < OpenShift::Runtime::WatchmanPlugin
 
       @logger.info %Q(watchman frontend plugin cleaned up #{conf_file})
       File.delete(conf_file)
+
+      reload_needed = true
+
+      # skip deleting the gear_dir if this is the _ha.conf file,
+      # as deletion will be handled by the regular .conf file.
+      next if conf_file.end_with?('_ha.conf')
+
       gear_dir = conf_file.gsub('_0_', '_')
       gear_dir = gear_dir.gsub('.conf', '')
 
       FileUtils.rm_r(gear_dir)
-      reload_needed = true
     end
 
     if reload_needed

--- a/node-util/sbin/oo-admin-gear
+++ b/node-util/sbin/oo-admin-gear
@@ -78,7 +78,7 @@ command :destroygear do |c|
       end
 
       if config.get('OPENSHIFT_FRONTEND_HTTP_PLUGINS').include?('openshift-origin-frontend-apache-vhost')
-        entries = Dir.glob("#{options.with_container_uuid}_*.conf")
+        entries = Dir.glob("#{options.with_container_uuid}_*.conf").reject {|e| e.end_with?("_ha.conf")}
         if 1 == entries.length
           fqdn = %x[/bin/awk -- '/ServerName/ {print $2; exit}' #{entries.first}].chomp
           options.default fqdn: fqdn unless fqdn.empty?

--- a/node/test/node_functional/frontend_plugin_test.rb
+++ b/node/test/node_functional/frontend_plugin_test.rb
@@ -52,6 +52,7 @@ class FrontendPluginTest < OpenShift::NodeBareTestCase
 
   def test_delete
     FileUtils.touch(File.join(@testdir, 'test_0_dir.conf'), mtime: (Time.now - 7200))
+    FileUtils.touch(File.join(@testdir, 'test_0_dir_ha.conf'), mtime: (Time.now - 7200))
     conf_dir = File.join(@testdir, 'test_dir')
     FileUtils.mkdir_p(conf_dir)
     FileUtils.touch(File.join(conf_dir, 'test_file'))


### PR DESCRIPTION
Modify the vhost frontend plugin to create a 2nd base vhost conf file
for the app dns so secondary haproxy gears can handle requests for
$OPENSHIFT_APP_DNS.

Bug 1161072
