### PR TITLE
Jboss-unified-push tests should not be run on enterprise deplpoyments

### DIFF
--- a/controller/test/cucumber/cartridge-lifecycle-jboss-unified-push.feature
+++ b/controller/test/cucumber/cartridge-lifecycle-jboss-unified-push.feature
@@ -1,3 +1,4 @@
+@not-enterprise
 @cartridge_extended4
 
 Feature: Cartridge Lifecycle JBoss Unified Push Server Verification Tests


### PR DESCRIPTION
The cartridge is not supplied in enterprise, so the test should not be run.
