### PR TITLE
Add java-1.6.0-openjdk requirment to jboss cartridges

### DIFF
--- a/cartridges/openshift-origin-cartridge-jbossas/openshift-origin-cartridge-jbossas.spec
+++ b/cartridges/openshift-origin-cartridge-jbossas/openshift-origin-cartridge-jbossas.spec
@@ -12,6 +12,8 @@ URL:           http://www.openshift.com
 Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
+Requires:      java-1.6.0-openjdk
+Requires:      java-1.6.0-openjdk-devel
 Requires:      java-1.7.0-openjdk
 Requires:      java-1.7.0-openjdk-devel
 Requires:      jboss-as7-modules >= %{jbossver}

--- a/cartridges/openshift-origin-cartridge-jbosseap/openshift-origin-cartridge-jbosseap.spec
+++ b/cartridges/openshift-origin-cartridge-jbosseap/openshift-origin-cartridge-jbosseap.spec
@@ -12,6 +12,8 @@ URL:           http://www.openshift.com
 Source0:       http://mirror.openshift.com/pub/openshift-origin/source/%{name}/%{name}-%{version}.tar.gz
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
+Requires:      java-1.6.0-openjdk
+Requires:      java-1.6.0-openjdk-devel
 Requires:      java-1.7.0-openjdk
 Requires:      java-1.7.0-openjdk-devel
 Requires:      java-1.8.0-openjdk

--- a/cartridges/openshift-origin-cartridge-jbossews/bin/util
+++ b/cartridges/openshift-origin-cartridge-jbossews/bin/util
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 function export_java_home() {
-  if marker_present "java8"; then
-    export JAVA_HOME=$OPENSHIFT_JBOSSEWS_JDK8
-  elif marker_present "java7"; then
+  if marker_present "java7"; then
     export JAVA_HOME=$OPENSHIFT_JBOSSEWS_JDK7
   else
     export JAVA_HOME=$OPENSHIFT_JBOSSEWS_JDK6

--- a/cartridges/openshift-origin-cartridge-jbossews/openshift-origin-cartridge-jbossews.spec
+++ b/cartridges/openshift-origin-cartridge-jbossews/openshift-origin-cartridge-jbossews.spec
@@ -13,6 +13,8 @@ Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
 Requires:      tomcat6
 Requires:      tomcat7
+Requires:      java-1.6.0-openjdk
+Requires:      java-1.6.0-openjdk-devel
 Requires:      java-1.7.0-openjdk
 Requires:      java-1.7.0-openjdk-devel
 %if 0%{?rhel}


### PR DESCRIPTION
Additionally, remove the java8 marker option from jbossews since jbossews-2.0 does not support java8.

Previously, `java-1.6.0-openjdk-devel` was always installed as a requirement to the Jenkins cartridge. Since a [recent change](https://github.com/openshift/origin-server/commit/7915b7915c1b905303f81150a15b005e39be5174) to require java7 instead, `java-1.6.0-openjdk-devel` may not be installed at all. This will ensure that jboss cartridges that offer the use of java6 require the `java-1.6.0-openjdk-devel` package.
