### PR TITLE
oo-accept-broker: testrecord DNS w/absolute domain

### DIFF
--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -826,19 +826,19 @@ function check_dns_bind() {
     dns_bind_update_record ${APP_VALUES[DNS_AUTH]} ${APP_VALUES[DNS_SERVER]} "${APP_VALUES[DNS_KEYNAME]}" "${APP_VALUES[DNS_KEYVAL]}" "${APP_VALUES[DNS_KEYALGORITHM]}" "${APP_VALUES[DNS_KRB_KEYTAB]}" "${APP_VALUES[DNS_KRB_PRINCIPAL]}" add txt testrecord.${APP_VALUES[DNS_SUFFIX]} this_is_a_test
 
     # verify that the record is there
-    if host -t txt testrecord.${APP_VALUES[DNS_SUFFIX]} ${APP_VALUES[DNS_SERVER]} >/dev/null
+    if host -t txt testrecord.${APP_VALUES[DNS_SUFFIX]}. ${APP_VALUES[DNS_SERVER]} >/dev/null
     then
         verbose "txt record successfully added"
     else
-        fail "txt record testrecord.${APP_VALUES[DNS_SUFFIX]} does not resolve on server ${APP_VALUES[DNS_SERVER]}"
+        fail "txt record testrecord.${APP_VALUES[DNS_SUFFIX]}. does not resolve on server ${APP_VALUES[DNS_SERVER]}"
     fi
 
     # remove it.
     dns_bind_update_record ${APP_VALUES[DNS_AUTH]} ${APP_VALUES[DNS_SERVER]} "${APP_VALUES[DNS_KEYNAME]}" "${APP_VALUES[DNS_KEYVAL]}" "${APP_VALUES[DNS_KEYALGORITHM]}" "${APP_VALUES[DNS_KRB_KEYTAB]}" "${APP_VALUES[DNS_KRB_PRINCIPAL]}" delete txt testrecord.${APP_VALUES[DNS_SUFFIX]} 
     # verify that the record is removed
-    if host -t txt testrecord.${APP_VALUES[DNS_SUFFIX]} ${APP_VALUES[DNS_SERVER]} >/dev/null
+    if host -t txt testrecord.${APP_VALUES[DNS_SUFFIX]}. ${APP_VALUES[DNS_SERVER]} >/dev/null
     then
-        fail "txt record testrecord.${APP_VALUES[DNS_SUFFIX]} still resolves on server ${APP_VALUES[DNS_SERVER]}"
+        fail "txt record testrecord.${APP_VALUES[DNS_SUFFIX]}. still resolves on server ${APP_VALUES[DNS_SERVER]}"
     else
         verbose "txt record successfully deleted"
     fi


### PR DESCRIPTION
Bug 1172495 - oo-accept-broker should look for testrecord DNS with absolute domain
https://bugzilla.redhat.com/show_bug.cgi?id=1172495
