### PR TITLE
Ignoer unpacked files error during the RPM build

### DIFF
--- a/plugins/container/libvirt/rubygem-openshift-origin-container-libvirt.spec
+++ b/plugins/container/libvirt/rubygem-openshift-origin-container-libvirt.spec
@@ -7,6 +7,7 @@
 %global gem_name openshift-origin-container-libvirt
 %global rubyabi 1.9.1
 %define  debug_package %{nil}
+%define _unpackaged_files_terminate_build 0 
 
 Summary:       OpenShift plugin for LibVirt-LXC based containers
 Name:          rubygem-%{gem_name}


### PR DESCRIPTION
When we build with this specfile, we will get these error

```
error: Installed (but unpackaged) file(s) found:
   /usr/lib/debug/.build-id/a2/5e6b92f2faa8c58679fc5e870d37a134d910eb
   /usr/lib/debug/.build-id/a2/5e6b92f2faa8c58679fc5e870d37a134d910eb.debug
   /usr/lib/debug/usr/sbin/oo-gear-init.debug
   /usr/src/debug/rubygem-openshift-origin-container-libvirt-0.0.0/misc/gear-init/oo-gear-init.c


RPM build errors:
    Installed (but unpackaged) file(s) found:
   /usr/lib/debug/.build-id/a2/5e6b92f2faa8c58679fc5e870d37a134d910eb
   /usr/lib/debug/.build-id/a2/5e6b92f2faa8c58679fc5e870d37a134d910eb.debug
   /usr/lib/debug/usr/sbin/oo-gear-init.debug
   /usr/src/debug/rubygem-openshift-origin-container-libvirt-0.0.0/misc/gear-init/oo-gear-init.c
```

If you need to copy unpacked files but not installed, you need to put the `_unpackaged_files_terminate_build 0` option.
