### PR TITLE
Bug 1250904 - Allow ssh keys to be replaced with an empty list

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/environment.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/environment.rb
@@ -248,8 +248,10 @@ module OpenShift
           krb5_principals = ssh_keys.select {|k| k['type'] == 'krb5-principal'}
 
           self.class.notify_observers(:before_replace_ssh_keys, self)
-          AuthorizedKeysFile.new(self).replace_keys(authorized_keys) if authorized_keys.count > 0
-          K5login.new(self).replace_principals(krb5_principals) if krb5_principals.count > 0
+          # If an empty ssh_keys list is passed, this will intentionally replace the ssh keys with an empty list
+          # The broker should pass all keys available for the application to this method
+          AuthorizedKeysFile.new(self).replace_keys(authorized_keys)
+          K5login.new(self).replace_principals(krb5_principals)
           self.class.notify_observers(:after_replace_ssh_keys, self)
 
         end

--- a/node/test/unit/ssh_authorized_keys.rb
+++ b/node/test/unit/ssh_authorized_keys.rb
@@ -603,6 +603,38 @@ EOF
 
   end
 
+  def test_replace_keys_with_empty_list
+    # define the temporary file locations
+    lockfile = Tempfile.new ['openshift-origin-node-test-ssh_authkey-replace-empty',
+                             '-lock']
+    keyfile = Tempfile.new ['openshift-origin-node-test-ssh_authkey-replace-empty',
+                            '-keyfile']
+    keyfile_name = keyfile.path
+
+    # create a one-line file for replacement
+    open(keyfile_name, 'w') {|f|
+      f.write 'command="/bin/false",no-X11-fowarding ssh-rsa aabbccddeeffgg0011223344556677889900 OPENSHIFT-testuser1-keyid1' + "\n"
+    }
+
+    # create the AuthorizedKeysFile object
+    auth_keys = AuthorizedKeysFile.new(@container, keyfile_name)
+    auth_keys.lockfile = lockfile
+    auth_keys.owner = nil
+    auth_keys.group = nil
+    auth_keys.mode = nil
+
+    new_keys = []
+
+    auth_keys.replace_keys(new_keys)
+
+    assert(File.exists? keyfile_name)
+    lines = open(keyfile_name) {|f|
+      f.readlines { |l| l.strip }
+    }
+
+    assert_equal(0, lines.length)
+  end
+
   def test_validate_keys
 
     a = AuthorizedKeysFile.new(@container)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1250904

This change allows ssh and krb5 keys for a user to be replaced with an empty list of keys when no keys exist for an application.

The broker passes all krb5 and ssh keys for a user in a single list to this node action. If no ssh keys are passed in the list, it is because no ssh keys exist any longer for the application.
