### PR TITLE
Use uft8mb4 to support 4-byte unicode characters

### DIFF
--- a/cartridges/openshift-origin-cartridge-mysql/bin/post_install
+++ b/cartridges/openshift-origin-cartridge-mysql/bin/post_install
@@ -11,7 +11,7 @@ password=$OPENSHIFT_MYSQL_DB_PASSWORD
 # TODO: Should be we running mysql_secure_installation
 
 echo "drop database test;
-create database \`${dbname}\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;" | mysql_context "/usr/bin/mysql -u root -S '$socket_file'" > /dev/null || error 'Failed to create database' 188
+create database \`${dbname}\` DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;" | mysql_context "/usr/bin/mysql -u root -S '$socket_file'" > /dev/null || error 'Failed to create database' 188
 
 echo "
 delete from user;

--- a/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb
+++ b/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb
@@ -8,8 +8,18 @@
 # max_connections -> OPENSHIFT_MYSQL_MAX_CONNECTIONS
 # ft_min_word_len -> OPENSHIFT_MYSQL_FT_MIN_WORD_LEN
 # ft_max_word_len -> OPENSHIFT_MYSQL_FT_MAX_WORD_LEN
+# default-character-set -> OPENSHIFT_MYSQL_DEFAULT_CHARACTER_SET
+# character-set-server -> OPENSHIFT_MYSQL_CHARACTER_SET_SERVER
+# collation-server -> OPENSHIFT_MYSQL_COLLATION_SERVER
+# character-set-client-handshake -> OPENSHIFT_MYSQL_CHARACTER_SET_CLIENT_HANDSHAKE
+
+[client]
+default-character-set = <%= ENV['OPENSHIFT_MYSQL_DEFAULT_CHARACTER_SET'] ? ENV['OPENSHIFT_MYSQL_DEFAULT_CHARACTER_SET'] : 'utf8mb4' %>
 
 [mysqld]
+character-set-server = <%= ENV['OPENSHIFT_MYSQL_CHARACTER_SET_SERVER'] ? ENV['OPENSHIFT_MYSQL_CHARACTER_SET_SERVER'] : 'utf8mb4' %>
+collation-server = <%= ENV['OPENSHIFT_MYSQL_COLLATION_SERVER'] ? ENV['OPENSHIFT_MYSQL_COLLATION_SERVER'] : 'utf8mb4_unicode_ci' %>
+character-set-client-handshake = <%= ENV['OPENSHIFT_MYSQL_CHARACTER_SET_CLIENT_HANDSHAKE'] ? ENV['OPENSHIFT_MYSQL_CHARACTER_SET_CLIENT_HANDSHAKE'] : 'TRUE' %>
 datadir=<%= ENV['OPENSHIFT_MYSQL_DIR'] %>data/
 socket=<%= ENV['OPENSHIFT_MYSQL_DB_SOCKET'] %>
 # Disable reverse DNS resolving of gear ip BZ#1051348
@@ -61,6 +71,7 @@ max_allowed_packet = 16M
 
 [mysql]
 no-auto-rehash
+default-character-set = <%= ENV['OPENSHIFT_MYSQL_DEFAULT_CHARACTER_SET'] ? ENV['OPENSHIFT_MYSQL_DEFAULT_CHARACTER_SET'] : 'utf8mb4' %>
 # Remove the next comment character if you are not familiar with SQL
 #safe-updates
 


### PR DESCRIPTION
Bug 1186681
https://bugzilla.redhat.com/show_bug.cgi?id=1186681
The utf8 character encoding in mysql supports unicode characters with 1-3 bytes. 4-byte unicode characters such as emojis require utf8mb4 encoding in mysql.

Fixes #6169 

Since the encoding is set for a database in `post_install`, this update shouldn't interfere with existing mysql cartridges. 

This pr also adds several environment variables. These are to set a default character set for client and server as well as to set a collation server and whether a client can specify a character set to use with its connection.
