### PR TITLE
Fix gear extended tests

### DIFF
--- a/controller/test/cucumber/step_definitions/upgrade_steps.rb
+++ b/controller/test/cucumber/step_definitions/upgrade_steps.rb
@@ -387,7 +387,7 @@ end
 EOF
 
   IO.write('/tmp/gear_upgrade.rb', gear_upgrade_content)
-  `echo 'GEAR_UPGRADE_EXTENSION=/tmp/gear_upgrade' >> /etc/openshift/node.conf`
+  `echo '\nGEAR_UPGRADE_EXTENSION=/tmp/gear_upgrade' >> /etc/openshift/node.conf`
 end
 
 Given /^a gear level upgrade extension to map the updated software version exists$/ do
@@ -446,7 +446,7 @@ module OpenShift
 end
 EOF
   IO.write('/tmp/gear_upgrade.rb', gear_upgrade_content)
-  `echo 'GEAR_UPGRADE_EXTENSION=/tmp/gear_upgrade' >> /etc/openshift/node.conf`
+  `echo '\nGEAR_UPGRADE_EXTENSION=/tmp/gear_upgrade' >> /etc/openshift/node.conf`
 end
 
 Then /^the invocation markers from the gear upgrade should exist$/ do

--- a/controller/test/cucumber/support/gear_upgrade_helper.rb
+++ b/controller/test/cucumber/support/gear_upgrade_helper.rb
@@ -7,5 +7,6 @@ After('@manipulates_gear_upgrade') do
 end
 
 def clean_gear_upgrade_extension_from_node_conf
-  `sed -i /etc/openshift/node.conf -e s,GEAR_UPGRADE_EXTENSION.*,,g`
+  `sed -i /etc/openshift/node.conf -e /GEAR_UPGRADE_EXTENSION/d`
+  `sed -i /etc/openshift/node.conf -e '${/^$/d}'`
 end


### PR DESCRIPTION
When appending a line for the `GEAR_UPGRADE_EXTENSION` setting to `/etc/openshift/node.conf`, include a leading `\n` EOL marker in case the last line of `node.conf` is incomplete and is missing the EOL marker.  Otherwise the `GEAR_UPGRADE_EXTENSION` setting will be appended to the incomplete line and will not take effect, and as a consequence, the test will fail the first time it runs (although it will succeed on subsequent runs).

Change the clean-up code to delete the entire line for the `GEAR_UPGRADE_EXTENSION` setting instead of substituting an empty line, and then delete the last line if it is empty.
## 

[test] [extended:gear]
