### PR TITLE
Bug 1232827 Include java-1.8 openjdk to support java8 in jbosseap

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbosseap/openshift-origin-cartridge-jbosseap.spec
+++ b/cartridges/openshift-origin-cartridge-jbosseap/openshift-origin-cartridge-jbosseap.spec
@@ -14,6 +14,8 @@ Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
 Requires:      java-1.7.0-openjdk
 Requires:      java-1.7.0-openjdk-devel
+Requires:      java-1.8.0-openjdk
+Requires:      java-1.8.0-openjdk-devel
 Requires:      jbossas-appclient
 Requires:      jbossas-bundles
 Requires:      jbossas-core


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1232827
To use the java8 marker introduced by 632d56c8cca60207504c5323301825e03aecb5fd, the java-1.8.0-openjdk packages will be required.
