### PR TITLE
Change the priority number for openshift-tc

### DIFF
--- a/node/misc/init/openshift-tc
+++ b/node/misc/init/openshift-tc
@@ -6,7 +6,7 @@
 # Liberally excerpted from an example by Scott Seong
 #   http://www.topwebhosts.org/tools/traffic-control.php
 #
-# chkconfig:    345 7 93
+# chkconfig:    345 11 89
 #
 # description:  Set OpenShift traffic control limits
 # processname:  NA


### PR DESCRIPTION
- Change the priority number to be higher than the network interfaces ( number 10).
- Causing issues (File : node/lib/openshift-origin-node/utils/tc.rb:105) when using bonding interfaces (bondx) as EXTERNAL_ETH_DEV as the MTU is not actually predefined before the start.
