### PR TITLE
Install cpan dependencies in listed order

### DIFF
--- a/cartridges/openshift-origin-cartridge-perl/bin/build
+++ b/cartridges/openshift-origin-cartridge-perl/bin/build
@@ -43,7 +43,7 @@ then
 
   DEPS=$(find $OPENSHIFT_REPO_DIR -type f \( -name \*\.pm -o -name \*\.pl \); )
 
-  for f in $(( echo "$DEPS" | xargs /usr/lib/rpm/perl.req | awk '{ print $1 }' | sed 's/^perl(\(.*\))$/\1/'; cat ${CPAN_PATH} 2>/dev/null ) | sort -u | grep . )
+  for f in $(( cat "$CPAN_PATH" ; echo "$DEPS" | xargs /usr/lib/rpm/perl.req | awk '{ print $1 }' | sed 's/^perl(\(.*\))$/\1/' 2>/dev/null ) | awk '/./ && !seen[$0]++' )
   do
     # Skipping well-known perl pragmas
     for element in ${EXCLUDED_PRAGMAS[@]}; do


### PR DESCRIPTION
Respect the order in which dependencies are listed in `.openshift/cpan.txt` or `deplist.txt`, and install them prior to detected dependencies.

Uniqueness is still enforced by excluding subsequent duplicates.

An instance where ordering matters is with Dancer and Plack::Builder.  Even though installing Dancer causes Plack::Builder to be installed, the installation of Dancer fails unless Plack::Builder is already installed. Thus it is required either to retry the installation of Dancer or to explicitly install Plack::Builder first (which can be done by listing it before Dancer in `.openshift/cpan.txt`).
