### PR TITLE
update mongo read_preference for OpenShift Stats

### DIFF
--- a/controller/lib/openshift/data_store.rb
+++ b/controller/lib/openshift/data_store.rb
@@ -1,6 +1,6 @@
 module OpenShift
   class DataStore
-    def self.db(read_preference=:secondary, session_name='default')
+    def self.db(read_preference=:secondary_preferred, session_name='default')
       config = Mongoid::Config.sessions[session_name]
       hosts = config['hosts']
       ssl = config['options']['ssl']


### PR DESCRIPTION
Hello,

I setup an OpenShift Origin with 1 Broker and 3 BSN (MongoDB, ActiveMQ).
Unfortunately, oo-stats fails and the admin-console too when trying to connect to MongoDB.

```
$ oo-stats 
...
/opt/rh/ruby193/root/usr/share/gems/gems/mongo-1.9.2/lib/mongo/util/read_preference.rb:72:in `read_pool': No replica set member available for query with read preference matching mode secondary and tags matching []. (Mongo::ConnectionFailure)
        from /opt/rh/ruby193/root/usr/share/gems/gems/mongo-1.9.2/lib/mongo/mongo_replica_set_client.rb:360:in `block in checkout_reader'
```

With this change, the read_preference is less restrictive.
