### PR TITLE
documentation/index.adoc: 4 repositories, not 5

### DIFF
--- a/documentation/index.adoc
+++ b/documentation/index.adoc
@@ -46,7 +46,7 @@ include::_pep_list.adoc[]
 
 == Source Code Repositories
 
-OpenShift Origin sources are arranged into 5 repositories:
+OpenShift Origin sources are arranged into 4 repositories:
 
 [cols="1,3",options="header"]
 |===


### PR DESCRIPTION
We now have 4 repositories, not 5, after the removal of origin-dev-tools in commit a3286bc64e2ad8d5063cb2ad2f5fa05233373b0b.
