### PR TITLE
Routing daemon monitor fixes

### DIFF
--- a/routing-daemon/bin/oo-admin-ctl-routing
+++ b/routing-daemon/bin/oo-admin-ctl-routing
@@ -303,7 +303,7 @@ argvs.each do |argv|
 
   rescue => e
     $stderr.print("#{e.class}: ") unless e.class == ArgumentError
-    $stderr.puts(e.to_s)
+    $stderr.puts(e.message)
     $stderr.puts(e.backtrace) unless e.class == ArgumentError
     exit 1
   end

--- a/routing-daemon/bin/oo-admin-ctl-routing
+++ b/routing-daemon/bin/oo-admin-ctl-routing
@@ -216,8 +216,10 @@ argvs.each do |argv|
         puts "Deleting monitor #{argv[0]} of type #{argv[1]}."
         lb.delete_monitor argv[0], nil, argv[1]
       else
-        puts "Deleting monitor #{argv[0]} from pool #{argv[1]} of type #{argv[2]}."
-        lb.delete_monitor *argv
+        puts "Deleting monitor #{argv[0]} from pool #{argv[2]}."
+        lb.pools[argv[2]].delete_monitor argv[0]
+        puts "Deleting monitor #{argv[0]} of type #{argv[1]}."
+        lb.delete_monitor argv[0], argv[2], argv[1]
       end
 
     when 'add-pool-monitor'

--- a/routing-daemon/bin/oo-admin-ctl-routing
+++ b/routing-daemon/bin/oo-admin-ctl-routing
@@ -141,6 +141,8 @@ add-pool-monitor <pool> <monitor>
   Associate the specified monitor with the specified pool.
 delete-pool-monitor <pool> <monitor>
   Dissociate the specified monitor from the specified pool.
+list-pool-monitors <pool>
+  List all monitors associated with the specified pool.
 list-pool-members <pool>
   List all members of the specified pool.
 add-pool-member <pool> <host>:<port>
@@ -227,6 +229,17 @@ argvs.each do |argv|
       raise ArgumentError.new "Requires a pool name and monitor name." unless 2 == argv.length
       puts "Deleting monitor #{argv[0]} from pool #{argv[1]}."
       lb.pools[argv[0]].delete_monitor argv[1]
+
+    when 'list-pool-monitors'
+      raise ArgumentError.new "Requires a pool name." unless 1 == argv.length
+      puts "Listing monitors for pool #{argv[0]}."
+      pool_name = argv[0]
+      monitors = lb.pools[pool_name].get_monitors
+      if monitors.count > 0
+        puts "Pool #{pool_name} has #{monitors.count} monitors:\n" + monitors.map {|m| "  "+m+"\n"}.join
+      else
+        puts "Pool #{pool_name} has 0 monitors.\n"
+      end
 
     when 'list-pool-members'
       raise ArgumentError.new "Requires a pool name." unless 1 == argv.length

--- a/routing-daemon/bin/oo-admin-ctl-routing
+++ b/routing-daemon/bin/oo-admin-ctl-routing
@@ -137,6 +137,10 @@ create-monitor <name> <path> <up-code>
   and expects to receive <up-code> to indicate that the pool is up.
 delete-monitor <name> [<pool>] <type>
   Delete the specified monitor.
+add-pool-monitor <pool> <monitor>
+  Associate the specified monitor with the specified pool.
+delete-pool-monitor <pool> <monitor>
+  Dissociate the specified monitor from the specified pool.
 list-pool-members <pool>
   List all members of the specified pool.
 add-pool-member <pool> <host>:<port>
@@ -213,6 +217,16 @@ argvs.each do |argv|
         puts "Deleting monitor #{argv[0]} from pool #{argv[1]} of type #{argv[2]}."
         lb.delete_monitor *argv
       end
+
+    when 'add-pool-monitor'
+      raise ArgumentError.new "Requires a pool name and monitor name." unless 2 == argv.length
+      puts "Adding monitor #{argv[0]} to pool #{argv[1]}."
+      lb.pools[argv[0]].add_monitor argv[1]
+
+    when 'delete-pool-monitor'
+      raise ArgumentError.new "Requires a pool name and monitor name." unless 2 == argv.length
+      puts "Deleting monitor #{argv[0]} from pool #{argv[1]}."
+      lb.pools[argv[0]].delete_monitor argv[1]
 
     when 'list-pool-members'
       raise ArgumentError.new "Requires a pool name." unless 1 == argv.length

