### PR TITLE
Bug 1192557 - Fixed creating application using --from-code=empty when database cartridge is also specified.

### DIFF
--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -380,8 +380,8 @@ module OpenShift
         cartridge              = get_cartridge(name)
 
         ::OpenShift::Runtime::Utils::Cgroups.new(@container.uuid).boost do
-          if empty_repository?
-            output << "CLIENT_MESSAGE: An empty Git repository has been created for your application.  Use 'git push' to add your code." if cartridge.name == primary_cartridge.name
+          if cartridge.name == primary_cartridge.name and empty_repository?
+            output << "CLIENT_MESSAGE: An empty Git repository has been created for your application.  Use 'git push' to add your code."
           else
             output << start_cartridge('start', cartridge, user_initiated: true)
           end


### PR DESCRIPTION
[Bug 1192557](https://bugzilla.redhat.com/show_bug.cgi?id=1192557)

//fyi @bparees @cianclarke
