### PR TITLE
Bug 1138522 - Ensure performance.conf is processed after httpd_nolog.conf

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/bin/control
+++ b/cartridges/openshift-origin-cartridge-php/bin/control
@@ -9,7 +9,7 @@ HTTPD_PASSENV_FILE=$HTTPD_CFG_DIR/passenv.conf
 HTTPD_PID_FILE=$OPENSHIFT_PHP_DIR/run/httpd.pid
 
 # construct the configuration directives for httpd
-HTTPD_CMD_CONF="-C 'Include $HTTPD_CFG_DIR/*.conf' -f $HTTPD_CFG_FILE"
+HTTPD_CMD_CONF="-c 'Include $HTTPD_CFG_DIR/*.conf' -f $HTTPD_CFG_FILE"
 for dir in /etc/openshift/cart.conf.d/httpd{,/php} ; do
     [ -d $dir ] && HTTPD_CMD_CONF="$HTTPD_CMD_CONF -c 'Include $dir/*.conf'"
 done


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1138522

Use the '-c' directive to ensure that `$OPENSHIFT_PHP_DIR/configuration/etc/conf.d/*` files (including performance.conf) are processed into configuration after `httpd_nolog.conf`. This will allow directives in the configuration files in `$OPENSHIFT_PHP_DIR/configuration/etc/conf.d/*` to overwrite directives in `httpd_nolog.conf`.

From the httpd man page:

```
       -C directive
              Process the configuration directive before reading config files.
       -c directive
              Process the configuration directive after reading config files.
```
