### PR TITLE
BZ1168036 -  Requests made to the nginx router at '/' are forwarded..

### DIFF
--- a/routing-daemon/lib/openshift/routing/models/nginx.rb
+++ b/routing-daemon/lib/openshift/routing/models/nginx.rb
@@ -374,6 +374,22 @@ match statusok {
 }
 <% end %>
 
+server {
+  listen <%= @http_port %> default_server;
+  server_name _;
+  location / {
+    return 404;
+  }
+}
+
+server {
+  listen <%= @ssl_port %> ssl default_server;
+  server_name _;
+  location / {
+    return 404;
+  }
+}
+
 }
 
     FRONTEND = %q{


### PR DESCRIPTION
- Requests made to the nginx router at '/' are forwarded to the first
  configured HA application.
