### PR TITLE
Unify shell attributes in all cartridge scripts

### DIFF
--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/control
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_10GENMMSAGENT_DIR}lib/util"

--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/install
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 

--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/setup
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_10GENMMSAGENT_DIR}lib/util"

--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/teardown
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/teardown
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/bash -eu
+
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 rm -rf $OPENSHIFT_LOG_DIR/10gen-mms-agent.log*

--- a/cartridges/openshift-origin-cartridge-cron/bin/control
+++ b/cartridges/openshift-origin-cartridge-cron/bin/control
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash -eu
+
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 function _are_cronjobs_enabled() {

--- a/cartridges/openshift-origin-cartridge-cron/bin/install
+++ b/cartridges/openshift-origin-cartridge-cron/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 

--- a/cartridges/openshift-origin-cartridge-cron/bin/setup
+++ b/cartridges/openshift-origin-cartridge-cron/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 

--- a/cartridges/openshift-origin-cartridge-cron/bin/teardown
+++ b/cartridges/openshift-origin-cartridge-cron/bin/teardown
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/bash -eu
+
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 rm -rf $OPENSHIFT_LOG_DIR/cron_*

--- a/cartridges/openshift-origin-cartridge-diy/bin/control
+++ b/cartridges/openshift-origin-cartridge-diy/bin/control
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/bash -eu
+
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 function run_hook() {

--- a/cartridges/openshift-origin-cartridge-haproxy/bin/control
+++ b/cartridges/openshift-origin-cartridge-haproxy/bin/control
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash -eu
+
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 export STOPTIMEOUT=20

--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/disable-colocated-gears
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/disable-colocated-gears
@@ -1,10 +1,9 @@
-#!/bin/bash
+#!/bin/bash -eu
 # Script to disable the local serving gears after either at least
 # one remote gear is visible to haproxy or 30 seconds have passed.
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
-set -x
 rm -f /tmp/disable_local*
 exec &> /tmp/disable_local.$$
 

--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/fix_local.sh
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/fix_local.sh
@@ -1,10 +1,9 @@
-#!/bin/bash
+#!/bin/bash -eu
 # Script to disable the local serving gear after either at least
 # one remote gear is visible to haproxy or 30 seconds have passed.
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
-set -x
 rm -f /tmp/fix_local*
 exec &> /tmp/fix_local.$$
 

--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/update-cluster
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/update-cluster
@@ -1,9 +1,7 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 # Adds a gear to the haproxy configuration.
 
-# Exit on any errors
-set -e
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source /etc/openshift/node.conf
 

--- a/cartridges/openshift-origin-cartridge-jbossas/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 

--- a/cartridges/openshift-origin-cartridge-jbossas/hooks/publish-jboss-cluster
+++ b/cartridges/openshift-origin-cartridge-jbossas/hooks/publish-jboss-cluster
@@ -1,9 +1,6 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 # Start the application httpd instance
-
-# Exit on any errors
-set -e
 
 function print_help {
     echo "Usage: $0 app-name namespace uuid"

--- a/cartridges/openshift-origin-cartridge-jbossas/hooks/publish-jboss-remoting
+++ b/cartridges/openshift-origin-cartridge-jbossas/hooks/publish-jboss-remoting
@@ -1,9 +1,6 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 # Start the application httpd instance
-
-# Exit on any errors
-set -e
 
 function print_help {
     echo "Usage: $0 app-name namespace uuid"

--- a/cartridges/openshift-origin-cartridge-jbossas/hooks/set-jboss-cluster
+++ b/cartridges/openshift-origin-cartridge-jbossas/hooks/set-jboss-cluster
@@ -1,7 +1,4 @@
-#!/bin/bash
-
-# Exit on any errors
-set -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 

--- a/cartridges/openshift-origin-cartridge-jbosseap/hooks/publish-jboss-cluster
+++ b/cartridges/openshift-origin-cartridge-jbosseap/hooks/publish-jboss-cluster
@@ -1,9 +1,6 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 # Start the application httpd instance
-
-# Exit on any errors
-set -e
 
 function print_help {
     echo "Usage: $0 app-name namespace uuid"

--- a/cartridges/openshift-origin-cartridge-jbosseap/hooks/publish-jboss-remoting
+++ b/cartridges/openshift-origin-cartridge-jbosseap/hooks/publish-jboss-remoting
@@ -1,9 +1,6 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 # Start the application httpd instance
-
-# Exit on any errors
-set -e
 
 function print_help {
     echo "Usage: $0 app-name namespace uuid"

--- a/cartridges/openshift-origin-cartridge-jbosseap/hooks/set-jboss-cluster
+++ b/cartridges/openshift-origin-cartridge-jbosseap/hooks/set-jboss-cluster
@@ -1,7 +1,4 @@
-#!/bin/bash
-
-# Exit on any errors
-set -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 

--- a/cartridges/openshift-origin-cartridge-jbosseap/hooks/set-jboss-remoting
+++ b/cartridges/openshift-origin-cartridge-jbosseap/hooks/set-jboss-remoting
@@ -1,9 +1,6 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 # Adds a gear to the haproxy configuration.
-
-# Exit on any errors
-set -e
 
 list=
 kvargs=$(echo "${@:4}" | tr -d "\n" )

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/build
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/build
@@ -1,5 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/bash -eu
 
 source ${OPENSHIFT_JBOSSEWS_DIR}/bin/util
 source $OPENSHIFT_CARTRIDGE_SDK_BASH

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/control
@@ -1,5 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source ${OPENSHIFT_JBOSSEWS_DIR}/bin/util

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/deploy
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/deploy
@@ -1,6 +1,4 @@
-#!/bin/bash
-set -e
-set -x
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source ${OPENSHIFT_JBOSSEWS_DIR}/bin/util

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/install
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 case "$1" in
   -v|--version)

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/setup
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 case "$1" in
   -v|--version)

--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/control
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 

--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/install
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 

--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/setup
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 # Create additional directories required by JENKINS
 mkdir -p ${OPENSHIFT_JENKINS_CLIENT_DIR}/{logs,data}

--- a/cartridges/openshift-origin-cartridge-jenkins-client/bin/teardown
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/bin/teardown
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/bash -eu
+
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 if [ -n "$JENKINS_URL" ]

--- a/cartridges/openshift-origin-cartridge-jenkins/bin/control
+++ b/cartridges/openshift-origin-cartridge-jenkins/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source $OPENSHIFT_JENKINS_DIR/bin/util

--- a/cartridges/openshift-origin-cartridge-jenkins/bin/install
+++ b/cartridges/openshift-origin-cartridge-jenkins/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -eu
 
 case "$1" in
   -v|--version)

--- a/cartridges/openshift-origin-cartridge-jenkins/bin/setup
+++ b/cartridges/openshift-origin-cartridge-jenkins/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 case "$1" in
   -v|--version)

--- a/cartridges/openshift-origin-cartridge-mariadb/bin/control
+++ b/cartridges/openshift-origin-cartridge-mariadb/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_MARIADB_DIR}/lib/mysql_context"

--- a/cartridges/openshift-origin-cartridge-mariadb/bin/install
+++ b/cartridges/openshift-origin-cartridge-mariadb/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_MARIADB_DIR}/lib/mysql_context"

