### PR TITLE
Bug 1064039: Add oo-diagnostic report 401 Unauthorized error

### DIFF
--- a/common/bin/oo-diagnostics
+++ b/common/bin/oo-diagnostics
@@ -194,7 +194,7 @@ class OODiag
     @project_is[:origin] = !(@project_is[:enterprise] || @project_is[:online])
     # detect whether the ruby193 SCL is in play.
     system "scl enable ruby193 echo >& /dev/null"
-    @scl_prefix = $?.success? ? "ruby193-" : "" 
+    @scl_prefix = $?.success? ? "ruby193-" : ""
     # detect whether we use service or systemctl
     @use_systemctl = executable? "systemctl"
 
@@ -561,7 +561,7 @@ class OODiag
     a_profile_for.each do |node,profile|
       # check that all nodes are in a district
       if !d_profile_for[node]
-        do_warn <<-NODIST 
+        do_warn <<-NODIST
           Node host #{node} with profile '#{profile}' is not a member of any district.
           Please add it to a district with oo-admin-ctl-district.
         NODIST
@@ -931,7 +931,7 @@ class OODiag
      if have_system_config_firewall
        do_warn <<-WARN
          Using system-config-firewall and lokkit with OpenShift is not recommended.
-         To continue using lokkit please ensure the following custom rules are 
+         To continue using lokkit please ensure the following custom rules are
          installed in #{conf_file}:
 
          --custom-rules=ipv4:filter:/etc/openshift/system-config-firewall-compat
@@ -994,9 +994,9 @@ class OODiag
     if bname && nname && bname != nname
       # broker and node both installed, node may be stealing traffic
       do_warn <<-CONFLICT
-        /etc/httpd/conf.d/000001_openshift_origin_node_servername.conf defines a 
+        /etc/httpd/conf.d/000001_openshift_origin_node_servername.conf defines a
         ServerName #{nname} which may cause the node intercept requests by that name
-        intended for the broker. Please reconfigure with the same ServerName as the 
+        intended for the broker. Please reconfigure with the same ServerName as the
         one in /etc/httpd/conf.d/000002_openshift_origin_broker_servername.conf
       CONFLICT
     end
@@ -1204,6 +1204,38 @@ class OODiag
 
   end
 
+  def test_auth_keys_salt_failure
+    skip_test unless @is_broker
+
+    log_dir = "/var/log/openshift/broker/"
+
+    if Rails.env.development?
+      mode = "development"
+    elsif Rails.env.production?
+      mode = "production"
+    else
+      mode = "test"
+    end
+    
+    msg_log = `grep 'Broker key authentication failed' #{log_dir + mode}.log`
+
+    unless msg_log.empty?
+      do_warn <<-AUTH_ERROR
+      Detected an '401 Unauthorized' error on the #{mode} log. This error
+      may indicate inconsistent authentication keys or salts among brokers.
+      Please follow below steps to fix the issue:
+      1. Manually synchronize the authentication keys and salt in broker's
+      configuration
+      2. Then use 'oo-admin-broker-auth' to resync all credentials on
+      existing gears
+
+      Note: This error message may continue to be displayed even if the issue
+      is already resolved as the error message is still in the #{mode} log.
+      The error will be cleared after the next log rotation.
+      AUTH_ERROR
+    end
+  end
+
   def test_broker_certificate
     skip_test unless @is_broker
 
@@ -1241,9 +1273,9 @@ class OODiag
         config_files = `grep -l -e "^[[:blank:]]*ServerName[[:blank:]]*#{badname}" /etc/httpd/conf.d/*.conf`
         config_files.each_line do |config_file|
           do_warn <<-CONFLICT
-            #{config_file.chomp} 
-            defines ServerName as #{badname}.  This does not match the certificate common name of 
-            #{commonname}.  
+            #{config_file.chomp}
+            defines ServerName as #{badname}.  This does not match the certificate common name of
+            #{commonname}.
             This can cause errors when client tools try to connect to the broker.
           CONFLICT
         end
@@ -1289,7 +1321,7 @@ class OODiag
   def test_yum_configuration
     if executable? "oo-admin-yum-validator"
       output = `oo-admin-yum-validator --report-all 2>&1`
-      $?.success? or do_warn <<-YUM 
+      $?.success? or do_warn <<-YUM
         oo-admin-yum-validator reported some possible problems
         with your package source configuration:
 --------------------------------------------------------------
@@ -1360,9 +1392,9 @@ class OODiag
         The following configuration files have names and locations indicating
         that the apache user should be able to read them, but are not readable
         by the apache user:
-          
+
           #{unreadable * "\n          "}
-          
+
         #{ broker_unreadable.empty? ? "" : "The broker and console services may malfunction without read access to these files." }
         #{ node_unreadable.empty? ? "" : "The host httpd server may malfunction without read access to these files."}
       UNREADABLE


### PR DESCRIPTION
The 'oo-diagnostics' currently won't fail if there are 410 Unauthorized
error in the production/development.log. After this change, 'oo-diagnostics'
will check either production or development.log depending on which mode the
broker is in. If the 401 errors exist, an error message will be displayed
with the sugguested solution to fix the issue. The warning message may
continue to be displayed in the subsequential 'oo-diagnostics'
until the 401 error message is cleared up in the next log rotation.

Bug <1064039>
Link https://bugzilla.redhat.com/show_bug.cgi?id=1064039

Signed-off-by: Vu Dinh vdinh@redhat.com
