### PR TITLE
Remove unused BuildRequires

### DIFF
--- a/admin-console/rubygem-openshift-origin-admin-console.spec
+++ b/admin-console/rubygem-openshift-origin-admin-console.spec
@@ -40,7 +40,6 @@ Requires:      rubygem-openshift-origin-controller
 Requires:      %{?scl:%scl_prefix}mcollective-client
 Requires:      openshift-origin-broker
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/common/rubygem-openshift-origin-common.spec
+++ b/common/rubygem-openshift-origin-common.spec
@@ -36,7 +36,6 @@ Requires:      openshift-origin-util-scl
 Requires:      openshift-origin-util
 %endif
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/console/rubygem-openshift-origin-console.spec
+++ b/console/rubygem-openshift-origin-console.spec
@@ -39,7 +39,6 @@ Requires:      %{?scl:%scl_prefix}rubygem(uglifier)
 Requires:      %{?scl:%scl_prefix}rubygem(syslog-logger)
 
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 BuildRequires:  v8314
 %endif

--- a/controller/rubygem-openshift-origin-controller.spec
+++ b/controller/rubygem-openshift-origin-controller.spec
@@ -26,7 +26,6 @@ Requires:      %{?scl:%scl_prefix}rubygem(dnsruby)
 Requires:      %{?scl:%scl_prefix}rubygem(httpclient)
 Requires:      rubygem(openshift-origin-common)
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/node-proxy/openshift-origin-node-proxy.spec
+++ b/node-proxy/openshift-origin-node-proxy.spec
@@ -29,7 +29,6 @@ BuildRequires: systemd-units
 %endif
 
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: nodejs010-build
 BuildRequires: scl-utils-build
 %else
 BuildRequires: nodejs-devel

--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -65,7 +65,6 @@ Requires:      libcgroup
 Requires:      libcgroup-tools
 %endif
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/openshift-console/openshift-origin-console.spec
+++ b/openshift-console/openshift-origin-console.spec
@@ -53,7 +53,6 @@ Requires:      gcc-c++
 %endif
 
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires:  ruby193-build
 BuildRequires:  scl-utils-build
 %endif
 BuildRequires: %{?scl:%scl_prefix}rubygem-rails

--- a/plugins/auth/kerberos/rubygem-openshift-origin-auth-kerberos.spec
+++ b/plugins/auth/kerberos/rubygem-openshift-origin-auth-kerberos.spec
@@ -27,7 +27,6 @@ Requires:      openshift-origin-broker
 Requires:      selinux-policy-targeted
 Requires:      policycoreutils-python
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/auth/mongo/rubygem-openshift-origin-auth-mongo.spec
+++ b/plugins/auth/mongo/rubygem-openshift-origin-auth-mongo.spec
@@ -30,7 +30,6 @@ Requires:      selinux-policy-targeted
 Requires:      policycoreutils-python
 Requires:      openssl
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/auth/remote-user/rubygem-openshift-origin-auth-remote-user.spec
+++ b/plugins/auth/remote-user/rubygem-openshift-origin-auth-remote-user.spec
@@ -27,7 +27,6 @@ Requires:      rubygem(openshift-origin-common)
 Requires:      %{?scl:%scl_prefix}rubygem(json)
 Requires:      openshift-broker
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/container/libvirt/rubygem-openshift-origin-container-libvirt.spec
+++ b/plugins/container/libvirt/rubygem-openshift-origin-container-libvirt.spec
@@ -27,7 +27,6 @@ Requires:      selinux-policy-targeted
 Requires:      policycoreutils-python
 Requires:      libvirt-sandbox
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/container/selinux/rubygem-openshift-origin-container-selinux.spec
+++ b/plugins/container/selinux/rubygem-openshift-origin-container-selinux.spec
@@ -25,7 +25,6 @@ Requires:      rubygem(openshift-origin-node)
 Requires:      selinux-policy-targeted
 Requires:      policycoreutils-python
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/dns/bind/rubygem-openshift-origin-dns-bind.spec
+++ b/plugins/dns/bind/rubygem-openshift-origin-dns-bind.spec
@@ -29,7 +29,6 @@ Requires:      openshift-origin-broker
 Requires:      selinux-policy-targeted
 Requires:      policycoreutils-python
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/dns/dynect/rubygem-openshift-origin-dns-dynect.spec
+++ b/plugins/dns/dynect/rubygem-openshift-origin-dns-dynect.spec
@@ -25,7 +25,6 @@ Requires:       rubygem(openshift-origin-common)
 Requires:       %{?scl:%scl_prefix}rubygem(json)
 
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires:  %{?scl:%scl_prefix}build
 BuildRequires:  scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/dns/fog/rubygem-openshift-origin-dns-fog.spec
