### PR TITLE
Adding Logic to allow for mvm mirror to be overwritten

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbossas/bin/control
@@ -207,11 +207,12 @@ function ismgmtup() {
 function build() {
   CONFIG_DIR="${OPENSHIFT_JBOSSAS_DIR}/standalone/configuration"
   OPENSHIFT_MAVEN_MIRROR="${CONFIG_DIR}/settings.base.xml"
-  if [[ $OPENSHIFT_GEAR_DNS =~ .*\.rhcloud\.com$ ]]
-  then
-      OPENSHIFT_MAVEN_MIRROR="${CONFIG_DIR}/settings.rhcloud.xml"
-  fi
-
+  if [[ -z OPENSHIFT_MAVEN_MIRROR ]]; then                     ## Allows for the mirror configuraiton file to be overwitten.
+      if [[ $OPENSHIFT_GEAR_DNS =~ .*\.rhcloud\.com$ ]]
+      then
+          OPENSHIFT_MAVEN_MIRROR="${CONFIG_DIR}/settings.rhcloud.xml"
+      fi
+  fi 
   max_memory_mb=${OPENSHIFT_GEAR_MEMORY_MB}
 
   # If hot deploy is enabled, we need to restrict the Maven memory size to fit

--- a/cartridges/openshift-origin-cartridge-jbosseap/bin/control
+++ b/cartridges/openshift-origin-cartridge-jbosseap/bin/control
@@ -206,12 +206,13 @@ function build() {
   echo "Building $cartridge_type cartridge"
 
   CONFIG_DIR="${OPENSHIFT_JBOSSEAP_DIR}/standalone/configuration"
-  OPENSHIFT_MAVEN_MIRROR="${CONFIG_DIR}/settings.base.xml"
-  if $(echo $OPENSHIFT_GEAR_DNS | egrep -qe "\.rhcloud\.com")
-  then
-      OPENSHIFT_MAVEN_MIRROR="${CONFIG_DIR}/settings.rhcloud.xml"
-  fi
-
+  if [[ -z OPENSHIFT_MAVEN_MIRROR ]]; then                     ## Allows for the mirror configuraiton file to be overwitten. 
+      OPENSHIFT_MAVEN_MIRROR="${CONFIG_DIR}/settings.base.xml"
+      if $(echo $OPENSHIFT_GEAR_DNS | egrep -qe "\.rhcloud\.com")
+      then
+          OPENSHIFT_MAVEN_MIRROR="${CONFIG_DIR}/settings.rhcloud.xml"
+      fi
+  fi 
   max_memory_mb=${OPENSHIFT_GEAR_MEMORY_MB}
 
   # If hot deploy is enabled, we need to restrict the Maven memory size to fit

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/build
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/build
@@ -12,7 +12,7 @@ if [ ! -f $OPENSHIFT_MAVEN_MIRROR ]; then
   OPENSHIFT_MAVEN_MIRROR="${OPENSHIFT_JBOSSEWS_DIR}/usr/versions/shared/configuration/settings.base.xml"
 fi
 
-if `echo $OPENSHIFT_GEAR_DNS | egrep -qe "\.rhcloud\.com"`; then 
+if `echo $OPENSHIFT_GEAR_DNS | egrep -qe "\.rhcloud\.com"`&& [ $OPENSHIFT_MAVEN_MIRROR != "${OPENSHIFT_REPO_DIR}/.openshift/config/settings.base.xml" ]; then 
   OPENSHIFT_MAVEN_MIRROR="${OPENSHIFT_REPO_DIR}/.openshift/config/settings.rhcloud.xml"
 
   if [ ! -f $OPENSHIFT_MAVEN_MIRROR ]; then


### PR DESCRIPTION
There is no way to override the mirror, if you are openshift online. 
