### PR TITLE
fix typo in oo-auto-idler that causes undefined variable error

### DIFF
--- a/node-util/sbin/oo-auto-idler
+++ b/node-util/sbin/oo-auto-idler
@@ -193,7 +193,7 @@ command :idle do |c|
           idle_gear(gear_uuid)
         rescue Exception => e
           $log.error e.message
-          $log.error "Failed to idle #{gear_dir}"
+          $log.error "Failed to idle #{gear_uuid}"
         end
       end
     end


### PR DESCRIPTION
Bug 1292137
Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1292137
Code references 'gear_dir' when it should be referencing 'gear_uuid'.
This is causing oo-auto-idler script to abort if a single gear fails to idle.
