### PR TITLE
BUG 1171066: disable_auto_scaling marker requires restart of haproxy cartridge

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/bin/control
+++ b/cartridges/openshift-origin-cartridge-haproxy/bin/control
@@ -60,10 +60,20 @@ function _stop_haproxy_ctld() {
 function _start_haproxy_ctld() {
     # Start auto-scaling only on the head-gear
     [ "${OPENSHIFT_GEAR_DNS}" != "${OPENSHIFT_APP_DNS}" ] && return 0
-    disable_as="${OPENSHIFT_REPO_DIR}/.openshift/markers/disable_auto_scaling"
-    [ -f "$disable_as" ]  &&  return 0
+    if [ -f "${OPENSHIFT_REPO_DIR}/.openshift/markers/disable_auto_scaling" ];then
+        print_disable_as_marker_notice
+        return 0
+    fi
     _stop_haproxy_ctld  ||  :
     nohup haproxy_ctld |& /usr/bin/logshifter -tag haproxy_ctld &
+}
+
+function print_disable_as_marker_notice() {
+    echo "NOTE: The 'disable_auto_scaling' marker has been detected in your application."
+    echo "NOTE: Please notice that if this is the first time you are using this marker in this"
+    echo "NOTE: application, you need to restart the HAProxy cartridge or the whole application "
+    echo "NOTE: manually, so the HAProxy cartridge can pick up the changes."
+
 }
 
 function _launch_haproxy_bg() {
@@ -108,6 +118,7 @@ function _start_haproxy_service() {
         wait_to_start
     else
         echo "HAProxy already running" 1>&2
+        [ -f "${OPENSHIFT_REPO_DIR}/.openshift/markers/disable_auto_scaling" ] && print_disable_as_marker_notice
         wait_to_start
         # support auto reloading of this action hook on git push
         if [ -x "$OPENSHIFT_REPO_DIR/.openshift/action_hooks/haproxy_ctld.rb" ]; then

--- a/documentation/oo_user_guide.adoc
+++ b/documentation/oo_user_guide.adoc
@@ -1367,6 +1367,13 @@ $ git commit -am "remove automatic scaling"
 $ git push
 ----
 
+After pushing the changes to the remote repository, you will need to restart the HAProxy cartridge, or the whole application. This applies only for the time you add the marker, so the HAProxy can pick up the changes. To restart the HAProxy cartridge you will need to SSH into the gear, run the _gear restart_ script and select the HAProxy cartridge. 
+To restart the whole application run:
+
+----
+$ rhc app-restart [AppName]
+----
+
 To add a new gear to your application, SSH to your application gear with the following command replacing the contents with the correct information for your application.
 
 ----


### PR DESCRIPTION
Updating the documentation for the HAProxy disable_auto_scaling marker, cause the cartridge needs to be restarted after the marker is added + adding an banner that warns user of the presence of the marker
