### PR TITLE
Revert "we do not want %ghost-ed log files"

### DIFF
--- a/broker/openshift-origin-broker.spec
+++ b/broker/openshift-origin-broker.spec
@@ -201,6 +201,10 @@ sed -i -e '/NON-RUNTIME BEGIN/,/NON-RUNTIME END/d' %{buildroot}%{brokerdir}/Gemf
 %defattr(0640,apache,apache,0750)
 %attr(0750,-,-) %{_var}/log/openshift/broker
 %attr(0750,-,-) %{_var}/log/openshift/broker/httpd
+%attr(0640,-,-) %ghost %{_var}/log/openshift/broker/production.log
+%attr(0640,-,-) %ghost %{_var}/log/openshift/broker/development.log
+%attr(0640,-,-) %ghost %{_var}/log/openshift/broker/user_action.log
+%attr(0640,-,-) %ghost %{_var}/log/openshift/broker/usage.log
 %attr(0750,-,-) %{brokerdir}/script
 %attr(0750,-,-) %{brokerdir}/tmp
 %attr(0750,-,-) %{brokerdir}/tmp/cache

--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -233,6 +233,8 @@ fi
 %attr(0750,-,-) /usr/sbin/*
 %attr(0755,-,-) /usr/bin/*
 %attr(0750,-,-) %{_var}/log/openshift/node
+%attr(0640,-,-) %ghost %{_var}/log/openshift/node/platform.log
+%attr(0640,-,-) %ghost %{_var}/log/openshift/node/platform-trace.log
 /usr/libexec/openshift/lib/quota_attrs.sh
 /usr/libexec/openshift/lib/archive_git_submodules.sh
 %dir %attr(0755,-,-) %{openshift_lib}/cartridge_sdk

--- a/openshift-console/openshift-origin-console.spec
+++ b/openshift-console/openshift-origin-console.spec
@@ -201,6 +201,10 @@ fi
 %{openshiftconfigdir}
 %attr(0750,-,-) %{_var}/log/openshift/console
 %attr(0750,-,-) %{_var}/log/openshift/console/httpd
+%attr(0644,-,-) %ghost %{_var}/log/openshift/console/production.log
+%attr(0644,-,-) %ghost %{_var}/log/openshift/console/development.log
+%attr(0644,-,-) %ghost %{_var}/log/openshift/console/httpd/error_log
+%attr(0644,-,-) %ghost %{_var}/log/openshift/console/httpd/access_log
 %attr(0750,-,-) %{consoledir}/script
 %attr(0750,-,-) %{consoledir}/tmp
 %attr(0750,-,-) %{consoledir}/tmp/cache


### PR DESCRIPTION
This reverts commit 0550ff74df3acb60f391dcd4b1f297ae881b36ea.
We do in fact want the log files to be %ghost so they are not
overwritten on every update.

Bug 1134578 - The Broker's user_action.log should not be overwritten on RPM upgrade
https://bugzilla.redhat.com/show_bug.cgi?id=1134578
