### PR TITLE
Fix typo for gear_whitelist (oo-admin-upgrade)

### DIFF
--- a/broker-util/oo-admin-upgrade
+++ b/broker-util/oo-admin-upgrade
@@ -491,8 +491,10 @@ class Upgrader
 
       gears.each do |gear|
         if gear_whitelist && gear_whitelist.length > 0
-          puts "Gear #{gear[:uuid]} is not in the whitelist and will be skipped"
-          next unless gear_whitelist.include?(gear[:uuid])
+          unless gear_whitelist.include?(gear[:uuid])
+            puts "Gear #{gear[:uuid]} is not in the whitelist and will be skipped"
+            next
+          end
         end
 
         if active_gears_map.include?(server_identity) && active_gears_map[server_identity].include?(gear[:uuid])

--- a/broker-util/openshift-origin-broker-util.spec
+++ b/broker-util/openshift-origin-broker-util.spec
@@ -110,6 +110,9 @@ cp -p man/*.8 %{buildroot}%{_mandir}/man8/
 %{_mandir}/man8/oo-admin-ctl-team.8.gz
 
 %changelog
+* Fri Oct 03 2015 William Burton <wburton@redhat.com> 1.37.3-1
+- Fix typo for gear_whitelist when calling oo-admin-move upgrade-node
+
 * Wed Sep 23 2015 Stefanie Forrester <sedgar@redhat.com> 1.37.2-1
 - oo-admin-broker-cache: Delete --console flag (miciah.masters@gmail.com)
 


### PR DESCRIPTION
Fix output regarding gear_whitelist when using oo-admin-upgrade upgrade-node.
