### PR TITLE
oo-admin-ctl-gears: removing a white space

### DIFF
--- a/node-util/sbin/oo-admin-ctl-gears
+++ b/node-util/sbin/oo-admin-ctl-gears
@@ -95,7 +95,7 @@ module OpenShift
       # @param msg [String] message denoting operation. E.g., 'Starting gear uuid'
       def okay(msg)
         NodeLogger.logger.info %Q((#{Process.pid}) #{msg}[ OK ])
-        $stdout.puts %Q(#{msg}[ #{$stdout.tty? ? GREEN : ''} OK #{$stdout.tty? ? NORMAL : ''}])
+        $stdout.puts %Q(#{msg}[#{$stdout.tty? ? GREEN : ''} OK #{$stdout.tty? ? NORMAL : ''}])
       end
 
       # Log success messages


### PR DESCRIPTION
This is just a cosmetic fix that will lift some stress factors for people with OCD.

Before:

```
# oo-admin-ctl-gears stopgear 5446ca52dbd93c9bac0000d7
Stopping gear 5446ca52dbd93c9bac0000d7 ... [  OK ] <---- OMG WHY
#
```

After:

```
# oo-admin-ctl-gears stopgear 5446ca52dbd93c9bac0000d7
Stopping gear 5446ca52dbd93c9bac0000d7 ... [ OK ]  <--- much better, thank you marek, you rock
#
```
