### PR TITLE
routing-daemon: Fix deletion of SSL cert key

### DIFF
--- a/routing-daemon/lib/openshift/routing/models/nginx.rb
+++ b/routing-daemon/lib/openshift/routing/models/nginx.rb
@@ -217,7 +217,7 @@ module OpenShift
       crt = "#{@confdir}/#{URI.escape(alias_str)}.crt"
       key = "#{@confdir}/#{URI.escape(alias_str)}.key"
       File.unlink(crt) if File.exist?(crt)
-      File.unlink(key) if FIle.exist?(key)
+      File.unlink(key) if File.exist?(key)
     end
 
     def update


### PR DESCRIPTION
Fix a typo that prevented the routing daemon's nginx backend from deleting the private key for SSL certs.

This commit fixes bug 1169392.
