### PR TITLE
Fix some oo-admin-ctl-routing-tool issues

### DIFF
--- a/routing-daemon/bin/oo-admin-ctl-routing
+++ b/routing-daemon/bin/oo-admin-ctl-routing
@@ -19,6 +19,8 @@ require 'rubygems'
 require 'logger'
 require 'parseconfig'
 
+DEFAULT_CONF = '/etc/openshift/routing-daemon.conf'
+
 # Initialize the controller lazily, so we initialize it exactly zero
 # times if we never use it and exactly one time if we do use it.
 class LazyLBController
@@ -78,7 +80,7 @@ class LazyLBController
   end
 end
 
-$cfgfile = '/etc/openshift/routing-daemon.conf'
+$cfgfile = DEFAULT_CONF
 if (pos = ARGV.find_index('--config'))
   ARGV.delete_at(pos)
   $cfgfile = ARGV.delete_at(pos)
@@ -100,7 +102,61 @@ argvs = ARGV.inject([[]]) do |args,arg|
 end.select {|argv| not argv.empty?}
 
 if argvs.empty? || ARGV.include?('--help') || ARGV.include?('-h')
-  puts "Usage: #{$0} {list-pools|add-pool <name> [<monitor-name>]|delete-pool <name>|list-routes|list-aliases|list-pool-aliases <pool>|add-alias <pool> <name>|delete-alias <pool> <name>|add-route <pool> <name> <path>|delete-route <pool> <route_name>|list-monitors|create-monitor <name> <path> <up-code>|delete-monitor <name>|list-pool-members <pool>|add-pool-member <pool> <host>:<port>|delete-pool-member <pool> <host>:<port>}"
+  puts <<USAGE
+== Synopsis
+
+oo-admin-ctl-routing: Modify the configuration of the external load-balancer.
+
+This tool requests information from or performs configuration updates to the
+external load-balancer configured in #{DEFAULT_CONF}.
+
+== Usage
+
+oo-admin-ctl-routing COMMAND ; COMMAND ; ...
+
+Available commands:
+
+list-pools
+  List all pools.
+add-pool <name> [<monitor-name>]
+  Create a new pool named <name>, optionally with the specified monitor.
+delete-pool <name>
+  Delete the pool named <name>.
+list-routes
+  List all routes for all pools.
+list-aliases
+  List all aliases for all pools.
+list-pool-aliases <pool>
+  List all aliases for the specified pool.
+add-alias <pool> <name>
+  Add an alias with domain <name> for the specified pool.
+delete-alias <pool> <name>
+  Delete the alias <name> for the specified pool.
+add-route <pool> <name> <path>
+  Add a route with the specified name that maps <path> to <pool>.
+delete-route <pool> <route_name>
+  Delete the specified route from the specified pool.
+list-monitors
+  List all monitors.
+create-monitor <name> <path> <up-code>
+  Create a new monitor with the specified name that queries <path>
+  and expects to receive <up-code> to indicate that the pool is up.
+delete-monitor <name>
+  Delete the specified monitor.
+list-pool-members <pool>
+  List all members of the specified pool.
+add-pool-member <pool> <host>:<port>
+  Add the given member to the specified pool.
+delete-pool-member <pool> <host>:<port>
+  Delete the specified member from the specified pool.
+
+Example:
+
+  oo-admin-ctl-routing list-pools ; list-aliases
+
+Note: Your shell may require you to escape semicolons in order to pass them
+as arguments to the oo-admin-ctl-routing command.
+USAGE
   exit 0
 end
 

--- a/routing-daemon/bin/oo-admin-ctl-routing
+++ b/routing-daemon/bin/oo-admin-ctl-routing
@@ -163,7 +163,12 @@ argvs.each do |argv|
     when 'list-monitors'
       raise ArgumentError.new "Requires no arguments." unless argv.empty?
       puts 'Listing monitors.'
-      puts lb.monitors.join "\n"
+      monitors = lb.monitors
+      if monitors.nil? or monitors.empty?
+        puts 'No monitors found.'
+      else
+        puts monitors.join "\n"
+      end
       # TODO: Extend the LoadBalancerController class with a method that
       # provides additional information about monitors.
 

