### PR TITLE
Round up if base filesystem quota is less than 1Gb

### DIFF
--- a/controller/app/models/gear.rb
+++ b/controller/app/models/gear.rb
@@ -74,7 +74,7 @@ class Gear
       proxy = OpenShift::ApplicationContainerProxy.find_one(gear_size)
       quota_blocks = proxy.get_quota_blocks
       # calculate the minimum storage in GB - blocks are 1KB each
-      quota_blocks / 1024 / 1024
+      [quota_blocks / 1048576, 1].max
     end
   end
 


### PR DESCRIPTION
Bug 1197123
https://bugzilla.redhat.com/show_bug.cgi?id=1197123

When a node profile specifies a 'quota_blocks' value less than 1Gb (1048576), round up to 1Gb rather than returning 0. This will inaccurately report base storage as 1Gb when it may be much less, but will avoid reporting that a gear has 0 base storage.
