### PR TITLE
deployments.rb: Changes :err to be visible to user

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container_ext/deployments.rb
+++ b/node/lib/openshift-origin-node/model/application_container_ext/deployments.rb
@@ -410,8 +410,8 @@ module OpenShift
           # explode file
           out, err, rc = run_in_container_context(extract_command,
                                                   in: options[:stdin],
-                                                  out: $stderr,
-                                                  err: $stderr,
+                                                  out: nil,
+                                                  err: nil,
                                                   env: env,
                                                   chdir: destination)
 

--- a/node/test/unit/deployments_test.rb
+++ b/node/test/unit/deployments_test.rb
@@ -422,8 +422,8 @@ EOF
 
     @container.expects(:run_in_container_context).with('extract',
                                                        in: nil,
-                                                       out: $stderr,
-                                                       err: $stderr,
+                                                       out: nil,
+                                                       err: nil,
                                                        env: gear_env,
                                                        chdir: destination).returns(["", "", 0])
 


### PR DESCRIPTION
Using the REST api for binary deployments could result in errors with the node using the curl command, however the user would not be able to see why or how the curl command failed.

Changes the :out and :err streams sent to the node to be nil, so that the error output is sent back to the user as part of the text variable.

Bug 1126836
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1126836
