### PR TITLE
Fix app info search by app name bug

### DIFF
--- a/broker-util/lib/app_info.rb
+++ b/broker-util/lib/app_info.rb
@@ -124,7 +124,7 @@ class AppQuery
     retval = []
 
     Application.where(name: appname).each { |app|
-      retval = _domain_user_loop(app)
+      retval.concat(_domain_user_loop(app))
     }
     return retval
   end


### PR DESCRIPTION
The bug causes only the final matching application to be shown
when searching by app name.
