### PR TITLE
Bug 1104750 - oo-admin-chk --level 0 takes too long in prod

### DIFF
--- a/broker-util/oo-admin-chk
+++ b/broker-util/oo-admin-chk
@@ -138,7 +138,7 @@ $datastore_hash.each do |gear_uuid, gear_info|
   server_identity = gear_info['server_identity']
   app_id = gear_info['app_id']
 
-  if (current_time - creation_time) > 600
+  if (current_time - creation_time) > 21600
     if !node_hash.has_key? gear_uuid
       gear_si_present = (gear_hash.has_key?server_identity)
       datastore_si_present = (datastore_has_gear?(gear_uuid, app_id))


### PR DESCRIPTION
The current threshold for gear creation time is 10 minutes (600 seconds)
which ends up generating a lot of false errors during oo-admin-chk run
as the command takes a long time to complete and during that time period
gears can be deleted and created.

This commit increases the threshold to 6 hours (21600 seconds) to reduce
the false errors generated oo-admin-chk.

Bug 1104750
Linkhttps://bugzilla.redhat.com/show_bug.cgi?id=1104750

Signed-off-by: Vu Dinh vdinh@redhat.com
