### PR TITLE
tuned-profiles-openshift-node: Don't load /etc/sysctl.ktune

### DIFF
--- a/tune-profiles/openshift-node/profile/ktune.sysconfig
+++ b/tune-profiles/openshift-node/profile/ktune.sysconfig
@@ -2,7 +2,7 @@
 
 # This is the ktune sysctl file.  You can comment this out to prevent ktune
 # from applying its sysctl settings.
-SYSCTL="/etc/sysctl.ktune"
+#SYSCTL="/etc/sysctl.ktune"
 
 # Use *.conf files in the ktune configuration directory /etc/ktune.d.
 #   Value: yes|no,  default: yes


### PR DESCRIPTION
RHEL6 tuned no longer uses this file nor do we ship it, so by default don't
attempt to load it. This only affects things if a user had created
/etc/sysctl.ktune on their own which is not likely.
