### PR TITLE
openshift.ddl: fix gear UUID regexes

### DIFF
--- a/msg-common/agent/openshift.ddl
+++ b/msg-common/agent/openshift.ddl
@@ -263,7 +263,7 @@ action "has_gear", :description => "Does this server contain a specified gear?" 
         :prompt         => "Gear uuid",
         :description    => "Gear uuid",
         :type           => :string,
-        :validation     => '^[a-zA-Z0-9]+$',
+        :validation     => '^[-a-zA-Z0-9]+$',
         :optional       => false,
         :maxlength      => 32
 
@@ -343,7 +343,7 @@ action "get_gear_uid", :description => "Returns uid for the given gear uuid" do
         :prompt         => "Gear uuid",
         :description    => "Gear uuid",
         :type           => :string,
-        :validation     => '^[a-zA-Z0-9]+$',
+        :validation     => '^[-a-zA-Z0-9]+$',
         :optional       => false,
         :maxlength      => 32
 
@@ -397,7 +397,7 @@ action "has_app_cartridge", :description => "Does this application contain the s
         :prompt         => "Gear uuid",
         :description    => "Gear uuid",
         :type           => :string,
-        :validation     => '^[a-zA-Z0-9]+$',
+        :validation     => '^[-a-zA-Z0-9]+$',
         :optional       => false,
         :maxlength      => 32
 
@@ -507,7 +507,7 @@ action "upgrade", :description => "upgrade a gear" do
         :prompt         => "Gear uuid",
         :description    => "Gear uuid",
         :type           => :string,
-        :validation     => '^[a-zA-Z0-9]+$',
+        :validation     => '^[-a-zA-Z0-9]+$',
         :optional       => false,
         :maxlength      => 32
 


### PR DESCRIPTION
Bug 1171002 - Moving gear from non-district node to district node will
fail when set USE_PREDICTABLE_GEAR_UUIDS=true
https://bugzilla.redhat.com/show_bug.cgi?id=1171002
