### PR TITLE
oo-watchman.8: "with it's" -> "with its"

### DIFF
--- a/node-util/conf/sysconfig/watchman
+++ b/node-util/conf/sysconfig/watchman
@@ -7,7 +7,7 @@
 # Number of seconds to wait before resetting retries
 #RETRY_PERIOD=28800
 
-# Number of seconds a gear must remain inconsistent with it's state before
+# Number of seconds a gear must remain inconsistent with its state before
 #   Watchman attempts to reset state
 #STATE_CHANGE_DELAY=900
 

--- a/node-util/man8/oo-watchman.8
+++ b/node-util/man8/oo-watchman.8
@@ -38,7 +38,7 @@ Number of seconds to wait before accepting another gear restart. Default: 300 se
 Number of seconds to wait before resetting retries. Default: 28800 seconds (8 hours)
 .TP
 .B  STATE_CHANGE_DELAY
-Number of seconds a gear must remain inconsistent with it's state before
+Number of seconds a gear must remain inconsistent with its state before
 Watchman attempts to reset state. Default: 900 seconds (15 minutes)
 .TP
 .B  STATE_CHECK_PERIOD


### PR DESCRIPTION
Fix a typo in oo-watchman.8 and the example configuration file.
