### PR TITLE
Fix the expression to allow the nightly build

### DIFF
--- a/rel-eng/build_instructions/build_openshift_origin.sh
+++ b/rel-eng/build_instructions/build_openshift_origin.sh
@@ -121,8 +121,8 @@ if [[ -z "$origin_release" ]]; then
     printf "ERROR: must profive an origin_release to build \n"
     f_help
 else
-    if ! [[ "$origin_release" == "v4" ]] || 
-         [[ "$origin_release" == "nightly" ]]; then
+    if [[ "$origin_release" != "v4" ]] && 
+       [[ "$origin_release" != "nightly" ]]; then
         printf "ERROR: invalid origin_release provided\n"
         f_help
     fi


### PR DESCRIPTION
giving -r nightly to this script fails when $origin_release is set to nightly.
the expected expression here should be $origin_release isn't v4 nor nightly but
it was $origin_release isn't v4 or nightly. so it always fails when it isn't v4.
