### PR TITLE
Protect 'gear' command from gems in $GEM_HOME

### DIFF
--- a/node/misc/bin/gear
+++ b/node/misc/bin/gear
@@ -15,6 +15,9 @@
 # limitations under the License.
 #++
 
+# bz1187829 - don't let gems in $GEM_HOME override OpenShift-provided ones
+ENV['GEM_HOME'] = ''
+
 require 'pp'
 require 'rubygems'
 require 'json'

--- a/node/misc/usr/lib/cartridge_sdk/ruby/sdk.rb
+++ b/node/misc/usr/lib/cartridge_sdk/ruby/sdk.rb
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+# bz1187829 - don't let gems in $GEM_HOME override OpenShift-provided ones
+ENV['GEM_HOME'] = ''
+
 require 'openshift-origin-node/model/application_container'
 require 'openshift-origin-node/utils/environ'
 


### PR DESCRIPTION
Explicitly set GEM_HOME to '' to protect the 'gear' command and the ruby
SDK from running with user-supplied gems.

Bug 1187829
