### PR TITLE
BZ1166518 - rubygem-openshift-origin-common should be installed...

### DIFF
--- a/routing-daemon/rubygem-openshift-origin-routing-daemon.spec
+++ b/routing-daemon/rubygem-openshift-origin-routing-daemon.spec
@@ -28,6 +28,7 @@ Requires:      %{?scl:%scl_prefix}rubygem(daemons)
 Requires:      %{?scl:%scl_prefix}rubygem(json)
 Requires:      %{?scl:%scl_prefix}rubygem(parseconfig)
 Requires:      %{?scl:%scl_prefix}rubygem(stomp)
+Requires:      rubygem(openshift-origin-common)
 %if 0%{?fedora}%{?rhel} <= 6
 BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build


### PR DESCRIPTION
- rubygem-openshift-origin-common should be installed as dependency when
  installing rubygem-openshift-origin-routing-daemon
