### PR TITLE
logshifter/config.go: modify logshifter config reader such that blank lines (line == \n) don't cause reading to stop

### DIFF
--- a/logshifter/config.go
+++ b/logshifter/config.go
@@ -66,6 +66,10 @@ func ParseConfig(file string) (*Config, error) {
 			break
 		}
 
+		if line == "\n" {
+			continue
+		}
+
 		c := strings.SplitN(line, "=", 2)
 
 		if len(c) != 2 {


### PR DESCRIPTION
While reading logshifter config, continue if line is only a newline. This allows config reading to continue until no more reading can occur rather than stopping as soon as a blank line is encountered.
## 

I ran into this with some hosts configured using an old version of [puppet-openshift_origin](https://github.com/openshift/puppet-openshift_origin) which would deploy a logshifter config with blank lines where conditional statements were not trimmed. This has since been fixed in the puppet module (via [575deb5](https://github.com/openshift/puppet-openshift_origin/commit/575deb5da6a06fe56e9f7a408a68b1ceed1ac326)) which no longer introduces blank lines to the file. I figured it couldn't hurt to attack this from both sides.

Thanks!
