### PR TITLE
routing-daemon: F5: Fix syntax error

### DIFF
--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -62,7 +62,7 @@ module OpenShift
       first = @hosts.first
 
       begin
-        options['url'] = "https://#{@hosts.first}#{options['resource']}"
+        options[:url] = "https://#{@hosts.first}#{options[:resource]}"
 
         RestClient::Request.execute(options).tap do |response|
           unless response.code == expected_code


### PR DESCRIPTION
`F5IControlRestLoadBalancerModel`#`rest_request`: Fix a syntax error that was introduced in commit f9d47828016d5085bdd9da252300c6feb642e9d6 and that caused errors on every REST API call.
