### PR TITLE
Bug 1214087 - return non-zero on all exceptions in oo-admin-move

### DIFF
--- a/broker-util/oo-admin-move
+++ b/broker-util/oo-admin-move
@@ -154,12 +154,14 @@ gear_uuid.split(',').each do |uuid|
       else
         puts ne.message
       end
+      rc |= 1
     rescue OpenShift::UserException => ue
       if json
         move_status[uuid].merge!({ :result => false, :message => ue.message, :trace => ue.backtrace })
       else
         puts ue.message
       end
+      rc |= 1
     end
 
     unless reply.nil?


### PR DESCRIPTION
These exit codes were removed when oo-admin-move was changed to take multiple gears as input.
