### PR TITLE
Bug 1175489: Updating sed logic and escaping env vars in jbossews

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossews/bin/tomcat
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/tomcat
@@ -65,12 +65,24 @@ replacement_conf_files=(
   "context.xml"
 )
 
+# Due to how bash handles quotes within variables, we need to write the entire
+# sed command out to a file and then run it, rather than running the sed
+# command directly from within the script, passing the variables as arguments
+# See http://mywiki.wooledge.org/BashFAQ/050
 for conf_file in "${replacement_conf_files[@]}"; do
   if [ -f ${OPENSHIFT_REPO_DIR}/.openshift/config/${conf_file} ]
   then
+    cat <<EOF > /tmp/${conf_file}.sh
     sed ${sed_replace_env} ${OPENSHIFT_REPO_DIR}/.openshift/config/${conf_file} > ${OPENSHIFT_JBOSSEWS_DIR}/conf/${conf_file}
-  else 
-    sed ${sed_replace_env} template/.openshift/config/${conf_file} > ${OPENSHIFT_JBOSSEWS_DIR}/conf/${conf_file}    
+EOF
+    . /tmp/${conf_file}.sh
+    rm /tmp/${conf_file}.sh
+  else
+    cat <<EOF > /tmp/${conf_file}.sh
+    echo "sed ${sed_replace_env} template/.openshift/config/${conf_file} > ${OPENSHIFT_JBOSSEWS_DIR}/conf/${conf_file}"
+EOF
+    . /tmp/${conf_file}.sh
+    rm /tmp/${conf_file}.sh
   fi
 done
 

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/util
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/util
@@ -18,15 +18,15 @@ function print_sed_exp_replace_env_var {
   for openshift_var in $(env | grep ^OPENSHIFT_ | awk -F '=' '{print $1}')
   do
     local variable_val=$(echo "${!openshift_var}" | sed -e "s@\/@\\\\/@g" | sed -e "s/\"/\\\\\"/g" | sed "s/'/\\\'/g")
-    sed_exp="${sed_exp} -e s/\${${openshift_var}}/${variable_val}/g"
-    sed_exp="${sed_exp} -e s/\${env.${openshift_var}}/${variable_val}/g"
+    sed_exp="${sed_exp} -e \"s/\\\${${openshift_var}}/${variable_val}/g\""
+    sed_exp="${sed_exp} -e \"s/\\\${env.${openshift_var}}/${variable_val}/g\""
   done
 
   # support legacy variables
-  sed_exp="${sed_exp} -e s/\${env.OPENSHIFT_INTERNAL_IP}/${OPENSHIFT_JBOSSEWS_IP}/g"
-  sed_exp="${sed_exp} -e s/\${env.OPENSHIFT_INTERNAL_PORT}/${OPENSHIFT_JBOSSEWS_HTTP_PORT}/g"
-  sed_exp="${sed_exp} -e s/\${OPENSHIFT_INTERNAL_IP}/${OPENSHIFT_JBOSSEWS_IP}/g"
-  sed_exp="${sed_exp} -e s/\${OPENSHIFT_INTERNAL_PORT}/${OPENSHIFT_JBOSSEWS_HTTP_PORT}/g"
+  sed_exp="${sed_exp} -e \"s/\\\${env.OPENSHIFT_INTERNAL_IP}/${OPENSHIFT_JBOSSEWS_IP}/g\""
+  sed_exp="${sed_exp} -e \"s/\\\${env.OPENSHIFT_INTERNAL_PORT}/${OPENSHIFT_JBOSSEWS_HTTP_PORT}/g\""
+  sed_exp="${sed_exp} -e \"s/\\\${OPENSHIFT_INTERNAL_IP}/${OPENSHIFT_JBOSSEWS_IP}/g\""
+  sed_exp="${sed_exp} -e \"s/\\\${OPENSHIFT_INTERNAL_PORT}/${OPENSHIFT_JBOSSEWS_HTTP_PORT}/g\""
 
   printf "%s\n" "$sed_exp"
 }


### PR DESCRIPTION
Fixing problem with unescaped characters and changing way how the substitution of the env vars is being done with sed in jbossews cartridge, based on the way how its done in other jboss cartridges.
Also adding cucumber TC's.
