### PR TITLE
oo-accept-node: check for missing gear directories

### DIFF
--- a/node-util/sbin/oo-accept-node
+++ b/node-util/sbin/oo-accept-node
@@ -852,6 +852,10 @@ def check_app_dirs
       user_fail(entry, "directory #{entry}/.env doesn't have OPENSHIFT_PRIMARY_CARTRIDGE_DIR")
     end
   end
+  # Bug 1281912 - Check for users that don't have a corresponding gear file
+  copy_all_users.each do |u|
+    user_fail(u, "user #{u} does not have a directory in #{$GEAR_BASE_DIR}")
+  end
 end
 
 def check_upgrades


### PR DESCRIPTION
Bug 1281912
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1281912

There was no check for the situation where a node has a user but is missing the corresponding gear directory.  The oo-accept-node script checks for valid file structures, but does not check that each user has a directory.  This change will cause oo-accept-node to fail when there are users without matching directories and let the users know that the file is missing.

Error output should look like:

```
FAIL: user 5661e47b5de94863ba000001 does not have a home directory /var/lib/openshift/5661e47b5de94863ba000001
```