--- a/routing-daemon/bin/oo-admin-ctl-routing
+++ b/routing-daemon/bin/oo-admin-ctl-routing
@@ -100,7 +100,7 @@ argvs = ARGV.inject([[]]) do |args,arg|
 end.select {|argv| not argv.empty?}
 
 if argvs.empty? || ARGV.include?('--help') || ARGV.include?('-h')
-  puts "Usage: #{$0} {list-pools|add-pool <name> [<monitor-name>]|delete-pool <name>|list-routes|list-pool-aliases <pool>|add-alias <pool> <name>|delete-alias <pool> <name>|add-route <pool> <name> <path>|delete-route <pool> <route_name>|list-monitors|create-monitor <name> <path> <up-code>|delete-monitor <name>|list-pool-members <pool>|add-pool-member <pool> <host>:<port>|delete-pool-member <pool> <host>:<port>}"
+  puts "Usage: #{$0} {list-pools|add-pool <name> [<monitor-name>]|delete-pool <name>|list-routes|list-aliases|list-pool-aliases <pool>|add-alias <pool> <name>|delete-alias <pool> <name>|add-route <pool> <name> <path>|delete-route <pool> <route_name>|list-monitors|create-monitor <name> <path> <up-code>|delete-monitor <name>|list-pool-members <pool>|add-pool-member <pool> <host>:<port>|delete-pool-member <pool> <host>:<port>}"
   exit 0
 end
 
@@ -202,6 +202,17 @@ argvs.each do |argv|
       raise ArgumentError.new "Requires a name and host:port." unless 2 == argv.length
       puts "Deleting pool member #{argv[0]} from pool #{argv[1]}."
       lb.pools[argv[0]].delete_member *argv[1].split(':')
+
+    when 'list-aliases'
+      puts "Listing aliases for all pools."
+      found_aliases = false
+      lb.pools.each do |k,v|
+        v.get_aliases.each do |a|
+          puts "Pool #{k} has alias #{a}."
+          found_aliases = true
+        end
+      end
+      puts 'No aliases found.' unless found_aliases
 
     when 'list-pool-aliases'
       raise ArgumentError.new "Requires an alias name." unless 1 == argv.length

--- a/routing-daemon/bin/oo-admin-ctl-routing
+++ b/routing-daemon/bin/oo-admin-ctl-routing
@@ -100,7 +100,7 @@ argvs = ARGV.inject([[]]) do |args,arg|
 end.select {|argv| not argv.empty?}
 
 if argvs.empty? || ARGV.include?('--help') || ARGV.include?('-h')
-  puts "Usage: #{$0} {list-pools|add-pool <name> [<monitor-name>]|delete-pool <name>|list-routes|add-alias <pool> <name>|delete-alias <pool> <name>|add-route <pool> <name> <path>|delete-route <pool> <route_name>|list-monitors|create-monitor <name> <path> <up-code>|delete-monitor <name>|list-pool-members <pool>|add-pool-member <pool> <host>:<port>|delete-pool-member <pool> <host>:<port>}"
+  puts "Usage: #{$0} {list-pools|add-pool <name> [<monitor-name>]|delete-pool <name>|list-routes|list-pool-aliases <pool>|add-alias <pool> <name>|delete-alias <pool> <name>|add-route <pool> <name> <path>|delete-route <pool> <route_name>|list-monitors|create-monitor <name> <path> <up-code>|delete-monitor <name>|list-pool-members <pool>|add-pool-member <pool> <host>:<port>|delete-pool-member <pool> <host>:<port>}"
   exit 0
 end
 

--- a/routing-daemon/bin/oo-admin-ctl-routing
+++ b/routing-daemon/bin/oo-admin-ctl-routing
@@ -99,10 +99,16 @@ argvs = ARGV.inject([[]]) do |args,arg|
   args
 end.select {|argv| not argv.empty?}
 
