### PR TITLE
Delete explicit haproxy component overrides when disabling ha

### DIFF
--- a/broker/test/functional/app_events_controller_test.rb
+++ b/broker/test/functional/app_events_controller_test.rb
@@ -149,10 +149,12 @@ class AppEventsControllerTest < ActionController::TestCase
     post :create, "event" => "disable-ha", "application_id" => @app.id
     assert_response :success
     overrides = @app.reload.group_instances_with_overrides
+    explicit_overrides = @app.group_overrides
     assert !@app.ha
     assert_equal 1, overrides.length
     assert_equal 1, overrides[0].min_gears
     assert_equal(-1, overrides[0].max_gears)
+    assert_equal 0, explicit_overrides.select {|xo| xo.class == ComponentOverrrideSpec && xo.name == "web_proxy" && defined? xo.min_gears}.length
     assert comp = overrides[0].components.detect{ |i| i.cartridge.is_web_proxy? }
   end
 

--- a/controller/app/pending_ops_models/disable_app_ha_op_group.rb
+++ b/controller/app/pending_ops_models/disable_app_ha_op_group.rb
@@ -3,7 +3,11 @@ class DisableAppHaOpGroup < PendingAppOpGroup
 
   def elaborate(app)
     app.ha = false
-    ops, add_gear_count, rm_gear_count = app.update_requirements(app.cartridges, nil, app.group_overrides)
+    overrides = app.group_overrides
+    overrides.each do |override|
+      override.components.delete_if {|c| c.class == ComponentOverrideSpec && c.name == "web_proxy" && defined? c.min_gears }
+    end
+    ops, add_gear_count, rm_gear_count = app.update_requirements(app.cartridges, nil, overrides)
     ops.unshift(UnsetHaOp.new)
     ops.push(DeregisterRoutingDnsOp.new) if Rails.configuration.openshift[:manage_ha_dns]
     try_reserve_gears(add_gear_count, rm_gear_count, app, ops)


### PR DESCRIPTION
Bug 1255426
https://bugzilla.redhat.com/show_bug.cgi?id=1255426

When an application has a minimum and/or maximum scaling limit set, it is possible that implicit overrides for HA applications will be set as explicit overrides in the database. This previously caused applications that were made ha, then had a scaling limit set, then had ha disabled to be unable to scale back down to a single haproxy cartridge.

With this change, the explicit overrides will be removed if they exist when an HA application has HA disabled.
