### PR TITLE
gear-placement plugin: fix example configuration

### DIFF
--- a/plugins/gear-placement/conf/openshift-origin-gear-placement.conf.pin-user-to-host-example
+++ b/plugins/gear-placement/conf/openshift-origin-gear-placement.conf.pin-user-to-host-example
@@ -1,2 +1,2 @@
-SLOW_HOST='node.example.com'
+SLOW_HOSTS='node.example.com'
 PINNED_USER='gshipley'


### PR DESCRIPTION
Fix a typo in the setting name for `SLOW_HOSTS` in the example gear placement plug-in.

This commit fixes bug 1241750.
## 

[merge]
