### PR TITLE
routing-daemon: F5: Fix syntax error

### DIFF
--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -60,7 +60,7 @@ module OpenShift
           end
         end
       rescue => e
-        raise unless options.wrap_exceptions
+        raise unless options[:wrap_exceptions]
 
         msg = "got #{e.class} exception: #{e.message}"
         begin


### PR DESCRIPTION
`F5IControlRestLoadBalancerModel#rest_request`: Fix a syntax error that was introduced in commit e131a07c8568877001d74b504315c2d838ac0a58 and that prevented the daemon from starting.
