### PR TITLE
 Add tc support for multiple IFs via TRAFFIC_CONTORL_DEVS

### DIFF
--- a/documentation/oo_deployment_guide_puppet.adoc
+++ b/documentation/oo_deployment_guide_puppet.adoc
@@ -752,7 +752,12 @@ max number of processes
 Default: 250
 
 ==== node_tc_max_bandwidth
-mbit/sec - Total bandwidth allowed for Libra
+mbit/sec - Total bandwidth allowed for OpenShift
+
+If `TRAFFIC_CONTROL_DEVS` includes the loopback interface (`lo`), this setting will
+be ignored only for that interface. For example, with a setting of
+`TRAFFIC_CONTROL_DEVS="eth0 lo"`, the `node_tc_max_bandwidth` setting would apply to
+`eth0` but not to `lo`.
 
 Default: 800
 

--- a/node-util/sbin/oo-accept-node
+++ b/node-util/sbin/oo-accept-node
@@ -204,6 +204,7 @@ def load_node_conf
     do_fail("GEAR_BASE_DIR does not exist or is not a directory: #{$GEAR_BASE_DIR}") unless File.exists? $GEAR_BASE_DIR
 
     $EXTERNAL_ETH_DEV = ($CONF.get('EXTERNAL_ETH_DEV') or 'eth0')
+    $TRAFFIC_CONTROL_DEVS = ($CONF.get('TRAFFIC_CONTROL_DEVS') or $EXTERNAL_ETH_DEV).gsub(/\s+/m, ' ').strip.split(' ')
 
     verbose("loading resource limit file #{$RESOURCE_LIMITS_FILE}")
     do_fail("No resource limits file: #{$RESOURCE_LIMITS_FILE}") unless File.exists? $RESOURCE_LIMITS_FILE
@@ -241,7 +242,7 @@ def load_users
   # Narrow the window where USERS, TC_DATA and ALL_QUOTAS can reflect
 # the system in different states.
   $START_TIME=Time.now
