### PR TITLE
oo-admin-ctl-user: clarify error msg

### DIFF
--- a/broker-util/oo-admin-ctl-user
+++ b/broker-util/oo-admin-ctl-user
@@ -384,7 +384,6 @@ def add_gear_size(user, gear_size)
     end
   rescue Exception=>e
     $stderr.puts e.message
-    $stderr.puts e.backtrace.join("\n")
     exit 1
   end
   puts "Done."

--- a/controller/app/models/cloud_user.rb
+++ b/controller/app/models/cloud_user.rb
@@ -398,7 +398,7 @@ class CloudUser
   def add_gear_size(gear_size)
     available_sizes = Rails.configuration.openshift[:gear_sizes]
     unless available_sizes.include?(gear_size)
-      raise Exception.new("Size #{gear_size} is not defined. Defined sizes are: #{available_sizes.join ', '}.")
+      raise Exception.new("\nERROR: Size '#{gear_size}' is not defined. Available gear sizes: #{available_sizes.join ', '}.")
     end
     unless capabilities['gear_sizes'].include?(gear_size)
       self._capabilities['gear_sizes'] = capabilities['gear_sizes'] + [gear_size]


### PR DESCRIPTION
Bug 1168480
Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1168480
Clarify oo-admin-ctl-user --addgearsize <invalid name> error msg.
Removed the backtrace info from the error msg and updated the error msg.
Error msg is now more readable for users.
