### PR TITLE
Resolve race condition for cartridges activated within the same second

### DIFF
--- a/controller/app/models/cartridge_type.rb
+++ b/controller/app/models/cartridge_type.rb
@@ -111,7 +111,10 @@ class CartridgeType
   def activate
     self.priority = Time.now
     if self.save
-      self.class.where(name: name, :priority.lt => self.priority).set(:priority, nil)
+      self.reload
+      # find all other types of the same name activated before this type and set their priority to nil
+      old_types = self.class.where(:name => name).select {|type| type.priority and type.priority < self.priority }
+      old_types.each {|type| type.set(:priority, nil)}
       if latest = self.class.where(name: name, :priority.ne => nil).only(:_id, :priority).first
         if latest._id == self._id
           true


### PR DESCRIPTION
Bug 1191283
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1191283

Using `:priority.lt => self.priority` in the `where` method would not find types with a priority set within the same second of this types priority. Mongo compares priorities at the 'second' granular level while ruby appears to compare DateTime objects at the millisecond level. 

If two cartridges had a priority set within the same second, mongo would consider them equivalent. We are now doing the comparison in Ruby, where the priority (being of type DateTime) is compared at the millisecond level.