-  $TC_DATA = %x[/sbin/tc clas show dev #{$EXTERNAL_ETH_DEV}].split("\n").grep(/parent/)
+  $TC_DATA = %x[/sbin/tc clas show dev #{$TRAFFIC_CONTROL_DEVS.first}].split("\n").grep(/parent/)
   $ALL_QUOTAS = %x[/usr/sbin/repquota -a].split("\n")
 
   # Aggregate per-user hash of lscgroup data. In some cases, multiple subsystems
@@ -517,21 +518,22 @@ def check_tc_config
 
     verbose("checking presence of tc qdisc")
     qdiscresponse="qdisc htb 1: root"
-
-    result = %x[/sbin/tc qdisc show dev #{$EXTERNAL_ETH_DEV} | /bin/grep -q "#{qdiscresponse}"]
-    if $?.exitstatus != 0
-        do_fail("tc htb qdisc not configured")
-        $TC_PASS=false
-    else
-        verbose("checking for cgroup filter")
-        if %x[/sbin/tc filter show dev #{$EXTERNAL_ETH_DEV} | /bin/grep 'cgroup handle' | /usr/bin/uniq | /usr/bin/wc -l].strip.to_i < 1
-            do_fail("no cgroup filter configured")
+    $TRAFFIC_CONTROL_DEVS.each do |tc_dev|
+        result = %x[/sbin/tc qdisc show dev #{tc_dev} | /bin/grep -q "#{qdiscresponse}"]
+        if $?.exitstatus != 0
+            do_fail("tc htb qdisc not configured")
             $TC_PASS=false
         else
-            verbose("checking presence of tc classes")
-            if %x[/sbin/tc class show dev #{$EXTERNAL_ETH_DEV} | /bin/grep 'class htb' | /usr/bin/wc -l].strip.to_i < 1
-                do_fail("no htb classes configured")
+            verbose("checking for cgroup filter")
+            if %x[/sbin/tc filter show dev #{tc_dev} | /bin/grep 'cgroup handle' | /usr/bin/uniq | /usr/bin/wc -l].strip.to_i < 1
+                do_fail("no cgroup filter configured")
                 $TC_PASS=false
+            else
+                verbose("checking presence of tc classes")
+                if %x[/sbin/tc class show dev #{tc_dev} | /bin/grep 'class htb' | /usr/bin/wc -l].strip.to_i < 1
+                    do_fail("no htb classes configured")
+                    $TC_PASS=false
+                end
             end
         end
     end

--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -80,6 +80,11 @@ REPORT_BUILD_ANALYTICS=false
 # openshift-tc service.
 # TRAFFIC_CONTROL_ENABLED=true
 
+# Traffic control is only enabled on the EXTERNAL_ETH_DEV interface by default.
+# To enable it on other interfaces, specify a space-separated list of interfaces
+# on the TRAFFIC_CONTROL_DEVS option.
+# TRAFFIC_CONTROL_DEVS="lo eth0 eth1"
+
 # MOTD_FILE="/etc/openshift/welcome.rhcsh"                   # Change the default rhcs welcome message
 
 # Gems for managing the frontend http server

--- a/node/conf/resource_limits.conf
+++ b/node/conf/resource_limits.conf
@@ -75,7 +75,7 @@ limits_nproc=250        # max number of processes
 
 # Traffic control.  used by /etc/init.d/openshift-tc
 #
-# For these settings to be active TRAFFIC_CONTROL_ENABLED=true must be set in
+# For these settings to be active TRAFFIC_CONTROL_ENABLED=false must not be set in
 # /etc/openshift/node.conf
 #
 # tc_max_bandwidth=800   # mbit/sec - Total bandwidth allowed for all gears

--- a/node/conf/resource_limits.conf
+++ b/node/conf/resource_limits.conf
@@ -79,6 +79,7 @@ limits_nproc=250        # max number of processes
 # /etc/openshift/node.conf
 #
 # tc_max_bandwidth=800   # mbit/sec - Total bandwidth allowed for all gears
+#                        # per interface (ignored for loopback)
 # tc_user_share=2    # mbit/sec - one gear is allotted...
 
 #

--- a/node/conf/resource_limits.conf.large.m3.xlarge
+++ b/node/conf/resource_limits.conf.large.m3.xlarge
@@ -76,7 +76,7 @@ limits_nproc=2142        # max number of processes
 
 # Traffic control.  used by /etc/init.d/openshift-tc
 #
-# For these settings to be active TRAFFIC_CONTROL_ENABLED=true must be set in
+# For these settings to be active TRAFFIC_CONTROL_ENABLED=false must not be set in
 # /etc/openshift/node.conf
 #
 tc_max_bandwidth=800   # mbit/sec - Total bandwidth allowed for all gears

--- a/node/conf/resource_limits.conf.large.m3.xlarge
+++ b/node/conf/resource_limits.conf.large.m3.xlarge
@@ -80,6 +80,7 @@ limits_nproc=2142        # max number of processes
 # /etc/openshift/node.conf
 #
 tc_max_bandwidth=800   # mbit/sec - Total bandwidth allowed for all gears
+                       # per interface (ignored for loopback)
 tc_user_share=50       # mbit/sec - one gear is allotted...
 
 #

--- a/node/conf/resource_limits.conf.medium.m3.xlarge
+++ b/node/conf/resource_limits.conf.medium.m3.xlarge
@@ -76,7 +76,7 @@ limits_nproc=2142        # max number of processes
 
 # Traffic control.  used by /etc/init.d/openshift-tc
 #
-# For these settings to be active TRAFFIC_CONTROL_ENABLED=true must be set in
+# For these settings to be active TRAFFIC_CONTROL_ENABLED=false must not be set in
 # /etc/openshift/node.conf
 #
 tc_max_bandwidth=800   # mbit/sec - Total bandwidth allowed for all gears

--- a/node/conf/resource_limits.conf.medium.m3.xlarge
+++ b/node/conf/resource_limits.conf.medium.m3.xlarge
@@ -80,6 +80,7 @@ limits_nproc=2142        # max number of processes
 # /etc/openshift/node.conf
 #
 tc_max_bandwidth=800   # mbit/sec - Total bandwidth allowed for all gears
+                       # per interface (ignored for loopback)
 tc_user_share=50    # mbit/sec - one gear is allotted...
 
 #

--- a/node/conf/resource_limits.conf.small.m3.xlarge
+++ b/node/conf/resource_limits.conf.small.m3.xlarge
@@ -75,7 +75,7 @@ limits_nproc=250        # max number of processes
 
 # Traffic control.  used by /etc/init.d/openshift-tc
 #
-# For these settings to be active TRAFFIC_CONTROL_ENABLED=true must be set in
+# For these settings to be active TRAFFIC_CONTROL_ENABLED=false must not be set in
 # /etc/openshift/node.conf
 #
 # tc_max_bandwidth=800   # mbit/sec - Total bandwidth allowed for all gears

--- a/node/conf/resource_limits.conf.small.m3.xlarge
+++ b/node/conf/resource_limits.conf.small.m3.xlarge
@@ -79,6 +79,7 @@ limits_nproc=250        # max number of processes
 # /etc/openshift/node.conf
 #
 # tc_max_bandwidth=800   # mbit/sec - Total bandwidth allowed for all gears
+#                        # per interface (ignored for loopback)
 # tc_user_share=2    # mbit/sec - one gear is allotted...
 
 #

--- a/node/conf/resource_limits.conf.xpaas.m3.xlarge
+++ b/node/conf/resource_limits.conf.xpaas.m3.xlarge
@@ -81,7 +81,7 @@ limits_nproc=2142        # max number of processes
 
 # Traffic control.  used by /etc/init.d/openshift-tc
 #
-# For these settings to be active TRAFFIC_CONTROL_ENABLED=true must be set in
+# For these settings to be active TRAFFIC_CONTROL_ENABLED=false must not be set in
 # /etc/openshift/node.conf
 #
 # tc_max_bandwidth=800   # mbit/sec - Total bandwidth allowed for Libra

--- a/node/conf/resource_limits.conf.xpaas.m3.xlarge
+++ b/node/conf/resource_limits.conf.xpaas.m3.xlarge
@@ -85,6 +85,7 @@ limits_nproc=2142        # max number of processes
 # /etc/openshift/node.conf
 #
 # tc_max_bandwidth=800   # mbit/sec - Total bandwidth allowed for Libra
+#                        # per interface (ignored for loopback)
 # tc_user_share=2    # mbit/sec - one user is allotted...
 
 #

--- a/node/lib/openshift-origin-node/utils/tc.rb
+++ b/node/lib/openshift-origin-node/utils/tc.rb
@@ -75,10 +75,10 @@ module OpenShift
           # the total bandwidth
           #
 
-          # The network interface we're planning on limiting bandwidth.
-          @tc_if=(@config.get('EXTERNAL_ETH_DEV') or "eth0")
-          @tc_if_mtu=get_interface_mtu(@tc_if)
-          @tc_min_quantum=(@resources.get('tc_min_quantum') or @tc_if_mtu).to_i
+          # The network interface(s) we're planning on limiting bandwidth.
+          @tc_ifs=(@config.get('TRAFFIC_CONTROL_DEVS') or @config.get('EXTERNAL_ETH_DEV') or 'eth0').gsub(/\s+/m, ' ').strip.split(" ")
+          # a map of interface name to min quantum (e.g. { 'eth0' => 1500, 'lo' => 65536 })
+          @tc_min_quantum=Hash[@tc_ifs.collect { |tc_if| [tc_if, (@resources.get('tc_min_quantum') or get_interface_mtu(tc_if)).to_i] }]
           @tc_max_quantum=(@resources.get('tc_max_quantum') or 100000).to_i
 
           # Normal bandwidths are in Mbit/s
@@ -90,7 +90,8 @@ module OpenShift
           # Throttles are in kbit/s
           @tc_throttle_user_share=(@resources.get('tc_throttle_user_share') or 128).to_i    # 128 kbits/s with no borrow
           @tc_throttle_user_limit=(@resources.get('tc_throttle_user_limit') or @tc_throttle_user_share).to_i
-          @tc_throttle_user_quantum=(@resources.get('tc_throttle_user_quantum') or @tc_min_quantum).to_i
+          # a map of interface name to throttle user quantum (e.g. { 'eth0' => 1500, 'lo' => 65536 })
+          @tc_throttle_user_quantum=Hash[@tc_ifs.collect { |tc_if| [tc_if, (@resources.get('tc_throttle_user_quantum') or @tc_min_quantum[tc_if]).to_i] }]
 
           # Where we keep track of throttled/high users
           @tc_user_dir=(@resources.get('tc_user_dir') or File.join(@config.get('GEAR_BASE_DIR'), '.tc_user_dir'))
@@ -104,7 +105,7 @@ module OpenShift
         def get_interface_mtu(iface)
           out, _, rc = ::OpenShift::Runtime::Utils.oo_spawn(%Q[ip link show dev #{iface}], :chdir=>"/")
           if rc != 0
-            raise RuntimeError, "Unable to determine external network interface IP address."
+            raise RuntimeError, "Unable to determine interface MTU for #{iface}."
           end
           if out=~/mtu\s+(\d+)/
             $~[1].to_i
@@ -154,23 +155,27 @@ module OpenShift
         def startuser_impl(uuid, pwent, netclass, f)
           # Select what type of user.  Note that a user can high bandwidth
           # normally but throttled for a specific and temporary reason.
-          if File.exists?("#{@tc_user_dir}/#{uuid}_throttle")
+          throttled = File.exists?("#{@tc_user_dir}/#{uuid}_throttle")
+          if throttled
             @output.last << "throttled"
             this_user_share="#{@tc_throttle_user_share}kbit"
             this_user_limit="#{@tc_throttle_user_limit}kbit"
-            this_user_quantum=@tc_throttle_user_quantum
           else
             @output.last << "normal"
             this_user_share="#{@tc_user_share}mbit"
             this_user_limit="#{@tc_user_limit}mbit"
-            this_user_quantum=@tc_user_quantum
           end
 
           # Overall class for the gear
-          f.puts %Q[class add dev #{@tc_if} parent 1:1 classid 1:#{netclass} htb rate #{this_user_share} ceil #{this_user_limit} quantum #{this_user_quantum}]
+          @tc_ifs.each do |tc_if|
+            this_user_quantum=throttled ? @tc_throttle_user_quantum[tc_if] : @tc_user_quantum
+            f.puts %Q[class add dev #{tc_if} parent 1:1 classid 1:#{netclass} htb rate #{this_user_share} ceil #{this_user_limit} quantum #{this_user_quantum}]
+          end
 
           # Specific constraints within the gear's limit
-          f.puts %Q[qdisc add dev #{@tc_if} parent 1:#{netclass} handle #{netclass}: htb default 0]
+          @tc_ifs.each do |tc_if|
+            f.puts %Q[qdisc add dev #{tc_if} parent 1:#{netclass} handle #{netclass}: htb default 0]
+          end
 
           @tc_outbound_htb.each.with_index do |htb_array, i|
             bandwidth, ports = htb_array
@@ -179,28 +184,40 @@ module OpenShift
             # configuring outbound htb minor numbers started at 2.
             minor_number = i+2
 
-            f.puts %Q[class add dev #{@tc_if} parent #{netclass}: classid #{netclass}:#{minor_number} htb rate #{rate} ceil #{ceil} quantum #{@tc_min_quantum}]
+            @tc_ifs.each do |tc_if|
+              f.puts %Q[class add dev #{tc_if} parent #{netclass}: classid #{netclass}:#{minor_number} htb rate #{rate} ceil #{ceil} quantum #{@tc_min_quantum[tc_if]}]
+            end
             ports.each do |p|
-              f.puts %Q[filter add dev #{@tc_if} parent #{netclass}: protocol ip prio 10 u32 match ip dport #{p} 0xffff flowid #{netclass}:#{minor_number}]
+              @tc_ifs.each do |tc_if|
+                f.puts %Q[filter add dev #{tc_if} parent #{netclass}: protocol ip prio 10 u32 match ip dport #{p} 0xffff flowid #{netclass}:#{minor_number}]
+              end
             end
           end
         end
 
         def stopuser_impl(uuid, pwent, netclass, f)
-          f.puts("class del dev #{@tc_if} parent 1:1 classid 1:#{netclass}")
+          @tc_ifs.each do |tc_if|
+            f.puts("class del dev #{tc_if} parent 1:1 classid 1:#{netclass}")
+          end
         end
 
         def tc_exists?(netclass)
-          out, _, _ = ::OpenShift::Runtime::Utils.oo_spawn("tc -s class show dev #{@tc_if} classid 1:#{netclass}", :chdir=>"/")
-          out.empty? ? false : out
+          exists_all = true
+          @tc_ifs.each do |tc_if|
+            out, _, _ = ::OpenShift::Runtime::Utils.oo_spawn("tc -s class show dev #{tc_if} classid 1:#{netclass}", :chdir=>"/")
+            exists_all = false if out.empty?
+          end
+          exists_all and not @tc_ifs.empty?
         end
 
         def with_tc_loaded
-          out, _, _ = ::OpenShift::Runtime::Utils.oo_spawn("tc qdisc show dev #{@tc_if}", :chdir=>"/")
-          if out.include?("qdisc htb 1:")
-            yield if block_given?
-          else
-            raise RuntimeError, "no htb qdisc on #{@tc_if}"
+          @tc_ifs.each do |tc_if|
+            out, _, _ = ::OpenShift::Runtime::Utils.oo_spawn("tc qdisc show dev #{tc_if}", :chdir=>"/")
+            if out.include?("qdisc htb 1:")
+              yield if block_given?
+            else
+              raise RuntimeError, "no htb qdisc on #{tc_if}"
+            end
           end
         end
 
@@ -239,9 +256,11 @@ module OpenShift
             all_stopped = false if tc_exists?(netclass)
           end
           if all_stopped
-            f.puts %Q[qdisc add dev #{@tc_if} root handle 1: htb]
-            f.puts %Q[class add dev #{@tc_if} parent 1: classid 1:1 htb rate #{@tc_max_bandwidth}mbit]
-            f.puts %Q[filter add dev #{@tc_if} parent 1: protocol ip prio 10 handle 1: cgroup]
+            @tc_ifs.each do |tc_if|
+              f.puts %Q[qdisc add dev #{tc_if} root handle 1: htb]
+              f.puts %Q[class add dev #{tc_if} parent 1: classid 1:1 htb rate #{@tc_max_bandwidth}mbit]
+              f.puts %Q[filter add dev #{tc_if} parent 1: protocol ip prio 10 handle 1: cgroup]
+            end
           end
 
           
@@ -265,7 +284,9 @@ module OpenShift
         end
 
         def stop_impl(f)
-          f.puts %Q[qdisc del dev #{@tc_if} root]
+          @tc_ifs.each do |tc_if|
+            f.puts %Q[qdisc del dev #{tc_if} root]
+          end
         end
 
         def stop
@@ -378,10 +399,12 @@ module OpenShift
                 statususer(uuid, pwent, netclass, verbose)
               end
             else
-              out, err, rc = ::OpenShift::Runtime::Utils.oo_spawn("tc -s qdisc show dev #{@tc_if}", :chdir=>"/")
-              @output << out
-              out, err, rc = ::OpenShift::Runtime::Utils.oo_spawn("tc -s class show dev #{@tc_if}", :chdir=>"/")
-              @output << out
+              @tc_ifs.each do |tc_if|
+                out, err, rc = ::OpenShift::Runtime::Utils.oo_spawn("tc -s qdisc show dev #{tc_if}", :chdir=>"/")
+                @output << out
+                out, err, rc = ::OpenShift::Runtime::Utils.oo_spawn("tc -s class show dev #{tc_if}", :chdir=>"/")
+                @output << out
+              end
             end
           end
         end

--- a/node/misc/man8/oo-admin-ctl-tc.8
+++ b/node/misc/man8/oo-admin-ctl-tc.8
@@ -75,8 +75,10 @@ Otherwise, display the traffic control (tc) status for \fIEXTERNAL_ETH_DEV\fR.
 Alias for \fIstatus\fR
 .SH ENVIRONMENT
 .TP
+.B  TRAFFIC_CONTROL_DEVS
+Interface(s) to use when limiting bandwidth. default: eth0
 .B  EXTERNAL_ETH_DEV
-Interface to use when limiting bandwidth. default: eth0
+Interface to use when limiting bandwidth. Ignored if TRAFFIC_CONTROL_DEVS is specified. default: eth0
 .SH FILES
 .TP
 .FN /etc/openshift/resource_limits.conf


### PR DESCRIPTION
Add a new configuration item, TRAFFIC_CONTORL_DEVS, which is a
space-delimited list of interfaces that should be tc-managed.

Update code so that tc changes are applied across all devices that
are to be traffic-controlled.

Also hard-code limits to very high numbers for the loopback interface if it is to be managed.
