### PR TITLE
Avoid skipping jenkins builders in gear ps list

### DIFF
--- a/node-util/conf/watchman/plugins.d/gear_state_plugin.rb
+++ b/node-util/conf/watchman/plugins.d/gear_state_plugin.rb
@@ -193,7 +193,8 @@ class GearStatePlugin < OpenShift::Runtime::WatchmanPlugin
       command = command.join(' ')
 
       # skip everything owned by root (for speed) and not a "daemon" (we can be fooled here)
-      next unless uid != '0' && ppid == '1'
+      # bz1134686 - but don't skip jenkins builder slaves
+      next unless uid != '0' && command =~ /jenkins\/slave.jar/ && ppid == '1'
 
       # bz1133629
       # skip haproxy and logshifter related processes


### PR DESCRIPTION
Jenkins builders don't show up as "daemons" (`ppid == 1`) but they
shouldn't be excluded in `GearStatePlugin#load_ps_table` when generating
`@ps_table`.

Bug 1134686
https://bugzilla.redhat.com/show_bug.cgi?id=1134686
Enterprise bug 1134206
