### PR TITLE
Bug 1163893 - Encode artifact url for app deployments

### DIFF
--- a/broker/test/functional/deployments_controller_test.rb
+++ b/broker/test/functional/deployments_controller_test.rb
@@ -96,7 +96,7 @@ class DeploymentsControllerTest < ActionController::TestCase
     @domain.members.find(@user).role = :edit
     @domain.save; @domain.run_jobs
 
-    supported_artifact_urls = ["http://localhost/test1.tgz", "http://localhost/test2.tar.gz", "https://localhost/test3.tgz", "https://localhost/test4.tar.gz", "ftp://localhost/test5.tgz", "ftp://localhost/test6.tar.gz"]
+    supported_artifact_urls = ["http://localhost/test1.tgz", "http://localhost/test2.tar.gz", "https://localhost/test3.tgz", "https://localhost/test4.tar.gz", "ftp://localhost/test5.tgz", "ftp://localhost/test6.tar.gz", "http://localhost/{558F2532-1116}/test.tgz", "https://localhost/url with space/test7.tgz"]
     unsupported_artifact_urls = ["badurl1/test7.tgz", "notreal://localhost/test8.tgz", "http://localhost/test9.txt", "https://localhost/test10.txt", "http://localhost/test11", "test12", "-1", '!@#!@#@!#!', "not a url", '$%*!&#@!&#!)*#@!DAZSXCAS#R@#_@(_$*%)@*)#@*$_#@i[sadfsa]ew34122]\safdsa|xczxcz', '&^#$%!CSCA#@$#@FDS', "http://localhost/test13.tar", "http://somehost/test14.gz"]
 
     supported_artifact_urls.each { |test_url|
@@ -113,7 +113,7 @@ class DeploymentsControllerTest < ActionController::TestCase
       json          = JSON.parse(response.body)
       message       = json["messages"][0]
       msg_exit_code = -1
-      msg_test      = "Invalid Binary Artifact URL(#{test_url})"
+      msg_test      = "Invalid Binary Artifact URL(#{URI::encode(test_url)})"
       assert_equal msg_test, message["text"]
       assert_equal msg_exit_code, message["exit_code"]
     }


### PR DESCRIPTION
Artifact url that contains special chars will be encoded and passed by
the user. By the time it reaches rails controller all params (including artifact url)
will be decoded and any subsuquent url parsing or retrieval using curl will fail.
This fix will encode the url again after apache/rails decoding to overcome the
limitation.
