### PR TITLE
Bug 1218841 - Adding the net-ssh requirement to the controller RPM

### DIFF
--- a/controller/rubygem-openshift-origin-controller.spec
+++ b/controller/rubygem-openshift-origin-controller.spec
@@ -24,6 +24,7 @@ Requires:      %{?scl:%scl_prefix}rubygems
 Requires:      %{?scl:%scl_prefix}rubygem(state_machine)
 Requires:      %{?scl:%scl_prefix}rubygem(dnsruby)
 Requires:      %{?scl:%scl_prefix}rubygem(httpclient)
+Requires:      %{?scl:%scl_prefix}rubygem-net-ssh
 Requires:      rubygem(openshift-origin-common)
 %if 0%{?fedora}%{?rhel} <= 6
 BuildRequires: %{?scl:%scl_prefix}build


### PR DESCRIPTION
[merge]

This requirement is already in the gemfile.  It technically pulled in by another dependency but this is the correct thing to do. :)