--- a/routing-daemon/bin/oo-admin-ctl-routing
+++ b/routing-daemon/bin/oo-admin-ctl-routing
@@ -135,7 +135,7 @@ list-monitors
 create-monitor <name> <path> <up-code>
   Create a new monitor with the specified name that queries <path>
   and expects to receive <up-code> to indicate that the pool is up.
-delete-monitor <name> <pool> <type>
+delete-monitor <name> [<pool>] <type>
   Delete the specified monitor.
 list-pool-members <pool>
   List all members of the specified pool.
@@ -205,9 +205,14 @@ argvs.each do |argv|
       lb.create_monitor *argv
 
     when 'delete-monitor'
-      raise ArgumentError.new "Requires a pool name and monitor type." unless 3 == argv.length
-      puts "Deleting monitor #{argv[0]} from pool #{argv[1]} of type #{argv[2]}."
-      lb.delete_monitor *argv
+      raise ArgumentError.new "Requires a pool name and monitor type." unless [2,3].include? argv.length
+      if 2 == argv.length
+        puts "Deleting monitor #{argv[0]} of type #{argv[1]}."
+        lb.delete_monitor argv[0], nil, argv[1]
+      else
+        puts "Deleting monitor #{argv[0]} from pool #{argv[1]} of type #{argv[2]}."
+        lb.delete_monitor *argv
+      end
 
     when 'list-pool-members'
       raise ArgumentError.new "Requires a pool name." unless 1 == argv.length

--- a/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
@@ -133,6 +133,10 @@ module OpenShift
         #   deleted, added, and deleted again).
         @lb_controller.queue_op Operation.new(:delete_pool_monitor, [self.name, monitor_name]), @lb_controller.ops.select {|op| (op.type == :create_pool && op.operands[0] == self.name) || ([:add_pool_monitor, :delete_pool_monitor].include?(op.type) && op.operands[0] == self.name && op.operands[1] == monitor_name)}
       end
+
+      def get_monitors
+        @lb_model.get_pool_monitors @name
+      end
     end
 
     def add_ssl alias_str, ssl_cert, private_key

--- a/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
@@ -348,7 +348,7 @@ module OpenShift
       # :delete_monitor blocks
       # if the corresponding pool is being deleted (if one is specified) or
       # if the monitor is being created.
-      queue_op Operation.new(:delete_monitor, [monitor_name, pool_name, type]), @ops.select {|op| (op.type == :create_monitor && op.operands[0] == monitor_name) || (pool_name && op.type == :delete_pool && op.operands[0] == pool_name)}
+      queue_op Operation.new(:delete_monitor, [monitor_name, type]), @ops.select {|op| (op.type == :create_monitor && op.operands[0] == monitor_name) || (pool_name && op.type == :delete_pool && op.operands[0] == pool_name)}
 
       monitors.delete monitor_name
     end

--- a/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
@@ -337,7 +337,7 @@ module OpenShift
 
       # :create_monitor blocks
       # if a monitor of the same name is currently being deleted.
-      queue_op Operation.new(:create_monitor, [monitor_name, path, up_code, type, interval, timeout]), @ops.select {|op| op.type == :delete_monitor_pool && op.operands[0] == monitor_name}
+      queue_op Operation.new(:create_monitor, [monitor_name, path, up_code, type, interval, timeout]), @ops.select {|op| op.type == :delete_monitor && op.operands[0] == monitor_name}
 
       monitors.push monitor_name
     end

--- a/routing-daemon/lib/openshift/routing/controllers/batched.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/batched.rb
@@ -70,6 +70,10 @@ module OpenShift
       def delete_monitor monitor_name
         @lb_model.delete_pool_monitor @name, monitor_name
       end
+
+      def get_monitors
+        @lb_model.get_pool_monitors @name
+      end
     end
 
     def add_ssl alias_str, ssl_cert, private_key

--- a/routing-daemon/lib/openshift/routing/controllers/batched.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/batched.rb
@@ -62,6 +62,14 @@ module OpenShift
         @aliases.delete alias_str
         @lb_model.delete_pool_alias @name, alias_str
       end
