### PR TITLE
oo-admin-chk: Adds solutions to a couple of error messages

### DIFF
--- a/broker-util/oo-admin-chk
+++ b/broker-util/oo-admin-chk
@@ -169,9 +169,11 @@ node_hash.each do |gear_uuid, gear_info|
   datastore_gear_info = $datastore_hash[gear_uuid]
   if !datastore_gear_info
     if !datastore_has_gear?(gear_uuid)
+      server_identity = gear_info[0]
       puts "#{gear_uuid}...FAIL" if $verbose
-      print_message "Gear #{gear_uuid} exists on node #{gear_info[0]} (uid: #{gear_info[1]}) but does not exist in mongo database"
-      print_message "Please see https://access.redhat.com/solutions/1171163 for more information."
+      print_message "Gear #{gear_uuid} exists on node #{server_identity} (uid: #{gear_info[1]}) but does not exist in mongo database"
+      print_message "To fix this issue, remove the gear by running the oo-devel-node command from the node '#{server_identity}':"
+      print_message "oo-devel-node app-destroy --with-container-uuid #{gear_uuid}"
     end
   elsif !datastore_gear_info['gear_uid'].nil?
     begin

--- a/controller/app/helpers/admin_helper.rb
+++ b/controller/app/helpers/admin_helper.rb
@@ -459,6 +459,8 @@ module AdminHelper
         user_consumed_gears, app_actual_gears = check_consumed_gears(user)
         if user_consumed_gears != app_actual_gears
           print_message "User #{owner_hash['login']} has a mismatch in consumed gears (#{user_consumed_gears}) and actual gears (#{app_actual_gears})"
+          print_message "Set the correct number of consumed gears with the oo-admin-ctl-user command:"
+          print_message "oo-admin-ctl-user --login username --setconsumedgears #{app_actual_gears}"
           error_consumed_gears_user_ids << owner_id
         end
       end


### PR DESCRIPTION
Bug 1111598
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1111598

Changes the incorrect error message for when a gear exists on the node, but not in mongo.  The error message now tells the user the correct solution for the error.

Also adds a solution to the error message for when there is a mismatch between consumed gears and actual gears.