+++ b/plugins/dns/fog/rubygem-openshift-origin-dns-fog.spec
@@ -25,7 +25,6 @@ Requires:      rubygem(openshift-origin-common)
 Requires:      openshift-origin-broker
 Requires:      %{?scl:%scl_prefix}rubygem-fog >= 1.7.0
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: ruby193-build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/dns/nsupdate/rubygem-openshift-origin-dns-nsupdate.spec
+++ b/plugins/dns/nsupdate/rubygem-openshift-origin-dns-nsupdate.spec
@@ -30,7 +30,6 @@ Requires:      openshift-origin-broker
 Requires:      selinux-policy-targeted
 Requires:      policycoreutils-python
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/dns/route53/rubygem-openshift-origin-dns-route53.spec
+++ b/plugins/dns/route53/rubygem-openshift-origin-dns-route53.spec
@@ -25,7 +25,6 @@ Requires:      rubygem(openshift-origin-common)
 Requires:      openshift-origin-broker
 Requires:      %{?scl:%scl_prefix}rubygem-aws-sdk >= 1.8.0
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: ruby193-build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/frontend/apache-mod-rewrite/rubygem-openshift-origin-frontend-apache-mod-rewrite.spec
+++ b/plugins/frontend/apache-mod-rewrite/rubygem-openshift-origin-frontend-apache-mod-rewrite.spec
@@ -37,7 +37,6 @@ BuildRequires: httpd-tools
 BuildRequires: httpd
 %endif
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/frontend/apache-vhost/rubygem-openshift-origin-frontend-apache-vhost.spec
+++ b/plugins/frontend/apache-vhost/rubygem-openshift-origin-frontend-apache-vhost.spec
@@ -31,7 +31,6 @@ BuildRequires: httpd-tools
 BuildRequires: httpd
 %endif
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/frontend/apachedb/rubygem-openshift-origin-frontend-apachedb.spec
+++ b/plugins/frontend/apachedb/rubygem-openshift-origin-frontend-apachedb.spec
@@ -38,7 +38,6 @@ BuildRequires: httpd-tools
 BuildRequires: httpd
 %endif
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/frontend/haproxy-sni-proxy/rubygem-openshift-origin-frontend-haproxy-sni-proxy.spec
+++ b/plugins/frontend/haproxy-sni-proxy/rubygem-openshift-origin-frontend-haproxy-sni-proxy.spec
@@ -32,7 +32,6 @@ Requires:      haproxy
 Requires:      haproxy >= 1.5
 %endif
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/frontend/nodejs-websocket/rubygem-openshift-origin-frontend-nodejs-websocket.spec
+++ b/plugins/frontend/nodejs-websocket/rubygem-openshift-origin-frontend-nodejs-websocket.spec
@@ -27,7 +27,6 @@ Requires:      rubygem(openshift-origin-node)
 Requires:      rubygem(openshift-origin-frontend-apachedb)
 Requires:      openshift-origin-node-proxy
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/gear-placement/rubygem-openshift-origin-gear-placement.spec
+++ b/plugins/gear-placement/rubygem-openshift-origin-gear-placement.spec
@@ -24,7 +24,6 @@ Requires:      %{?scl:%scl_prefix}rubygems
 Requires:      %{?scl:%scl_prefix}rubygem(json)
 Requires:      rubygem(openshift-origin-common)
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/msg-broker/mcollective/rubygem-openshift-origin-msg-broker-mcollective.spec
+++ b/plugins/msg-broker/mcollective/rubygem-openshift-origin-msg-broker-mcollective.spec
@@ -29,7 +29,6 @@ Requires:      selinux-policy-targeted
 Requires:      policycoreutils-python
 Requires:      openshift-origin-msg-common
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/plugins/routing/activemq/rubygem-openshift-origin-routing-activemq.spec
+++ b/plugins/routing/activemq/rubygem-openshift-origin-routing-activemq.spec
@@ -24,7 +24,6 @@ Requires:      %{?scl:%scl_prefix}rubygems
 Requires:      %{?scl:%scl_prefix}rubygem(json)
 Requires:      rubygem(openshift-origin-common)
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19

--- a/routing-daemon/rubygem-openshift-origin-routing-daemon.spec
+++ b/routing-daemon/rubygem-openshift-origin-routing-daemon.spec
@@ -30,7 +30,6 @@ Requires:      %{?scl:%scl_prefix}rubygem(parseconfig)
 Requires:      %{?scl:%scl_prefix}rubygem(stomp)
 Requires:      rubygem(openshift-origin-common)
 %if 0%{?fedora}%{?rhel} <= 6
-BuildRequires: %{?scl:%scl_prefix}build
 BuildRequires: scl-utils-build
 %endif
 %if 0%{?fedora} >= 19


### PR DESCRIPTION
ruby193-build and nodejs010-build are not necessary to build these packages. 
Additionally RHEL6  ruby193-build and nodejs010-build are not included in the RHEL6/SCL/OpenShift channel repositories.
I checked with https://rhn.redhat.com/rhn/channels/software/Search.do
