### PR TITLE
BZ1225291: Additional fix

### DIFF
--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
@@ -159,7 +159,7 @@ function build() {
         if curl -m 15 -f -s "$m" &>/dev/null
         then
             OPENSHIFT_PYTHON_MIRROR="-i $m"
-            OPENSHIFT_PIP_TRUSTED_HOST="--trusted-host $(echo ${OPENSHIFT_PYPI_MIRROR_URL} | awk -F/ '{print $3}')"
+            [ ${OPENSHIFT_PYTHON_VERSION} == "3.3" ] && OPENSHIFT_PIP_TRUSTED_HOST="--trusted-host $(echo ${OPENSHIFT_PYPI_MIRROR_URL} | awk -F/ '{print $3}')"
         fi
     fi
 


### PR DESCRIPTION
Since different versions of python use different version of pip, the --trusted-host option is only available in python-3.3 for which the BZ1225291 was reported.
@soltysh PTAL
