### PR TITLE
gear-placement plugin: provide namespace to plugin

### DIFF
--- a/broker/test/functional/node_selection_test.rb
+++ b/broker/test/functional/node_selection_test.rb
@@ -30,6 +30,7 @@ class NodeSelectionPluginTest < ActiveSupport::TestCase
 
     raise Exception.new("Application properties not specified") if app_props.nil?
     raise Exception.new("Application name mismatch") if app_props.name != @@appname
+    raise Exception.new("Domain namespace mismatch") if app_props.namespace != @@namespace
 
     raise Exception.new("Current gears list is empty") if current_gears.empty?
     raise Exception.new("Current gear count mismatch") if current_gears.length != 1

--- a/controller/app/plugin_models/application_properties.rb
+++ b/controller/app/plugin_models/application_properties.rb
@@ -1,5 +1,5 @@
 class ApplicationProperties
-  attr_accessor :id, :name, :web_cartridge
+  attr_accessor :id, :name, :web_cartridge, :namespace
 
   def initialize(app)
     self.id = app._id.to_s
@@ -7,5 +7,6 @@ class ApplicationProperties
     if cart = app.web_cartridge
       self.web_cartridge = cart.name
     end
+    self.namespace = app.domain.namespace
   end
 end


### PR DESCRIPTION
Make the application's domain namespace available as an input parameter to the gear-placement plugin.

Thanks Boris Kurktchiev boris@unc.edu!

This commit fixes 1238305.
## 

[test]
