### PR TITLE
Make console functional tests less random

### DIFF
--- a/console/test/functional/application_types_controller_test.rb
+++ b/console/test/functional/application_types_controller_test.rb
@@ -2,6 +2,26 @@ require File.expand_path('../../test_helper', __FILE__)
 
 class ApplicationTypesControllerTest < ActionController::TestCase
 
+  QUICKSTARTS_WHITELIST = [
+    "WordPress 4",
+    "Drupal 7",
+    "CodeIgniter",
+    "Cartridge Development Kit",
+    "Go Language",
+    "AeroGear Push 0.X",
+    #"JBoss Fuse 6.1",
+    "MEAN",
+    "Ruby on Rails 3",
+    "CapeDwarf",
+    "Django",
+    "Ruby on Rails 4",
+    #"JBoss BPM Suite",
+    #"JBoss BRMS",
+    #"Laravel 5.0",
+    "Sinatra",
+    "Ghost 0.5.10",
+  ]
+
   with_clean_cache
 
   setup{ Quickstart.reset! }
@@ -105,6 +125,11 @@ class ApplicationTypesControllerTest < ActionController::TestCase
 
   def random_application_type_id
     ApplicationType.all.select{ |t| t.cartridge? }.sample(1).first.id
+  end
+
+  def random_quickstart_application_type
+    ApplicationType.all.select(&:quickstart?).
+      select {|t| QUICKSTARTS_WHITELIST.include? t.display_name}.sample(1).first
   end
 
   test "should default 'No preference' radio button for gear region where there is more than 1 and no default" do
@@ -269,7 +294,7 @@ class ApplicationTypesControllerTest < ActionController::TestCase
 
   test "should show type page for quickstart" do
     with_unique_user
-    type = ApplicationType.all.select(&:quickstart?).sample(1).first
+    type = random_quickstart_application_type
     omit("No quickstarts registered on this server") if type.nil?
 
     get :show, :id => type.id

--- a/node/test/node_functional/jboss_plugin_test.rb
+++ b/node/test/node_functional/jboss_plugin_test.rb
@@ -26,10 +26,6 @@ class JbossPluginTest < OpenShift::NodeBareTestCase
   # Time format => 2012/02/08 17:57:11,034
   TEMPLATE = "%s ERROR [org.apache.catalina.core.ContainerBase.[jboss.web].[default-host].[/].[HelloWorldServlet]] (http--127.0.250.1-8080-1) Servlet.service() for servlet HelloWorldServlet threw exception: java.lang.OutOfMemoryError: Java heap space\n"
 
-  def jboss_name
-    %w(JBOSSEAP JBOSSEWS JBOSSAS).sample
-  end
-
   def setup
     @uuid = 'bfc83ec2b49444fba1c657b0462eddb9'
     @testdir = '/tmp/jboss_plugin_test'


### PR DESCRIPTION
#### Make console functional tests less random

Replace random selection of application types for console functional tests with arbitrary selections.  This change should fix test failures that result when the tests randomly select invalid application types from the OpenShift Hub.
#### Delete deadcode in node functional test

Delete `JbossPlugin#jboss_name`, which has been deadcode since commit 356a189fa3991bd0e1b50d23f7f75e775d0f2edd.
## 

[test]