--- a/cartridges/openshift-origin-cartridge-mariadb/bin/setup
+++ b/cartridges/openshift-origin-cartridge-mariadb/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_MARIADB_DIR}/lib/mysql_context"

--- a/cartridges/openshift-origin-cartridge-mariadb/bin/teardown
+++ b/cartridges/openshift-origin-cartridge-mariadb/bin/teardown
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/bash -eu
+
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 rm -rf $OPENSHIFT_LOG_DIR/mariadb.log*

--- a/cartridges/openshift-origin-cartridge-mock-plugin/bin/install
+++ b/cartridges/openshift-origin-cartridge-mock-plugin/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 # Mock cartridge for testing and verifying node platform code. This is
 # not an example of how to write a well-formed cartridge.

--- a/cartridges/openshift-origin-cartridge-mock/bin/install
+++ b/cartridges/openshift-origin-cartridge-mock/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 # Mock cartridge for testing and verifying node platform code. This is
 # not an example of how to write a well-formed cartridge.

--- a/cartridges/openshift-origin-cartridge-mock/bin/setup
+++ b/cartridges/openshift-origin-cartridge-mock/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 # Mock cartridge for testing and verifying node platform code. This is
 # not an example of how to write a well-formed cartridge.

--- a/cartridges/openshift-origin-cartridge-mongodb/bin/control
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/control
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash -eu
+
 source "${OPENSHIFT_MONGODB_DIR}/lib/mongodb_context"
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 export STOPTIMEOUT=20

--- a/cartridges/openshift-origin-cartridge-mongodb/bin/install
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 case "$1" in
   -v|--version)

--- a/cartridges/openshift-origin-cartridge-mongodb/bin/setup
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/setup
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash -eu
+
 source "${OPENSHIFT_MONGODB_DIR}/lib/mongodb_context"
 
 mkdir -p $OPENSHIFT_MONGODB_DIR/{pid,socket,data,run}

--- a/cartridges/openshift-origin-cartridge-mongodb/bin/teardown
+++ b/cartridges/openshift-origin-cartridge-mongodb/bin/teardown
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/bash -eu
+
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 rm -rf $OPENSHIFT_LOG_DIR/mongodb.log*

--- a/cartridges/openshift-origin-cartridge-mysql/bin/control
+++ b/cartridges/openshift-origin-cartridge-mysql/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_MYSQL_DIR}/lib/mysql_context"

--- a/cartridges/openshift-origin-cartridge-mysql/bin/install
+++ b/cartridges/openshift-origin-cartridge-mysql/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -ue
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_MYSQL_DIR}/lib/mysql_context"

