### PR TITLE
Bug 1140816 - oo-admin-ctl-district missing documentation for listing districts

### DIFF
--- a/broker-util/man/oo-admin-ctl-district.txt2man
+++ b/broker-util/man/oo-admin-ctl-district.txt2man
@@ -1,10 +1,10 @@
 NAME
-  oo-admin-ctl-district 
-  
+  oo-admin-ctl-district
+
 SYNOPSIS
-  oo-admin-ctl-district [-h|--help] [-u|--uuid district_uuid] 
-  [-c|--command cmd] [-n|--name district_name] 
-  [-p|--node_profile gear_size] [-i|--server_identity srv_ident] 
+  oo-admin-ctl-district [-h|--help] [-u|--uuid district_uuid]
+  [-c|--command cmd] [-n|--name district_name]
+  [-p|--node_profile gear_size] [-i|--server_identity srv_ident]
   [-s|--size cap_size] [-r|--region region_name] [-z|--zone zone_name]
   [-b|--bypass]
 
@@ -12,27 +12,27 @@ DESCRIPTION
   This is a utility for all district operations on OpenShift Origin.
 
 OPTIONS
-  -h|--help  
+  -h|--help
     Display a simple help dialog.
-  
-  -u|--uuid district_uuid  
+
+  -u|--uuid district_uuid
     District uuid (alphanumeric, canonical way to identify the district).
 
-  -c|--command cmd  
-    Available commands: add-node, remove-node, deactivate-node, activate-node,
-    add-capacity, remove-capacity, create, destroy, set-region, unset-region
+  -c|--command cmd
+    Available commands: list, nodes-available, add-node, remove-node, deactivate-node,
+    activate-node, add-capacity, remove-capacity, create, destroy, set-region, unset-region
 
-  -n|--name district_name  
+  -n|--name district_name
     District name. Arbitrary identifier used on create or in place of uuid for
     other commands. (alphanumeric, underscore, hyphen, dot)
 
-  -p|--node_profile gear_size  
+  -p|--node_profile gear_size
     Specify gear profile when creating a district. Example: small|medium
 
-  -i|--server_identity srv_ident  
+  -i|--server_identity srv_ident
     Node server_identity (FQDN, required when operating on a node).
 
-  -s|--size  
+  -s|--size
     Capacity to add or remove. Must be positive integer, required for capacity
     operations.
 
@@ -42,18 +42,18 @@ OPTIONS
   -z|--zone zone_name
     Zone within the region. Only valid when region is specified.
 
-  -b|--bypass  
+  -b|--bypass
     Ignore all warnings.
 
 EXAMPLE
 
   $ oo-admin-ctl-district
-  
+
 SEE ALSO
   oo-admin-ctl-district(8), oo-admin-move(8),
   oo-admin-chk(8), oo-accept-broker(8),
   oo-admin-ctl-app(8), oo-admin-ctl-domain(8),
   oo-admin-ctl-user(8), oo-register-dns(8)
- 
+
 AUTHOR
-  Adam Miller <admiller@redhat.com> - man page written for OpenShift Origin 
+  Adam Miller <admiller@redhat.com> - man page written for OpenShift Origin

--- a/broker-util/oo-admin-ctl-district
+++ b/broker-util/oo-admin-ctl-district
@@ -2,7 +2,7 @@
 require 'getoptlong'
 require 'pp'
 
-CTL_DISTRICT_COMMANDS = %w[list-available create add-node set-region unset-region deactivate-node activate-node remove-node add-capacity remove-capacity destroy publish-uids ]
+CTL_DISTRICT_COMMANDS = %w[list nodes-available create add-node set-region unset-region deactivate-node activate-node remove-node add-capacity remove-capacity destroy publish-uids]
 DEFAULT_PLATFORM = "Linux"
 
 def usage
@@ -92,7 +92,7 @@ rescue GetoptLong::Error => e
   exit 255
 end
 
-if args["--help"]
+if args["--help"] || args.empty?
   usage
   exit 0
 end
@@ -166,7 +166,7 @@ if uuid || name
     puts "--size is required with command: #{command}"
     exit 1
   end
-elsif command && ! %w[list-available publish-uids remove-node deactivate-node activate-node set-region unset-region].include?(command)
+elsif command && ! %w[list nodes-available publish-uids remove-node deactivate-node activate-node set-region unset-region].include?(command)
   if command != 'create'
     puts "--uuid or --name is required with command: #{command}"
   else
@@ -197,7 +197,7 @@ end
 reply = ResultIO.new
 begin
   case command
-  when "list-available"
+  when "nodes-available"
     available_nodes.each do |profile, nodes|
       next if node_profile && profile != node_profile
       reply.resultIO << "Nodes in profile: #{profile}\n"

--- a/broker-util/oo-admin-ctl-region
+++ b/broker-util/oo-admin-ctl-region
@@ -56,7 +56,7 @@ rescue GetoptLong::Error => e
   exit 255
 end
 
-if args["--help"]
+if args["--help"] || args.empty?
   usage
   exit 0
 end


### PR DESCRIPTION
The 'oo-admin-ctl-district' doesn't have option to list all districts. Instead,
if command is executed without any parameters, the command will display a list
of districts. Also, the option 'list-available' is misleading as it displays a
list of available nodes, not districts. The 'oo-admin-ctl-district' experiences
the same behavior with displaying a list of regions when no options are selected.
This issue causes certainly confusions for those two commands.

This commit will explicitly display usage when user runs those commands without
parameters. A 'list' option is added to command list for 'oo-admin-ctl-district'
to allow user to display available districts. Also, 'list-available' is renamed
to nodes-available to clearly state which info will be displayed.

Bug 1140816
Link https://bugzilla.redhat.com/show_bug.cgi?id=1140816

Signed-off-by: Vu Dinh vdinh@redhat.com
