### PR TITLE
[TO_STAGE] - apache lacks permission to access openshift-node-web-proxy log files

### DIFF
--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -235,7 +235,7 @@ fi
 %{gem_spec}
 %attr(0750,-,-) /usr/sbin/*
 %attr(0755,-,-) /usr/bin/*
-%attr(0750,-,-) %{_var}/log/openshift/node
+%attr(0751,-,-) %{_var}/log/openshift/node
 %attr(0640,-,-) %ghost %{_var}/log/openshift/node/platform.log
 %attr(0640,-,-) %ghost %{_var}/log/openshift/node/platform-trace.log
 /usr/libexec/openshift/lib/quota_attrs.sh


### PR DESCRIPTION
The directory /var/log/openshift/node is currently owned by root under 750 node.
As a result, any other processes will not be able to access that directory which
will cause permission failure.

This commit changes the directory permission to 751 which allows users such as
apache-owned processes to traverse the directory and access to sub-directory
/node-web-proxy which is owned by apache.

Bug 1285424
Link https://bugzilla.redhat.com/show_bug.cgi?id=1285424

Signed-off-by: Vu Dinh vdinh@redhat.com
