### PR TITLE
Remove SSL Cert Chain Field from web console

### DIFF
--- a/console/app/views/aliases/edit.html.haml
+++ b/console/app/views/aliases/edit.html.haml
@@ -84,16 +84,9 @@
           = f.file_field :certificate_file, :id => 'certificate_file', :disabled => !@private_ssl_certificates_supported 
           = f.inline_errors_for :certificate_file
         .controls
-          %p.help-block Certificate files must be Base64 PEM-encoded and typically have a .crt or .pem extension. You may combine multiple certificates and certificate chains in a single file, but the RSA or DSA private key must always be provided in a separate file.
+          %p.help-block Certificate files must be Base64 PEM-encoded and typically have a .crt or .pem extension. You must combine primary and intermediate certificates into a single file.  If your SSL certificate does not include a concatenated full chain file (ex: fullchain.pem) then you must manually concatenate the certificate files and upload as a single file.  The RSA or DSA private key must be uploaded as a separate file in the 'Certificate Private Key*' field below.
 
-      = control_group(e.has_key?(:certificate_chain_file)) do
-        %label.control-label{:for => 'certificate_chain_file'} 
-          SSL Certificate Chain
-        .controls
-          = f.file_field :certificate_chain_file, :id => 'certificate_chain_file', :disabled => !@private_ssl_certificates_supported 
-          = f.inline_errors_for :certificate_chain_file
-        .controls
-          %p.help-block  Optionally you can provide a certificate chain/bundle in a separate PEM-encoded file.
+          %li= link_to "More on how to concatenate and upload SSL Certs", community_developer_portal_url(path='en/managing-domains-ssl.html#using-a-custom-ssl-certificate'), :target => '_blank', :class => 'external'
 
       = control_group(e.has_key?(:certificate_private_key_file)) do
         %label.control-label{:for => 'certificate_private_key_file'} 

--- a/console/app/views/aliases/new.html.haml
+++ b/console/app/views/aliases/new.html.haml
@@ -13,7 +13,7 @@
       %li= link_to 'Set up the CNAME record with your DNS provider', alias_docs_url, :target => '_blank', :class => 'external'
       %li Configure OpenShift to use your alias:
     - e = @alias.errors
-    = f.semantic_errors :except => [:id, :name, :certificate_file, :certificate_chain_file, :certificate_private_key_file]
+    = f.semantic_errors :except => [:id, :name, :certificate_file, :certificate_private_key_file]
 
     = f.inputs do
       .control-group
@@ -42,16 +42,9 @@
             = f.file_field :certificate_file, :id => 'certificate_file', :disabled => !@private_ssl_certificates_supported 
             = f.inline_errors_for :certificate_file
           .controls
-            %p.help-block Certificate files must be Base64 PEM-encoded and typically have a .crt or .pem extension. You may combine multiple certificates and certificate chains in a single file, but the RSA or DSA private key must always be provided in a separate file.
+            %p.help-block Certificate files must be Base64 PEM-encoded and typically have a .crt or .pem extension. You must combine primary and intermediate certificates into a single file.  If your SSL certificate does not include a concatenated full chain file (ex: fullchain.pem) then you must manually concatenate the certificate files and upload as a single file.  The RSA or DSA private key must be uploaded as a separate file in the 'Certificate Private Key*' field below.
 
-        = control_group(e.has_key?(:certificate_chain_file)) do
-          %label.control-label{:for => 'certificate_chain_file'} 
-            SSL Certificate Chain
-          .controls
-            = f.file_field :certificate_chain_file, :id => 'certificate_chain_file', :disabled => !@private_ssl_certificates_supported 
-            = f.inline_errors_for :certificate_chain_file
-          .controls
-            %p.help-block  Optionally you can provide a certificate chain in a separate PEM-encoded file.
+            %li= link_to "More on how to concatenate and upload SSL Certs", community_developer_portal_url(path='en/managing-domains-ssl.html#using-a-custom-ssl-certificate'), :target => '_blank', :class => 'external'
 
         = control_group(e.has_key?(:certificate_private_key_file)) do
           %label.control-label{:for => 'certificate_private_key_file'} 

--- a/console/test/functional/aliases_controller_test.rb
+++ b/console/test/functional/aliases_controller_test.rb
@@ -71,16 +71,13 @@ class AliasesControllerTest < ActionController::TestCase
 
   [{:name => "empty cert file", :cert => "empty.crt", :key => "cert_key_rsa"},
     {:name => "empty key file", :cert => "cert.crt", :key => "empty_cert_key_rsa"},
-    {:name => "empty chain file", :cert => "cert.crt", :key => "cert_key_rsa", :chain => "empty.crt"},
     {:name => "key file present and nil cert", :key => "cert_key_rsa"},
-    {:name => "cert file present and nil key", :cert => "cert.crt"},
-    {:name => "chain file present and nil cert", :key => "cert_key_rsa", :chain => "cert.crt"},
-    {:name => "chain file present and nil key", :cert => "cert.crt", :chain => "cert.crt"}
+    {:name => "cert file present and nil key", :cert => "cert.crt"}
   ].each do |files| 
     test "should assign error with #{files[:name]}" do
       app = with_app
 
