### PR TITLE
Don't delete archives if tar returns !0

### DIFF
--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -242,6 +242,25 @@ OPENSHIFT_FRONTEND_HTTP_PLUGINS=openshift-origin-frontend-apache-vhost,openshift
 #
 # ARCHIVE_DESTROYED_GEARS_DIR=
 
+# Compression to use for gear directory archives. Valid options
+# include "bzip2", "gzip", or "none".
+#
+# "bzip2" yields the best compression ratio, but tends to be
+# significantly slower than gzip. This should be used when the disk
+# space available in ARCHIVE_DESTROYED_GEARS_DIR is the primary
+# resource constraint.
+#
+# "gzip" typically generates larger archives than bzip2, but is
+# consistently between 2 to 10 times faster than bzip2.
+#
+# "none" is little more than a filesystem copy, and applies no
+# compression to generated archives. It is the fastest of the three
+# options, and is useful when time is the primary resource constraint.
+#
+# Defaults:
+#
+# ARCHIVE_DESTROYED_GEARS_COMPRESSION="bzip2"
+
 # Have oo-trap-user write an entry to syslog when a gear user logs in.
 # Leave 'true' to enable this, comment out or change to disable it.
 SYSLOG_GEAR_LOGIN=true


### PR DESCRIPTION
`tar` will return `1` if a "recoverable" error has happened, e.g. if a
file changed while it was being archived. We were erroneously deleting
the archive if this happened. Also, a "broken" archive may still be
useful, so now we only report if archiving failed, we don't delete the
archive.

This change also adds the `ARCHIVE_DESTROYED_GEARS_COMPRESSION` option,
which can be '`bzip2`', '`gzip`' or '`none`'.

Enterprise bug: 1200096
https://bugzilla.redhat.com/show_bug.cgi?id=1200096
