### PR TITLE
Add zend opcache template to enable it

### DIFF
--- a/cartridges/dependencies/openshift-origin-cartridge-dependencies.spec
+++ b/cartridges/dependencies/openshift-origin-cartridge-dependencies.spec
@@ -301,6 +301,7 @@ Conflicts: php-pecl-apcu
 Requires:  php-pecl-imagick
 Requires:  php-pecl-memcache
 Requires:  php-pecl-xdebug
+Requires:  php-pecl-opcache
 Requires:  php-process
 Requires:  php-soap
 Requires:  php-xml
@@ -320,6 +321,7 @@ Conflicts: php54-php-pecl-apcu
 Requires:  php54-php-pecl-imagick
 Requires:  php54-php-pecl-memcache
 Requires:  php54-php-pecl-xdebug
+Requires:  php54-php-pecl-zendopcache
 Requires:  php54-php-process
 Requires:  php54-php-soap
 Requires:  php54-php-xml

--- a/cartridges/openshift-origin-cartridge-php/usr/5.4/etc/php.d/opcache.ini.erb
+++ b/cartridges/openshift-origin-cartridge-php/usr/5.4/etc/php.d/opcache.ini.erb
@@ -1,5 +1,5 @@
 ; Enable Zend OPcache extension module
-<%= (ENV['OPENSHIFT_PHP_ZEND_ENABLED'] == "true") ? "" : ";" %>zend_extension=/opt/rh/php54/root/usr/lib64/php/modules/opcache.so
+<%= (ENV['OPENSHIFT_PHP_OPCACHE_ENABLED'] == "true") ? "" : ";" %>zend_extension=/opt/rh/php54/root/usr/lib64/php/modules/opcache.so
 
 ; Determines if Zend OPCache is enabled
 opcache.enable=1
@@ -8,7 +8,7 @@ opcache.enable=1
 ;opcache.enable_cli=0
 
 ; The OPcache shared memory storage size.
-opcache.memory_consumption=128
+opcache.memory_consumption=<%= (ENV['OPENSHIFT_PHP_OPCACHE_SHM_SIZE'] =~ /^[0-9]+[MG]$/) ? ENV['OPENSHIFT_PHP_OPCACHE_SHM_SIZE'] : ((ENV['OPENSHIFT_GEAR_MEMORY_MB'].to_i/8).to_i.to_s+"M") %>
 
 ; The amount of memory for interned strings in Mbytes.
 opcache.interned_strings_buffer=8
@@ -67,7 +67,7 @@ opcache.blacklist_filename=/opt/rh/php54/root/etc/php.d/opcache*.blacklist
 
 ; Allows exclusion of large files from being cached. By default all files
 ; are cached.
-;opcache.max_file_size=0
+;opcache.max_file_size=1M
 
 ; Check the cache checksum each N requests.
 ; The default value of "0" means that the checks are disabled.

