### PR TITLE
oo-admin-broker-cache: Delete --console flag

### DIFF
--- a/broker-util/oo-admin-broker-cache
+++ b/broker-util/oo-admin-broker-cache
@@ -47,7 +47,6 @@ end
 
 opts = GetoptLong.new(
     ["--clear",            "-c", GetoptLong::NO_ARGUMENT],
-    ["--console",            GetoptLong::NO_ARGUMENT],
     ["--quiet",            "-q", GetoptLong::NO_ARGUMENT],
     ["--help",             "-h", GetoptLong::NO_ARGUMENT]
 )


### PR DESCRIPTION
Delete the `--console` flag, which has been deprecated for over a year now (since commit a09f8c3187a51807930065ea7df0798a6d831946 on 2014-03-28), from the oo-admin-broker-cache command.  After this commit, giving the `--console` flag will result in an error with usage information instead of silently ignoring the flag, which could give the administrator the false impression that the `--console` flag did in fact do something.

This commit fixes bug 1110415.