+
+      def add_monitor monitor_name
+        @lb_model.add_pool_monitor @name, monitor_name
+      end
+
+      def delete_monitor monitor_name
+        @lb_model.delete_pool_monitor @name, monitor_name
+      end
     end
 
     def add_ssl alias_str, ssl_cert, private_key

--- a/routing-daemon/lib/openshift/routing/controllers/load_balancer.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/load_balancer.rb
@@ -110,6 +110,10 @@ module OpenShift
       # force an immediate update.
       def delete_monitor monitor_name
       end
+
+      # Get the list of monitors associated with the pool.
+      def get_monitors
+      end
     end
 
     # @pools is a hash that maps String to LoadBalancerPool.

--- a/routing-daemon/lib/openshift/routing/controllers/load_balancer.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/load_balancer.rb
@@ -86,6 +86,30 @@ module OpenShift
       # force an immediate update.
       def remove_ssl alias_str
       end
+
+      # Add a monitor to the pool.
+      #
+      # The argument should be a String representing the name of a monitor.  The
+      # monitor must already exist.
+      #
+      # Depending on the model, adding a monitor may overwrite any existing
+      # monitor.
+      #
+      # This method does not necessarily update the load balancer itself; use
+      # the update method of the corresponding LoadBalancerController object to
+      # force an immediate update.
+      def add_monitor monitor_name
+      end
+
+      # Delete a monitor from the pool.
+      #
+      # The argument should be a String representing the name of a monitor.
+      #
+      # This method does not necessarily update the load balancer itself; use
+      # the update method of the corresponding LoadBalancerController object to
+      # force an immediate update.
+      def delete_monitor monitor_name
+      end
     end
 
     # @pools is a hash that maps String to LoadBalancerPool.

--- a/routing-daemon/lib/openshift/routing/controllers/simple.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/simple.rb
@@ -74,6 +74,10 @@ module OpenShift
       def delete_monitor monitor_name
         @lb_model.delete_pool_monitor @name, monitor_name
       end
+
+      def get_monitors
+        @lb_model.get_pool_monitors @name
+      end
     end
 
     def read_config cfgfile

--- a/routing-daemon/lib/openshift/routing/controllers/simple.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/simple.rb
@@ -66,6 +66,14 @@ module OpenShift
         @certs.delete alias_str
         @lb_model.remove_ssl @name, alias_str
       end
+
+      def add_monitor monitor_name
+        @lb_model.add_pool_monitor @name, monitor_name
+      end
+
+      def delete_monitor monitor_name
+        @lb_model.delete_pool_monitor @name, monitor_name
+      end
     end
 
     def read_config cfgfile

--- a/routing-daemon/lib/openshift/routing/models/dummy.rb
+++ b/routing-daemon/lib/openshift/routing/models/dummy.rb
@@ -40,6 +40,16 @@ module OpenShift
       [] # If using AsyncLoadBalancerController, return an array of jobids.
     end
 
+    def add_pool_monitor pool_name, monitor_name
+      @logger.debug "add monitor #{monitor_name} to pool #{pool_name}"
+      [] # If using AsyncLoadBalancerController, return an array of jobids.
+    end
+
+    def delete_pool_monitor pool_name, monitor_name
+      @logger.debug "delete monitor #{monitor_name} from pool #{pool_name}"
+      [] # If using AsyncLoadBalancerController, return an array of jobids.
+    end
+
     def get_pool_certificates pool_name
       @logger.debug "get pool certificates #{pool_name}"
       [] # Return an array of String representing certificates.

--- a/routing-daemon/lib/openshift/routing/models/dummy.rb
+++ b/routing-daemon/lib/openshift/routing/models/dummy.rb
@@ -50,6 +50,11 @@ module OpenShift
       [] # If using AsyncLoadBalancerController, return an array of jobids.
     end
 
+    def get_pool_monitors pool_name
+      @logger.debug "get monitors of pool #{pool_name}"
+      [] # If using AsyncLoadBalancerController, return an array of jobids.
+    end
+
     def get_pool_certificates pool_name
       @logger.debug "get pool certificates #{pool_name}"
       [] # Return an array of String representing certificates.

