### PR TITLE
Attempting to fix BZ 1212020

### DIFF
--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -125,6 +125,7 @@ module OpenShift
     end
 
     def delete_monitor monitor_name, type
+      type = type == 'https-ecv' ? 'https' : 'http'
       delete(url: "https://#{@host}/mgmt/tm/ltm/monitor/#{type}/#{monitor_name}")
     end
 


### PR DESCRIPTION
Doing the same type checking that we do for the create monitor should, also allow us to resolve issues seen in miss/off configurations, when we delete monitors. 
