### PR TITLE
Remove duplicate call to pre_start_httpd_config

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -46,9 +46,9 @@ function reload() {
 
 function restart() {
     echo "Restarting PHP ${OPENSHIFT_PHP_VERSION} cartridge (Apache+mod_php)"
-    pre_start_httpd_config
     ensure_httpd_restart_succeed "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     if [ -f "$HTTPD_PID_FILE" ]; then
+        pre_start_httpd_config
         httpd_pid=`cat "$HTTPD_PID_FILE" 2> /dev/null`
         kill -HUP $httpd_pid
     else


### PR DESCRIPTION
'pre_start_httpd_config' is already called from 'start' in the else clause

[test] [extended:cartridge]
