### PR TITLE
Set the Host header appropriately in Nginx alias SSL configuration

### DIFF
--- a/routing-daemon/lib/openshift/routing/models/nginx.rb
+++ b/routing-daemon/lib/openshift/routing/models/nginx.rb
@@ -244,6 +244,7 @@ server {
   server_name <%= alias_str %>;
   location / {
     proxy_pass http://<%= pool_name %>;
+    proxy_set_header Host $host;
     <%= @health_check %>
   }
 }


### PR DESCRIPTION
Bug 1248439
https://bugzilla.redhat.com/show_bug.cgi?id=1248439

The nginx host header was added to the regular alias configuration for nginx, but should also be added to the ssl alias configuration
