### PR TITLE
oo-admin-cartridge: remove duplicate results

### DIFF
--- a/node/lib/openshift-origin-node/model/cartridge_repository.rb
+++ b/node/lib/openshift-origin-node/model/cartridge_repository.rb
@@ -461,7 +461,7 @@ module OpenShift
           names.inject(memo) do |memo, (name, sw_hash)|
             sw_hash.inject(memo) do |memo, (sw_ver, cart_hash)|
               cart_hash.inject(memo) do |memo, (cart_ver, cartridge)|
-                memo << "(#{vendor}, #{name}, #{sw_ver}, #{cart_ver}): " << cartridge.to_s << "\n"
+                cart_ver != "_" ? memo << "(#{vendor}, #{name}, #{sw_ver}, #{cart_ver}): " << cartridge.to_s << "\n" : memo
               end
             end << '>'
           end


### PR DESCRIPTION
Bug 1111105
BZ https://bugzilla.redhat.com/show_bug.cgi?id=1111105

Fixes double output for the oo-admin-cartridge --action list --debug command.
Output will now avoid printing a second copy of the cartridge without a
cartridge version number.

The way the code is written, there will sometimes be an extra '>' printed - however the entire cartridge object will no longer be printed twice.
