### PR TITLE
Remove RC4 from allowed SSL ciphers

### DIFF
--- a/node-proxy/config/web-proxy-config.json
+++ b/node-proxy/config/web-proxy-config.json
@@ -121,7 +121,8 @@
       "ssl"            : {
         "ca"         : "/etc/pki/tls/certs/localhost.crt",
         "certificate": "/etc/pki/tls/certs/localhost.crt",
-        "private_key": "/etc/pki/tls/private/localhost.key"
+        "private_key": "/etc/pki/tls/private/localhost.key",
+        "ciphers"    : "kEECDH:+kEECDH+SHA:kEDH:+kEDH+SHA:+kEDH+CAMELLIA:kECDH:+kECDH+SHA:kRSA:+kRSA+SHA:+kRSA+CAMELLIA:!aNULL:!eNULL:!SSLv2:!RC4:!DES:!EXP:!SEED:!IDEA:+3DES"
       }
     }
   },

--- a/node-proxy/lib/utils/http-utils.js
+++ b/node-proxy/lib/utils/http-utils.js
@@ -29,12 +29,15 @@ exports.createProtocolServer = function(protocol, opts) {
       break;
     case 'https':
       var ssl_opts  = {
-        secureProtocol: 'SSLv23_method',
         secureOptions: constants.SSL_OP_NO_SSLv3
       };
       ssl_opts.ca   = fs.readFileSync(opts.ca);
       ssl_opts.cert = fs.readFileSync(opts.certificate);
       ssl_opts.key  = fs.readFileSync(opts.private_key);
+
+      ssl_opts.ciphers = opts.ciphers || "kEECDH:+kEECDH+SHA:kEDH:+kEDH+SHA:+\
+          kEDH+CAMELLIA:kECDH:+kECDH+SHA:kRSA:+kRSA+SHA:+kRSA+\
+          CAMELLIA:!aNULL:!eNULL:!SSLv2:!RC4:!DES:!EXP:!SEED:!IDEA:+3DES";
 
       proto_handler = https.createServer(ssl_opts);
       break;

--- a/node-proxy/openshift-origin-node-proxy.spec
+++ b/node-proxy/openshift-origin-node-proxy.spec
@@ -132,6 +132,7 @@ fi
 %endif
 %attr(0755,-,-) %{_bindir}/node-find-proxy-route-files
 %attr(0640,-,-) %{_sysconfdir}/openshift/web-proxy-config.json
+%config(noreplace) %{_sysconfdir}/openshift/web-proxy-config.json
 %attr(0644,-,-) %{_sysconfdir}/logrotate.d/%{name}
 %ghost %attr(0660,root,root) %{logroot}/supervisor.log
 %dir %attr(0700,apache,apache) %{logroot}

--- a/node-proxy/test/wsapp.js
+++ b/node-proxy/test/wsapp.js
@@ -55,10 +55,12 @@ createWebSocketServer(app8080);
 
 var  sslcerts_path = "../sslcerts/";
 var  server_name = "localhost";
+var  cipher_list = "kEECDH:+kEECDH+SHA:kEDH:+kEDH+SHA:+kEDH+CAMELLIA:kECDH:+kECDH+SHA:kRSA:" + 
+               "+kRSA+SHA:+kRSA+CAMELLIA:!aNULL:!eNULL:!SSLv2:!RC4:!DES:!EXP:!SEED:!IDEA:+3DES";
 var ssl_options = {
   key:  fs.readFileSync(sslcerts_path + server_name + ".key"),
   cert: fs.readFileSync(sslcerts_path + server_name + ".crt"),
-  secureProtocol: 'SSLv23_method',
+  ciphers: cipher_list,
   secureOptions: constants.SSL_OP_NO_SSLv3
 };
 


### PR DESCRIPTION
Bug 1299014
https://bugzilla.redhat.com/show_bug.cgi?id=1299014

Added a configuration option in the node-web-proxy json to specify the list of ciphers. The list of ciphers specified by default is the same cipher suite list that is used on the broker's proxy as well as both provided frontends:

```
broker/httpd/000002_openshift_origin_broker_proxy.conf:  
SSLCipherSuite kEECDH:+kEECDH+SHA:kEDH:+kEDH+SHA:+kEDH+CAMELLIA:kECDH:+kECDH+SHA:kRSA:+kRSA+SHA:+kRSA+CAMELLIA:!aNULL:!eNULL:!SSLv2:!RC4:!DES:!EXP:!SEED:!IDEA:+3DES

plugins/frontend/apache-vhost/httpd/000001_openshift_origin_frontend_vhost.conf:
SSLCipherSuite kEECDH:+kEECDH+SHA:kEDH:+kEDH+SHA:+kEDH+CAMELLIA:kECDH:+kECDH+SHA:kRSA:+kRSA+SHA:+kRSA+CAMELLIA:!aNULL:!eNULL:!SSLv2:!RC4:!DES:!EXP:!SEED:!IDEA:+3DES

/plugins/frontend/apache-mod-rewrite/httpd/000001_openshift_origin_node.conf:
SSLCipherSuite kEECDH:+kEECDH+SHA:kEDH:+kEDH+SHA:+kEDH+CAMELLIA:kECDH:+kECDH+SHA:kRSA:+kRSA+SHA:+kRSA+CAMELLIA:!aNULL:!eNULL:!SSLv2:!RC4:!DES:!EXP:!SEED:!IDEA:+3DES
```

Additionally, disabling forcing the use of sslv2_3, since sslv2 has been known to be insecure for some time.
