### PR TITLE
[TO_STAGE] Bug 1171289 - background pkill command in OOMPlugin

### DIFF
--- a/node-util/conf/watchman/plugins.d/oom_plugin.rb
+++ b/node-util/conf/watchman/plugins.d/oom_plugin.rb
@@ -22,8 +22,6 @@ require 'openshift-origin-node/utils/cgroups'
 require 'openshift-origin-node/utils/cgroups/libcgroup'
 require 'openshift-origin-node/model/application_container'
 
-OP_TIMEOUT=360
-
 # Provide Watchman with monitoring of CGroups resource killing of gears
 class OomPlugin < OpenShift::Runtime::WatchmanPlugin
   PLUGIN_NAME    = 'OOM Plugin'
@@ -107,19 +105,22 @@ class OomPlugin < OpenShift::Runtime::WatchmanPlugin
         # Verify that we are ready to reset to the old limit
         current = try_cgfetch(cgroup, MEMSW_USAGE)[MEMSW_USAGE].to_i
         increased = orig_memsw_limit
-        app = OpenShift::Runtime::ApplicationContainer.from_uuid(uuid)
-        while (current >= restore_memsw_limit or current == 0) && retries > 0
+        while (current >= restore_memsw_limit or current == 0 or oom_control['under_oom'] == '1') && retries > 0
           # Increase limit by 10% in order to clean up processes. Trying to
           # restart a gear already at its memory limit is treacherous.
           increased = (increased * @memsw_multiplier).round(0)
           Syslog.info %Q(#{PLUGIN_NAME}: Increasing memory for gear #{uuid} to #{increased} and killing processes)
-          app.kill_procs()
+          # We need to background and detach this pkill command, because it
+          # will usually hang until the memsw limit is bumped.
+          pid = Kernel.spawn("pkill -9 -u #{uuid}")
+          Process.detach(pid)
           if not try_cgstore(cgroup, MEMSW_LIMIT, increased)
             Syslog.warning %Q(#{PLUGIN_NAME}: Failed to increase memsw limit for gear #{uuid})
           end
           sleep @stop_wait_seconds
           retries -= 1
           current = try_cgfetch(cgroup, MEMSW_USAGE)[MEMSW_USAGE].to_i
+          oom_control = try_cgfetch(cgroup, 'memory.oom_control')['memory.oom_control']
         end
       rescue Exception => e
         Syslog.warning %Q(#{PLUGIN_NAME}: exception in OOM handling: #{e})


### PR DESCRIPTION
There are two significant fixes here:

1) Instead of using ApplicationContainer.kill_procs, which waits for pkill/pgrep process to return, we simply spawn a pkill and detach it, because we don't actually care about its return code, and we cannot wait for it.

2) The while loop runs when oom_control['under_oom'] is 1, even if the memory usage indicates that the cgroup has fallen below its memsw limit.
