### PR TITLE
Fix PHP 5.4 Zend OPCache default gear memory consumption

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/usr/5.4/etc/php.d/opcache.ini.erb
+++ b/cartridges/openshift-origin-cartridge-php/usr/5.4/etc/php.d/opcache.ini.erb
@@ -8,7 +8,7 @@ opcache.enable=1
 ;opcache.enable_cli=0
 
 ; The OPcache shared memory storage size.
-opcache.memory_consumption=<%= (ENV['OPENSHIFT_PHP_OPCACHE_MEMORY_CONSUMPTION'] =~ /^[0-9]+[MG]$/) ? ENV['OPENSHIFT_PHP_OPCACHE_MEMORY_CONSUMPTION'] : ((ENV['OPENSHIFT_PHP_OPCACHE_MEMORY_CONSUMPTION'].to_i/8).to_i.to_s+"M") %>
+opcache.memory_consumption=<%= (ENV['OPENSHIFT_PHP_OPCACHE_MEMORY_CONSUMPTION'] =~ /^[0-9]+[MG]$/) ? ENV['OPENSHIFT_PHP_OPCACHE_MEMORY_CONSUMPTION'] : ((ENV['OPENSHIFT_GEAR_MEMORY_MB'].to_i/8).to_i.to_s+"M") %>
 
 ; The amount of memory for interned strings in Mbytes.
 opcache.interned_strings_buffer=8


### PR DESCRIPTION
@nak3 fyi, fixing typo

Should have been same logic as in https://github.com/openshift/origin-server/blob/master/cartridges/openshift-origin-cartridge-php/usr/5.4/etc/php.d/opcache.ini.erb#L11.

[merge]
