### PR TITLE
Added the "--all" option to oo-admin-ctl-cartridge

### DIFF
--- a/broker-util/man/oo-admin-ctl-cartridge.8
+++ b/broker-util/man/oo-admin-ctl-cartridge.8
@@ -75,6 +75,9 @@ Mark imported or updated cartridges as active.
 \fB-n\fP|\fB--name\fP NAMES
 A comma-delimited list of cartridge names. Used by the "delete" command.
 .PP
+\fB--all\fP
+Display all information
+.PP
 \fB--ids\fP IDS
 ID for a cartridge version to activate or deactivate (comma-delimited).
 .PP

--- a/broker-util/man/oo-admin-ctl-cartridge.txt2man
+++ b/broker-util/man/oo-admin-ctl-cartridge.txt2man
@@ -64,6 +64,9 @@ OPTIONS
   -n|--name NAMES
     A comma-delimited list of cartridge names. Used by the "delete" command.
 
+  --all
+    Display all information
+
   --ids IDS
     ID for a cartridge version to activate or deactivate (comma-delimited).
 

--- a/broker-util/oo-admin-ctl-cartridge
+++ b/broker-util/oo-admin-ctl-cartridge
@@ -573,6 +573,10 @@ or names.
     options.names = names.split(/[\, ]/)
   end
 
+  opts.on('--all', "Display all information") do
+    options.all = true
+  end
+
   opts.on('-q', "Display only ids") do
     options.quiet = true
   end

--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -125,6 +125,7 @@ module OpenShift
     end
 
     def delete_monitor monitor_name, type
+      type = type == 'https-ecv' ? 'https' : 'http'
       delete(url: "https://#{@host}/mgmt/tm/ltm/monitor/#{type}/#{monitor_name}")
     end
 


### PR DESCRIPTION
broker-util/oo-admin-ctl-cartridge: Added the "--all" option to allow for all information to be displayed (including the IDs/OIDs)

For more information, please see Bugzilla:
https://bugzilla.redhat.com/show_bug.cgi?id=1207300
