### PR TITLE
Unify `-x' shell attribute in cartridge scripts

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/disable-colocated-gears
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/disable-colocated-gears
@@ -4,7 +4,14 @@
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
-set -x
+while getopts 'd' OPTION
+do
+    case $OPTION in
+        d) set -x
+        ;;
+    esac
+done
+
 rm -f /tmp/disable_local*
 exec &> /tmp/disable_local.$$
 

--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/fix_local.sh
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/fix_local.sh
@@ -4,7 +4,14 @@
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
-set -x
+while getopts 'd' OPTION
+do
+    case $OPTION in
+        d) set -x
+        ;;
+    esac
+done
+
 rm -f /tmp/fix_local*
 exec &> /tmp/fix_local.$$
 

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/deploy
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/deploy
@@ -1,9 +1,16 @@
 #!/bin/bash
 set -e
-set -x
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source ${OPENSHIFT_JBOSSEWS_DIR}/bin/util
+
+while getopts 'd' OPTION
+do
+    case $OPTION in
+        d) set -x
+        ;;
+    esac
+done
 
 relink_configs
 

--- a/cartridges/openshift-origin-cartridge-jenkins/bin/install
+++ b/cartridges/openshift-origin-cartridge-jenkins/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 case "$1" in
   -v|--version)
@@ -7,6 +7,14 @@ esac
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source $OPENSHIFT_JENKINS_DIR/bin/util
+
+while getopts 'd' OPTION
+do
+    case $OPTION in
+        d) set -x
+        ;;
+    esac
+done
 
 function generate_ssh_keys {
     mkdir -p ${OPENSHIFT_DATA_DIR}/.ssh/

--- a/cartridges/openshift-origin-cartridge-jenkins/bin/util
+++ b/cartridges/openshift-origin-cartridge-jenkins/bin/util
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 function obfuscate_password {
     local password="$1"


### PR DESCRIPTION
Turn off debugging level output:
- `set +x' by default
- `set -x' should be enabled explicitely for debugging purposes only

Bug 1168512 - https://bugzilla.redhat.com/show_bug.cgi?id=1168512

[test] [extended:cartridge]
