### PR TITLE
Fix typos in manpages: "an utility" -> "a utility"

### DIFF
--- a/broker-util/man/oo-admin-ctl-district.8
+++ b/broker-util/man/oo-admin-ctl-district.8
@@ -17,7 +17,7 @@
 .fam T
 .fi
 .SH DESCRIPTION
-This is an utility for all district operations on OpenShift Origin.
+This is a utility for all district operations on OpenShift Origin.
 .SH OPTIONS
 .TP
 .B

--- a/broker-util/man/oo-admin-ctl-district.txt2man
+++ b/broker-util/man/oo-admin-ctl-district.txt2man
@@ -9,7 +9,7 @@ SYNOPSIS
   [-b|--bypass]
 
 DESCRIPTION
-  This is an utility for all district operations on OpenShift Origin.
+  This is a utility for all district operations on OpenShift Origin.
 
 OPTIONS
   -h|--help  

--- a/broker-util/man/oo-admin-ctl-domain.8
+++ b/broker-util/man/oo-admin-ctl-domain.8
@@ -15,7 +15,7 @@
 .fam T
 .fi
 .SH DESCRIPTION
-This is an utility for all district operations on OpenShift Origin.
+This is a utility for all district operations on OpenShift Origin.
 .SH OPTIONS
 .TP
 .B
@@ -43,7 +43,7 @@ for \fB--command\fP update.
 .TP
 .B
 \fB-c\fP|\fB--command\fP \fIcmd\fP
-Command to enact upon the domain. Available commands are: create,
+Command to enact upon the domain. Available commands are create,
 update, delete, info.
 .PP
 \fB-s\fP|\fB--ssh_key\fP \fIsshkey\fP

--- a/broker-util/man/oo-admin-ctl-domain.txt2man
+++ b/broker-util/man/oo-admin-ctl-domain.txt2man
@@ -7,7 +7,7 @@ SYNOPSIS
   [-t|--key_type sshkey_type] [-k|--key_name sshkey_name]
 
 DESCRIPTION
-  This is an utility for all district operations on OpenShift Origin.
+  This is a utility for all district operations on OpenShift Origin.
 
 OPTIONS
   -h|--help  
@@ -29,7 +29,7 @@ OPTIONS
     for --command update.
 
   -c|--command cmd  
-    Command to enact upon the domain. Available commands are: create,
+    Command to enact upon the domain. Available commands are create,
     update, delete, info.
 
   -s|--ssh_key sshkey

--- a/broker-util/man/oo-admin-ctl-region.8
+++ b/broker-util/man/oo-admin-ctl-region.8
@@ -15,7 +15,7 @@
 .fam T
 .fi
 .SH DESCRIPTION
-This is an utility for all region/zone operations on OpenShift Origin.
+This is a utility for all region/zone operations on OpenShift Origin.
 .SH OPTIONS
 .TP
 .B

--- a/broker-util/man/oo-admin-ctl-region.txt2man
+++ b/broker-util/man/oo-admin-ctl-region.txt2man
@@ -7,7 +7,7 @@ SYNOPSIS
   [-b|--bypass] [-d|--description region_description]
 
 DESCRIPTION
-  This is an utility for all region/zone operations on OpenShift Origin.
+  This is a utility for all region/zone operations on OpenShift Origin.
 
 OPTIONS
   -h|--help  


### PR DESCRIPTION
Change several instances of "an utility" to "a utility" in manpages, and delete some extraneous colons.
## 

[merge]
