### PR TITLE
Require java7 for latest jenkins

### DIFF
--- a/cartridges/openshift-origin-cartridge-jenkins/openshift-origin-cartridge-jenkins.spec
+++ b/cartridges/openshift-origin-cartridge-jenkins/openshift-origin-cartridge-jenkins.spec
@@ -10,7 +10,7 @@ URL:           http://www.openshift.com
 Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 Requires:      rubygem(openshift-origin-node)
 #https://issues.jenkins-ci.org/browse/JENKINS-15047
-Requires:      java >= 1.6
+Requires:      java >= 1.7
 Requires:      jenkins
 Requires:      jenkins-plugin-openshift
 Requires:      openshift-origin-node-util


### PR DESCRIPTION
Since the jenkins-1.614 release, java7 is a requirement.

Fixes #6193
