### PR TITLE
FrontendHttpServer: Recover from missing manifest

### DIFF
--- a/node/lib/openshift-origin-node/model/frontend_httpd.rb
+++ b/node/lib/openshift-origin-node/model/frontend_httpd.rb
@@ -178,7 +178,7 @@ module OpenShift
         @container_name = container.name
         @namespace = container.namespace
 
-        @standalone_web_proxy = container.cartridge_model.standalone_web_proxy?
+        @standalone_web_proxy = (container.cartridge_model.standalone_web_proxy? rescue false)
 
         # this is ONLY used when invoking "connect" so the app uuid can be stored
         # in the nodes db, so it can be added to the node openshift_log (access log)


### PR DESCRIPTION
`OpenShift::Runtime::FrontendHttpServer#initialize`: Rescue any exception from initializing the cartridge model, and set `@standalone_web_proxy` to false in that contingency.

Before this commit, failure to initialize the cartridge model would cause a failure to initialize the frontend http server, which would cause a failure to initialize the container plugin, which would prevent the container plugin's `destroy` method from finishing.  Consequently, it was impossible to delete a gear with a bad `manifest.yml` file.

This commit fixes bug 1273658.
## 

[test] [extended:gear]
## 

@jwhonce, does this look reasonable?
