### PR TITLE
Bug 1207486 - stop_lock gears have status of "started"

### DIFF
--- a/node-util/conf/watchman/plugins.d/gear_state_plugin.rb
+++ b/node-util/conf/watchman/plugins.d/gear_state_plugin.rb
@@ -193,8 +193,12 @@ class GearStatePlugin < OpenShift::Runtime::WatchmanPlugin
       command = command.join(' ')
 
       # skip everything owned by root (for speed) and not a "daemon" (we can be fooled here)
-      # bz1134686 - but don't skip jenkins builder slaves
-      next unless uid != '0' && command =~ /jenkins\/slave.jar/ && ppid == '1'
+      if uid == '0' || ppid != '1'
+        # bz1134686 - don't skip jenkins builder slaves
+        if command !~ /jenkins\/slave.jar/
+          next
+        end
+      end
 
       # bz1133629
       # skip haproxy and logshifter related processes


### PR DESCRIPTION
The previous code was:

next unless uid != '0' && command =~ /jenkins\/slave.jar/ && ppid == '1'

that's the same as:

next if !(uid != '0' && command =~ /jenkins\/slave.jar/ && ppid == '1')

or:

next if uid == '0' || command !~ /jenkins\/slave.jar/ || ppid != '1'

Which is actually not what we wanted because the jenkins slave check would
short circuit the non-deamon check in the case of stop_lock checks.  The
process would be non-root and non-jenkins related which would cuase it to be
skipped.  We only wanted to do that if the process was not a daemon:

next if uid == '0' || ppid != '1' && command !~ /jenkins\/slave.jar/

That will skip root process, skip things that aren't daemons except for the
jenkins slave process.  The version committed is simply a more commented
version of this.
