### PR TITLE
Bug 1179006 - CartridgeRepository latest_versions

### DIFF
--- a/node/lib/openshift-origin-node/model/cartridge_repository.rb
+++ b/node/lib/openshift-origin-node/model/cartridge_repository.rb
@@ -438,9 +438,11 @@ module OpenShift
           names.each do |name, software_versions|
             lcv = latest_cartridge_version(vendor, name)
             software_versions.keys.sort.reverse.each do |software_version|
-              unless software_versions[software_version][lcv].instance_of?(Hash)
-                latest = software_versions[software_version]['_']
-                cartridges << latest unless latest.instance_of?(Hash)
+              if software_versions[software_version].has_key? lcv
+                unless software_versions[software_version][lcv].instance_of?(Hash)
+                  latest = software_versions[software_version]['_']
+                  cartridges << latest unless latest.instance_of?(Hash)
+                end
               end
             end
           end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1179006
- When latest_versions is invoked from the MCO cartridge_list method, and
  there is an older cartridge that should be not be desplayed for providing a
  unique version, the cartridge database is corrupted.
