### PR TITLE
oo-admin-ctl-domain uses underscores in command options

### DIFF
--- a/broker-util/oo-admin-ctl-domain
+++ b/broker-util/oo-admin-ctl-domain
@@ -294,7 +294,7 @@ when "delete"
     reply.resultIO << "Successfully deleted user.\n"
   end
 
-when "add-member"
+when "add_member"
   if namespace.nil?
     puts "Please provide a namespace."
     exit 1
@@ -344,7 +344,7 @@ when "add-member"
   end
   reply.resultIO << "Successfully added \"#{user.login}\" to domain \"#{domain.canonical_namespace}\" with role \"#{role}\".\n"
 
-when "update-member"
+when "update_member"
   if namespace.nil?
     puts "Please provide a namespace."
     exit 1
@@ -387,7 +387,7 @@ when "update-member"
   end
   reply.resultIO << "Successfully updated \"#{user.login}\" in domain \"#{domain.canonical_namespace}\" with role \"#{role}\".\n"
 
-when "remove-member"
+when "remove_member"
   if namespace.nil?
     puts "Please provide a namespace."
     exit 1
@@ -434,7 +434,7 @@ when "remove-member"
   end
   reply.resultIO << "Successfully removed \"#{user.login}\" from domain \"#{domain.canonical_namespace}\".\n"
 
-when "list-members"
+when "list_members"
   if namespace.nil?
     puts "Please provide a namespace."
     exit 1

--- a/controller/test/cucumber/step_definitions/domain_member_steps.rb
+++ b/controller/test/cucumber/step_definitions/domain_member_steps.rb
@@ -11,7 +11,7 @@ end
 
 When /^the (?:user|member) "([^\"]*)" is added to the (?:domain|namespace) "([^\"]*)"$/ do |new_member, namespace|
     app_login = get_app_login_from_namespace(namespace)
-    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c add-member -m #{new_member}"
+    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c add_member -m #{new_member}"
     $logger.info("Executing the command: #{command}")
     output_buffer = []
     exit_code = run(command, output_buffer)
@@ -20,7 +20,7 @@ end
 
 When /^the (?:user|member) "([^\"]*)" is removed from the (?:domain|namespace) "([^\"]*)"$/ do |removed_member, namespace|
     app_login = get_app_login_from_namespace(namespace)
-    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c remove-member -m #{removed_member}"
+    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c remove_member -m #{removed_member}"
     $logger.info("Executing the command: #{command}")
     output_buffer = []
     exit_code = run(command, output_buffer)
@@ -29,7 +29,7 @@ end
 
 Then /^the (?:user|member) "([^\"]*)" is a member of the (?:domain|namespace) "([^\"]*)"$/ do |member, namespace|
     app_login = get_app_login_from_namespace(namespace)
-    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c list-members"
+    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c list_members"
     $logger.info("Executing the command: #{command}")
     output_buffer = []
     exit_code = run(command, output_buffer)
@@ -39,7 +39,7 @@ end
 
 Then /^the (?:user|member) "([^\"]*)" is not a member of the (?:domain|namespace) "([^\"]*)"$/ do |member, namespace|
     app_login = get_app_login_from_namespace(namespace)
-    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c list-members"
+    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c list_members"
     $logger.info("Executing the command: #{command}")
     output_buffer = []
     exit_code = run(command, output_buffer)
@@ -49,7 +49,7 @@ end
 
 When /^the "([^\"]*)" (?:user|member)'s role is modified to "([^\"]*)" in the namespace "([^\"]*)"$/ do |member, role, namespace|
     app_login = get_app_login_from_namespace(namespace)
-    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c update-member -m #{member} -r #{role}"
+    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c update_member -m #{member} -r #{role}"
     $logger.info("Executing the command: #{command}")
     output_buffer = []
     exit_code = run(command, output_buffer)
@@ -58,7 +58,7 @@ end
 
 Then /^the (?:user|member) "([^\"]*)" has the role "([^\"]*)" in the (?:namespace|domain) "([^\"]*)"$/ do |member, role, namespace|
     app_login = get_app_login_from_namespace(namespace)
-    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c list-members"
+    command = "oo-broker --non-interactive oo-admin-ctl-domain -l \"#{app_login}\" -n #{namespace} -c list_members"
     $logger.info("Executing the command: #{command}")
     output_buffer = []
     exit_code = run(command, output_buffer)


### PR DESCRIPTION
Bug 1145344
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1145344
oo-admin-ctl-domain uses underscores in domain options. Fix command parsing and tests to reflect this.
