### PR TITLE
Routing SPI: Send notifications on rollbacks

### DIFF
--- a/controller/app/pending_ops_models/notify_add_alias_op.rb
+++ b/controller/app/pending_ops_models/notify_add_alias_op.rb
@@ -6,4 +6,8 @@ class NotifyAliasAddOp < PendingAppOp
     OpenShift::RoutingService.notify_add_alias application,fqdn
   end
 
+  def rollback
+    OpenShift::RoutingService.notify_remove_alias application,fqdn
+  end
+
 end

--- a/controller/app/pending_ops_models/notify_app_create_op.rb
+++ b/controller/app/pending_ops_models/notify_app_create_op.rb
@@ -4,4 +4,8 @@ class NotifyAppCreateOp < PendingAppOp
     OpenShift::RoutingService.notify_create_application application
   end
 
+  def rollback
+    OpenShift::RoutingService.notify_delete_application application
+  end
+
 end

--- a/controller/app/pending_ops_models/notify_ssl_cert_add_op.rb
+++ b/controller/app/pending_ops_models/notify_ssl_cert_add_op.rb
@@ -10,4 +10,8 @@ class NotifySslCertAddOp < PendingAppOp
     OpenShift::RoutingService.notify_ssl_cert_add application,fqdn,ssl_certificate,private_key,pass_phrase
   end
 
+  def rollback
+    OpenShift::RoutingService.notify_ssl_cert_remove application,fqdn
+  end
+
 end


### PR DESCRIPTION
Add rollback methods to `NotifyAliasAddOp`, `NotifyAppCreateOp`, and `NotifySslCertAddOp`.  These rollback methods invoke the `notify_remove_alias`, `notify_delete_application`, and `notify_ssl_cert_remove` methods, respectively, of the routing service.

This change causes the ActiveMQ routing plug-in to send `:remove_alias`, `:delete_application`, and `:remove_ssl` notifications when an application creation fails so that anything listening for these notifications (such as the OpenShift routing daemon) can properly clean up any configuration that it may have done in response to the earlier corresponding `:add_alias`, `:create_application`, and `:add_ssl` notifications during the application's creation.

This commit fixes bug 1186036.
