### PR TITLE
Add membership manipulation to oo-admin-ctl-domain

### DIFF
--- a/broker-util/oo-admin-ctl-domain
+++ b/broker-util/oo-admin-ctl-domain
@@ -23,7 +23,7 @@ Options:
    --new_namespace <Namespace>
     New namespace for application(s) (alphanumeric - max 16 chars) (required
       for --command update)
--c|--command (create|update|delete|info|env_add|env_del)
+-c|--command (create|update|delete|info|env_add|env_del|add_member|remove_member|update_member|list_members)
 -s|--ssh_key <ssh key>
     User\'s SSH key
 -t|--key_type <ssh key type>
@@ -34,6 +34,10 @@ Options:
 -v|--env_value <env var value>
    --allowed_gear_sizes <allowed gear sizes>
     A comma separated list of gear sizes allowed on the domain
+-m|--member <member>
+    User whose membership will be added, removed or updated
+-r|--role (view|edit|admin) (default: admin)
+    Role to be assigned to a member
 -h|--help:
     Show Usage info
 USAGE
@@ -52,6 +56,8 @@ opts = GetoptLong.new(
     ["--env_value",        "-v", GetoptLong::REQUIRED_ARGUMENT],
     ["--new_namespace"         , GetoptLong::REQUIRED_ARGUMENT],
     ["--allowed_gear_sizes"    , GetoptLong::REQUIRED_ARGUMENT],
+    ["--role",             "-r", GetoptLong::REQUIRED_ARGUMENT],
+    ["--member",           "-m", GetoptLong::REQUIRED_ARGUMENT],
     ["--help",             "-h", GetoptLong::NO_ARGUMENT]
 )
 
@@ -72,6 +78,8 @@ new_namespace = args["--new_namespace"]
 env_name = args["--env_name"]
 env_value = args["--env_value"]
 allowed_gear_sizes = args["--allowed_gear_sizes"]
+role = args["--role"]
+member = args["--member"]
 
 if login.nil? or args["--help"]
   usage
@@ -285,6 +293,174 @@ when "delete"
     user.delete
     reply.resultIO << "Successfully deleted user.\n"
   end
