### PR TITLE
man/oo-admin-gear.8: Fixes incorrect flag option

### DIFF
--- a/node-util/man8/oo-admin-gear.8
+++ b/node-util/man8/oo-admin-gear.8
@@ -1,14 +1,14 @@
 .\" Process this file with
 .\" groff -man -Tascii oo-admin-gear.8
-.\" 
+.\"
 .de FN
 \fI\|\\$1\|\fP
 ..
-.TH "OO-ADMIN-GEAR" "8" "2014-03-11" "OpenShift" "OpenShift Management Commands"
+.TH "OO-ADMIN-GEAR" "8" "2015-11-24" "OpenShift" "OpenShift Management Commands"
 .SH NAME
 oo-admin-gear \- Administrative operations for OpenShift gears hosted on this node
 .SH SYNOPSIS
-.B "oo-admin-gear {COMMAND} [--help|-h] [--version|-v] [--trace|-t] {--with-container-uuid|-u } gear uuid"
+.B "oo-admin-gear {COMMAND} [--help|-h] [--version|-v] [--trace|-t] {--with-container-uuid|-c } gear uuid"
 .SH DESCRIPTION
 .B "oo-admin-gear"
 may be used to operate on a gear
@@ -26,4 +26,3 @@ is of no value on a Broker node that does not host gears.
 .\" .IP \n+[step] 2
 .SH BUGS
 .SH SEE ALSO
-


### PR DESCRIPTION
Bug 1283372
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1283372

The man page for oo-admin-gear incorrectly stated that the short flag for --with-container-uuid was -u.  Attempting to use -u will result in an error.  The actual flag is -c, which is consistent with other oo-admin commands.

Changes man page to show '-c' instead of the incorrect '-u'.
