### PR TITLE
Bug 1082610 - ssh in head gear of scalable app doesn't return any errors

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/ssh
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/ssh
@@ -1,3 +1,0 @@
-#!/bin/bash
-# SSH wrapper to specify right config and other files
-/usr/bin/ssh -q -o 'BatchMode=yes' -o 'StrictHostKeyChecking=no' -o "UserKnownHostsFile=$OPENSHIFT_HOMEDIR/.openshift_ssh/known_hosts" -F "$OPENSHIFT_HOMEDIR/.openshift_ssh/config" -i ${OPENSHIFT_APP_SSH_KEY} $@


### PR DESCRIPTION
The HAProxy cartridge in head gear contains a ssh wrapper that is set to
quiet mode (-q flag). As a result, if user executes ssh commands with
invalid parameters, no errors are shown as they are suppressed by the
-q flag.

This commit will remove the ssh wrapper as it's no longer needed in
the HAProxy cartridge. The oo-ssh now exists and the node runtime either
uses it or specifies the required flags wherever it invokes ssh commands.
As a result, ssh in head gear will use standard ssh from /usr/bin/ssh
which doesn't have -q flag.

Bug 1082610
Link https://bugzilla.redhat.com/show_bug.cgi?id=1082610

Signed-off-by: Vu Dinh vdinh@redhat.com
