### PR TITLE
BZ1186171 - scp needs additional arguments to avoid prompts

### DIFF
--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -200,8 +200,8 @@ module OpenShift
 
         # scp cert and to F5 LTM (requires ssh key to be in authorized_keys on the F5 LTM
         @logger.debug("Copying certificate and key for alias #{alias_str} for pool #{pool_name} to LTM host")
-        result = `scp -i #{@ssh_private_key} #{certfname.path} admin@#{@host}:/var/tmp/#{alias_str}.crt`
-        result = `scp -i #{@ssh_private_key} #{keyfname.path} admin@#{@host}:/var/tmp/#{alias_str}.key`
+        result = `scp -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} #{certfname.path} admin@#{@host}:/var/tmp/#{alias_str}.crt`
+        result = `scp -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} #{keyfname.path} admin@#{@host}:/var/tmp/#{alias_str}.key`
 
         @logger.debug("LTM cert to be installed /var/tmp/#{alias_str}.crt")
         post(url: "https://#{@host}/mgmt/tm/sys/crypto/cert",
@@ -237,9 +237,9 @@ module OpenShift
 
         # Requires LTM System->Users->admin terminal setting to be set to advanced (bash)
         @logger.debug("LTM removing temporary alias certificate. rm -f /var/tmp/#{alias_str}.crt")
-        result = `ssh -i #{@ssh_private_key} admin@#{@host} 'rm -f /var/tmp/#{alias_str}.crt'`
+        result = `ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} admin@#{@host} 'rm -f /var/tmp/#{alias_str}.crt'`
         @logger.debug("LTM removing temporary alias key. rm -f /var/tmp/#{alias_str}.key")
-        result = `ssh -i #{@ssh_private_key} admin@#{@host} 'rm -f /var/tmp/#{alias_str}.key'`
+        result = `ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} admin@#{@host} 'rm -f /var/tmp/#{alias_str}.key'`
       rescue Errno::ENOENT
         # Nothing to do;
       ensure


### PR DESCRIPTION
- Improper scp command cause the failure of copying certificate and key
  for alias to BIGIP LTM host
