### PR TITLE
Require only SCL packages for centos and rhel installs

### DIFF
--- a/cartridges/openshift-origin-cartridge-mariadb/openshift-origin-cartridge-mariadb.spec
+++ b/cartridges/openshift-origin-cartridge-mariadb/openshift-origin-cartridge-mariadb.spec
@@ -8,13 +8,13 @@ Group:         Network/Daemons
 License:       ASL 2.0
 URL:           http://www.openshift.com
 Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
-Requires:      mariadb-server
-Requires:      mariadb-devel
 
-# For RHEL6 install mysql55 from SCL
 %if 0%{?rhel}
 Requires:      mariadb55
 Requires:      mariadb55-mariadb-devel
+%else
+Requires:      mariadb-server
+Requires:      mariadb-devel
 %endif
 
 Requires:      rubygem(openshift-origin-node)


### PR DESCRIPTION
The mariadb-server and related packages are only available through SCL for CentOS 6 and RHEL 6 installations. They should only be required for fedora installs. Additionally, the SCL packages are not required for fedora installs.

Fixes #5759 