--- a/cartridges/openshift-origin-cartridge-php/usr/5.4/etc/php.d/opcache.ini.erb
+++ b/cartridges/openshift-origin-cartridge-php/usr/5.4/etc/php.d/opcache.ini.erb
@@ -1,0 +1,95 @@
+; Enable Zend OPcache extension module
+<%= (ENV['OPENSHIFT_PHP_ZEND_ENABLED'] == "true") ? "" : ";" %>zend_extension=/opt/rh/php54/root/usr/lib64/php/modules/opcache.so
+
+; Determines if Zend OPCache is enabled
+opcache.enable=1
+
+; Determines if Zend OPCache is enabled for the CLI version of PHP
+;opcache.enable_cli=0
+
+; The OPcache shared memory storage size.
+opcache.memory_consumption=128
+
+; The amount of memory for interned strings in Mbytes.
+opcache.interned_strings_buffer=8
+
+; The maximum number of keys (scripts) in the OPcache hash table.
+; Only numbers between 200 and 100000 are allowed.
+opcache.max_accelerated_files=4000
+
+; The maximum percentage of "wasted" memory until a restart is scheduled.
+;opcache.max_wasted_percentage=5
+
+; When this directive is enabled, the OPcache appends the current working
+; directory to the script key, thus eliminating possible collisions between
+; files with the same name (basename). Disabling the directive improves
+; performance, but may break existing applications.
+;opcache.use_cwd=1
+
+; When disabled, you must reset the OPcache manually or restart the
+; webserver for changes to the filesystem to take effect.
+;opcache.validate_timestamps=1
+
+; How often (in seconds) to check file timestamps for changes to the shared
+; memory storage allocation. ("1" means validate once per second, but only
+; once per request. "0" means always validate)
+;opcache.revalidate_freq=2
+
+; Enables or disables file search in include_path optimization
+;opcache.revalidate_path=0
+
+; If disabled, all PHPDoc comments are dropped from the code to reduce the
+ ;size of the optimized code.
+;opcache.save_comments=1
+
+; If disabled, PHPDoc comments are not loaded from SHM, so "Doc Comments"
+; may be always stored (save_comments=1), but not loaded by applications
+; that don't need them anyway.
+;opcache.load_comments=1
+
+; If enabled, a fast shutdown sequence is used for the accelerated code
+opcache.fast_shutdown=1
+
+; Allow file existence override (file_exists, etc.) performance feature.
+;opcache.enable_file_override=0
+
+; A bitmask, where each bit enables or disables the appropriate OPcache
+; passes
+;opcache.optimization_level=0xffffffff
+
+;opcache.inherited_hack=1
+;opcache.dups_fix=0
+
+; The location of the OPcache blacklist file (wildcards allowed).
+; Each OPcache blacklist file is a text file that holds the names of files
+; that should not be accelerated.
+opcache.blacklist_filename=/opt/rh/php54/root/etc/php.d/opcache*.blacklist
+
+; Allows exclusion of large files from being cached. By default all files
+; are cached.
+;opcache.max_file_size=0
+
+; Check the cache checksum each N requests.
+; The default value of "0" means that the checks are disabled.
+;opcache.consistency_checks=0
+
+; How long to wait (in seconds) for a scheduled restart to begin if the cache
+; is not being accessed.
+;opcache.force_restart_timeout=180
+
+; OPcache error_log file name. Empty string assumes "stderr".
+;opcache.error_log=
+
+; All OPcache errors go to the Web server log.
+; By default, only fatal errors (level 0) or errors (level 1) are logged.
+; You can also enable warnings (level 2), info messages (level 3) or
+; debug messages (level 4).
+;opcache.log_verbosity_level=1
+
+; Preferred Shared Memory back-end. Leave empty and let the system decide.
+;opcache.preferred_memory_model=
+
+; Protect the shared memory from unexpected writing during script execution.
+; Useful for internal debugging only.
+;opcache.protect_memory=0
+

--- a/cartridges/openshift-origin-cartridge-php/usr/5.4/etc/php.d/opcache.ini.erb
+++ b/cartridges/openshift-origin-cartridge-php/usr/5.4/etc/php.d/opcache.ini.erb
@@ -1,5 +1,5 @@
 ; Enable Zend OPcache extension module
-<%= (ENV['OPENSHIFT_PHP_OPCACHE_ENABLED'] == "true") ? "" : ";" %>zend_extension=/opt/rh/php54/root/usr/lib64/php/modules/opcache.so
+zend_extension=/opt/rh/php54/root/usr/lib64/php/modules/opcache.so
 
 ; Determines if Zend OPCache is enabled
 opcache.enable=1
@@ -8,7 +8,7 @@ opcache.enable=1
 ;opcache.enable_cli=0
 
 ; The OPcache shared memory storage size.
-opcache.memory_consumption=<%= (ENV['OPENSHIFT_PHP_OPCACHE_SHM_SIZE'] =~ /^[0-9]+[MG]$/) ? ENV['OPENSHIFT_PHP_OPCACHE_SHM_SIZE'] : ((ENV['OPENSHIFT_GEAR_MEMORY_MB'].to_i/8).to_i.to_s+"M") %>
+opcache.memory_consumption=<%= (ENV['OPENSHIFT_PHP_OPCACHE_MEMORY_CONSUMPTION'] =~ /^[0-9]+[MG]$/) ? ENV['OPENSHIFT_PHP_OPCACHE_MEMORY_CONSUMPTION'] : ((ENV['OPENSHIFT_PHP_OPCACHE_MEMORY_CONSUMPTION'].to_i/8).to_i.to_s+"M") %>
 
 ; The amount of memory for interned strings in Mbytes.
 opcache.interned_strings_buffer=8
@@ -67,7 +67,7 @@ opcache.blacklist_filename=/opt/rh/php54/root/etc/php.d/opcache*.blacklist
 
 ; Allows exclusion of large files from being cached. By default all files
 ; are cached.
-;opcache.max_file_size=1M
+opcache.max_file_size=1M
 
 ; Check the cache checksum each N requests.
 ; The default value of "0" means that the checks are disabled.


### PR DESCRIPTION
Add zend opcache template to enable it. This template is based on the opcache.ini in the php54-php-pecl-zendopcache-7.0.2-4.el6.x86_64.
