### PR TITLE
Ignore least preferred servers if all servers are least preferred

### DIFF
--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -3173,6 +3173,15 @@ module OpenShift
       # Remove the restricted servers from the list
       server_infos.delete_if { |server_info| restricted_servers.include?(server_info.name) } if restricted_servers.present? and server_infos.present?
       unless server_infos.empty?
+        # Ignore least_preferred_servers if all servers are considered least preferred
+        ignore_least_preferred_servers = false
+        if least_preferred_servers.present?
+          server_identities = server_infos.map {|server_info| server_info.name}
+          if server_identities.all? {|identity| least_preferred_servers.include?(identity)}
+            ignore_least_preferred_servers = true
+          end
+        end
+
         if gear
           server = nil
           reloaded_app = Application.find_by(_id: gear.application._id)
@@ -3223,21 +3232,23 @@ module OpenShift
             end
 
             # Find least preferred zones
-            least_preferred_zone_ids = []
-            least_preferred_servers.each do |server_identity|
-              next unless server_identity
-              server = District.find_server(server_identity, districts)
-              least_preferred_zone_ids << server.zone_id if server.zone_id
-            end if least_preferred_servers.present?
-            least_preferred_zone_ids = least_preferred_zone_ids.uniq
+            unless ignore_least_preferred_servers
+              least_preferred_zone_ids = []
+              least_preferred_servers.each do |server_identity|
+                next unless server_identity
+                server = District.find_server(server_identity, districts)
+                least_preferred_zone_ids << server.zone_id if server.zone_id
+              end if least_preferred_servers.present?
+              least_preferred_zone_ids = least_preferred_zone_ids.uniq
 
-            if least_preferred_zone_ids.present?
-              available_zone_ids = zones_consumed_capacity.keys
-              # Consider least preferred zones only when we have no available zone that's not in least preferred zones.
-              unless (available_zone_ids - least_preferred_zone_ids).empty?
-                # Remove least preferred zones from the list, ensuring there is at least one server remaining
-                server_infos.delete_if { |server_info| (server_infos.length > 1) && least_preferred_zone_ids.include?(server_info.zone_id) }
-                zones_consumed_capacity.delete_if { |zone_id, capacity| least_preferred_zone_ids.include?(zone_id) }
+              if least_preferred_zone_ids.present?
+                available_zone_ids = zones_consumed_capacity.keys
+                # Consider least preferred zones only when we have no available zone that's not in least preferred zones.
+                unless (available_zone_ids - least_preferred_zone_ids).empty?
+                  # Remove least preferred zones from the list, ensuring there is at least one server remaining
+                  server_infos.delete_if { |server_info| (server_infos.length > 1) && least_preferred_zone_ids.include?(server_info.zone_id) }
+                  zones_consumed_capacity.delete_if { |zone_id, capacity| least_preferred_zone_ids.include?(zone_id) }
+                end
               end
             end
 
@@ -3251,7 +3262,10 @@ module OpenShift
         end
 
         # Remove the least preferred servers from the list, ensuring there is at least one server remaining
-        server_infos.delete_if { |server_info| (server_infos.length > 1) && least_preferred_servers.include?(server_info.name) } if least_preferred_servers.present?
+        # Ignore least preferred servers if all servers are considered least preferred
+        if least_preferred_servers.present? && !ignore_least_preferred_servers
+          server_infos.delete_if { |server_info| least_preferred_servers.include?(server_info.name) }
+        end
       end
 
       return server_infos


### PR DESCRIPTION
Bug 1228373
Bug link https://bugzilla.redhat.com/show_bug.cgi?id=1228373

If an application is already scaled out so that it has a gear on all available nodes, all nodes will be considered 'least_preferred_servers'. This will cause only one server to be returned from rpc_find_all_available, giving select_best_fit_node only one server to choose. This caused sparatic and uneven gear placement from highly scaled applications.

This fix will ignore the least_preferred_servers list if all available servers are included in the list.
