### PR TITLE
Bug 1160934 - "oo-admin-ctl-gears stopgear" failed to stop idled gear

### DIFF
--- a/node/lib/openshift-origin-node/model/application_container.rb
+++ b/node/lib/openshift-origin-node/model/application_container.rb
@@ -504,6 +504,7 @@ module OpenShift
 
         begin
           buffer << @cartridge_model.stop_gear(options)
+          state.value = State::STOPPED
         rescue ::OpenShift::Runtime::Utils::ShellExecutionException => e
           raise e if options[:user_initiated] == true || options[:force] == false
 

--- a/node/test/unit/application_container_test.rb
+++ b/node/test/unit/application_container_test.rb
@@ -1245,6 +1245,7 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
     options = {}
     @container.cartridge_model.expects(:web_proxy).returns(nil)
     @container.cartridge_model.expects(:stop_gear).with(options).returns('stop')
+    @container.state.expects(:value=).with(OpenShift::Runtime::State::STOPPED)
     @container.expects(:stopped_status_attr).returns('attr')
     @container.stop_gear(options)
   end
@@ -1262,6 +1263,7 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
                                                   persist:   false)
         .returns(proxy_result)
     @container.cartridge_model.expects(:stop_gear).with(options).returns('stop')
+    @container.state.expects(:value=).with(OpenShift::Runtime::State::STOPPED)
     @container.expects(:stopped_status_attr).returns('attr')
     @container.stop_gear(options)
   end
@@ -1272,6 +1274,7 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
     @container.cartridge_model.expects(:web_proxy).returns(proxy_cart)
     @container.expects(:update_proxy_status).never
     @container.cartridge_model.expects(:stop_gear).with(options).returns('stop')
+    @container.state.expects(:value=).with(OpenShift::Runtime::State::STOPPED)
     @container.expects(:stopped_status_attr).returns('attr')
     @container.stop_gear(options)
   end
@@ -1282,6 +1285,7 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
     @container.cartridge_model.expects(:web_proxy).returns(proxy_cart)
     @container.expects(:update_proxy_status).never
     @container.cartridge_model.expects(:stop_gear).with(options).returns('stop')
+    @container.state.expects(:value=).with(OpenShift::Runtime::State::STOPPED)
     @container.expects(:stopped_status_attr).returns('attr')
     @container.stop_gear(options)
   end
@@ -1299,6 +1303,7 @@ class ApplicationContainerTest < OpenShift::NodeTestCase
   def test_stop_gear_no_exception
     options = {user_initiated: false, force: true}
     @container.cartridge_model.expects(:stop_gear).with(options).returns('stop')
+    @container.state.expects(:value=).with(OpenShift::Runtime::State::STOPPED)
 
     assert_nothing_raised do
       @container.stop_gear(options)


### PR DESCRIPTION
During the 'idlegear' operation, the gear in fact is stopped but the
state value is changed to 'idle'. Then, subsequently, when 'stopgear'
operation is excuted, the cartridge doesn't perform any extra works
as the gear is already stopped. However, the state is not modified
to 'stopped' due to lacking of explicit state change in application
container itself.

This commit will add explicit state change to application container
to ensuring the state is changed accordingly.

Bug 1160934
Link https://bugzilla.redhat.com/show_bug.cgi?id=1160934

Signed-off-by: Vu Dinh vdinh@redhat.com
