### PR TITLE
deployments_controller.rb: Adds check for app deployment mode via REST

### DIFF
--- a/broker/test/functional/deployments_controller_test.rb
+++ b/broker/test/functional/deployments_controller_test.rb
@@ -49,6 +49,8 @@ class DeploymentsControllerTest < ActionController::TestCase
   test "deployment create show list" do
     @domain.members.find(@user).role = :edit
     @domain.save; @domain.run_jobs
+    @app.config["deployment_type"] = "git"
+    @app.save
 
     ResultIO.any_instance.stubs(:deployments).returns([{:id => 1, :ref => "mybranch", :sha1 => "1234", :created_at => Time.now, :activations => [Time.now, Time.now]}])
     post :create, {"ref" => "mybranch", "application_id" => @app._id}
@@ -95,6 +97,8 @@ class DeploymentsControllerTest < ActionController::TestCase
   test "validate supported binary artifact formats" do
     @domain.members.find(@user).role = :edit
     @domain.save; @domain.run_jobs
+    @app.config["deployment_type"] = "binary"
+    @app.save
 
     supported_artifact_urls = ["http://localhost/test1.tgz", "http://localhost/test2.tar.gz", "https://localhost/test3.tgz", "https://localhost/test4.tar.gz", "ftp://localhost/test5.tgz", "ftp://localhost/test6.tar.gz", "http://localhost/{558F2532-1116}/test.tgz", "https://localhost/url with space/test7.tgz"]
     unsupported_artifact_urls = ["badurl1/test7.tgz", "notreal://localhost/test8.tgz", "http://localhost/test9.txt", "https://localhost/test10.txt", "http://localhost/test11", "test12", "-1", '!@#!@#@!#!', "not a url", '$%*!&#@!&#!)*#@!DAZSXCAS#R@#_@(_$*%)@*)#@*$_#@i[sadfsa]ew34122]\safdsa|xczxcz', '&^#$%!CSCA#@$#@FDS', "http://localhost/test13.tar", "http://somehost/test14.gz"]
@@ -120,6 +124,9 @@ class DeploymentsControllerTest < ActionController::TestCase
   end
 
   test "validate ref" do
+    @app.config["deployment_type"] = "git"
+    @app.save
+
     # See git-check-ref-format man page for rules
     invalid_values = ["a"*257, "abc.lock", "abc/.xyz", "abc..xyz", "/abc", "abc/", "abc//xyz", "abc.", "abc@{xyz}"]
     invalid_chars = ["^", "~", ":", "?", "*", "\\", " ", "[", ";"]

--- a/controller/app/controllers/deployments_controller.rb
+++ b/controller/app/controllers/deployments_controller.rb
@@ -43,6 +43,12 @@ class DeploymentsController < BaseController
     return render_error(:unprocessable_entity, "Must specify a git deployment or a binary artifact deployment",
                           -1) unless artifact_url || ref
 
+    return render_error(:unprocessable_entity, "The binary artifact provided is not compatible with the app deployment type, '#{@application.config['deployment_type']}'.",
+                          -1, "artifact_url") if artifact_url && @application.config["deployment_type"] != "binary"
+
+    return render_error(:unprocessable_entity, "The git ref provided is not compatible with the app deployment type, '#{@application.config['deployment_type']}'.",
+                          -1, "ref") if ref && @application.config["deployment_type"] != "git"
+
     result = @application.deploy(hot_deploy, force_clean_build, ref, artifact_url)
 
     #@analytics_tracker.track_event("app_deploy", nil, @application)


### PR DESCRIPTION
Bug 1104140
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1104140

Adds additional checks to verify that the app is in the correct deployment mode when deploying via the REST api.  Will throw 422 error when attempting to binary deploy in git mode or vice versa.

Adds deployment types to relevant REST api tests to specify deployment mode.
