### PR TITLE
Bugs 1217572 and 1226061: Add F5 device-group sync, fix ssh/scp error handling

### DIFF
--- a/routing-daemon/conf/routing-daemon.conf
+++ b/routing-daemon/conf/routing-daemon.conf
@@ -43,6 +43,9 @@ BIGIP_PASSWORD=passwd
 # .ssh/authorized_keys and the admin user must have Terminal Access set to
 # 'Advanced shell', which is configured in System->Users->admin
 BIGIP_SSHKEY=/etc/openshift/bigip.key
+# To enable device-group synchronization, configure your device group in
+# F5 and specify the device group name using the following setting:
+#BIGIP_DEVICE_GROUP=traffic-group-1
 
 LBAAS_HOST=127.0.0.1
 LBAAS_TENANT=openshift

--- a/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
@@ -435,6 +435,8 @@ module OpenShift
           @logger.info "Done."
         end
       end
+
+      @lb_model.update if @lb_model.respond_to?(:update)
     end
 
     # Returns a Hash representing the JSON response from the load balancer.

--- a/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
@@ -203,12 +203,6 @@ module OpenShift
 
     attr_reader :ops # [Operation]
 
-    def read_config cfgfile
-      cfg = ParseConfig.new(cfgfile)
-
-      @virtual_server_name = cfg['VIRTUAL_SERVER']
-    end
-
     # Set the @blocked_on_cnt of the given Operation to the size of the given
     # Array of Operations, add the Operation to @blocked_ops of each of those
     # operations, and finally add the Operation to @ops.
@@ -508,8 +502,6 @@ module OpenShift
       @logger = logger
 
       @logger.info 'Initializing asynchronous controller...'
-
-      read_config cfgfile
 
       @lb_model = lb_model_class.new @logger, cfgfile
 

--- a/routing-daemon/lib/openshift/routing/controllers/batched.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/batched.rb
@@ -84,12 +84,6 @@ module OpenShift
 
     attr_reader :pending_add_member_ops, :pending_delete_member_ops
 
-    def read_config cfgfile
-      cfg = ParseConfig.new(cfgfile)
-
-      @virtual_server_name = cfg['VIRTUAL_SERVER']
-    end
-
     def create_pool pool_name, monitor_name=nil
       raise LBControllerException.new "Pool already exists: #{pool_name}" if pools.include? pool_name
 
@@ -148,8 +142,6 @@ module OpenShift
       @logger = logger
 
       @logger.info 'Initializing batched controller...'
-
-      read_config cfgfile
 
       @lb_model = lb_model_class.new @logger, cfgfile
       @lb_model.authenticate

--- a/routing-daemon/lib/openshift/routing/controllers/batched.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/batched.rb
@@ -136,6 +136,7 @@ module OpenShift
       @lb_model.delete_pool_members dels.keys, dels.values unless dels.empty?
       @pending_add_member_ops = []
       @pending_delete_member_ops = []
+      @lb_model.update if @lb_model.respond_to?(:update)
     end
 
     def initialize lb_model_class, logger, cfgfile

--- a/routing-daemon/lib/openshift/routing/controllers/simple.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/simple.rb
@@ -80,12 +80,6 @@ module OpenShift
       end
     end
 
-    def read_config cfgfile
-      cfg = ParseConfig.new(cfgfile)
-
-      @virtual_server_name = cfg['VIRTUAL_SERVER']
-    end
-
     def create_pool pool_name, monitor_name=nil
       raise LBControllerException.new "Pool already exists: #{pool_name}" if pools.include? pool_name
 
@@ -150,8 +144,6 @@ module OpenShift
       @logger = logger
 
       @logger.info 'Initializing controller...'
-
-      read_config cfgfile
 
       @lb_model = lb_model_class.new @logger, cfgfile
       @lb_model.authenticate

--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -22,6 +22,7 @@ module OpenShift
       @https_vserver = cfg['VIRTUAL_HTTPS_SERVER'] || 'https-ose-vserver'
       @vserver = cfg['VIRTUAL_SERVER'] || 'ose-vserver'
       @ssh_private_key = cfg['BIGIP_SSHKEY'] || '/etc/openshift/bigip.key'
+      @device_group = cfg['BIGIP_DEVICE_GROUP']
     end
 
     def run cmd
@@ -331,6 +332,14 @@ module OpenShift
     def get_pool_certificates pool_name
       pool_certs = []
       return pool_certs
+    end
+
+    def update
+      post(url: "https://#{@host}/mgmt/tm/cm",
+           payload: {
+             "command" => "run",
+             "utilCmdArgs" => "config-sync to-group #{@device_group}",
+           }.to_json) unless @device_group.nil? || @device_group.empty?
     end
 
     def initialize logger, cfgfile

--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -247,8 +247,8 @@ module OpenShift
 
         # scp cert and to F5 LTM (requires ssh key to be in authorized_keys on the F5 LTM
         @logger.debug("Copying certificate and key for alias #{alias_str} for pool #{pool_name} to LTM host")
