### PR TITLE
haproxy: use POSIX locale for validating endpoints

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/update-cluster
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/update-cluster
@@ -25,7 +25,8 @@ do
     esac
 done
 
-
+ORIG_LC_ALL="${LC_ALL}"
+REGEX_LC_ALL="POSIX"
 #[ $# -gt 3 ] || print_help
 
 exitcode=0
@@ -52,12 +53,16 @@ for arg in $kvargs; do
 
     # And of the form: $valid-dns-entry:$port-number
     # (valid-dns-entry regex portion from http://stackoverflow.com/a/3824105/305572)
+    # Set locale to POSIX for regex match - Bug 1261147
+    LC_ALL="${REGEX_LC_ALL}"
     if [[ ! $ep =~ ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*:[0-9]{4,5}$ ]]; then
        # write/log error, set exit code but continue/process remaining entries.
        echo "${@:1:3} - Invalid endpoint '$ep' passed in input - $zinfo" 1>&2
        exitcode=22
        continue
     fi
+    # Restore user-set locale
+    LC_ALL="${ORIG_LC_ALL}"
 
 	# If this is the local gear, we are NOT creating an entry for it
 	# The local gear entry is made separately later below


### PR DESCRIPTION
Bug 1261147
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1261147

Different locales have different ideas of what `[a-z]` mean in a
regex. The regex used for endpoint validation in `update-cluster`
depends on the `POSIX` locale being set. Users that want to control the
locale their apps run in by setting `LC_ALL` to some non-`POSIX`
locale via `rhc set-env LC_ALL=xyz` (e.g. Estonian - `ee_ET`) would find
that scaling events might fail because `[a-z]` in the new locale
excludes some letters that might appear in a valid hostname.

This change updates the `update-cluster` script in the `haproxy`
cartridge so that it preserves the user's locale setting and switches to
the `POSIX` locale only for the part of the script that does the
endpoint validation.

See also:
- https://bugzilla.redhat.com/show_bug.cgi?id=1056666
