### PR TITLE
Fix broker functional tests to allow for concurrency

### DIFF
--- a/broker/test/functional/application_test.rb
+++ b/broker/test/functional/application_test.rb
@@ -99,7 +99,7 @@ class ApplicationsTest < ActionDispatch::IntegrationTest
     e = RuntimeError.new("Failure")
     Application.any_instance.expects(:save!).raises(e)
     assert_difference "@user.consumed_gears", 0 do
-      assert_difference "Application.all.count", 0 do
+      assert_difference "Application.where(:domain => @domain).count", 0 do
         assert_raises(RuntimeError){ Application.create_app(@appname, cartridge_instances_for(:php), @domain) }
       end
     end

--- a/broker/test/functional/domains_controller_test.rb
+++ b/broker/test/functional/domains_controller_test.rb
@@ -142,17 +142,17 @@ class DomainsControllerTest < ActionController::TestCase
   test "user can create multiple domains" do
     CloudUser.any_instance.stubs(:max_domains).returns(2)
 
-    assert_difference("Domain.count", 1) do
+    assert_difference("@user.domains.count", 1) do
       post :create, {"name" => "ns1#{@random}"}
       assert_response :success
     end
 
-    assert_difference("Domain.count", 1) do
+    assert_difference("@user.domains.count", 1) do
       post :create, {"name" => "ns2#{@random}"}
       assert_response :success
     end
 
-    assert_difference("Domain.count", 0) do
+    assert_difference("@user.domains.count", 0) do
       post :create, {"name" => "ns3#{@random}"}
       assert_response :conflict
     end


### PR DESCRIPTION
This fix modifies the broker's functional `application_test` and `domains_controller_test` to ensure no issues are seen due to concurrency. Prior to theses fixes, it was possible for another test to interfere with the test results.
