### PR TITLE
rhc-list-ports: Delete scaled gears output code

### DIFF
--- a/node-util/bin/rhc-list-ports
+++ b/node-util/bin/rhc-list-ports
@@ -37,20 +37,3 @@ fi
 for binding in "${!local_bindings[@]}"; do
   echo "${local_bindings[${binding}]} -> ${binding}"
 done | sort -d -k1 1>&2
-
-# Report scaling information
-gear_registry_locations=(
-  "./haproxy-1.4/conf/gear-registry.db"
-  "./haproxy/conf/gear-registry.db"
-)
-
-for candidate_registry in "${gear_registry_locations[@]}"; do
-  if [ -f "$candidate_registry" ]; then
-    gear_registry=$candidate_registry
-    break
-  fi
-done
-
-if [ ! -z "$gear_registry" ]; then
-  cat "$gear_registry" | while read line; do echo "$line" | awk -F"@" '{ printf "SCALE%s\n", $1; }' ; done
-fi


### PR DESCRIPTION
Delete the code that prints the list of scaled gears because it has been broken for a over a year and has no users.

Commit 487e6e238d1d4ce68fd7df852f50ed5c161cf4ea broke the code in question by replacing `haproxy/conf/gear-registry.db` with `gear-registry/gear-registry.json`.

This pull request supersedes PR #5988.
