### PR TITLE
oo-accept-node: Test BROKER_HOST & CLOUD_DOMAIN are consistent

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -194,7 +194,7 @@ class OODiag
     @project_is[:origin] = !(@project_is[:enterprise] || @project_is[:online])
     # detect whether the ruby193 SCL is in play.
     system "scl enable ruby193 echo >& /dev/null"
-    @scl_prefix = $?.success? ? "ruby193-" : "" 
+    @scl_prefix = $?.success? ? "ruby193-" : ""
     # detect whether we use service or systemctl
     @use_systemctl = executable? "systemctl"
 
@@ -561,7 +561,7 @@ class OODiag
     a_profile_for.each do |node,profile|
       # check that all nodes are in a district
       if !d_profile_for[node]
-        do_warn <<-NODIST 
+        do_warn <<-NODIST
           Node host #{node} with profile '#{profile}' is not a member of any district.
           Please add it to a district with oo-admin-ctl-district.
         NODIST
@@ -931,7 +931,7 @@ class OODiag
      if have_system_config_firewall
        do_warn <<-WARN
          Using system-config-firewall and lokkit with OpenShift is not recommended.
-         To continue using lokkit please ensure the following custom rules are 
+         To continue using lokkit please ensure the following custom rules are
          installed in #{conf_file}:
 
          --custom-rules=ipv4:filter:/etc/openshift/system-config-firewall-compat
@@ -994,9 +994,9 @@ class OODiag
     if bname && nname && bname != nname
       # broker and node both installed, node may be stealing traffic
       do_warn <<-CONFLICT
-        /etc/httpd/conf.d/000001_openshift_origin_node_servername.conf defines a 
+        /etc/httpd/conf.d/000001_openshift_origin_node_servername.conf defines a
         ServerName #{nname} which may cause the node intercept requests by that name
-        intended for the broker. Please reconfigure with the same ServerName as the 
+        intended for the broker. Please reconfigure with the same ServerName as the
         one in /etc/httpd/conf.d/000002_openshift_origin_broker_servername.conf
       CONFLICT
     end
@@ -1226,6 +1226,30 @@ class OODiag
       do_warn "Using a self-signed certificate for the broker"
     end
 
+    broker_host_env = File.read("/etc/openshift/env/OPENSHIFT_BROKER_HOST")
+
+    # Retrieve the SSL cert from broker_host_env
+    env_response = `curl -k -s -v https://#{broker_host_env.chomp}/ -o /dev/null 2>&1`
+    if $? != 0
+      do_fail <<-CANNOTCONNECT
+        Attempt to connect to #{broker_host_env} but failed. curl returned with
+        #{env_response.strip.empty? ? "no output." : "the following output:\n" + env_response}
+
+        Please check whether the httpd service in #{broker_host_env} is running.
+      CANNOTCONNECT
+      return
+    end
+
+    # Get SSL cert's issuer, subject and commonname
+    env_issuer = env_response.slice(/^\*\s*issuer: .*$/).gsub(/^\*\s*issuer: /,"")
+    env_subject = env_response.slice(/^\*\s*subject: .*$/).gsub(/^\*\s*subject: /,"")
+    env_commonname = env_response.slice(/^\*\s*common name: .*$/).gsub(/^\*\s*common name: /,"")
+
+    # Check to see if SSL certs from current broker and BROKER_HOST match
+    do_fail "SSL cert issuer doesn't match between localhost and #{broker_host_env} defined in /etc/openshift/env/OPENSHIFT_BROKER_HOST" if env_issuer != issuer
+    do_fail "SSL cert subject doesn't match between localhost and #{broker_host_env} defined in /etc/openshift/env/OPENSHIFT_BROKER_HOST" if env_subject != subject
+    do_fail "SSL cert commonname doesn't match between localhost and #{broker_host_env} defined in /etc/openshift/env/OPENSHIFT_BROKER_HOST" if env_commonname != commonname
+
     apacheconfig = `httpd -S 2> /dev/null`.slice(  / ^\*:443.*  (\n^\s.*)*  \n(\S|\z) /x  )
     servername = apacheconfig.scan(/(?:(?:default server )|(?:port 443 namevhost ))(\S+) \((?:[^:]+)/)
     badnames = []
@@ -1241,9 +1265,9 @@ class OODiag
         config_files = `grep -l -e "^[[:blank:]]*ServerName[[:blank:]]*#{badname}" /etc/httpd/conf.d/*.conf`
         config_files.each_line do |config_file|
           do_warn <<-CONFLICT
-            #{config_file.chomp} 
-            defines ServerName as #{badname}.  This does not match the certificate common name of 
-            #{commonname}.  
+            #{config_file.chomp}
+            defines ServerName as #{badname}.  This does not match the certificate common name of
+            #{commonname}.
             This can cause errors when client tools try to connect to the broker.
           CONFLICT
         end
@@ -1289,7 +1313,7 @@ class OODiag
   def test_yum_configuration
     if executable? "oo-admin-yum-validator"
       output = `oo-admin-yum-validator --report-all 2>&1`
-      $?.success? or do_warn <<-YUM 
+      $?.success? or do_warn <<-YUM
         oo-admin-yum-validator reported some possible problems
         with your package source configuration:
 --------------------------------------------------------------
@@ -1360,9 +1384,9 @@ class OODiag
         The following configuration files have names and locations indicating
         that the apache user should be able to read them, but are not readable
         by the apache user:
-          
+
           #{unreadable * "\n          "}
-          
+
         #{ broker_unreadable.empty? ? "" : "The broker and console services may malfunction without read access to these files." }
         #{ node_unreadable.empty? ? "" : "The host httpd server may malfunction without read access to these files."}
       UNREADABLE


### PR DESCRIPTION
The oo-diagnostics doesn't compare SSL certs from broker & BROKER_HOST
to see if they match since it only collects SSL cert from broker only.

After the commit, the oo-diagnostics gets SSL cert from BROKER_HOST along
with current broker. Then, it compares issuer, subject and common name
records from SSL certs to see if they match. If not, errors are issued.

This commit fixes bug 1054441

Signed-off-by: Vu Dinh vdinh@redhat.com
