### PR TITLE
REPORT_BUILD_ANALYTICS=false by default

### DIFF
--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -72,7 +72,7 @@ LIBVIRT_PRIVATE_IP_GW=172.16.0.1
 CONTAINERIZATION_PLUGIN=openshift-origin-container-selinux
 QUOTA_WARNING_PERCENT=90.0
 
-REPORT_BUILD_ANALYTICS=true
+REPORT_BUILD_ANALYTICS=false
 
 # Traffic control is enabled by default.  To ignore the bandwidth settings in
 # resource_limits.conf this can be set to false.  Changing this value requires

--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -683,7 +683,7 @@ module OpenShift
       # Send a fire-and-forget request to the broker to report build analytics.
       #
       def report_build_analytics
-        return unless @config.get_bool('REPORT_BUILD_ANALYTICS', true)
+        return unless @config.get_bool('REPORT_BUILD_ANALYTICS', false)
 
         broker_addr = @config.get('BROKER_HOST')
         url         = "https://#{broker_addr}/broker/analytics"


### PR DESCRIPTION
Change the default value of `REPORT_BUILD_ANALYTICS` in `node.conf` and in the code that uses this setting from `true` to `false` to avoid spurious requests to /broker/analytics.

This commit fixes bug 1111501.
## 

[test]
## 

@abhgupta, is there any reason this would be a bad idea? This change should not impact existing deployments because we have `%config(noreplace) /etc/openshift/node.conf` in `rubygem-openshift-origin-node.spec`, and anyway there probably isn't even anyone using /broker/analytics outside of OpenShift Online.  As for Online, @dak1n1 is making the change to set explicitly the value needed there.

An alternative to making this change here would be to change the installation tools to set REPORT_BUILD_ANALYTICS=false after the fact, but this change seems cleaner.
