### PR TITLE
deployments_controller.rb: Adds check for REST deployment without arguments

### DIFF
--- a/broker/test/functional/deployments_controller_test.rb
+++ b/broker/test/functional/deployments_controller_test.rb
@@ -132,4 +132,18 @@ class DeploymentsControllerTest < ActionController::TestCase
     end
   end
 
+  test "check for both binary and git deployment input" do
+    # Check for cases where we have both a ref and an artifact_url
+    test_url = "http://localhost/test.tgz"
+    test_ref = "branchname"
+    post :create, { "application_id" => @app._id, "artifact_url" => test_url, "ref" => test_ref }
+    assert_response :unprocessable_entity, "Cannot specify a git deployment and a binary artifact deployment"
+  end
+
+  test "check for no binary or git deployment input" do
+    # Check for cases where we have have neither a ref nor an artifact_url
+    post :create, { "application_id" => @app._id, "artifact_url" => nil, "ref" => nil }
+    assert_response :unprocessable_entity, "Must specify a git deployment or a binary artifact deployment"
+  end
+
 end

--- a/controller/app/controllers/deployments_controller.rb
+++ b/controller/app/controllers/deployments_controller.rb
@@ -26,7 +26,7 @@ class DeploymentsController < BaseController
     authorize! :create_deployment, @application
 
     hot_deploy = get_bool(params[:hot_deploy].presence)
-    force_clean_build = get_bool(params[:force_clean_build].presence) 
+    force_clean_build = get_bool(params[:force_clean_build].presence)
     ref = params[:ref].presence
     artifact_url = params[:artifact_url].presence
     artifact_url = URI::encode(artifact_url) if artifact_url
@@ -39,6 +39,9 @@ class DeploymentsController < BaseController
 
     return render_error(:unprocessable_entity, "Cannot specify a git deployment and a binary artifact deployment",
                           -1, "artifact_url") if artifact_url && ref
+
+    return render_error(:unprocessable_entity, "Must specify a git deployment or a binary artifact deployment",
+                          -1) unless artifact_url || ref
 
     result = @application.deploy(hot_deploy, force_clean_build, ref, artifact_url)
 


### PR DESCRIPTION
deployments_controller.rb: Adds check for REST deployment without arguments

Bug 1223025
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1223025

Currently, attempting to change a deployment and not passing in a target variable (either ref or artifact_url) will result in a false success message.

Adds a check to ensure that a ref or artifact_url variable is present before attempting to deploy.