+
+when "add-member"
+  if namespace.nil?
+    puts "Please provide a namespace."
+    exit 1
+  end
+  if member.nil?
+    puts "Please provide a member to add to the domain"
+    exit 1
+  end
+  begin
+    owner = CloudUser.with(consistency: :eventual).find_by(login: login)
+  rescue Mongoid::Errors::DocumentNotFound
+    puts "User with login '#{login}' not found"
+    exit 1
+  end
+  begin
+    user = CloudUser.with(consistency: :eventual).find_by(login: member)
+  rescue Mongoid::Errors::DocumentNotFound
+    puts "Member with login '#{member}' not found"
+    exit 1
+  end
+  begin
+    domain = Domain.with(consistency: :eventual).find_by(owner: owner, canonical_namespace: namespace.downcase)
+  rescue Mongoid::Errors::DocumentNotFound
+    puts "Domain with namespace: #{namespace} not found for user #{owner.login}"
+    exit 1
+  end
+
+  if domain.members.include?(user)
+    puts "User \"#{member}\" is already a member of domain \"#{namespace}\"."
+    exit 1
+  end
+  if domain.members.length >= Rails.configuration.openshift[:max_members_per_resource]
+    puts "Cannot add \"#{member}\" to domain \"#{namespace}\". Domain already has maximum number of members."
+    puts "Domain members:  #{domain.members.length}"
+    puts "Maximum members: #{Rails.configuration.openshift[:max_members_per_resource]} (Defined with MAX_MEMBERS_PER_RESOURCE in the broker configuration)"
+    exit 1
+  end
+  role = "admin" if role.nil?
+  domain.add_members(user, Role.for(role))
+  begin
+    domain.save
+    domain.run_jobs
+  rescue
+    puts "Unable to add \"#{user.login}\" to domain \"#{domain.canonical_namespace}\" with role \"#{role}\"."
+    puts "Errors: #{domain.errors.messages}"
+    exit 3
+  end
+  reply.resultIO << "Successfully added \"#{user.login}\" to domain \"#{domain.canonical_namespace}\" with role \"#{role}\".\n"
+
+when "update-member"
+  if namespace.nil?
+    puts "Please provide a namespace."
+    exit 1
+  end
+  if member.nil?
+    puts "Please provide a member to update in the domain."
+    exit 1
+  end
+  if role.nil?
+    puts "Please provide a role for the updated member."
+    exit 1
+  end
+  begin
+    owner = CloudUser.with(consistency: :eventual).find_by(login: login)
+  rescue Mongoid::Errors::DocumentNotFound
+    puts "User with login '#{login}' not found"
+    exit 1
+  end
+  begin
+    user = CloudUser.with(consistency: :eventual).find_by(login: member)
+  rescue Mongoid::Errors::DocumentNotFound
+    puts "Member with login '#{member}' not found"
+    exit 1
+  end
+  begin
+    domain = Domain.with(consistency: :eventual).find_by(owner: owner, canonical_namespace: namespace.downcase)
+  rescue Mongoid::Errors::DocumentNotFound
+    puts "Domain with namespace: #{namespace} not found for user #{owner.login}"
+    exit 1
+  end
+
+  domain.add_members(user, Role.for(role))
+  begin
+    domain.save
+    domain.run_jobs
+  rescue
+    puts "Unable to update \"#{user.login}\" in domain \"#{domain.canonical_namespace}\" with role \"#{role}\"."
+    puts "Errors: #{domain.errors.messages}"
+    exit 3
+  end
+  reply.resultIO << "Successfully updated \"#{user.login}\" in domain \"#{domain.canonical_namespace}\" with role \"#{role}\".\n"
+
+when "remove-member"
+  if namespace.nil?
+    puts "Please provide a namespace."
+    exit 1
+  end
+  if member.nil?
+    puts "Please provide a member to add to the domain"
+    exit 1
+  end
+  if login == member
+    puts "Cannot remove domain owner \"#{member}\" from domain \"#{namespace}\"."
+    exit 1
+  end
+  begin
+    owner = CloudUser.with(consistency: :eventual).find_by(login: login)
+  rescue Mongoid::Errors::DocumentNotFound
+    puts "User with login '#{login}' not found"
+    exit 1
+  end
+  begin
+    user = CloudUser.with(consistency: :eventual).find_by(login: member)
+  rescue Mongoid::Errors::DocumentNotFound
+    puts "Member with login '#{member}' not found"
+    exit 1
+  end
+  begin
+    domain = Domain.with(consistency: :eventual).find_by(owner: owner, canonical_namespace: namespace.downcase)
+  rescue Mongoid::Errors::DocumentNotFound
+    puts "Domain with namespace: #{namespace} not found for user #{owner.login}"
+    exit 1
+  end
+
+  if !domain.members.include?(user)
+    puts "User \"#{member}\" is not a member of domain \"#{namespace}\""
+    exit 1
+  end
+  domain.remove_members(user)
+  begin
+    domain.save
+    domain.run_jobs
+  rescue
+    puts "Unable to remove \"#{user.login}\" from domain \"#{domain.canonical_namespace}\"."
+    puts "Errors: #{domain.errors.messages}"
+    exit 3
+  end
+  reply.resultIO << "Successfully removed \"#{user.login}\" from domain \"#{domain.canonical_namespace}\".\n"
+
+when "list-members"
+  if namespace.nil?
+    puts "Please provide a namespace."
+    exit 1
+  end
+  begin
+    user = CloudUser.with(consistency: :eventual).find_by(login: login)
+  rescue Mongoid::Errors::DocumentNotFound
+    puts "User with login '#{login}' not found"
+    exit 1
+  end
+  begin
+    domain = Domain.with(consistency: :eventual).find_by(owner: user, canonical_namespace: namespace.downcase)
+  rescue Mongoid::Errors::DocumentNotFound
+    puts "Domain with namespace: #{namespace} not found for user #{user.login}"
+    exit 1
+  end
+
+  puts "Members of the \"#{namespace}\" domain:"
+  domain.members.each_with_index do |member, i|
+    if (domain.members.length - 1) != i
+      print "#{member.name}(#{member.role}), "
+    else
+      print "#{member.name}(#{member.role})\n"
+    end
+  end
+
 else
   user = nil
   begin

--- a/controller/test/cucumber/platform-oo-admin.feature
+++ b/controller/test/cucumber/platform-oo-admin.feature
@@ -71,3 +71,26 @@ Feature: Adding and deleting domain environment variable
 
     Then the domain environment variable TEST_VAR_1 will equal 'Foo' for all the applications in the namespace "randomNamespaceA"
     And the domain environment variable TEST_VAR_1 will not exist for the application "mock01app3"
+
+  @node_extended3
+  @domain_member_test_1
+  Scenario: Add and remove a member from a namespace
+
+    Given a new user with login "foo1" and namespace "bar1"
+    Given a new user with login "foo2" and namespace "bar2"
+    When the user "foo1" is added to the namespace "bar2"
+    Then the user "foo1" is a member of the domain "bar2"
+    When the user "foo1" is removed from the namespace "bar2"
+    Then the user "foo1" is not a member of the domain "bar2"
+
+  @node_extended3
+  @domain_member_test_2
+  Scenario: Add a member to a namespace and modify the members role
+
+    Given a new user with login "foo1" and namespace "bar1"
+    Given a new user with login "foo2" and namespace "bar2"
+    When the user "foo1" is added to the namespace "bar2"
+    Then the user "foo1" is a member of the domain "bar2"
+    When the "foo1" user's role is modified to "edit" in the namespace "bar2"
+    Then the user "foo1" has the role "edit" in the namespace "bar2"
+

