### PR TITLE
oo-admin-usage: fix help message

### DIFF
--- a/broker-util/oo-admin-usage
+++ b/broker-util/oo-admin-usage
@@ -4,7 +4,7 @@ require 'rubygems'
 require 'getoptlong'
 
 def show_usage
-    puts << "USAGE
+    puts <<USAGE
 == Synopsis
 
 oo-admin-usage: List the usage data for a user or aggregated usage data of all users for the given timeframe.
@@ -30,7 +30,7 @@ Options:
     The end date (yyyy-mm-dd) to filter the usage data (defaults to the current time in UTC)
 -h|--help
     Show Usage info
-USAGE"
+USAGE
 end
 
 def get_time(date)


### PR DESCRIPTION
Bug 1289008
BZ https://bugzilla.redhat.com/show_bug.cgi?id=1289008

The help options for oo-admin-usage (-h and --help) were giving error messages
instead of displaying the usage options.  The -h and --help flags will now
correctly display the usage options.
