### PR TITLE
Enable APC opcode cache by default

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/usr/5.4/etc/php.d/apc.ini.erb
+++ b/cartridges/openshift-origin-cartridge-php/usr/5.4/etc/php.d/apc.ini.erb
@@ -7,7 +7,7 @@ extension = apc.so
 
 ; This can be set to enable the APC opcode cache
 ; Don't set this option if another opcode cache is enabled
-apc.enable_opcode_cache=0
+apc.enable_opcode_cache=1
 
 ; This can be set to 0 to disable APC. 
 apc.enabled=1


### PR DESCRIPTION
APC opcode cache is disabled by default now.  Enable it.