--- a/cartridges/openshift-origin-cartridge-mysql/bin/setup
+++ b/cartridges/openshift-origin-cartridge-mysql/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_MYSQL_DIR}/lib/mysql_context"

--- a/cartridges/openshift-origin-cartridge-mysql/bin/teardown
+++ b/cartridges/openshift-origin-cartridge-mysql/bin/teardown
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/bash -eu
+
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 rm -rf $OPENSHIFT_LOG_DIR/mysql.log*

--- a/cartridges/openshift-origin-cartridge-nodejs/bin/control
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 # Source utility functions.
 source $OPENSHIFT_CARTRIDGE_SDK_BASH

--- a/cartridges/openshift-origin-cartridge-nodejs/bin/install
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/install
@@ -1,5 +1,4 @@
-#!/bin/bash
-#set -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_NODEJS_DIR}/lib/util"

--- a/cartridges/openshift-origin-cartridge-nodejs/bin/setup
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 case "$1" in
   -v|--version)
@@ -7,9 +7,8 @@ esac
 
 # Parse arguments
 source "${OPENSHIFT_NODEJS_DIR}/lib/util"
+set +u
 parse_args $@
-
-# Don't set -u until after the above arg parsing is complete
 set -u
 
 # Copy the version specific files to nodejs directory

--- a/cartridges/openshift-origin-cartridge-perl/bin/control
+++ b/cartridges/openshift-origin-cartridge-perl/bin/control
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash -eu
+
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source ${OPENSHIFT_PERL_DIR}usr/lib/perl_config
 

--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source ${OPENSHIFT_PHP_DIR}usr/lib/php_config
 

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/bin/control
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/bin/install
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 if [[ -d /usr/lib64 ]]; then
   _libdir=/usr/lib64

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/bin/setup
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 case "$1" in
   -v|--version)

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/bin/teardown
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/bin/teardown
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/bash -eu
+
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 rm -rf $OPENSHIFT_LOG_DIR/phpmyadmin.log*

--- a/cartridges/openshift-origin-cartridge-postgresql/bin/control
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash -ue
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_POSTGRESQL_DIR}/lib/util"

--- a/cartridges/openshift-origin-cartridge-postgresql/bin/install
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -ue
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_POSTGRESQL_DIR}/lib/util"

--- a/cartridges/openshift-origin-cartridge-postgresql/bin/setup
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/bash -ue
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_POSTGRESQL_DIR}/lib/util"

--- a/cartridges/openshift-origin-cartridge-postgresql/bin/teardown
+++ b/cartridges/openshift-origin-cartridge-postgresql/bin/teardown
@@ -1,4 +1,4 @@
-#!/bin/bash -ue
+#!/bin/bash -eu
 
 rm -f $OPENSHIFT_HOMEDIR/.psqlrc
 rm -f $OPENSHIFT_HOMEDIR/.pgpass

--- a/cartridges/openshift-origin-cartridge-python/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_PYTHON_DIR}usr/versions/${OPENSHIFT_PYTHON_VERSION}/lib/create-virtenv"

--- a/cartridges/openshift-origin-cartridge-ruby/bin/control
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source "${OPENSHIFT_RUBY_DIR}/lib/util"

--- a/cartridges/openshift-origin-cartridge-ruby/bin/install
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 if [[ -d /usr/lib64 ]]; then
   _libdir=/usr/lib64

--- a/cartridges/openshift-origin-cartridge-ruby/bin/setup
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 

--- a/cartridges/openshift-origin-cartridge-switchyard/bin/control
+++ b/cartridges/openshift-origin-cartridge-switchyard/bin/control
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 

--- a/cartridges/openshift-origin-cartridge-switchyard/bin/install
+++ b/cartridges/openshift-origin-cartridge-switchyard/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 

--- a/cartridges/openshift-origin-cartridge-switchyard/bin/setup
+++ b/cartridges/openshift-origin-cartridge-switchyard/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
@@ -7,4 +7,3 @@ then
       client_error "SwitchYard is only supported for JBoss AS/EAP"
       exit 152
 fi
-

--- a/cartridges/openshift-origin-cartridge-switchyard/bin/teardown
+++ b/cartridges/openshift-origin-cartridge-switchyard/bin/teardown
@@ -1,6 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
 #source $OPENSHIFT_CARTRIDGE_SDK_BASH
 #set_uservars "OPENSHIFT_JBOSS_MODULE_PATH=OPENSHIFT_JBOSS_MODULE_PATH="
 exit 0
-


### PR DESCRIPTION
Turn off debugging level output:
- `set +x' by default
- `set -x' should be explicitely enabled for debugging purposes only

Be more strict, fail on errors:
- `set -e' by default
- `set +e' should be enabled explicitely for a certain sequence of commands only

Be more strict, fail on unset variables:
- `set -u' by default
- `set +u' should be enabled explicitely for a certain sequence of commands only

https://bugzilla.redhat.com/show_bug.cgi?id=1168512

[test] [extended:cartridge]
