### PR TITLE
Revert "Bug 1183135 - Added ror40 bin directory to ruby-2.0 OPENSHIFT_RUBY_PATH_ELEMENT and ror40 gems dirs to GEM_PATH."

### DIFF
--- a/cartridges/openshift-origin-cartridge-ruby/bin/setup
+++ b/cartridges/openshift-origin-cartridge-ruby/bin/setup
@@ -35,6 +35,7 @@ if [ $version == '1.9' ]; then
     ld_path=$(LD_LIBRARY_PATH="" scl enable ruby193 "printenv LD_LIBRARY_PATH")
     set_env_var 'OPENSHIFT_RUBY_LD_LIBRARY_PATH_ELEMENT' $ld_path $env_dir
     scl enable ruby193 "printenv MANPATH"         > $OPENSHIFT_RUBY_DIR/env/MANPATH
+
 fi
 
 if [ $version == '2.0' ]; then
@@ -44,19 +45,15 @@ if [ $version == '2.0' ]; then
     [ -f $OPENSHIFT_RUBY_DIR/env/LD_LIBRARY_PATH ] && rm -f $OPENSHIFT_RUBY_DIR/env/LD_LIBRARY_PATH
     [ -f $OPENSHIFT_RUBY_DIR/env/MANPATH ] && rm -f $OPENSHIFT_RUBY_DIR/env/MANPATH
 
-    ruby_bin=$(dirname $(scl enable ruby200 ror40 "which ruby"))
-    bundle_bin=$(dirname $(scl enable ruby200 ror40 "which bundle"))
-    set_env_var 'OPENSHIFT_RUBY_PATH_ELEMENT' "$ruby_bin:$bundle_bin" $env_dir
-
-    ruby_gems="${ruby_bin/%bin/share/gems}:${ruby_bin/%bin/local/share/gems}"
-    bundle_gems="${bundle_bin/%bin/share/gems}:${bundle_bin/%bin/local/share/gems}"
-    set_env_var 'GEM_PATH' "$ruby_gems:$bundle_gems" $env_dir
+    dirname $(scl enable ruby200 ror40 "which ruby")    > $OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_PATH_ELEMENT
 
     ld_path=$(LD_LIBRARY_PATH="" scl enable ruby200 ror40 "printenv LD_LIBRARY_PATH")
     set_env_var 'OPENSHIFT_RUBY_LD_LIBRARY_PATH_ELEMENT' $ld_path $env_dir
     # Standard ENV var for the SECRET > rails 4.0
     set_env_var 'SECRET_KEY_BASE' $OPENSHIFT_SECRET_TOKEN $env_dir
     scl enable ruby200 ror40 "printenv MANPATH"         > $OPENSHIFT_RUBY_DIR/env/MANPATH
+
+
 fi
 
 cp versions/shared/etc/conf.d/performance.conf.erb conf/performance.conf.erb

--- a/cartridges/openshift-origin-cartridge-ruby/lib/util
+++ b/cartridges/openshift-origin-cartridge-ruby/lib/util
@@ -114,17 +114,10 @@ function update-configuration {
         ;;
 
       2.0)
+        echo -n "${GEM_HOME}/bin:" >$OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_PATH_ELEMENT
+        dirname $(scl enable ruby200 ror40 "which ruby") >>$OPENSHIFT_RUBY_DIR/env/OPENSHIFT_RUBY_PATH_ELEMENT
+
         local env_dir="${OPENSHIFT_RUBY_DIR}/env"
-
-        local gem_bin="${GEM_HOME}/bin"
-        local ruby_bin=$(dirname $(scl enable ruby200 ror40 "which ruby"))
-        local bundle_bin=$(dirname $(scl enable ruby200 ror40 "which bundle"))
-        set_env_var 'OPENSHIFT_RUBY_PATH_ELEMENT' "$gem_bin:$ruby_bin:$bundle_bin" $env_dir
-
-        local ruby_gems="${ruby_bin/%bin/share/gems}:${ruby_bin/%bin/local/share/gems}"
-        local bundle_gems="${bundle_bin/%bin/share/gems}:${bundle_bin/%bin/local/share/gems}"
-        set_env_var 'GEM_PATH' "$ruby_gems:$bundle_gems" $env_dir
-
         local ld_path=$(LD_LIBRARY_PATH="" scl enable ruby200 ror40 "printenv LD_LIBRARY_PATH")
         set_env_var 'OPENSHIFT_RUBY_LD_LIBRARY_PATH_ELEMENT' $ld_path $env_dir
 


### PR DESCRIPTION
This is to revert changes from #6055 as it'll break extended cartridge tests and is not applicable anymore.
