### PR TITLE
Default configuration parameter to set Private SSL certificates allowed

### DIFF
--- a/broker/conf/broker.conf
+++ b/broker/conf/broker.conf
@@ -31,6 +31,8 @@ DEFAULT_VIEW_GLOBAL_TEAMS="false"
 DEFAULT_MAX_UNTRACKED_ADDTL_STORAGE_PER_GEAR="0"
 # Default max tracked additional storage per gear
 DEFAULT_MAX_TRACKED_ADDTL_STORAGE_PER_GEAR="0"
+# Default user capability to use private SSL certificates
+DEFAULT_ALLOW_PRIVATE_SSL_CERTIFICATES="false"
 
 # For replica sets, use ',' delimiter for multiple servers
 # Eg: MONGO_HOST_PORT="<host1:port1>,<host2:port2>..."

--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -109,6 +109,7 @@ Broker::Application.configure do
     :app_template_for => OpenShift::Controller::Configuration.parse_url_hash(conf.get('DEFAULT_APP_TEMPLATES', nil)),
     :default_max_teams => (conf.get("DEFAULT_MAX_TEAMS", "0")).to_i,
     :default_view_global_teams => conf.get_bool('DEFAULT_VIEW_GLOBAL_TEAMS', 'false'),
+    :default_private_ssl_certificates => conf.get_bool('DEFAULT_ALLOW_PRIVATE_SSL_CERTIFICATES', 'false'),
     :node_platforms => OpenShift::Controller::Configuration.parse_list(conf.get('NODE_PLATFORMS', 'linux')).map { |platform| platform.downcase },
     :default_max_untracked_addtl_storage_per_gear => (conf.get("DEFAULT_MAX_UNTRACKED_ADDTL_STORAGE_PER_GEAR", "0")).to_i,
     :default_max_tracked_addtl_storage_per_gear => (conf.get("DEFAULT_MAX_TRACKED_ADDTL_STORAGE_PER_GEAR", "0")).to_i,

--- a/broker/config/environments/production.rb
+++ b/broker/config/environments/production.rb
@@ -98,6 +98,7 @@ Broker::Application.configure do
     :app_template_for => OpenShift::Controller::Configuration.parse_url_hash(conf.get('DEFAULT_APP_TEMPLATES', nil)),
     :default_max_teams => (conf.get("DEFAULT_MAX_TEAMS", "0")).to_i,
     :default_view_global_teams => conf.get_bool('DEFAULT_VIEW_GLOBAL_TEAMS', 'false'),
+    :default_private_ssl_certificates => conf.get_bool('DEFAULT_ALLOW_PRIVATE_SSL_CERTIFICATES', 'false'),
     :node_platforms => OpenShift::Controller::Configuration.parse_list(conf.get('NODE_PLATFORMS', 'linux')).map { |platform| platform.downcase },
     :default_max_untracked_addtl_storage_per_gear => (conf.get("DEFAULT_MAX_UNTRACKED_ADDTL_STORAGE_PER_GEAR", "0")).to_i,
     :default_max_tracked_addtl_storage_per_gear => (conf.get("DEFAULT_MAX_TRACKED_ADDTL_STORAGE_PER_GEAR", "0")).to_i,

--- a/broker/config/environments/test.rb
+++ b/broker/config/environments/test.rb
@@ -107,6 +107,7 @@ Broker::Application.configure do
     :app_template_for => OpenShift::Controller::Configuration.parse_url_hash(conf.get('DEFAULT_APP_TEMPLATES', nil)),
     :default_max_teams => (conf.get("DEFAULT_MAX_TEAMS", "100")).to_i,
     :default_view_global_teams => conf.get_bool('DEFAULT_VIEW_GLOBAL_TEAMS', 'true'),
+    :default_private_ssl_certificates => conf.get_bool('DEFAULT_ALLOW_PRIVATE_SSL_CERTIFICATES', 'false'),
     :node_platforms => OpenShift::Controller::Configuration.parse_list(conf.get('NODE_PLATFORMS', 'linux')).map { |platform| platform.downcase },
     :default_max_untracked_addtl_storage_per_gear => (conf.get("DEFAULT_MAX_UNTRACKED_ADDTL_STORAGE_PER_GEAR", "0")).to_i,
     :default_max_tracked_addtl_storage_per_gear => (conf.get("DEFAULT_MAX_TRACKED_ADDTL_STORAGE_PER_GEAR", "0")).to_i,

--- a/controller/app/models/cloud_user.rb
+++ b/controller/app/models/cloud_user.rb
@@ -244,6 +244,7 @@ class CloudUser
       "view_global_teams" => Rails.application.config.openshift[:default_view_global_teams],
       "max_untracked_addtl_storage_per_gear" =>  Rails.application.config.openshift[:default_max_untracked_addtl_storage_per_gear],
       "max_tracked_addtl_storage_per_gear" =>  Rails.application.config.openshift[:default_max_tracked_addtl_storage_per_gear],
+      "private_ssl_certificates" => Rails.application.config.openshift[:default_private_ssl_certificates],
     }
   end
 


### PR DESCRIPTION
Even though private_ssl_certificates function to set it in controller/app/models/cloud_user.rb, it is not exposed. This patch will fix it.
