### PR TITLE
fix rhcsh error output, clean up cart sub hooks

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/hooks/set-haproxy-status-url
+++ b/cartridges/openshift-origin-cartridge-haproxy/hooks/set-haproxy-status-url
@@ -1,19 +1,23 @@
 #!/bin/bash -e
 # Update the list of non-local haproxy status URLs meant to be used by the
 # auto scaler.
-source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 # Parse the arguments to populate the status URLs list.
 list=
-kvargs=$(echo "${@:4}" | tr -d "\n" )
-for arg in $kvargs; do
-    surl=$(echo "$arg" | cut -f 2 -d '=' | tr -d "'")
+args=($(printf "%s\n" "${@:4}"))
+for arg in "${args[@]}" ; do
+    # skip if it's not a k/v arg
+    [[ "${arg}" =~ '=' ]] || continue
+    # drop single-quotes
+    arg="${arg//\'/}"
+    # grab the 'value' bit
+    arg="${arg#*=}"
     # Do not add an entry for the local gear.
-    if [[ ! $surl =~ $OPENSHIFT_GEAR_DNS ]]; then
-        if [ -z "$list" ]; then
-            list="$surl"
+    if [[ ! $arg =~ $OPENSHIFT_GEAR_DNS ]] ; then
+        if [[ -z "$list" ]] ; then
+            list="$arg"
         else
-            list="$list\n$surl"
+            list="$list\n$arg"
         fi
     fi
 done

--- a/cartridges/openshift-origin-cartridge-jbosseap/hooks/set-jboss-cluster
+++ b/cartridges/openshift-origin-cartridge-jbosseap/hooks/set-jboss-cluster
@@ -1,15 +1,17 @@
-#!/bin/bash
-
+#!/bin/bash -e
 # Exit on any errors
-set -e
-
-source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 list=
-kvargs=$(echo "${@:4}" | tr -d "\n" )
-for arg in $kvargs; do
-    ip=$(echo "$arg" | cut -f 2 -d '=' | tr -d "'")
-    ip=$(echo "$ip" | sed "s/:/[/g")
+args=($(printf "%s\n" "${@:4}"))
+for arg in "${args[@]}" ; do
+    # skip if it's not a k/v arg
+    [[ "${arg}" =~ '=' ]] || continue
+    # drop single-quotes
+    arg="${arg//\'/}"
+    # grab the 'value' bit
+    arg="${arg#*=}"
+    # trim whitespace
+    ip="${arg/:/[}"
     if [ -z "$list" ]; then
         list="$ip]"
     else

--- a/cartridges/openshift-origin-cartridge-jbosseap/hooks/set-jboss-remoting
+++ b/cartridges/openshift-origin-cartridge-jbosseap/hooks/set-jboss-remoting
@@ -1,15 +1,19 @@
-#!/bin/bash
+#!/bin/bash -e
+# Exit on any errors
 
 # Adds a gear to the haproxy configuration.
 
-# Exit on any errors
-set -e
-
 list=
-kvargs=$(echo "${@:4}" | tr -d "\n" )
-for arg in $kvargs; do
-    ip=$(echo "$arg" | cut -f 2 -d '=' | tr -d "'")
-    ip=$(echo "$ip" | sed "s/:/[/g")
+args=($(printf "%s\n" "${@:4}"))
+for arg in "${args[@]}" ; do
+    # skip if it's not a k/v arg
+    [[ "${arg}" =~ '=' ]] || continue
+    # drop single-quotes
+    arg="${arg//\'/}"
+    # grab the 'value' bit
+    arg="${arg#*=}"
+    # trim whitespace
+    ip="${arg/:/[}"
     if [ -z "$list" ]; then
         list="$ip]"
     else

--- a/node/misc/bin/rhcsh
+++ b/node/misc/bin/rhcsh
@@ -88,19 +88,19 @@ function welcome {
       local usage=$(quota -w 2>/dev/null| grep '^.*/dev/' | awk '{printf "%3.1f", ($2 / $4 * 100)}')
       if float_test "${usage:-0} > 90.0"
       then
-        echo "Warning: Gear ${OPENSHIFT_GEAR_UUID} is using ${usage}% of disk quota"
+        echo 1>&2 "Warning: Gear ${OPENSHIFT_GEAR_UUID} is using ${usage}% of disk quota"
       fi
 
       local usage=$(quota -w 2>/dev/null| grep '^.*/dev/' | awk '{printf "%3.1f",  ($5 / $7 * 100)}')
       if float_test "${usage:-0} > 90.0"
       then
-        echo "Warning: Gear ${OPENSHIFT_GEAR_UUID} is using ${usage}% of inodes allowed"
+        echo 1>&2 "Warning: Gear ${OPENSHIFT_GEAR_UUID} is using ${usage}% of inodes allowed"
       fi
     else
-      echo "Your application is out of disk space; please run \"rhc app-tidy $OPENSHIFT_APP_NAME\"" 1>&2
+      echo 1>&2 "Your application is out of disk space; please run \"rhc app-tidy $OPENSHIFT_APP_NAME\""
     fi
   else
-    echo "Command \"quota\" not found for app $OPENSHIFT_APP_NAME, please check the node hosting this app"
+    echo 1>&2 "Command \"quota\" not found for app $OPENSHIFT_APP_NAME, please check the node hosting this app"
   fi
 }
 


### PR DESCRIPTION
The `welcome` function in `rhcsh` was sending messages to `stdout` which
should have gone to `stderr`.

The subscriber hooks for `haproxy`, `jbosseap` and `jbossas` carts were
modified at first to fix Bug 1261540, but since Miciah has addressed
that in the runtime code, the scripts are now simply optimized to use
bash built-ins to avoid forking new processes.

Depends on https://github.com/openshift/origin-server/pull/6271/
