### PR TITLE
BZ1158704 - Broker fails to create HA DNS entry for HA app

### DIFF
--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1919,8 +1919,8 @@ class Application
                            gear_size: gear_size, prereq: [create_gear_op._id.to_s])
 
       register_dns_op = RegisterDnsOp.new(gear_id: gear_id, prereq: [create_gear_op._id.to_s])
-
       ops.push(init_gear_op, reserve_uid_op, create_gear_op, register_dns_op)
+      ops.push(RegisterRoutingDnsOp.new(prereq: [register_dns_op._id.to_s])) if self.ha and Rails.configuration.openshift[:manage_ha_dns]
 
       if additional_filesystem_gb != 0
         # FIXME move into CreateGearOp


### PR DESCRIPTION
- If the ha parameter is passed as part of the application creation api,
- the broker was not adding the pending operation to create the routing
- dns. After adding this patch, the routing DNS record is created if and
- only if the broker.conf is set to manage the external routing DNS.
