### PR TITLE
PHP 5.3/5.4: Fix loading Zend Extension PECLs

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -144,7 +144,7 @@ function build() {
         local composer_lock_msg="\nPlease, consider committing the composer.lock file into your repository:\n"
         composer_lock_msg+=" $ rhc scp ${OPENSHIFT_APP_NAME} download ./ app-root/repo/composer.lock\n"
         composer_lock_msg+=" $ git add composer.lock && git commit -am'Lock specific set of Composer dependencies'\n"
-        if [ "$APPLICATION_ENV" != "development" ]; then
+        if [ "${APPLICATION_ENV:-}" != "development" ]; then
             # Production
             echo -n "Checking composer.json for Composer dependency... "
             if [ -f ${OPENSHIFT_REPO_DIR}composer.json ]; then

--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -36,8 +36,20 @@ function start() {
     return $?
 }
 
+# Explicitely stop and start instead of reload/restart, until the
+# https://bugzilla.redhat.com/show_bug.cgi?id=1173796 is fixed (segfault)
+function bug_1173796() {
+    # PHP 5.4 + Zend OPCache enabled?
+    if [[ "$OPENSHIFT_PHP_VERSION" == "5.4" && -n "$(php_context 'php -m' | grep -i opcache)" ]]; then
+        stop
+        start
+        exit $?
+    fi
+}
+
 function reload() {
     echo "Reloading PHP ${OPENSHIFT_PHP_VERSION} cartridge (Apache+mod_php)"
+    bug_1173796
     pre_start_httpd_config
     httpd_pid=`cat "$HTTPD_PID_FILE" 2> /dev/null`
     kill -USR1 $httpd_pid && wait_for_pid_file $HTTPD_PID_FILE
@@ -46,6 +58,7 @@ function reload() {
 
 function restart() {
     echo "Restarting PHP ${OPENSHIFT_PHP_VERSION} cartridge (Apache+mod_php)"
+    bug_1173796
     ensure_httpd_restart_succeed "$HTTPD_PID_FILE" "$HTTPD_CFG_FILE"
     if [ -f "$HTTPD_PID_FILE" ]; then
         pre_start_httpd_config

--- a/cartridges/openshift-origin-cartridge-php/usr/5.3/etc/php.d/xdebug.ini.erb
+++ b/cartridges/openshift-origin-cartridge-php/usr/5.3/etc/php.d/xdebug.ini.erb
@@ -1,3 +1,3 @@
 ; Enable xdebug extension module
-<%= (ENV['OPENSHIFT_PHP_XDEBUG_ENABLED'] == "true" || (ENV['OPENSHIFT_PHP_XDEBUG_ENABLED'] != "false" && ENV['APPLICATION_ENV'] == "development")) ? "" : ";" %>zend_extension=/usr/lib64/php/modules/xdebug.so
+zend_extension=/usr/lib64/php/modules/xdebug.so
 xdebug.max_nesting_level = 200

--- a/cartridges/openshift-origin-cartridge-php/usr/5.4/etc/php.d/xdebug.ini.erb
+++ b/cartridges/openshift-origin-cartridge-php/usr/5.4/etc/php.d/xdebug.ini.erb
@@ -1,5 +1,5 @@
 ; Enable xdebug extension module
-<%= (ENV['OPENSHIFT_PHP_XDEBUG_ENABLED'] == "true" || (ENV['OPENSHIFT_PHP_XDEBUG_ENABLED'] != "false" && ENV['APPLICATION_ENV'] == "development")) ? "" : ";" %>zend_extension=/opt/rh/php54/root/usr/lib64/php/modules/xdebug.so
+zend_extension=/opt/rh/php54/root/usr/lib64/php/modules/xdebug.so
 xdebug.max_nesting_level = 200
 
 ; see http://xdebug.org/docs/all_settings

--- a/cartridges/openshift-origin-cartridge-php/usr/lib/php_config
+++ b/cartridges/openshift-origin-cartridge-php/usr/lib/php_config
@@ -28,6 +28,11 @@ function enable_modules {
     local module=
     local modvar=
 
+    # Disable Xdebug in production by default, if not already enabled
+    if [[ "${APPLICATION_ENV:-}" != "development" ]]; then
+        OPENSHIFT_PHP_XDEBUG_ENABLED=${OPENSHIFT_PHP_XDEBUG_ENABLED:-false}
+    fi
+
     # Generate OpenShift php.ini
     oo-erb ${phprc} > ${PHPRC}
 

--- a/cartridges/openshift-origin-cartridge-php/usr/lib/php_config.
+++ b/cartridges/openshift-origin-cartridge-php/usr/lib/php_config.
@@ -51,24 +51,24 @@ function enable_modules {
 
         # Is module disabled via ENV VAR?
         modvar="OPENSHIFT_PHP_${module^^}_ENABLED"
-        if [[ "${!modvar,,}" == "false" ]]; then
-            [ -n "${DEBUG:-}" ] && printf "%14s disabled via %s=false, ignoring %s\n" "$module" "\$OPENSHIFT_PHP_${module^^}_ENABLED" "$file"
+        if [ "${!modvar,,}" == "false" ]; then
+            [ "${DEBUG:-}" = true ] && printf "%14s disabled via %s=false, ignoring %s\n" "$module" "\$OPENSHIFT_PHP_${module^^}_ENABLED" "$file"
             continue
         fi
 
         # Is module already loaded (from the path with higher priority)?
         if [ -n "${modules[$module]:-}" ]; then
-            [ -n "${DEBUG:-}" ] && printf "%14s already enabled, ignoring %s\n" "$module" "$file"
+            [ "${DEBUG:-}" = true ] && printf "%14s already enabled, ignoring %s\n" "$module" "$file"
             continue
         fi
 
         # Save module for later reference and put its configuration into openshift.ini
         modules[$module]=$file
         if [[ $file == *\.erb ]]; then
-            [ -n "${DEBUG:-}" ] && printf "%14s enabled, loading from %s (erb-processed)\n" "$module" "$file"
+            [ "${DEBUG:-}" = true ] && printf "%14s enabled, loading from %s (erb-processed)\n" "$module" "$file"
             oo-erb $file >> ${PHP_INI_SCAN_DIR}/openshift.ini
         else
-            [ -n "${DEBUG:-}" ] && printf "%14s enabled, loading from %s\n" "$module" "$file"
+            [ "${DEBUG:-}" = true ] && printf "%14s enabled, loading from %s\n" "$module" "$file"
             cat $file >> ${PHP_INI_SCAN_DIR}/openshift.ini
         fi
     done
@@ -81,7 +81,7 @@ function enable_modules {
     while read line; do
         # Did we hit a .so library loading error?
         if [[ ! "$line" == *"cannot open shared object file: No such file or directory"* ]]; then
-            [ -n "${DEBUG:-}" ] && printf "Skipping unknown error: %s\n" "$line"
+            [ "${DEBUG:-}" = true ] && printf "Skipping unknown error: %s\n" "$line"
             continue
         fi
 
@@ -94,17 +94,17 @@ function enable_modules {
         # Did we load the module that caused the error? If yes, put it to failed_modules
         if [ -n "${modules[$module]:-}" ]; then
             file="${modules[$module]:-}"
-            [ -n "${DEBUG:-}" ] && printf "%14s to be disabled for PHP Warnings, it failed to be loaded (RPM not installed?)\n" "$module"
+            [ "${DEBUG:-}" = true ] && printf "%14s to be disabled for PHP Warnings, it failed to be loaded (RPM not installed?)\n" "$module"
             failed_modules+=("$module")
         else
-            [ -n "${DEBUG:-}" ] && printf "%14s failed to be disabled, can't remember loading that module\n" "$module"
+            [ "${DEBUG:-}" = true ] && printf "%14s failed to be disabled, can't remember loading that module\n" "$module"
         fi
     done < <(php_context "php -m" 2>&1 1>/dev/null)
 
     # Disable modules that caused the errors at once
     if [ ${#failed_modules[@]} -gt 0 ]; then
         tmpfile=$(mktemp)
-        [ -n "${DEBUG:-}" ] && local IFS=',' && printf "%14s => disabling %s modules in openshift.ini\n" "" "${failed_modules[*]}"
+        [ "${DEBUG:-}" = true ] && local IFS=',' && printf "%14s => disabling %s modules in openshift.ini\n" "" "${failed_modules[*]}"
         local IFS='|'
         sed -r 's/(.*[ =/]('"${failed_modules[*]}"')\.so)/;**DISABLED by OpenShift runtime** \1/g' ${PHP_INI_SCAN_DIR}/openshift.ini > $tmpfile
         cat $tmpfile > ${PHP_INI_SCAN_DIR}/openshift.ini


### PR DESCRIPTION
@dobbymoodge review pls. Could you run you performance tests from https://github.com/openshift/origin-server/pull/5307 as well?

```
1. Move Xdebug enabling/disabling logic to enable_modules

2. Refactor PHP enable_modules to support Zend Extensions

    Do not use dl() function for testing the shared libraries:
    - It can't load Zend Extensions (xdebug, opcache etc.)
    - It doesn't handle PHP Extension dependency
    - The function has been disabled from some SAPIs in upstream

    Add debugging and verbose messages for enable_modules logic:
        DEBUG=true ./php/bin/control restart

    Related:
    - Bug 1082963 - https://bugzilla.redhat.com/show_bug.cgi?id=1082963
    - Commit 02b8866be70322f4a0c0ac255479c0871e0fa4fb
```

[test] [extended:cartridge]
