### PR TITLE
[TO_STAGE] Remove pinging servers when starting haproxy

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/bin/control
+++ b/cartridges/openshift-origin-cartridge-haproxy/bin/control
@@ -26,13 +26,6 @@ function isrunning() {
     return 1
 }
 
-function ping_server_gears() {
-    #  Ping the server gears and wake 'em up on startup.
-    for geardns in $(web_gears | cut -f 3 -d ','); do
-          [ -z "$geardns" ]  ||  curl "http://$geardns/" > /dev/null 2>&1  ||  :
-    done
-}
-
 function wait_to_start() {
    ep=$(grep "listen stats" $OPENSHIFT_HAPROXY_DIR/conf/haproxy.cfg | sed 's#listen\s*stats\s*\(.*\)#\1#')
    i=0
@@ -78,7 +71,6 @@ function print_disable_as_marker_notice() {
 
 function _launch_haproxy_bg() {
     [ -n "$1" ]  &&  zopts="-sf $1"
-    ping_server_gears
     _load_user_configs
     LOGPIPE=${OPENSHIFT_HOMEDIR}/app-root/runtime/logshifter-haproxy
     rm -f $LOGPIPE && mkfifo $LOGPIPE


### PR DESCRIPTION
The change this commit is removing was originally added with 2a6c5d0

When a gear is unidled, whether it be through a request hitting the application URL or the use of oo-admin-ctl-gears, an application `start` event is sent to the broker. The broker then starts every component in the application, starting with the web_proxy cartridges. Before this fix, haproxy would make a request to every idle gear. This would commence anouther application `start` event sent to the broker, causing the application to be `start`'d twice.

The `ping_server_gears` function is no longer necessary since the method of unidling an application has changed. When a single gear in an application is unidled, all gears are started through the broker, making it unnecessary for haproxy to attempt to wake up the application's gears.

Additionally, the curl command in ping_server_gears has the potential to hang for some time, as described in [BZ#1257757](https://bugzilla.redhat.com/show_bug.cgi?id=1257757).
