### PR TITLE
Bug 1264722: Fix oo-register-dns shows errors with any option

### DIFF
--- a/broker-util/oo-register-dns
+++ b/broker-util/oo-register-dns
@@ -1,13 +1,13 @@
 #!/usr/bin/env oo-ruby
 #--
 # Copyright 2010 Red Hat, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,9 +37,9 @@ oo-register-dns --with-node-hostname node1 \\
 == List of arguments
   -h|--with-node-hostname   host        Hostname for the node (required)
   -n|--with-node-ip         ip          IP of the node (required)
-  -d|--domain               domain      Domain name for this node (optional, default: example.com)  
-  -s|--dns-server           server      IP address or hostname of DNS server to update (optional, default: 127.0.0.1)  
-  -k|--key-file             file        Bind key (optional, default: /var/named/<domain name>.key)  
+  -d|--domain               domain      Domain name for this node (optional, default: example.com)
+  -s|--dns-server           server      IP address or hostname of DNS server to update (optional, default: 127.0.0.1)
+  -k|--key-file             file        Bind key (optional, default: /var/named/<domain name>.key)
   -g|--gss-tsig                         Use GSS-TSIG Kerberos credentials to bind (optional)
   -?|--help                             Print this message
 
@@ -54,7 +54,7 @@ opts = GetoptLong.new(
     ["--dns-server",          "-s", GetoptLong::OPTIONAL_ARGUMENT],
     ["--key-file",            "-k", GetoptLong::OPTIONAL_ARGUMENT],
     ["--gss-tsig",            "-g", GetoptLong::NO_ARGUMENT],
-    ["--help",                "-h", GetoptLong::NO_ARGUMENT]
+    ["--help",                "-?", GetoptLong::NO_ARGUMENT]
 )
 
 args = {}


### PR DESCRIPTION
There is a command conflict as '-h' option is linked link both '--help'
and '--with-node-hostname' which causes 'getoptlong' object to fail.
In fact, '--help' should be linked to '-?' instead. This commit recrifies
the issue by linking '--help' back to '-?' as it shows in help message.

Bug <1264722>
Link https://bugzilla.redhat.com/show_bug.cgi?id=1264722

Signed-off-by: Vu Dinh vdinh@redhat.com
