### PR TITLE
Bug 1292445: Out of memory error due to insufficient mysql sort buffer size

### DIFF
--- a/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb
+++ b/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb
@@ -8,6 +8,9 @@
 # max_connections -> OPENSHIFT_MYSQL_MAX_CONNECTIONS
 # ft_min_word_len -> OPENSHIFT_MYSQL_FT_MIN_WORD_LEN
 # ft_max_word_len -> OPENSHIFT_MYSQL_FT_MAX_WORD_LEN
+# max_allowed_packet -> OPENSHIFT_MYSQL_MAX_ALLOWED_PACKET
+# table_open_cache -> OPENSHIFT_MYSQL_TABLE_OPEN_CACHE
+# sort_buffer_size -> OPENSHIFT_MYSQL_SORT_BUFFER_SIZE
 
 [mysqld]
 datadir=<%= ENV['OPENSHIFT_MYSQL_DIR'] %>data/
@@ -26,7 +29,7 @@ innodb_use_native_aio = <%= ENV['OPENSHIFT_MYSQL_AIO'] || '1'%>
 key_buffer_size = <%= ENV['OPENSHIFT_APP_DNS'] == ENV['OPENSHIFT_GEAR_DNS'] ? '32' : (ENV['OPENSHIFT_GEAR_MEMORY_MB'].to_i * 0.1).to_i %>M
 max_allowed_packet = <%= ENV['OPENSHIFT_MYSQL_MAX_ALLOWED_PACKET'] ? ENV['OPENSHIFT_MYSQL_MAX_ALLOWED_PACKET'] : '200M' %>
 table_open_cache = <%= ENV['OPENSHIFT_MYSQL_TABLE_OPEN_CACHE'] ? ENV['OPENSHIFT_MYSQL_TABLE_OPEN_CACHE'] : '4' %>
-sort_buffer_size = 128K
+sort_buffer_size = <%= ENV['OPENSHIFT_MYSQL_SORT_BUFFER_SIZE'] ? ENV['OPENSHIFT_MYSQL_SORT_BUFFER_SIZE'] : '256K' %>
 read_buffer_size = <%= ENV['OPENSHIFT_APP_DNS'] == ENV['OPENSHIFT_GEAR_DNS'] ? '8' : (ENV['OPENSHIFT_GEAR_MEMORY_MB'].to_i * 0.05).to_i %>M
 read_rnd_buffer_size = 256K
 net_buffer_length = 2K
@@ -72,4 +75,3 @@ sort_buffer_size = 8M
 
 [mysqlhotcopy]
 interactive-timeout
-

--- a/documentation/oo_cartridge_guide.adoc
+++ b/documentation/oo_cartridge_guide.adoc
@@ -692,6 +692,9 @@ OPENSHIFT_MYSQLDB_DB_PORT:: The MySQL port
 OPENSHIFT_MYSQLDB_DB_LOG_DIR:: The path to the MySQL log directory
 OPENSHIFT_MYSQL_VERSION:: The version of the MySQL server
 OPENSHIFT_MYSQL_TIMEZONE:: The MySQL server timezone
+OPENSHIFT_MYSQL_SORT_BUFFER_SIZE:: The maximum size of MySQL sort buffer
+OPENSHIFT_MYSQL_MAX_ALLOWED_PACKET:: The maximum size of MySQL communication packet
+OPENSHIFT_MYSQL_TABLE_OPEN_CACHE:: The maximum number of tables the server keeps open
 OPENSHIFT_MYSQL_LOWER_CASE_TABLE_NAMES:: Sets how the table names are stored and compared
 OPENSHIFT_MYSQL_DEFAULT_STORAGE_ENGINE:: The default storage engine (table type)
 OPENSHIFT_MYSQL_MAX_CONNECTIONS:: The maximum permitted number of simultaneous client connections


### PR DESCRIPTION
The new SilverStripe CMS app using php and mysql cartridges fails due to out
of memory on mysql sort buffer which is currently set at 128K.

This commit increases the sort buffer size to 256K and also add the environment
variable OPENSHIFT_MYSQL_SORT_BUFFER_SIZE to allow user to modify the 
mysql sort buffer size at their own choices without having modify the my.cnf directly.

Bug 1292445
Link https://bugzilla.redhat.com/show_bug.cgi?id=1292445

Signed-off-by: Vu Dinh vdinh@redhat.com
