### PR TITLE
Bug 1191181 - Added checking server certs existence when turning on SSL.

### DIFF
--- a/cartridges/openshift-origin-cartridge-postgresql/versions/8.4/conf/postgresql.conf.erb
+++ b/cartridges/openshift-origin-cartridge-postgresql/versions/8.4/conf/postgresql.conf.erb
@@ -34,7 +34,7 @@ max_connections = 100
 <% end %>
 unix_socket_directory = '<%= ENV['OPENSHIFT_POSTGRESQL_DB_SOCKET'] %>'
 unix_socket_permissions = 0700
-<% if ENV['OPENSHIFT_POSTGRESQL_SSL_ENABLED'] && ENV['OPENSHIFT_POSTGRESQL_SSL_ENABLED'].downcase == 'true' %>
+<% if ENV['OPENSHIFT_POSTGRESQL_SSL_ENABLED'] && ENV['OPENSHIFT_POSTGRESQL_SSL_ENABLED'].downcase == 'true' && File.exists?(ENV['PGDATA']+"/server.key") && File.exists?(ENV['PGDATA']+"/server.crt") %>
 ssl = on
 <% end %>
 

--- a/cartridges/openshift-origin-cartridge-postgresql/versions/9.2/conf/postgresql.conf.erb
+++ b/cartridges/openshift-origin-cartridge-postgresql/versions/9.2/conf/postgresql.conf.erb
@@ -35,7 +35,7 @@ max_connections = 100
 <% end %>
 unix_socket_directories  = '<%= ENV['OPENSHIFT_POSTGRESQL_DB_SOCKET'] %>'
 unix_socket_permissions = 0700
-<% if ENV['OPENSHIFT_POSTGRESQL_SSL_ENABLED'] && ENV['OPENSHIFT_POSTGRESQL_SSL_ENABLED'].downcase == 'true' %>
+<% if ENV['OPENSHIFT_POSTGRESQL_SSL_ENABLED'] && ENV['OPENSHIFT_POSTGRESQL_SSL_ENABLED'].downcase == 'true' && File.exists?(ENV['PGDATA']+"/server.key") && File.exists?(ENV['PGDATA']+"/server.crt") %>
 ssl = on
 <% end %>
 


### PR DESCRIPTION
For SSL in postgresql to work properly it's needed to have `server.crt` and `server.key` defined in `$PGDATA`, I'm extending the check for SSL to incorporate that as well, otherwise postgresql fails to start. 
For details see [bug 1191181](https://bugzilla.redhat.com/show_bug.cgi?id=1191181) and [postgresql docs](http://www.postgresql.org/docs/9.2/static/ssl-tcp.html).
