### PR TITLE
Bug 1292206 - oo-idler-stats crashes when there is idled gear in the app

### DIFF
--- a/node-util/sbin/oo-idler-stats
+++ b/node-util/sbin/oo-idler-stats
@@ -77,7 +77,6 @@ def is_idled(appid):
         ret, all_idled_apps = run("/usr/sbin/oo-admin-ctl-gears listidle | /bin/cut -d' ' -f1")
         if ret != 0:
             return False  # an error occurred, bail
-        all_idled_apps.remove('')
 
     return appid in all_idled_apps
 


### PR DESCRIPTION
The oo-idler-stats command is currently broken as it crashes with ValueError
if there is idled gear in the application.

This issue is due to PR 6324 on origin-server has removed the unwanted empty
item ('') on the list which is returned by run() method. However, is_idled()
method has not been fixed and still attempts to remove that unwanted item
manually from the list which causes ValueError due to the fact that item is
no longer existed. This commit removes the unnecessary code that attempts
to remove non-exist item from the list in is_idled() method to avoid the
ValueError issue.

Bug 1292206
Link https://bugzilla.redhat.com/show_bug.cgi?id=1292206

Signed-off-by: Vu Dinh vdinh@redhat.com
