### PR TITLE
More routing-daemon and oo-admin-ctl-routing fixes related to bug 1199904

### DIFF
--- a/routing-daemon/bin/oo-admin-ctl-routing
+++ b/routing-daemon/bin/oo-admin-ctl-routing
@@ -211,7 +211,7 @@ argvs.each do |argv|
       lb.create_monitor *argv
 
     when 'delete-monitor'
-      raise ArgumentError.new "Requires a pool name and monitor type." unless [2,3].include? argv.length
+      raise ArgumentError.new "Requires a monitor name and monitor type." unless [2,3].include? argv.length
       if 2 == argv.length
         puts "Deleting monitor #{argv[0]} of type #{argv[1]}."
         lb.delete_monitor argv[0], nil, argv[1]

--- a/routing-daemon/bin/oo-admin-ctl-routing
+++ b/routing-daemon/bin/oo-admin-ctl-routing
@@ -135,7 +135,7 @@ list-monitors
 create-monitor <name> <path> <up-code>
   Create a new monitor with the specified name that queries <path>
   and expects to receive <up-code> to indicate that the pool is up.
-delete-monitor <name> [<pool>] <type>
+delete-monitor <name> <type> [<pool>]
   Delete the specified monitor.
 add-pool-monitor <pool> <monitor>
   Associate the specified monitor with the specified pool.

--- a/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
@@ -359,7 +359,12 @@ module OpenShift
     end
 
     def create_monitor monitor_name, path, up_code, type, interval, timeout
-      raise LBControllerException.new "Monitor already exists: #{monitor_name}" if monitors.include? monitor_name
+      @logger.debug "Creating monitor #{monitor_name}, #{path}, #{up_code}, #{type}, #{interval}, #{timeout}"
+      if monitors.include? monitor_name
+        @logger.debug "Monitor #{monitor_name} already exists in cached list of monitors; clearing cache to force a refresh..."
+        @monitors = nil
+        raise LBControllerException.new "Monitor already exists: #{monitor_name}" if monitors.include? monitor_name
+      end
 
       # :create_monitor blocks
       # if a monitor of the same name is currently being deleted.
@@ -369,7 +374,12 @@ module OpenShift
     end
 
     def delete_monitor monitor_name, pool_name, type
-      raise LBControllerException.new "Monitor not found: #{monitor_name}" unless monitors.include? monitor_name
+      @logger.debug "Deleting monitor #{monitor_name}, #{pool_name}, #{type}"
+      unless monitors.include? monitor_name
+        @logger.debug "Monitor #{monitor_name} does not exist in cached list of monitors; clearing cache to force a refresh..."
+        @monitors = nil
+        raise LBControllerException.new "Monitor not found: #{monitor_name}" unless monitors.include? monitor_name
+      end
 
       # :delete_monitor blocks
       # if the corresponding pool is being deleted (if one is specified) or

--- a/routing-daemon/lib/openshift/routing/controllers/batched.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/batched.rb
@@ -109,7 +109,12 @@ module OpenShift
     end
 
     def create_monitor monitor_name, path, up_code, type, interval, timeout
-      raise LBControllerException.new "Monitor already exists: #{monitor_name}" if monitors.include? monitor_name
+      @logger.debug "Creating monitor #{monitor_name}, #{path}, #{up_code}, #{type}, #{interval}, #{timeout}"
+      if monitors.include? monitor_name
+        @logger.debug "Monitor #{monitor_name} already exists in cached list of monitors; clearing cache to force a refresh..."
+        @monitors = nil
+        raise LBControllerException.new "Monitor already exists: #{monitor_name}" if monitors.include? monitor_name
+      end
 
       @lb_model.create_monitor monitor_name, path, up_code, type, interval, timeout
 
@@ -117,7 +122,12 @@ module OpenShift
     end
 
     def delete_monitor monitor_name, pool_name, type
-      raise LBControllerException.new "Monitor not found: #{monitor_name}" unless monitors.include? monitor_name
+      @logger.debug "Deleting monitor #{monitor_name}, #{pool_name}, #{type}"
+      unless monitors.include? monitor_name
+        @logger.debug "Monitor #{monitor_name} does not exist in cached list of monitors; clearing cache to force a refresh..."
+        @monitors = nil
+        raise LBControllerException.new "Monitor not found: #{monitor_name}" unless monitors.include? monitor_name
+      end
 
       # we assume the types won't be modified at runtime
       @lb_model.delete_monitor monitor_name, type if monitors.include? monitor_name

