### PR TITLE
controller: execute_connections: nix client output

### DIFF
--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1595,6 +1595,8 @@ class Application
             pub_out[tag][gear_id] = output
           else
             pub_out[tag] = [] if pub_out[tag].nil?
+            re = /^CLIENT_(MESSAGE|RESULT|DEBUG|ERROR|INTERNAL_ERROR)/
+            output = output.lines.reject {|line| line =~ re}.join
             pub_out[tag].push("'#{gear_id}'='#{output}'")
           end
         end

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1588,6 +1588,7 @@ class Application
       pub_out = {}
       RemoteJob.execute_parallel_jobs(handle)
       RemoteJob.get_parallel_run_results(handle) do |tag, gear_id, output, status|
+        output.chomp!
         conn_type = self.connections.find { |c| c._id.to_s == tag}.connection_type
         if status==0
           if conn_type.start_with?("ENV:")


### PR DESCRIPTION
Filter client output out from the publish hooks output before providing it as input to subscribe hooks.

This commit fixes bug 1261540.
## 

RFC @dobbymoodge.
## 

[test]
