### PR TITLE
Add option to have the default application URL use https - updated

### DIFF
--- a/broker/conf/broker.conf
+++ b/broker/conf/broker.conf
@@ -134,6 +134,9 @@ CART_DOWNLOAD_CONN_TIMEOUT="2"
 #
 # HTTP_PROXY="proxy.server.com:3128"
 
+# Set to "true" to make application default to use https in advertised URL
+APP_ADVERTISE_HTTPS="false"
+
 # Team collaboration settings
 MAX_MEMBERS_PER_RESOURCE="100"
 MAX_TEAMS_PER_RESOURCE="5"

--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -119,6 +119,7 @@ Broker::Application.configure do
     :normalize_username_method => conf.get("NORMALIZE_USERNAME_METHOD", "noop"),
     :use_predictable_gear_uuids => conf.get_bool("USE_PREDICTABLE_GEAR_UUIDS", false),
     :limit_app_name_chars => conf.get("LIMIT_APP_NAME_CHARS", -1).to_i,
+    :app_advertise_https => conf.get_bool("APP_ADVERTISE_HTTPS", false),
   }
 
   config.auth = {

--- a/broker/config/environments/production.rb
+++ b/broker/config/environments/production.rb
@@ -108,6 +108,7 @@ Broker::Application.configure do
     :normalize_username_method => conf.get("NORMALIZE_USERNAME_METHOD", "noop"),
     :use_predictable_gear_uuids => conf.get_bool("USE_PREDICTABLE_GEAR_UUIDS", false),
     :limit_app_name_chars => conf.get("LIMIT_APP_NAME_CHARS", -1).to_i,
+    :app_advertise_https => conf.get_bool("APP_ADVERTISE_HTTPS", false),
   }
 
   config.auth = {

--- a/broker/config/environments/test.rb
+++ b/broker/config/environments/test.rb
@@ -117,6 +117,7 @@ Broker::Application.configure do
     :normalize_username_method => conf.get("NORMALIZE_USERNAME_METHOD", "noop"),
     :use_predictable_gear_uuids => conf.get_bool("USE_PREDICTABLE_GEAR_UUIDS", false),
     :limit_app_name_chars => conf.get("LIMIT_APP_NAME_CHARS", -1).to_i,
+    :app_advertise_https => conf.get_bool("APP_ADVERTISE_HTTPS", false),
   }
 
   config.auth = {

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1113,6 +1113,14 @@ class Application
   end
 
   ##
+  # Returns the application URL with the proper protocol (http vs https) based on configuration
+  # @return [String]
+  def app_url
+    proto = Rails.application.config.openshift[:app_advertise_https] ? "https" : "http"
+    "#{proto}://#{fqdn()}/"
+  end
+
+  ##
   # Returns the SSH URI for an application gear (unless specified, the primary)
   # @return [String]
   def ssh_uri(gear_uuid=nil)

--- a/controller/app/rest_models/rest_application.rb
+++ b/controller/app/rest_models/rest_application.rb
@@ -102,7 +102,7 @@ class RestApplication < OpenShift::Model
       self.git_url = "ssh://#{ssh_uri}/~/git/#{@name}.git/"
       self.ssh_url = "ssh://#{ssh_uri}"
     end
-    self.app_url = "http://#{app.fqdn}/"
+    self.app_url = app.app_url
     self.health_check_path = app.health_check_path
 
     self.building_with = nil

--- a/controller/app/rest_models/rest_application10.rb
+++ b/controller/app/rest_models/rest_application10.rb
@@ -109,7 +109,7 @@ class RestApplication10 < OpenShift::Model
       self.git_url = "ssh://#{ssh_uri}/~/git/#{@name}.git/"
       self.ssh_url = "ssh://#{ssh_uri}"
     end
-    self.app_url = "http://#{app.fqdn}/"
+    self.app_url = app.app_url
     self.health_check_path = app.health_check_path
 
     self.building_with = nil

--- a/controller/app/rest_models/rest_application13.rb
+++ b/controller/app/rest_models/rest_application13.rb
@@ -20,7 +20,7 @@ class RestApplication13 < OpenShift::Model
       self.git_url = "ssh://#{ssh_uri}/~/git/#{@name}.git/"
       self.ssh_url = "ssh://#{ssh_uri}"
     end
-    self.app_url = "http://#{app.fqdn}/"
+    self.app_url = app.app_url
     self.health_check_path = app.health_check_path
 
     self.building_with = nil

--- a/controller/app/rest_models/rest_application15.rb
+++ b/controller/app/rest_models/rest_application15.rb
@@ -101,7 +101,7 @@ class RestApplication15 < OpenShift::Model
       self.git_url = "ssh://#{ssh_uri}/~/git/#{@name}.git/"
       self.ssh_url = "ssh://#{ssh_uri}"
     end
-    self.app_url = "http://#{app.fqdn}/"
+    self.app_url = app.app_url
     self.health_check_path = app.health_check_path
 
     self.building_with = nil


### PR DESCRIPTION
This is the code change for issue outlined in bugzilla #1144894 - https://bugzilla.redhat.com/show_bug.cgi?id=1144894

If configuration in broker.conf (APP_ADVERTISE_HTTPS) is set to true, the URL created to access an application will by default be using https rather than http. 

The customer is currently actively using this change in their environment and are happy with what it provides. Thanks to @timothyh for making the initial changes for this.