--- a/routing-daemon/lib/openshift/routing/controllers/simple.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/simple.rb
@@ -107,7 +107,12 @@ module OpenShift
     end
 
     def create_monitor monitor_name, path, up_code, type, interval, timeout
-      raise LBControllerException.new "Monitor already exists: #{monitor_name}" if monitors.include? monitor_name
+      @logger.debug "Creating monitor #{monitor_name}, #{path}, #{up_code}, #{type}, #{interval}, #{timeout}"
+      if monitors.include? monitor_name
+        @logger.debug "Monitor #{monitor_name} already exists in cached list of monitors; clearing cache to force a refresh..."
+        @monitors = nil
+        raise LBControllerException.new "Monitor already exists: #{monitor_name}" if monitors.include? monitor_name
+      end
 
       @lb_model.create_monitor monitor_name, path, up_code, type, interval, timeout
 
@@ -116,7 +121,11 @@ module OpenShift
 
     def delete_monitor monitor_name, pool_name, type
       @logger.debug "Deleting monitor #{monitor_name}, #{pool_name}, #{type}"
-      raise LBControllerException.new "Monitor not found: #{monitor_name}" unless monitors.include? monitor_name
+      unless monitors.include? monitor_name
+        @logger.debug "Monitor #{monitor_name} does not exist in cached list of monitors; clearing cache to force a refresh..."
+        @monitors = nil
+        raise LBControllerException.new "Monitor not found: #{monitor_name}" unless monitors.include? monitor_name
+      end
 
       @lb_model.delete_monitor monitor_name, type
 

--- a/routing-daemon/lib/openshift/routing/daemon.rb
+++ b/routing-daemon/lib/openshift/routing/daemon.rb
@@ -304,7 +304,11 @@ module OpenShift
         monitor_path = generate_monitor_path app_name, namespace
         unless monitor_name.nil? or monitor_name.empty? or monitor_path.nil? or monitor_path.empty?
           @logger.info "Creating new monitor #{monitor_name} with path #{monitor_path}"
-          @lb_controller.create_monitor monitor_name, monitor_path, @monitor_up_code, @monitor_type, @monitor_interval, @monitor_timeout
+          begin
+            @lb_controller.create_monitor monitor_name, monitor_path, @monitor_up_code, @monitor_type, @monitor_interval, @monitor_timeout
+          rescue LBControllerException => e
+            @logger.warn "#{e.class}: #{e.message}"
+          end
         end
       end
 


### PR DESCRIPTION
#### `oo-admin-ctl-routing`: Fix `delete-monitor` help text

Fix the help text for `oo-admin-ctl-routing`'s `delete-monitor` command.

The `delete-monitor` command takes arguments `<name> <type> [<pool>]`.  It makes sense for the monitor name and type to be together and for the optional argument to be last, so rather than changing ordering of arguments in the command, it makes more sense to change the help text to match the way the command actually works.
#### `oo-admin-ctl-routing`: Fix `delete-monitor` error msg

Fix the error message for `oo-admin-ctl-routing`'s `delete-monitor` command when it is given a wrong number of arguments.  The pool name is optional, but the monitor name is always required.
#### routing-daemon: Refresh monitors in case of error

Modify the controllers' `create_monitor` and `delete_monitor` methods to refresh the controller's cached list of monitors from the load balancer when the controller is told to create a monitor that already exists in the controller's list, or if it is told to delete a monitor that does not exist in its list.

After this commit, the routing daemon is better able to cope with the load-balancer's state's being modified from outside the routing daemon while the routing daemon is running.
#### routing-daemon: Try harder to create pool

Modify `OpenShift::RoutingDaemon#create_application` to rescue and log any `LBControllerException` raised in the controller's `create_monitor` method so that `create_application` will continue on to try to create the pool.

The goal of this commit is to make the routing daemon try a little harder to cope with inconsistent state.

This pull request addresses issue raised in bug 1199904.
