### PR TITLE
Use absolute path to apachectl

### DIFF
--- a/node-util/sbin/oo-httpd-singular.apache-2.3
+++ b/node-util/sbin/oo-httpd-singular.apache-2.3
@@ -33,7 +33,7 @@ require 'tempfile'
 require 'json'
 require 'openshift-origin-node/utils/shell_exec'
 
-HTTPD_SYSTEM="apachectl"
+HTTPD_SYSTEM="/usr/sbin/apachectl"
 HTTPD_CMDS=["graceful"]
 HTTPD_PRE_CMDS=["configtest"]
 LOCKFILE=File.join(Dir::tmpdir,"httpd_singular.lock")


### PR DESCRIPTION
When the auto-idler is called from root's cron,
it may not have /usr/sbin in its PATH.
