### PR TITLE
Encode the response to bytes before determining the length

### DIFF
--- a/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-scl/template/wsgi.py
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-scl/template/wsgi.py
@@ -280,12 +280,13 @@ $ git push</pre>
 </section>
 </body>
 </html>'''
+    response_body = response_body.encode('utf-8')
 
     status = '200 OK'
     response_headers = [('Content-Type', ctype), ('Content-Length', str(len(response_body)))]
     #
     start_response(status, response_headers)
-    return [response_body.encode('utf-8') ]
+    return [response_body ]
 
 #
 # Below for testing only


### PR DESCRIPTION
The Content-Length is the length of the content in octets, while the
legnth of the string before encoding to bytes is the length in
characters. These two lengths are not necessarily the same.
