### PR TITLE
oo-accept-node: honor application names starting with 0

### DIFF
--- a/node-util/sbin/oo-accept-node
+++ b/node-util/sbin/oo-accept-node
@@ -755,7 +755,7 @@ def check_system_httpd_configs
     if mod_vhost && has_framework
       vhost_file = Dir.glob(File.join($CONF.get('OPENSHIFT_HTTP_CONF_DIR'), "#{u.name}_*_0_*.conf"))[0]
       if vhost_file
-        vhost_dir = vhost_file.gsub(/(\.conf)$/, "").gsub("_0", "")
+        vhost_dir = vhost_file.gsub(/(\.conf)$/, "").sub("_0_", "_")
         if File.directory?(vhost_dir)
           vhost_dir_files = Dir.glob(File.join(vhost_dir, "*.conf"))
           unless vhost_dir_files.empty?


### PR DESCRIPTION
oo-accept-node new check for vhost configuration should honor application with 0 as the first character in its name.

The format of the vhost directory is `$UUID_$DOMAIN_$APPNAME` thus we cannot gsub all of the _0 from the file name to get the directory.

Example:

```
# ls -d /etc/httpd/conf.d/openshift/5454cf405973ca8a4500017f_uaforce02_01a/
/etc/httpd/conf.d/openshift/5454cf405973ca8a4500017f_uaforce02_01a/
#
>> vhost_file = Dir.glob(File.join("/etc/httpd/conf.d/openshift/","5454cf405973ca8a4500017f_*_0_*.conf"))[0]
=> "/etc/httpd/conf.d/openshift/5454cf405973ca8a4500017f_uaforce02_0_01a.conf"
>> vhost_file.gsub(/(\.conf)$/, "").gsub("_0", "")
=> "/etc/httpd/conf.d/openshift/5454cf405973ca8a4500017f_uaforce021a"
>> vhost_file.gsub(/(\.conf)$/, "").sub("_0", "")
=> "/etc/httpd/conf.d/openshift/5454cf405973ca8a4500017f_uaforce02_01a"
```
