### PR TITLE
Bug 1265609: Fix pandas not getting installed

### DIFF
--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/bin/control
@@ -182,9 +182,17 @@ function build() {
         ( cd $OPENSHIFT_REPO_DIR; pip install -r ${OPENSHIFT_REPO_DIR}${requirements_file} $OPENSHIFT_PYTHON_MIRROR $OPENSHIFT_PIP_TRUSTED_HOST )
     fi
 
+    echo "Checking pip install marker.."
+    export_pip_install
+
     if [ -f ${OPENSHIFT_REPO_DIR}/setup.py ]; then
-        echo "Running setup.py script.."
-        ( cd $OPENSHIFT_REPO_DIR; python ${OPENSHIFT_REPO_DIR}/setup.py develop $OPENSHIFT_PYTHON_MIRROR )
+        if [ $OPENSHIFT_PYTHON_USE_PIP == "enable" ]; then
+          echo "Running pip install.."
+          ( cd $OPENSHIFT_REPO_DIR; pip install -e . )
+        else
+          echo "Running setup.py script.."
+          ( cd $OPENSHIFT_REPO_DIR; python ${OPENSHIFT_REPO_DIR}/setup.py develop $OPENSHIFT_PYTHON_MIRROR )
+        fi
     fi
 
     relative-virtenv

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/lib/util
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/lib/util
@@ -1,6 +1,14 @@
 #!/bin/bash
 # Utility functions for use in the cartridge scripts.
 
+function export_pip_install() {
+  if marker_present "pip_install"; then
+    export OPENSHIFT_PYTHON_USE_PIP="enable"
+  else
+    export OPENSHIFT_PYTHON_USE_PIP="disable"
+  fi
+}
+
 function appserver_pid() {
 	pgrep -f "python -u app.py"
 }


### PR DESCRIPTION
Pandas package fails to install properly if it's included in setup.py for
Python 2 & 3 applications. This issue is possibly due to a bug with numpy
dependency of pandas package. This commit allows pandas package to be
installed using 'pip install -e .' instead of 'python setup.py install'
to work around the numpy bug.

Bug <1265609>
Link https://bugzilla.redhat.com/show_bug.cgi?id=1265609

Signed-off-by: Vu Dinh vdinh@redhat.com