-        result = `scp -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} #{certfname.path} admin@#{@host}:/var/tmp/#{alias_str}.crt`
-        result = `scp -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} #{keyfname.path} admin@#{@host}:/var/tmp/#{alias_str}.key`
+        result = `scp -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} #{certfname.path} #{@username}@#{@host}:/var/tmp/#{alias_str}.crt`
+        result = `scp -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} #{keyfname.path} #{@username}@#{@host}:/var/tmp/#{alias_str}.key`
 
         @logger.debug("LTM cert to be installed /var/tmp/#{alias_str}.crt")
         post(url: "https://#{@host}/mgmt/tm/sys/crypto/cert",
@@ -284,9 +284,9 @@ module OpenShift
 
         # Requires LTM System->Users->admin terminal setting to be set to advanced (bash)
         @logger.debug("LTM removing temporary alias certificate. rm -f /var/tmp/#{alias_str}.crt")
-        result = `ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} admin@#{@host} 'rm -f /var/tmp/#{alias_str}.crt'`
+        result = `ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} #{@username}@#{@host} 'rm -f /var/tmp/#{alias_str}.crt'`
         @logger.debug("LTM removing temporary alias key. rm -f /var/tmp/#{alias_str}.key")
-        result = `ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} admin@#{@host} 'rm -f /var/tmp/#{alias_str}.key'`
+        result = `ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} #{@username}@#{@host} 'rm -f /var/tmp/#{alias_str}.key'`
       rescue Errno::ENOENT
         # Nothing to do;
       ensure

--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -249,24 +249,24 @@ module OpenShift
 
       begin
         # write temp cert and key
-        certfname = Tempfile.new('bigip-ssl-cert')
-        keyfname = Tempfile.new('bigip-ssl-key')
+        certfile = Tempfile.new('bigip-ssl-cert')
+        keyfile = Tempfile.new('bigip-ssl-key')
 
-        certfname.write(ssl_cert)
-        certfname.close
-        keyfname.write(private_key)
-        keyfname.close
+        certfile.write(ssl_cert)
+        certfile.close
+        keyfile.write(private_key)
+        keyfile.close
 
         sshflags = "-o StrictHostKeyChecking=no -o PasswordAuthentication=no" \
           " -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null" \
           " -i \"#{@ssh_private_key}\""
 
-        # scp cert and to F5 LTM (requires ssh key to be in authorized_keys on the F5 LTM
+        # scp cert and key to F5 LTM (requires ssh key to be in authorized_keys on the F5 LTM).
         @logger.debug("Copying certificate for alias #{alias_str} for pool #{pool_name} to LTM host")
-        run("scp #{sshflags} #{certfname.path} #{@username}@#{@host}:/var/tmp/#{alias_str}.crt")
+        run("scp #{sshflags} #{certfile.path} #{@username}@#{@host}:/var/tmp/#{alias_str}.crt")
 
         @logger.debug("Copying key for alias #{alias_str} for pool #{pool_name} to LTM host")
-        run("scp #{sshflags} #{keyfname.path} #{@username}@#{@host}:/var/tmp/#{alias_str}.key")
+        run("scp #{sshflags} #{keyfile.path} #{@username}@#{@host}:/var/tmp/#{alias_str}.key")
 
         @logger.debug("LTM cert to be installed /var/tmp/#{alias_str}.crt")
         post(url: "https://#{@host}/mgmt/tm/sys/crypto/cert",
@@ -309,8 +309,8 @@ module OpenShift
       rescue Errno::ENOENT
         # Nothing to do;
       ensure
-        certfname.unlink
-        keyfname.unlink
+        certfile.unlink
+        keyfile.unlink
       end
     end
 


### PR DESCRIPTION
##### routing-daemon: F5: Use configured SSH user

This commit fixes bug 1227501.
##### routing-daemon: F5: check for and log SSH errors

`F5IControlRestLoadBalancerModel`: Add `run` method that runs the given command, captures stdout and stderr, and raises an exception if the command fails.

`F5IControlRestLoadBalancerModel#add_ssl`: Use the new `run` method to check for, log, and handle errors from the `ssh` and `scp` commands.  Modify the logging output to be neater and more consistent.

This commit fixes bug 1226061.
##### routing-daemon: F5: Fix variable names & comments

`F5IControlRestLoadBalancerModel#add_ssl`: Change `certfname` and `keyfname` to `certfile` and `keyfile` so as better to reflect the variables' contents, and fix some grammatical errors in a comment.
##### routing-daemon: Delete `read_config` in controllers

`SimpleLoadBalancerController`, `BatchedLoadBalancerController`, `AsyncLoadBalancerController`: Delete `@virtual_server_name` initialization in `read_config` because we never use `@virtual_server_name`, and delete `read_config` because it doesn't initialize anything else.
##### routing-daemon: controllers: invoke model update

`AsyncLoadBalancerController#update`, `BatchedLoadBalancerController#update`: Invoke the model's `update` method if it exists.

Note that `SimpleLoadBalancerController` does not define its own `update` method, so it inherits the `update` method from `LoadBalancerController`, which also invokes the model's `update` method.

Note too that the only model that has an `update` method is `NginxLoadBalancerModel`, and we use `SimpleLoadBalancerController` with this model, so we haven't been missing the update method in the other controllers.
##### routing-daemon: F5: Sync device-group on update

`routing-daemon.conf`: Add commented-out example `BIGIP_DEVICE_GROUP` setting.

`F5IControlRestLoadBalancerModel#read_config`: Read `BIGIP_DEVICE_GROUP` setting and assign it to `@device_group`.

`F5IControlRestLoadBalancerModel`: Add `update` method that synchronizes the device group if `@device_group` is set.

This commit fixes bug 1217572.
