### PR TITLE
routing-daemon: F5: Fix policy check

### DIFF
--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -396,12 +396,12 @@ module OpenShift
 
         policy = JSON.parse(policy_json)
 
-        unless policy['controls'].include? 'forwarding'
+        if policy['controls'].nil? || !policy['controls'].include?('forwarding')
           patch(resource: policy_url,
                 payload: { 'controls' => ['forwarding'] }.to_json)
         end
 
-        unless policy['requires'].include? 'http'
+        if policy['requires'].nil? || !policy['requires'].include?('http')
           patch(resource: policy_url, payload: { 'requires' => ['http'] }.to_json)
         end
       rescue RestClient::ResourceNotFound


### PR DESCRIPTION
`F5IControlRestLoadBalancerModel`#`initialize`: Check if the policy's "controls" or "requires" field is defined before checking whether the field has the correct value.
