### PR TITLE
Read configuration files from Gemfile as a binary

### DIFF
--- a/broker/Gemfile
+++ b/broker/Gemfile
@@ -63,18 +63,26 @@ else
 end
 
 # Load extra gems specified in the broker configuration file
-conf_file_path = (ENV['OPENSHIFT_CONF_DIR'] || "/etc/openshift/") + 'broker.conf'
-if File.exists?(conf_file_path)
-  conf_file = File.open(conf_file_path)
-  additional_gems = conf_file.read[/^ADDITIONAL_RUBYGEMS\s*=\s*(.+)/, 1]
-  if additional_gems
-    gem_list = additional_gems.split(" ").uniq
-    gem_list.each do |name|
-      gem name.gsub(/["']/, "")
+begin
+  conf_file_path = (ENV['OPENSHIFT_CONF_DIR'] || "/etc/openshift/") + 'broker.conf'
+  if File.exists?(conf_file_path)
+    # Read file as binary to avoid encoding issues when configuration
+    # file is encoded as UTF-8
+    conf_file = File.open(conf_file_path, 'rb')
+    additional_gems = conf_file.read[/^ADDITIONAL_RUBYGEMS\s*=\s*(.+)/, 1]
+    if additional_gems
+      gem_list = additional_gems.split(" ").uniq
+      gem_list.each do |name|
+        gem name.gsub(/["']/, "")
+      end
     end
+  else
+    $stderr.puts "Could not find broker configuration file at #{conf_file_path}. Skipping loading additional gems."
   end
-else
-  puts "Could not find broker configuration file at #{conf_file_path}. Skipping loading additional gems."
+rescue => e
+  $stderr.puts "Could not parse additional gems for broker: #{e.message}"
+  $stderr.puts e.backtrace
+  $stderr.puts "Skipping loading additional gems for broker."
 end
 
 # Bundle edge Rails instead:

--- a/openshift-console/Gemfile
+++ b/openshift-console/Gemfile
@@ -37,16 +37,24 @@ group :assets do
 end
 
 # Load extra gems specified in the console configuration file
-conf_file_path = (ENV['OPENSHIFT_CONF_DIR'] || "/etc/openshift/") + 'console.conf'
-if File.exists?(conf_file_path)
-  conf_file = File.open(conf_file_path)
-  additional_gems = conf_file.read[/^ADDITIONAL_RUBYGEMS\s*=\s*(.+)/, 1]
-  if additional_gems
-    gem_list = additional_gems.split(" ").uniq
-    gem_list.each do |name|
-      gem name.gsub(/["']/, "")
+begin
+  conf_file_path = (ENV['OPENSHIFT_CONF_DIR'] || "/etc/openshift/") + 'console.conf'
+  if File.exists?(conf_file_path)
+    # Read file as binary to avoid encoding issues when configuration
+    # file is encoded as UTF-8
+    conf_file = File.open(conf_file_path, 'rb')
+    additional_gems = conf_file.read[/^ADDITIONAL_RUBYGEMS\s*=\s*(.+)/, 1]
+    if additional_gems
+      gem_list = additional_gems.split(" ").uniq
+      gem_list.each do |name|
+        gem name.gsub(/["']/, "")
+      end
     end
+  else
+    $stderr.puts "Could not find console configuration file at #{conf_file_path}. Skipping loading additional gems."
   end
-else
-  puts "Could not find console configuration file at #{conf_file_path}. Skipping loading additional gems."
+rescue => e
+  $stderr.puts "Could not parse additional gems for console: #{e.message}"
+  $stderr.puts e.backtrace
+  $stderr.puts "Skipping loading additional gems for console."
 end


### PR DESCRIPTION
Bug 1094454
https://bugzilla.redhat.com/show_bug.cgi?id=1094454
External data must be read in as binary to avoid encoding conflicts in some environments where the encoding of the configuration files does not match the default encoding for ruby.

The problem became evident on an environment with a UTF-8 encoded broker.conf file:

  # file /etc/openshift/broker.conf
  /etc/openshift/broker.conf: UTF-8 Unicode English text
