### PR TITLE
Use EXTERNAL_ETH_DEV to determine the node IP

### DIFF
--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -690,24 +690,26 @@ module OpenShift
     end
 
     # <<accessor>>
-    # Get the public IP address of a Node
+    # Get the IP address of a Node
+    # i.e. the IP that PUBLIC_NIC is using
     #
     # INPUTS:
     # none
     #
     # RETURNS:
-    # * String: the public IP address of a node
+    # * String: the IP address of a node's PUBLIC_NIC
     #
     # NOTES:
     # * method on Node
     # * calls rpc_get_fact_direct
     #
     def get_ip_address
-      rpc_get_fact_direct('ipaddress_eth0')
+      rpc_get_fact_direct('host_ip')
     end
 
     # <<accessor>>
     # Get the public IP address of a Node
+    # as configured in PUBLIC_IP
     #
     # INPUTS:
     # none

--- a/plugins/msg-node/mcollective/facts/openshift_facts.rb
+++ b/plugins/msg-node/mcollective/facts/openshift_facts.rb
@@ -41,7 +41,7 @@ Facter.add(:public_hostname) { setcode { public_hostname } }
 #
 # public_ip assigned to the config specified NIC (default eth0)
 #
-public_nic = get_node_config_value("PUBLIC_NIC", "eth0").gsub(/['"]/,"")
+public_nic = get_node_config_value("EXTERNAL_ETH_DEV", "eth0").gsub(/['"]/,"")
 host_public_ip = `/sbin/ifconfig #{public_nic} | /bin/grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'`.chomp
 Facter.add(:host_ip) { setcode { host_public_ip } }
 


### PR DESCRIPTION
Facter was using PUBLIC_NIC to determine host_ip, but node.conf specifies EXTERNAL_ETH_DEV for the purpose of identifying the NIC for public traffic.

I haven't found other references to PUBLIC_NIC elsewhere; also I believe INTERNAL_ETH_DEV is not used anywhere, so changed facter to use EXTERNAL_ETH_DEV to determine host_ip.

After that, use that value instead of hardcoding eth0 as the source of the node's IP address.
