### PR TITLE
Delete bogus nodejs_context invocation

### DIFF
--- a/cartridges/openshift-origin-cartridge-nodejs/bin/control
+++ b/cartridges/openshift-origin-cartridge-nodejs/bin/control
@@ -211,7 +211,6 @@ function build() {
     unset GIT_DIR
     unset GIT_WORK_TREE
 
-    nodejs_context /bin/bash
     if [ -f "${OPENSHIFT_REPO_DIR}"/package.json ]; then
         (cd "${OPENSHIFT_REPO_DIR}"; nodejs_context "npm install -d")
     fi


### PR DESCRIPTION
Delete a useless invocation of `nodejs_context /bin/bash`, which was introduced in commit 4572b9be00f0d18c05a237f524f7cb1f33eaeba7.
