### PR TITLE
Fix Jenkins failures on pull/merge requests

### DIFF
--- a/node/lib/openshift-origin-node/model/cartridge_repository.rb
+++ b/node/lib/openshift-origin-node/model/cartridge_repository.rb
@@ -220,7 +220,7 @@ module OpenShift
 
           FileUtils.rm_r(entry.repository_path)
           parent = Pathname.new(entry.repository_path).parent
-          FileUtils.rm_r(parent) if 0 == parent.children.count
+          FileUtils.rm_r(parent.to_s) if 0 == parent.children.count
         end
 
         entry


### PR DESCRIPTION
Jenkins reports failures across multiple tests with the false blame in fakefs package.
However, this issue is due to mismatch variable type in origin-sever code base. The
code is now fixed as the variable is explicitly casted to string type to avoid mismatch
type problem.

Signed-off-by: Vu Dinh vdinh@redhat.com