--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -44,7 +44,7 @@ module OpenShift
           end
         end
       rescue => e
-        msg = "got #{e.class} exception: #{e.to_s}"
+        msg = "got #{e.class} exception: #{e.message}"
         begin
           resp = JSON.parse e.response
           m = resp['message']

--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -128,6 +128,22 @@ module OpenShift
       delete(url: "https://#{@host}/mgmt/tm/ltm/monitor/#{type}/#{monitor_name}")
     end
 
+    # add_pool_monitor :: String, String -> undefined
+    def add_pool_monitor pool_name, monitor_name
+      patch(url: "https://#{@host}/mgmt/tm/ltm/pool/#{pool_name}",
+            payload: {
+              "monitor" => "/Common/#{monitor_name}",
+            }.to_json)
+    end
+
+    # delete_pool_monitor :: String, String -> undefined
+    def delete_pool_monitor pool_name, monitor_name
+      patch(url: "https://#{@host}/mgmt/tm/ltm/pool/#{pool_name}",
+            payload: {
+              "monitor" => nil,
+            }.to_json)
+    end
+
     def get_pool_members pool_name
       JSON.parse(get(url: "https://#{@host}/mgmt/tm/ltm/pool/#{pool_name}/members"))['items'].map {|item| item['name']}
     end

--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -37,10 +37,21 @@ module OpenShift
 
       expected_code = options.delete(:expected_code) || 200
 
-      RestClient::Request.execute(defaults.merge(options)).tap do |response|
-        unless response.code == expected_code
-          raise LBModelException.new "Expected HTTP #{expected_code} but got #{response.code} instead"
+      begin
+        RestClient::Request.execute(defaults.merge(options)).tap do |response|
+          unless response.code == expected_code
+            raise LBModelException.new "Expected HTTP #{expected_code} but got #{response.code} instead"
+          end
         end
+      rescue => e
+        msg = "got #{e.class} exception: #{e.to_s}"
+        begin
+          resp = JSON.parse e.response
+          m = resp['message']
+          msg += " (#{m})" unless m.empty?
+        rescue
+        end
+        raise LBModelException.new msg
       end
     end
 

--- a/routing-daemon/lib/openshift/routing/models/lbaas.rb
+++ b/routing-daemon/lib/openshift/routing/models/lbaas.rb
@@ -148,6 +148,12 @@ module OpenShift
       parse_jobids response
     end
 
+    def add_pool_monitor pool_name, monitor_name
+    end
+
+    def delete_pool_monitor pool_name, monitor_name
+    end
+
     # Returns [String] of pool names.
     def get_pool_members pool_name
       begin

--- a/routing-daemon/lib/openshift/routing/models/lbaas.rb
+++ b/routing-daemon/lib/openshift/routing/models/lbaas.rb
@@ -154,6 +154,9 @@ module OpenShift
     def delete_pool_monitor pool_name, monitor_name
     end
 
+    def get_pool_monitors pool_name
+    end
+
     # Returns [String] of pool names.
     def get_pool_members pool_name
       begin

--- a/routing-daemon/lib/openshift/routing/models/load_balancer.rb
+++ b/routing-daemon/lib/openshift/routing/models/load_balancer.rb
@@ -46,6 +46,14 @@ module OpenShift
     def delete_monitor monitor_name, type
     end
 
+    # add_pool_monitor :: String, String -> undefined
+    def add_pool_monitor pool_name, monitor_name
+    end
+
+    # delete_pool_monitor :: String, String -> undefined
+    def delete_pool_monitor pool_name, monitor_name
+    end
+
     def get_pool_certificates pool_name
       @logger.debug "get pool certificates #{pool_name}"
       [] # Return an array of String representing certificates.

--- a/routing-daemon/lib/openshift/routing/models/load_balancer.rb
+++ b/routing-daemon/lib/openshift/routing/models/load_balancer.rb
@@ -54,6 +54,10 @@ module OpenShift
     def delete_pool_monitor pool_name, monitor_name
     end
 
+    # get_pool_monitors :: String -> [String]
+    def get_pool_monitors pool_name
+    end
+
     def get_pool_certificates pool_name
       @logger.debug "get pool certificates #{pool_name}"
       [] # Return an array of String representing certificates.