+if argvs.empty? || ARGV.include?('--help') || ARGV.include?('-h')
+  puts "Usage: #{$0} {list-pools|add-pool <name> [<monitor-name>]|delete-pool <name>|list-routes|add-alias <pool> <name>|delete-alias <pool> <name>|add-route <pool> <name> <path>|delete-route <pool> <route_name>|list-monitors|create-monitor <name> <path> <up-code>|delete-monitor <name>list-pool-members <pool>|add-pool-member <pool> <host>:<port>|delete-pool-member <pool> <host>:<port>}"
+  exit 0
+end
+
 exitval = 0
 argvs.each do |argv|
   begin
-    case argv.shift
+    arg = argv.shift
+    case arg
     when 'get-job-status'
       raise ArgumentError.new 'Requires a job id.' unless 1 == argv.count
       begin
@@ -214,7 +220,7 @@ argvs.each do |argv|
       lb.pools[argv[0]].delete_alias argv[1]
 
     else
-      raise ArgumentError.new "Usage: #{$0} {list-pools|add-pool <name> [<monitor-name>]|delete-pool <name>|list-routes|add-alias <pool> <name>|delete-alias <pool> <name>|add-route <pool> <name> <path>|delete-route <pool> <route_name>|list-monitors|create-monitor <name> <path> <up-code>|delete-monitor <name>list-pool-members <pool>|add-pool-member <pool> <host>:<port>|delete-pool-member <pool> <host>:<port>}"
+      raise ArgumentError.new "Unrecognized argument: #{arg}.\nUse #{$0} --help for usage."
     end
 
   rescue => e

--- a/routing-daemon/bin/oo-admin-ctl-routing
+++ b/routing-daemon/bin/oo-admin-ctl-routing
@@ -100,7 +100,7 @@ argvs = ARGV.inject([[]]) do |args,arg|
 end.select {|argv| not argv.empty?}
 
 if argvs.empty? || ARGV.include?('--help') || ARGV.include?('-h')
-  puts "Usage: #{$0} {list-pools|add-pool <name> [<monitor-name>]|delete-pool <name>|list-routes|add-alias <pool> <name>|delete-alias <pool> <name>|add-route <pool> <name> <path>|delete-route <pool> <route_name>|list-monitors|create-monitor <name> <path> <up-code>|delete-monitor <name>list-pool-members <pool>|add-pool-member <pool> <host>:<port>|delete-pool-member <pool> <host>:<port>}"
+  puts "Usage: #{$0} {list-pools|add-pool <name> [<monitor-name>]|delete-pool <name>|list-routes|add-alias <pool> <name>|delete-alias <pool> <name>|add-route <pool> <name> <path>|delete-route <pool> <route_name>|list-monitors|create-monitor <name> <path> <up-code>|delete-monitor <name>|list-pool-members <pool>|add-pool-member <pool> <host>:<port>|delete-pool-member <pool> <host>:<port>}"
   exit 0
 end
 


### PR DESCRIPTION
##### `oo-admin-ctl-routing`: Print usage with no args

Print usage information and exit with exit code 0 if no arguments are provided or if `-h` or `--help` is provided.

If an unrecognized argument is provided, print out the offending argument and advise to run `oo-admin-ctl-routing` with the `--help` argument.

This commit fixes part 1 of bug 1169424.
##### `oo-admin-ctl-routing` usage info: Add missing `|`

Add a missing `|` delimiter between `delete-monitor` and `list-pool-members` in the usage information.

This commit fixes part 2 of bug 1169424.
##### `oo-admin-ctl-routing`: Fix `list-monitors`

Make `oo-admin-ctl-routing` properly handle the case where the routing daemon's backend returns nil when the list of monitors is requested.

This commit fixes part 3 of bug 1169424.
##### `oo-admin-ctl-routing`: Add `list-pool-aliases` usage

Add `list-pool-aliases` to the usage information for `oo-admin-ctl-routing`.

This commit addresses part 4 of bug 1169424.
##### `oo-admin-ctl-routing`: Add `list-aliases`

Add the `list-aliases` subcommand to `oo-admin-ctl-routing` to list all aliases of all pools.

This commit addresses part 4 of bug 1169424.
##### `oo-admin-ctl-routing`: Better usage output

Reformat the usage output for `oo-admin-ctl-user` to make it easier to read and more complete.
