### PR TITLE
Make cronjob timeout customizable

### DIFF
--- a/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
+++ b/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
@@ -49,6 +49,8 @@ fi
 freq=$1
 source "$CART_CONF_DIR/limits"
 
+[[ -f /etc/openshift/cron/limits ]] && source /etc/openshift/cron/limits
+
 # First up check if the cron jobs are enabled.
 if [ ! -f $OPENSHIFT_CRON_DIR/run/jobs.enabled ]; then
    # Jobs are not enabled - just exit.


### PR DESCRIPTION
Bug 1197873
https://bugzilla.redhat.com/show_bug.cgi?id=1197873
This fix allows a system administrator to set a custom timeout for cronjobs.
