### PR TITLE
Use nsupdate since oo-register-dns is not available yet

### DIFF
--- a/documentation/oo_deployment_guide_comprehensive.adoc
+++ b/documentation/oo_deployment_guide_comprehensive.adoc
@@ -430,10 +430,13 @@ chkconfig named on
 NOTE: If you get unknown locale error when running _lokkit_, consult the troubleshooting section at the end of this manual.
 
 === Add the Broker Host to DNS
-If you configured and started a BIND server per this document, or you are working against a BIND server that was already in place, you now need to add a record for your broker node (or host) to BIND's database. To accomplish this task, you will use the `nsupdate` command, which opens an interactive shell. Replace "broker.example.com" with your preferred hostname:
+If you configured and started a BIND server per this document, or you are working against a BIND server that was already in place, you now need to add a record for your broker node (or host) to BIND's database. To accomplish this task, you will use the `nsupdate` command, which opens an interactive shell. Replace "broker.example.com" with your preferred hostname and "10.0.0.1" with the ip address of the broker:
 
 ----
-# oo-register-dns -h broker -d example.com -n 10.4.59.x -k ${keyfile}
+# nsupdate -k $keyfile
+server 127.0.0.1
+update add broker.example.com 180 A 10.0.0.1
+send
 ----
 
 Press <ctrl-D> to exit from the interactive session.


### PR DESCRIPTION
Instruct a user to use nsupdate, as the previous paragraph states, instead of oo-register-dns. oo-register-dns (provided by the openshift-origin-broker-util rpm) is not yet available at this stage in the documentation.
