### PR TITLE
Kill haproxy during restart even when pid does not exist

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/bin/control
+++ b/cartridges/openshift-origin-cartridge-haproxy/bin/control
@@ -41,9 +41,9 @@ function wait_to_start() {
 
 function _stop_haproxy_ctld() {
   if [ -f ${HAPROXY_CTLD_PID} ]; then
-    pid=$( /bin/cat "${HAPROXY_CTLD_PID}" )
-    if ps --no-headers --pid ${pid} > /dev/null 2>&1; then
-      kill -TERM $pid
+    local ctld_pid=$( /bin/cat "${HAPROXY_CTLD_PID}" )
+    if ps --no-headers --pid ${ctld_pid} > /dev/null 2>&1; then
+      kill -TERM $ctld_pid
     else
       rm -f ${HAPROXY_CTLD_PID}
     fi
@@ -147,15 +147,19 @@ function _stop_haproxy_service() {
     else
         if `pgrep -x haproxy > /dev/null 2>&1`
         then
-            echo "Warning: HAProxy process exists without a pid file.  Use force-stop to kill." 1>&2
+            client_message "Warning: HAProxy process exists without a pid file."
         else
-            echo "HAProxy already stopped" 1>&2
+            client_message "HAProxy already stopped"
         fi
     fi
 }
 
 function _restart_haproxy_service() {
-    _stop_haproxy_service || pkill haproxy || :
+    _stop_haproxy_service
+    if `pgrep -x haproxy > /dev/null 2>&1`; then
+      client_message "Could not stop HAProxy. Forcefully killing the process."
+      pkill haproxy
+    fi
     _start_haproxy_service
 }
 
@@ -175,17 +179,31 @@ function _reload_service() {
 
 function start() {
     _start_haproxy_service
-    isrunning  &&  echo "HAProxy instance is started"
+    if isrunning; then
+      client_result "HAProxy instance is started"
+    else
+      client_error "HAProxy instance could not be started"
+      exit 1
+    fi
 }
 
 function stop() {
     _stop_haproxy_service
-    isrunning  ||  echo "HAProxy instance is stopped"
+    if `pgrep -x haproxy > /dev/null 2>&1`; then
+      client_message "Could not stop HAProxy. Forcefully killing the process."
+      pkill haproxy
+      if `pgrep -x haproxy > /dev/null 2>&1`; then
+        client_error "Could not stop the HAProxy process."
+        exit 1
+      fi
+    fi
+
+    client_result "HAProxy instance is stopped"
 }
 
 function restart() {
     _restart_haproxy_service
-    isrunning  &&  echo "Restarted HAProxy instance"
+    isrunning  &&  client_result "Restarted HAProxy instance"
 }
 
 function reload() {
@@ -196,14 +214,14 @@ function reload() {
        _reload_service
     fi
 
-    isrunning  &&  echo "Reloaded HAProxy instance"
+    isrunning  &&  client_result "Reloaded HAProxy instance"
 }
 
 function force-reload() {
     if isrunning; then
-        echo "`date`: Conditionally reloading HAProxy service " 1>&2
+        client_message "`date`: Conditionally reloading HAProxy service "
         _reload_service
-        isrunning  &&  echo "Conditionally reloaded HAProxy"
+        isrunning  &&  client_result "Conditionally reloaded HAProxy"
     fi
 }
 


### PR DESCRIPTION
Bug 1211526
https://bugzilla.redhat.com/show_bug.cgi?id=1211526

The haproxy process was not killed with pkill as expected due to a logging message being reported instead of returning non-zero at the end of the `_stop_haproxy_service` function. `pkill` is now run if the haproxy process still exists after the stop during a restart.

The `_stop_haproxy_ctld` method was setting $pid to the haproxy_ctld pid. This same variable is set in `_stop_haproxy_service` only if the haproxy pid file does exist. If the haproxy pid file doesn't exist, the $pid variable still contains the haproxy_ctld pid, causing us to assume that the haproxy pid file does exist.

The stop function would report that the haproxy instance is stopped when the haproxy pid files does not exist. Now, a helpful message will be reported suggesting to run force-stop, as the orignal code appears to have intended.

 Lastly, I modified several `echo` statements to use the sdk's `client_*` methods. This ensures that the user perfoming these actions using rhc will receive the message in the rhc output.
