### PR TITLE
haproxy/bin/control: Fix error for no haproxy.cfg

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/bin/control
+++ b/cartridges/openshift-origin-cartridge-haproxy/bin/control
@@ -357,7 +357,7 @@ function tidy() {
 
 
 if ! [ -f ${OPENSHIFT_HAPROXY_DIR}/conf/haproxy.cfg ]; then
-  client_error "HAProxy required configuration file \"$(basename $f)\" not found."
+  client_error 'HAProxy required configuration file "haproxy.cfg" not found.'
   exit 129
 fi
 


### PR DESCRIPTION
Fix the error message that the haproxy cartridge prints if does not find `haproxy.cfg`.  The error message was referring to the `$f` variable that was deleted in commit f5986a7bddaac5588ab330384e38b1c977ec36b2.
## 

[merge]