--- a/routing-daemon/lib/openshift/routing/models/nginx.rb
+++ b/routing-daemon/lib/openshift/routing/models/nginx.rb
@@ -74,6 +74,9 @@ module OpenShift
     def delete_pool_monitor pool_name, monitor_name
     end
 
+    def get_pool_monitors pool_name
+    end
+
     def get_pool_members pool_name
       begin
         fname = "#{@confdir}/#{pool_name}.conf"

--- a/routing-daemon/lib/openshift/routing/models/nginx.rb
+++ b/routing-daemon/lib/openshift/routing/models/nginx.rb
@@ -68,6 +68,12 @@ module OpenShift
     def delete_monitor monitor_name, type
     end
 
+    def add_pool_monitor pool_name, monitor_name
+    end
+
+    def delete_pool_monitor pool_name, monitor_name
+    end
+
     def get_pool_members pool_name
       begin
         fname = "#{@confdir}/#{pool_name}.conf"


### PR DESCRIPTION
### routing-daemon: Fix async `create_monitor` queueing

Fix the logic for queueing `:create_monitor` operations in the asynchronous controller.  Previously, the queueing logic checked for `:delete_monitor_pool` operations; this commit fixes the logic to use the correct name for delete operations, namely `:delete_monitor`.
### routing-daemon: Fix async `delete_monitor` arguments

Fix the arguments specified when queueing a `:delete_monitor` operation in the asynchronous controller.  The `delete_monitor` method on the model does not take a `pool_name` argument, so we must not include any such argument when queueing the `:delete_monitor` operation.
### routing-daemon: Improve error reporting for F5

In the `rest_request` method, rescue exceptions from `RestClient::Request` and check the response body for a description of the problem from F5 in order to provide more descriptive error logging.
### `oo-admin-ctl-routing` `delete-monitor`: pool optional

Make the pool-name optional for `oo-admin-ctl-routing`'s `delete-monitor` subcommand.  A monitor is not necessarily associated with a pool, and indeed some backends (such as F5) do not allow a monitor to be deleted if it is associated with any pool.
### routing-daemon: Associate/dissociate monitors

Allow monitors to be associated with pools or dissociated from pools as a separate operation from pool creation and deletion.

`oo-admin-ctl-routing`: Add `add-pool-monitor` and `delete-pool-monitor` subcommands.

`AsyncLoadBalancerController::Pool`, `BatchedLoadBalancerController::Pool`, `LoadBalancerController::Pool`, `SimpleLoadBalancerController::Pool`: Add `add_monitor` and `delete_monitor` methods.

`DummyLoadBalancerModel`, `F5IControlRestLoadBalancerModel`, `LBaaSLoadBalancerModel`, `LoadBalancerModel`, `NginxLoadBalancerModel`: Add `add_pool_monitor` and `delete_pool_monitor` methods.

`AsyncLoadBalancerController#delete_pool`: Make the `:delete_pool` operation block on any `:delete_pool_monitor` operations on the same pool.
### routing-daemon: Allow list monitors of pool

Provide means to get the list of monitors associated with a pool (as opposed to the list of all monitors on the load balancer).
### `oo-admin-ctl-routing`: Add `list-pool-monitors` subcommand.

`AsyncLoadBalancerController::Pool`, `BatchedLoadBalancerController::Pool`, `LoadBalancerController::Pool`, `SimpleLoadBalancerController::Pool`: Add `get_monitors` method.

`DummyLoadBalancerModel`, `F5IControlRestLoadBalancerModel`, `LBaaSLoadBalancerModel`, `LoadBalancerModel`, `NginxLoadBalancerModel`: Add `list_pool_monitors` method.

`F5IControlRestLoadBalancerModel#add_pool_monitor`, `#delete_pool_monitor`: Modify the list of monitors to add or remove the given monitor to the list of monitors associated with the pool instead of simply replacing that list of monitors with only the given monitor.
### `oo-admin-ctl-routing`: Make `delete-monitor` cleverer

Make `oo-admin-ctl-routing`'s `delete-monitor` subcommand a little cleverer: Given a pool name, it will now try to dissociate the monitor from the pool before trying to delete the monitor.
### routing-daemon: Use `e.message,` not `e.to_s`

Use `e.message` instead of `e.to_s` to get the message of an exception.
