### PR TITLE
Bug1176491: pass the pear channel-update with error due to the internet access problem

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/bin/install
+++ b/cartridges/openshift-origin-cartridge-php/bin/install
@@ -35,6 +35,6 @@ rm -f $OPENSHIFT_HOMEDIR/.pearrc
 php_context "pear config-create ${OPENSHIFT_PHP_DIR}phplib/pear/ ${OPENSHIFT_HOMEDIR}.pearrc"
 php_context "pear -c ${OPENSHIFT_HOMEDIR}.pearrc config-set php_ini ${OPENSHIFT_PHP_DIR}configuration/etc/php.ini"
 php_context "pear -c ${OPENSHIFT_HOMEDIR}.pearrc config-set auto_discover 1"
-php_context "pear -c ${OPENSHIFT_HOMEDIR}.pearrc channel-update pear.php.net"
+php_context "pear -c ${OPENSHIFT_HOMEDIR}.pearrc channel-update pear.php.net" && true
 
 update_configuration

--- a/cartridges/openshift-origin-cartridge-php/bin/install
+++ b/cartridges/openshift-origin-cartridge-php/bin/install
@@ -35,6 +35,6 @@ rm -f $OPENSHIFT_HOMEDIR/.pearrc
 php_context "pear config-create ${OPENSHIFT_PHP_DIR}phplib/pear/ ${OPENSHIFT_HOMEDIR}.pearrc"
 php_context "pear -c ${OPENSHIFT_HOMEDIR}.pearrc config-set php_ini ${OPENSHIFT_PHP_DIR}configuration/etc/php.ini"
 php_context "pear -c ${OPENSHIFT_HOMEDIR}.pearrc config-set auto_discover 1"
-php_context "pear -c ${OPENSHIFT_HOMEDIR}.pearrc channel-update pear.php.net" && true
+php_context "pear -c ${OPENSHIFT_HOMEDIR}.pearrc channel-update pear.php.net" || true
 
 update_configuration


### PR DESCRIPTION
See also [bz1176491](https://bugzilla.redhat.com/show_bug.cgi?id=1176491)

The root cause of bz1176491 is that the script bash [sets "-e" option](https://github.com/openshift/origin-server/blob/master/cartridges/openshift-origin-cartridge-php/bin/install#L1).
So, putting "&& true" like below will be able to fix it.

I know it is better if showing warning messages if the channel-update didn't work out. However, to output such a message needs several change in the other components more than openshift-origin-cartridge-php/bin/install.

So I think putting "&& true" is OK for this issue.
