### PR TITLE
Node: create tuned-profiles-openshift-node

### DIFF
--- a/rel-eng/packages/tuned-profiles-openshift-node
+++ b/rel-eng/packages/tuned-profiles-openshift-node
@@ -1,0 +1,1 @@
+0.1.0-1 tune-profiles/openshift-node/

--- a/tune-profiles/openshift-node/profile/ktune.sh
+++ b/tune-profiles/openshift-node/profile/ktune.sh
@@ -1,0 +1,6 @@
+start() {
+  set_cpu_governor performance
+  set_transparent_hugepages always
+  echo 65536 > /selinux/avc/cache_threshold
+  return 0
+}

--- a/tune-profiles/openshift-node/profile/ktune.sysconfig
+++ b/tune-profiles/openshift-node/profile/ktune.sysconfig
@@ -1,0 +1,15 @@
+# ktune service configuration
+
+# This is the ktune sysctl file.  You can comment this out to prevent ktune
+# from applying its sysctl settings.
+SYSCTL="/etc/sysctl.ktune"
+
+# Use *.conf files in the ktune configuration directory /etc/ktune.d.
+#   Value: yes|no,  default: yes
+# It is useful if you want to load settings from additional files. Set this to
+# no if you to prevent ktune from using these additional files.
+USE_KTUNE_D="yes"
+
+# This is the custom sysctl configuration file.  Any settings in this file will
+# be applied prior to the ktune settings.
+SYSCTL_PRE="/etc/sysctl.conf"

--- a/tune-profiles/openshift-node/profile/sysctl.ktune
+++ b/tune-profiles/openshift-node/profile/sysctl.ktune
@@ -1,0 +1,16 @@
+# ktune sysctl settings for OpenShift Enterprise nodes
+#
+#  This will increase kernel semaphores to accommodate more httpds:
+kernel.sem = 250  32000 32  4096
+# This increases the ephemeral port range to accommodate application proxies:
+net.ipv4.ip_local_port_range = 15000 35530
+# This increases the connection-tracking table size
+net.netfilter.nf_conntrack_max = 1048576
+net.ipv4.ip_forward = 1
+net.ipv4.conf.all.route_localnet = 1
+kernel.msgmnb = 65536
+kernel.msgmax = 65536
+# prevents short requests from exhausting connection table BZ#1085115
+net.ipv4.tcp_tw_reuse = 1
+# allow for processes with a lot of threads (JBOSS)
+kernel.pid_max=131072

--- a/tune-profiles/openshift-node/profile/tuned.conf
+++ b/tune-profiles/openshift-node/profile/tuned.conf
@@ -1,0 +1,22 @@
+# disable tuned
+
+[main]
+
+[DiskMonitor]
+enabled=False
+
+[DiskTuning]
+enabled=False
+
+[NetMonitor]
+enabled=False
+
+[NetTuning]
+enabled=False
+
+[CPUMonitor]
+enabled=False
+
+[CPUTuning]
+enabled=False
+

--- a/tune-profiles/openshift-node/tuned-profiles-openshift-node.spec
+++ b/tune-profiles/openshift-node/tuned-profiles-openshift-node.spec
@@ -1,0 +1,41 @@
+Name:     tuned-profiles-openshift-node
+Version:  0.1.0
+Release:  1%{?dist}
+Summary:  tuned profile for openshift node hosts
+
+Group:    Development/System
+License:  ASL 2.0
+URL:      https://openshift.com
+Source0:  %{name}-%{version}.tar.gz
+
+Requires: tuned
+
+%description
+A tuned profile customized for OpenShift Node host roles.
+
+%prep
+%setup -q
+
+
+%build
+
+%install
+mkdir -p %{buildroot}/etc/tune-profiles/openshift-node/
+cp -r profile/* %{buildroot}/etc/tune-profiles/openshift-node/
+
+
+%files
+/etc/tune-profiles/openshift-node/ktune.sh
+/etc/tune-profiles/openshift-node/ktune.sysconfig
+/etc/tune-profiles/openshift-node/sysctl.ktune
+/etc/tune-profiles/openshift-node/tuned.conf
+
+%post
+/usr/sbin/tuned-adm profile openshift-node
+
+%preun
+/usr/sbin/tuned-admin profile default
+
+%changelog
+* Mon Jan 05 2015 Scott Dodson <sdodson@redhat.com> - 0.1-1
+- Initial packaging

--- a/tune-profiles/openshift-node/tuned-profiles-openshift-node.spec
+++ b/tune-profiles/openshift-node/tuned-profiles-openshift-node.spec
@@ -37,5 +37,8 @@ cp -r profile/* %{buildroot}/etc/tune-profiles/openshift-node/
 /usr/sbin/tuned-admin profile default
 
 %changelog
+* Mon Jan 05 2015 Scott Dodson <sdodson@redhat.com> 0.1.0-1
+- new package built with tito
+
 * Mon Jan 05 2015 Scott Dodson <sdodson@redhat.com> - 0.1-1
 - Initial packaging


### PR DESCRIPTION
Bug 889539 - [RFE] create tuned profile for openshift-enterprise nodes
This adds an optional subpackage named 'tuned-profiles-openshift-node' which
contains a tuned profile suitable for OpenShift Node hosts. When installed this
RPM will enable the profile starting tuned if it's not currently running.
