### PR TITLE
Bug 1175489: Wrong regexp in jbossews

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/versions/7/bin/standalone.conf
+++ b/cartridges/openshift-origin-cartridge-jbossas/versions/7/bin/standalone.conf
@@ -1,11 +1,11 @@
 #!/bin/bash
 function print_sed_exp_replace_env_var {
   sed_exp=""
-  for openshift_var in $(env | grep OPENSHIFT_ | awk -F '=' '{print $1}')
+  for openshift_var in $(env | grep ^OPENSHIFT_ | awk -F '=' '{print $1}')
   do
     # environment variable values that contain " or / need to be escaped
     # or they will cause problems in the sed command line.
-    variable_val=$(echo "${!openshift_var}" | sed -e "s@\/@\\\\/@g" | sed -e "s/\"/\\\\\"/g")
+    variable_val=$(echo "${!openshift_var}" | sed -e "s@\/@\\\\/@g" | sed -e "s/\"/\\\\\"/g" | sed "s/'/\\\'/g")
     # the entire sed s/search/replace/g command needs to be quoted in case the variable value
     # contains a space. 
     sed_exp="${sed_exp} -e \"s/\\\${env.${openshift_var}}/${variable_val}/g\""

--- a/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/bin/standalone.conf
+++ b/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/bin/standalone.conf
@@ -2,11 +2,11 @@
 
 function print_sed_exp_replace_env_var {
   sed_exp=""
-  for openshift_var in $(env | grep OPENSHIFT_ | awk -F '=' '{print $1}')
+  for openshift_var in $(env | grep ^OPENSHIFT_ | awk -F '=' '{print $1}')
   do
     # environment variable values that contain " or / need to be escaped
     # or they will cause problems in the sed command line.
-    variable_val=$(echo "${!openshift_var}" | sed -e "s@\/@\\\\/@g" | sed -e "s/\"/\\\\\"/g")
+    variable_val=$(echo "${!openshift_var}" | sed -e "s@\/@\\\\/@g" | sed -e "s/\"/\\\\\"/g" | sed "s/'/\\\'/g")
     # the entire sed s/search/replace/g command needs to be quoted in case the variable value
     # contains a space. 
     sed_exp="${sed_exp} -e \"s/\\\${env.${openshift_var}}/${variable_val}/g\""

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/util
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/util
@@ -15,9 +15,9 @@ function reinstall_path {
 
 function print_sed_exp_replace_env_var {
   local sed_exp=""
-  for openshift_var in $(env | grep OPENSHIFT_ | awk -F '=' '{print $1}')
+  for openshift_var in $(env | grep ^OPENSHIFT_ | awk -F '=' '{print $1}')
   do
-    local variable_val=$(echo "${!openshift_var}" | sed -e "s@\/@\\\\/@g")
+    local variable_val=$(echo "${!openshift_var}" | sed -e "s@\/@\\\\/@g" | sed -e "s/\"/\\\\\"/g" | sed "s/'/\\\'/g")
     sed_exp="${sed_exp} -e s/\${${openshift_var}}/${variable_val}/g"
     sed_exp="${sed_exp} -e s/\${env.${openshift_var}}/${variable_val}/g"
   done

--- a/controller/test/cucumber/cartridge-lifecycle-jbossas.feature
+++ b/controller/test/cucumber/cartridge-lifecycle-jbossas.feature
@@ -33,6 +33,7 @@ Feature: Cartridge Lifecycle JBossAS Verification Tests
     When I snapshot the application
     Then the application should be accessible
     When a new environment variable key=OPENSHIFT_DUMMY value="\"value with spaces\"" is added
+    When a new environment variable key=OPENSHIFT_DUMMY2 value="value with' 'simple quotes" is added
     And a new file is added and pushed to the client-created application repo
     And the application is changed
     Then it should be updated successfully


### PR DESCRIPTION
grep regexp should only match those env vars which start with `OPENSHIFT_`, not those env vars which have it as a value.
