### PR TITLE
Removed Double backslashes in variables

### DIFF
--- a/cartridges/openshift-origin-cartridge-python/usr/versions/2.7-scl/lib/update-configuration
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/2.7-scl/lib/update-configuration
@@ -8,19 +8,20 @@ function update-configuration {
     # SCL installs of python 2.7
     sclpath=$(dirname $(scl enable python27 "which python"))
     env_dir="${OPENSHIFT_PYTHON_DIR}/env"
-    echo "$OPENSHIFT_PYTHON_DIR/virtenv/bin:$OPENSHIFT_PYTHON_DIR/bin:${sclpath}" > $OPENSHIFT_PYTHON_DIR/env/OPENSHIFT_PYTHON_PATH_ELEMENT
+    echo "${OPENSHIFT_PYTHON_DIR}virtenv/bin:${OPENSHIFT_PYTHON_DIR}bin:${sclpath}" > ${env_dir}/OPENSHIFT_PYTHON_PATH_ELEMENT
 
     local ld_path=$(LD_LIBRARY_PATH="" scl enable python27 "printenv LD_LIBRARY_PATH")
     set_env_var 'OPENSHIFT_PYTHON_LD_LIBRARY_PATH_ELEMENT' $ld_path $env_dir
 
     local man_path=$(MANPATH="" scl enable python27 "printenv MANPATH")
-    path_append ${MANPATH:-:} ${man_path:-:} > $OPENSHIFT_PYTHON_DIR/env/MANPATH
+    path_append ${MANPATH:-:} ${man_path:-:} > ${env_dir}/MANPATH
 
     local xdg_data_dirs=$(XDG_DATA_DIRS="" scl enable python27 "printenv XDG_DATA_DIRS")
-    path_append ${XDG_DATA_DIRS:-:} ${xdg_data_dirs:-:} > $OPENSHIFT_PYTHON_DIR/env/XDG_DATA_DIRS
+    path_append ${XDG_DATA_DIRS:-:} ${xdg_data_dirs:-:} > ${env_dir}/XDG_DATA_DIRS
 
     local pkg_config_path=$(PKG_CONFIG_PATH="" scl enable python27 "printenv PKG_CONFIG_PATH")
-    path_append ${PKG_CONFIG_PATH:-:} ${pkg_config_path:-:} > $OPENSHIFT_PYTHON_DIR/env/PKG_CONFIG_PATH
+    path_append ${PKG_CONFIG_PATH:-:} ${pkg_config_path:-:} > ${env_dir}/PKG_CONFIG_PATH
 
-    echo "$OPENSHIFT_PYTHON_DIR/virtenv" > $OPENSHIFT_PYTHON_DIR/env/VIRTUAL_ENV
+    echo "${OPENSHIFT_PYTHON_DIR}virtenv" > ${env_dir}/VIRTUAL_ENV
 }
+

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-scl/lib/update-configuration
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/3.3-scl/lib/update-configuration
@@ -8,19 +8,20 @@ function update-configuration {
     # SCL installs of python 3.3
     sclpath=$(dirname $(scl enable python33 "which python"))
     env_dir="${OPENSHIFT_PYTHON_DIR}/env"
-    echo "$OPENSHIFT_PYTHON_DIR/virtenv/venv/bin:$OPENSHIFT_PYTHON_DIR/bin:${sclpath}" > $OPENSHIFT_PYTHON_DIR/env/OPENSHIFT_PYTHON_PATH_ELEMENT
+    echo "${OPENSHIFT_PYTHON_DIR}virtenv/venv/bin:${OPENSHIFT_PYTHON_DIR}bin:${sclpath}" > ${env_dir}/OPENSHIFT_PYTHON_PATH_ELEMENT
 
     local ld_path=$(LD_LIBRARY_PATH="" scl enable python33 "printenv LD_LIBRARY_PATH")
     set_env_var 'OPENSHIFT_PYTHON_LD_LIBRARY_PATH_ELEMENT' $ld_path $env_dir
 
     local man_path=$(MANPATH="" scl enable python33 "printenv MANPATH")
-    path_append ${MANPATH:-:} ${man_path:-:} > $OPENSHIFT_PYTHON_DIR/env/MANPATH
+    path_append ${MANPATH:-:} ${man_path:-:} > ${env_dir}/MANPATH
 
     local xdg_data_dirs=$(XDG_DATA_DIRS="" scl enable python33 "printenv XDG_DATA_DIRS")
-    path_append ${XDG_DATA_DIRS:-:} ${xdg_data_dirs:-:} > $OPENSHIFT_PYTHON_DIR/env/XDG_DATA_DIRS
+    path_append ${XDG_DATA_DIRS:-:} ${xdg_data_dirs:-:} > ${env_dir}/XDG_DATA_DIRS
 
     local pkg_config_path=$(PKG_CONFIG_PATH="" scl enable python33 "printenv PKG_CONFIG_PATH")
-    path_append ${PKG_CONFIG_PATH:-:} ${pkg_config_path:-:} > $OPENSHIFT_PYTHON_DIR/env/PKG_CONFIG_PATH
+    path_append ${PKG_CONFIG_PATH:-:} ${pkg_config_path:-:} > ${env_dir}/PKG_CONFIG_PATH
 
-    echo "$OPENSHIFT_PYTHON_DIR/virtenv/venv" > $OPENSHIFT_PYTHON_DIR/env/VIRTUAL_ENV
+    echo "${OPENSHIFT_PYTHON_DIR}virtenv/venv" > ${env_dir}/VIRTUAL_ENV
 }
+

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/lib/update-configuration
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/lib/update-configuration
@@ -4,6 +4,7 @@
 
 function update-configuration {
     # Native installations of python
-    echo "$OPENSHIFT_PYTHON_DIR/virtenv/bin:$OPENSHIFT_PYTHON_DIR/bin" > $OPENSHIFT_PYTHON_DIR/env/OPENSHIFT_PYTHON_PATH_ELEMENT
-    echo "$OPENSHIFT_PYTHON_DIR/virtenv" > $OPENSHIFT_PYTHON_DIR/env/VIRTUAL_ENV
+    echo "${OPENSHIFT_PYTHON_DIR}virtenv/bin:${OPENSHIFT_PYTHON_DIR}bin" > ${OPENSHIFT_PYTHON_DIR}/env/OPENSHIFT_PYTHON_PATH_ELEMENT
+    echo "${OPENSHIFT_PYTHON_DIR}virtenv" > ${OPENSHIFT_PYTHON_DIR}/env/VIRTUAL_ENV
 }
+


### PR DESCRIPTION
Some env vars come up with double backslashes. Although harmless,
some programmers using path.split('/') will be dangerously perplexed by
them. So the strings which are stored in the paths are removed of the
duplicates.

Also substituted the variable for env_dir.