-      post :create, {:alias => get_post_form_with_certificate(files[:cert], files[:key], files[:chain]), :application_id => app}
+      post :create, {:alias => get_post_form_with_certificate(files[:cert], files[:key]), :application_id => app}
 
       assert a = assigns(:alias)
       assert !a.errors.empty?
@@ -93,7 +90,7 @@ class AliasesControllerTest < ActionController::TestCase
     @ssl_test_alias = "www.example#{uuid}.com"
     
     assert_difference('Alias.find(:all, :as => @user, :params => {:application_name => app.name, :domain_id => app.domain_id}).length', 1) do
-      post :create, {:alias => get_post_form_with_certificate("cert.crt", "cert_key_rsa", nil), :application_id => app}
+      post :create, {:alias => get_post_form_with_certificate("cert.crt", "cert_key_rsa"), :application_id => app}
     end
 
     assert a = assigns(:alias)
@@ -149,7 +146,7 @@ class AliasesControllerTest < ActionController::TestCase
     a.application = app
     a.save!
 
-    post :update, {:alias => get_post_form_with_certificate("empty.crt", nil, nil), :id => test_alias, :application_id => app}
+    post :update, {:alias => get_post_form_with_certificate("empty.crt", nil), :id => test_alias, :application_id => app}
 
     assert a = assigns(:alias)
     assert !a.errors.empty?
@@ -198,10 +195,9 @@ class AliasesControllerTest < ActionController::TestCase
     {:id => alias_id}
   end
 
-  def get_post_form_with_certificate (cert_file_name, key_file_name, chain_file_name)
+  def get_post_form_with_certificate (cert_file_name, key_file_name)
     get_post_form_without_certificate(ssl_test_alias).merge({
       :certificate_file => cert_file_name.nil? ? nil : fixture_file_upload(cert_file_name, 'application/pkix-cert'),
-      :certificate_chain_file => chain_file_name.nil? ? nil : fixture_file_upload(chain_file_name, 'application/pkix-cert'),
       :certificate_private_key_file => key_file_name.nil? ? nil : fixture_file_upload(key_file_name, 'application/octet-stream'),
       :certificate_pass_phrase => ''
     })

--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -46,7 +46,6 @@ OPENSHIFT_HTTP_CONF_DIR="/etc/httpd/conf.d/openshift"
 # Apache vhost frontend plugin defaults
 #OPENSHIFT_DEFAULT_SSL_KEY_PATH="/etc/pki/tls/private/localhost.key"
 #OPENSHIFT_DEFAULT_SSL_CRT_PATH="/etc/pki/tls/certs/localhost.crt"
-#OPENSHIFT_DEFAULT_SSL_CRT_CHAIN_PATH="/etc/pki/tls/certs/localhost.crt"
 
 # The following are basically vestigial. Normally UIDs are prescribed by the broker. In the case
 # where districts are disabled and nodes can choose their own UIDs, this is the range chosen.

--- a/plugins/frontend/apache-vhost/httpd/frontend-vhost-https-template.erb
+++ b/plugins/frontend/apache-vhost/httpd/frontend-vhost-https-template.erb
@@ -9,7 +9,6 @@
 
   SSLCertificateFile <%= ssl_certificate_file %>
   SSLCertificateKeyFile <%= ssl_key_file %>
-  SSLCertificateChainFile <%= ssl_certificate_chain_file %>
 
   RewriteEngine              On
 

--- a/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
+++ b/plugins/frontend/apache-vhost/lib/openshift/runtime/frontend/http/plugins/apache-vhost.rb
@@ -52,7 +52,6 @@ module OpenShift
               @template_http  = PathUtils.join(@basedir, TEMPLATE_HTTP)
               @template_https = PathUtils.join(@basedir, TEMPLATE_HTTPS)
               @ssl_cert_path = (@config.get("OPENSHIFT_DEFAULT_SSL_CRT_PATH") || "/etc/pki/tls/certs/localhost.crt")
-              @ssl_chain_path = (@config.get("OPENSHIFT_DEFAULT_SSL_CRT_CHAIN_PATH") || "/etc/pki/tls/certs/localhost.crt")
               @ssl_key_path = (@config.get("OPENSHIFT_DEFAULT_SSL_KEY_PATH") || "/etc/pki/tls/private/localhost.key")
             end
 
@@ -133,7 +132,6 @@ module OpenShift
                 gear_uuid                  = @container_uuid
                 app_namespace              = @namespace
                 ssl_certificate_file       = @ssl_cert_path
-                ssl_certificate_chain_file = @ssl_chain_path
                 ssl_key_file               = @ssl_key_path
 
                 buffer = ERB.new(File.read(@template_http)).result(binding) << "\n"
@@ -385,7 +383,6 @@ module OpenShift
 
                 ssl_certificate_file = ssl_certificate_path(server_alias)
                 ssl_key_file = ssl_key_path(server_alias)
-                ssl_certificate_chain_file = ssl_certificate_path(server_alias)
 
                 File.open(ssl_certificate_file, FILE_OPTS, 0600) do |f|
                   f.write(ssl_cert)


### PR DESCRIPTION
Bug 1268317, Bug 1281901, Bug 1269637
Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1268317
Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1281901
Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1269637

Remove SSL Certificate Chain Field from web console.
Document that the user must concatenate SSL cert files into a single file to upload,
or upload the already-concatenated file included in the SSL certificate from
the SSL certificate provider.
