### PR TITLE
Fixing auth user issue.

### DIFF
--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -247,8 +247,8 @@ module OpenShift
 
         # scp cert and to F5 LTM (requires ssh key to be in authorized_keys on the F5 LTM
         @logger.debug("Copying certificate and key for alias #{alias_str} for pool #{pool_name} to LTM host")
-        result = `scp -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} #{certfname.path} admin@#{@host}:/var/tmp/#{alias_str}.crt`
-        result = `scp -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} #{keyfname.path} admin@#{@host}:/var/tmp/#{alias_str}.key`
+        result = `scp -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} #{certfname.path} #{@username}@#{@host}:/var/tmp/#{alias_str}.crt`
+        result = `scp -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} #{keyfname.path} #{@username}@#{@host}:/var/tmp/#{alias_str}.key`
 
         @logger.debug("LTM cert to be installed /var/tmp/#{alias_str}.crt")
         post(url: "https://#{@host}/mgmt/tm/sys/crypto/cert",
@@ -284,9 +284,9 @@ module OpenShift
 
         # Requires LTM System->Users->admin terminal setting to be set to advanced (bash)
         @logger.debug("LTM removing temporary alias certificate. rm -f /var/tmp/#{alias_str}.crt")
-        result = `ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} admin@#{@host} 'rm -f /var/tmp/#{alias_str}.crt'`
+        result = `ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} #{@username}@#{@host} 'rm -f /var/tmp/#{alias_str}.crt'`
         @logger.debug("LTM removing temporary alias key. rm -f /var/tmp/#{alias_str}.key")
-        result = `ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} admin@#{@host} 'rm -f /var/tmp/#{alias_str}.key'`
+        result = `ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o VerifyHostKeyDNS=no -o UserKnownHostsFile=/dev/null -i #{@ssh_private_key} #{@username}@#{@host} 'rm -f /var/tmp/#{alias_str}.key'`
       rescue Errno::ENOENT
         # Nothing to do;
       ensure


### PR DESCRIPTION
If using this this config in etc/openshift/routing-daemon.conf 

BIGIP_HOST=F5LTM
BIGIP_USERNAME=ose
BIGIP_PASSWORD=xxxxxxx
BIGIP_SSHKEY=/etc/openshift/bigip.key

After setting up and installing a custom alias with a certificate and key, the routing daemon reports that it’s removing both temp key and cert:

D, [2015-05-27T09:32:04.687843 #25771] DEBUG -- : LTM removing temporary alias certificate. rm -f /var/tmp/www.example.com.crt
D, [2015-05-27T09:32:09.921415 #25771] DEBUG -- : LTM removing temporary alias key. rm -f /var/tmp/www.example.com.key

However, the removal of the temp key does not work. This is verified by looking in /var/tmp/ on the BigIP. 

This is due to "admin" being hard coded to the commands and using the BIGIP_SSHKEY value. This will fail since the ssh key is most likely configure to the username defined in the config file.  

Changed it to be "username" which is defined as BIGIP_USERNAME using BIGIP_SSHKEY. This will work, User must still have terminal settings in F5 = advanced shell"