--- a/controller/test/cucumber/step_definitions/domain_member_steps.rb
+++ b/controller/test/cucumber/step_definitions/domain_member_steps.rb
@@ -1,0 +1,73 @@
+include AppHelper
+
+Given /^a new user with login "([^\"]*)" and (?:domain|namespace) "([^\"]*)"$/ do |login, namespace|
+    @unique_namespace_apps_hash ||= {}
+    register_user(login, "xyz123") if $registration_required
+    empty_app = AppHelper::TestApp.new(namespace, login, nil, nil, "xyz123", nil)
+    rhc_create_domain(empty_app)
+    raise "Could not create domain: #{empty_app.create_domain_code}" unless empty_app.create_domain_code == 0
+    @unique_namespace_apps_hash[namespace] = empty_app
+end
+
+When /^the (?:user|member) "([^\"]*)" is added to the (?:domain|namespace) "([^\"]*)"$/ do |new_member, namespace|
+    app_login = get_app_login_from_namespace(namespace)
+    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c add-member -m #{new_member}"
+    $logger.info("Executing the command: #{command}")
+    output_buffer = []
+    exit_code = run(command, output_buffer)
+    raise "Failed to add member #{new_member} to namespace #{namespace}. Exit code: #{exit_code} and output message: #{output_buffer}" if exit_code != 0
+end
+
+When /^the (?:user|member) "([^\"]*)" is removed from the (?:domain|namespace) "([^\"]*)"$/ do |removed_member, namespace|
+    app_login = get_app_login_from_namespace(namespace)
+    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c remove-member -m #{removed_member}"
+    $logger.info("Executing the command: #{command}")
+    output_buffer = []
+    exit_code = run(command, output_buffer)
+    raise "Failed to remove member #{new_member} from namespace #{namespace}. Exit code: #{exit_code} and output message: #{output_buffer}" if exit_code != 0
+end
+
+Then /^the (?:user|member) "([^\"]*)" is a member of the (?:domain|namespace) "([^\"]*)"$/ do |member, namespace|
+    app_login = get_app_login_from_namespace(namespace)
+    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c list-members"
+    $logger.info("Executing the command: #{command}")
+    output_buffer = []
+    exit_code = run(command, output_buffer)
+    raise "Failed to list members of namespace #{namespace}. Exit code: #{exit_code} and output message: #{output_buffer}" if exit_code != 0
+    output_buffer[0].split("\n")[1].should == "#{app_login}(admin), #{member}(admin)\r"
+end
+
+Then /^the (?:user|member) "([^\"]*)" is not a member of the (?:domain|namespace) "([^\"]*)"$/ do |member, namespace|
+    app_login = get_app_login_from_namespace(namespace)
+    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c list-members"
+    $logger.info("Executing the command: #{command}")
+    output_buffer = []
+    exit_code = run(command, output_buffer)
+    raise "Failed to list members of namespace #{namespace}. Exit code: #{exit_code} and output message: #{output_buffer}" if exit_code != 0
+    output_buffer[0].split("\n")[1].should == "#{app_login}(admin)\r"
+end
+
+When /^the "([^\"]*)" (?:user|member)'s role is modified to "([^\"]*)" in the namespace "([^\"]*)"$/ do |member, role, namespace|
+    app_login = get_app_login_from_namespace(namespace)
+    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c update-member -m #{member} -r #{role}"
+    $logger.info("Executing the command: #{command}")
+    output_buffer = []
+    exit_code = run(command, output_buffer)
+    raise "Failed to list members of namespace #{namespace}. Exit code: #{exit_code} and output message: #{output_buffer}" if exit_code != 0
+end
+
+Then /^the (?:user|member) "([^\"]*)" has the role "([^\"]*)" in the (?:namespace|domain) "([^\"]*)"$/ do |member, role, namespace|
+    app_login = get_app_login_from_namespace(namespace)
+    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c list-members"
+    $logger.info("Executing the command: #{command}")
+    output_buffer = []
+    exit_code = run(command, output_buffer)
+    raise "Failed to list members of namespace #{namespace}. Exit code: #{exit_code} and output message: #{output_buffer}" if exit_code != 0
+    output_buffer[0].split("\n")[1].should == "#{app_login}(admin), #{member}(edit)\r"
+end
+
+def get_app_login_from_namespace(namespace)
+  app = @unique_namespace_apps_hash[namespace]
+  raise "Could not find existing namepsace #{namespace}" unless app
+  app.login
+end

--- a/controller/test/cucumber/support/domain_member_helper.rb
+++ b/controller/test/cucumber/support/domain_member_helper.rb
@@ -1,0 +1,18 @@
+After('@domain_member_test_1') do
+  clean_domains
+end
+
+After('@domain_member_test_2') do
+  clean_domains
+end
+
+def clean_domains
+  if @unique_namespace_apps_hash.nil? || @unique_namespace_apps_hash.empty?
+    $logger.info("No unique domains found, not deleting domains.")
+    return
+  end
+  @unique_namespace_apps_hash.each do |namespace, app|
+    rhc_delete_domain(app)
+  end
+  @unique_namespace_apps_hash = {}
+end


### PR DESCRIPTION
Bug 1145344
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1145344
Adds the ability to manipulate and list membership of a domain through the oo-admin-ctl-domain tool.
