### PR TITLE
Allow gear prioritization in startall/stopall

### DIFF
--- a/node-util/sbin/oo-admin-ctl-gears
+++ b/node-util/sbin/oo-admin-ctl-gears
@@ -153,6 +153,12 @@ module OpenShift
         failures.empty? ? 0 : 254
       end
 
+      def list(honor_lock = true)
+        gears(honor_lock).each do |gear|
+          puts "#{gear.uuid} #{gear.start_priority}"
+        end
+      end
+
       def start(honor_lock = true)
         results = Parallel.map(gears(honor_lock), @options) do |gear|
           gear_action(gear, "Starting gear #{gear.uuid} ... ") { |g| g.start_gear }
@@ -161,7 +167,7 @@ module OpenShift
       end
 
       def stop(honor_lock = true, force = false, init_owned = false)
-        results = Parallel.map(gears(honor_lock), @options) do |gear|
+        results = Parallel.map(gears(honor_lock, true), @options) do |gear|
           opt = {user_initiated: false}
           opt.merge!(@forced_options) if force
           opt.merge!({init_owned: true}) if init_owned
@@ -232,10 +238,10 @@ module OpenShift
         end
       end
 
-      def gears(honor_lock = true)
+      def gears(honor_lock = true, reversed = false)
         Enumerator.new do |yielder|
           if @uuids.nil?
-            ApplicationContainer.all(nil, false).each do |gear|
+            ApplicationContainer.all(nil, false).sort { |a,b| reversed ? b.start_priority <=> a.start_priority : a.start_priority <=> b.start_priority }.each do |gear|
               yielder.yield(gear) unless honor_lock && gear.stop_lock?
             end
           else
@@ -450,6 +456,15 @@ command :list do |c|
   c.description = %q(list all gears on node)
 
   c.action { OpenShift::Runtime::ApplicationContainer.all_uuids.each { |u| $stdout.puts u } }
+end
+
+command :listbypriority do |c|
+  c.syntax      = "#{$name} #{c.name}"
+  c.description = %q(list all gears without a stop_lock)
+
+  c.action do |_, options|
+    OpenShift::Runtime::AdminGearsControl.new(options).list
+  end
 end
 
 command :listidle do |c|

--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -69,6 +69,7 @@ module OpenShift
 
       GEAR_TO_GEAR_SSH = "/usr/bin/ssh -q -o 'BatchMode=yes' -o 'StrictHostKeyChecking=no' -i $OPENSHIFT_APP_SSH_KEY "
       DEFAULT_SKEL_DIR = PathUtils.join(OpenShift::Config::CONF_DIR,"skel")
+      DEFAULT_START_PRIORITY = 100
       $OpenShift_ApplicationContainer_SSH_KEY_MUTEX = Mutex.new
 
       attr_reader :uuid, :application_uuid, :state, :container_name, :application_name, :namespace, :container_dir,
@@ -657,6 +658,25 @@ module OpenShift
 
       def stop_lock?
         @cartridge_model.stop_lock?
+      end
+
+      def start_priority_file
+        return PathUtils.join(@container_dir, '.start_priority')
+      end
+
+      def start_priority
+        if @start_priority.nil? && File.exists?(start_priority_file)
+          @start_priority = File.open(start_priority_file).read.to_i rescue nil
+        end
+        @start_priority ||= DEFAULT_START_PRIORITY
+        return @start_priority
+      end
+
+      def start_priority=(prio)
+        File.open(start_priority_file, File::CREAT|File::TRUNC|File::WRONLY, 0644) do |sp|
+          sp.write(prio)
+        end
+        @start_priority = prio.to_i
       end
 
       #


### PR DESCRIPTION
On nodes with many active gears, a server reboot can result in long outages as gears are restarted.  This change allows an administrator to influence the start/stop order of gears to minimize outages for critical apps.
