### PR TITLE
Handle all encodings during regex comparisons

### DIFF
--- a/node-util/conf/watchman/plugins.d/jboss_plugin.rb
+++ b/node-util/conf/watchman/plugins.d/jboss_plugin.rb
@@ -35,7 +35,7 @@ def apply(iteration)
         # skip missing log files as jboss may be coming up.
         next unless File.exist?(log)
 
-        File.open(log, 'r:utf-8').grep(/ java.lang.OutOfMemoryError/) do |event|
+        File.open(log, 'rb').grep(/ java.lang.OutOfMemoryError/) do |event|
           # timezones are just a PITA. server.log message doesn't include timezone or date so inject both from today
           #
           # Set the timestamp for messages with invalid timestamps to the 'epoch',

--- a/node/test/node_functional/jboss_plugin_test.rb
+++ b/node/test/node_functional/jboss_plugin_test.rb
@@ -122,8 +122,11 @@ class JbossPluginTest < OpenShift::NodeBareTestCase
   def test_utf8
     start_time = DateTime.civil(2012, 2, 7, 12, 0, 0, -6)
     File.open(@server_log, 'w') do |file|
+      # Write something using utf-8
       file.write('2012/02/07 17:57:11,034 INFO  [stdout] (Ergebnisse_Holen) {pointsTeam2=2, matchIsFinished=true, pointsTeam1=0, nameTeam1=Borussia Mönchengladbach, nameTeam2=Bayern München}')
       file.write("\n")
+      # Write something using ISO-8859-1 
+      file.write("\xe9\n")
     end
 
     @restart.expects(:call).never


### PR DESCRIPTION
Open files in binary mode to support regex matching on all encodings.

Fix bug #1191681
