### PR TITLE
BZ1210489 -  Enable-HA registers routing appliaction DNS twice

### DIFF
--- a/broker/test/functional/application_controller_test.rb
+++ b/broker/test/functional/application_controller_test.rb
@@ -300,6 +300,18 @@ class ApplicationControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  # Follows user workflow to make an application ha
+  test "app create available routing dns created only once" do
+    Rails.configuration.openshift[:manage_ha_dns] = true
+    @user.ha = true
+    @user.save
+    @app_name = "app#{@random}"
+    Application.any_instance.expects(:register_routing_dns).once
+    post :create, {"name" => @app_name, "cartridge" => jbosseap_version, "domain_id" => @domain.namespace, "scale" => true}
+    assert app = assigns(:application)
+    assert app.make_ha
+  end
+
   test "app create available show destroy by domain and app name" do
     @user.ha=true
     @user.save

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1938,7 +1938,10 @@ class Application
       register_dns_op = RegisterDnsOp.new(gear_id: gear_id, prereq: [create_gear_op._id.to_s])
       register_sso_op = RegisterSsoOp.new(gear_id: gear_id, prereq: [register_dns_op._id.to_s])
       ops.push(init_gear_op, reserve_uid_op, create_gear_op, register_dns_op, register_sso_op)
-      ops.push(RegisterRoutingDnsOp.new(prereq: [register_sso_op._id.to_s])) if self.ha and Rails.configuration.openshift[:manage_ha_dns]
+      # Only register the routing dns here on application creation:
+      if self.component_instances == []
+        ops.push(RegisterRoutingDnsOp.new(prereq: [register_sso_op._id.to_s])) if self.ha and Rails.configuration.openshift[:manage_ha_dns]
+      end
 
       if additional_filesystem_gb != 0
         # FIXME move into CreateGearOp


### PR DESCRIPTION
Bug 1210489
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1210489
The routing dns entry is added twice. This addition, added in d15a9d2aad33cd3ae0723ee9ac2c126c1ab1966e, is not needed as a method to create an HA application in a single API call is not implemented.
