### PR TITLE
Set the Host header appropriately in Nginx alias configuration

### DIFF
--- a/routing-daemon/lib/openshift/routing/models/nginx.rb
+++ b/routing-daemon/lib/openshift/routing/models/nginx.rb
@@ -232,6 +232,7 @@ server {
   server_name <%= alias_str %>;
   location / {
     proxy_pass http://<%= pool_name %>;
+    proxy_set_header Host $host;
     <%= @health_check %>
   }
 }


### PR DESCRIPTION
Bug 1248439
https://bugzilla.redhat.com/show_bug.cgi?id=1248439

When using nginx as a routing-daemon, the host header should be set to the host provided by the request to the nginx load balancer. Otherwise, the pool_xxx host may be passed as the host header.
