### PR TITLE
Changes to php_context to fix Drush installation issues

### DIFF
--- a/cartridges/openshift-origin-cartridge-php/usr/lib/php_context
+++ b/cartridges/openshift-origin-cartridge-php/usr/lib/php_context
@@ -9,7 +9,7 @@ function php_context {
 
 function update_configuration {
   # PEAR bin_dir
-  local path=${OPENSHIFT_PHP_DIR}phplib/pear/pear
+  local path=${OPENSHIFT_PHP_DIR}phplib/pear/pear:${OPENSHIFT_HOMEDIR}.composer/vendor/bin
 
   case $OPENSHIFT_PHP_VERSION in
     5.4)


### PR DESCRIPTION
This adds ${OPENSHIFT_HOMEDIR}.composer/vendor/bin to the default path so that when drush is installed via composer, it's available by default.  It fixes some of the [issues with Drush](https://github.com/openshift/drupal-quickstart/issues/31).  drupal-quickstart still won't run on this but this is step one in getting it working.
