### PR TITLE
Fix inconsistent return exit code for various commands

### DIFF
--- a/broker-util/oo-admin-broker-auth
+++ b/broker-util/oo-admin-broker-auth
@@ -70,9 +70,14 @@ rescue GetoptLong::Error => e
 end
 
 # Check this _before_ loading the rails env
-if args["--help"] || (STDIN.tty? && args.empty?)
+if args["--help"]
   usage
   exit 0
+end
+
+if STDIN.tty? && args.empty?
+  usage
+  exit 255
 end
 
 if args['--timeout']

--- a/broker-util/oo-admin-broker-cache
+++ b/broker-util/oo-admin-broker-cache
@@ -58,9 +58,14 @@ rescue GetoptLong::Error => e
   exit 255
 end
 
-if args["--help"] || (STDIN.tty? && args.empty?)
+if args["--help"]
   usage
   exit 0
+end
+
+if STDIN.tty? && args.empty?
+  usage
+  exit 255
 end
 
 if args['--clear']

--- a/broker-util/oo-admin-ctl-app
+++ b/broker-util/oo-admin-ctl-app
@@ -72,9 +72,14 @@ cartridge = args['--cartridge']
 server_alias = args['--alias'].dup if args['--alias']
 multiplier = args['--multiplier']
 
-if login.nil? or app_name.nil? or command.nil? or args["--help"]
+if args["--help"]
   usage
   exit 0
+end
+
+if login.nil? or app_name.nil? or command.nil?
+  usage
+  exit 255
 end
 
 require "#{ENV['OPENSHIFT_BROKER_DIR'] || '/var/www/openshift/broker'}/config/environment"

--- a/broker-util/oo-admin-ctl-district
+++ b/broker-util/oo-admin-ctl-district
@@ -92,9 +92,14 @@ rescue GetoptLong::Error => e
   exit 255
 end
 
-if args["--help"] || args.empty?
+if args["--help"]
   usage
   exit 0
+end
+
+if args.empty?
+  usage
+  exit 255
 end
 
 uuid     = args["--uuid"]

--- a/broker-util/oo-admin-ctl-domain
+++ b/broker-util/oo-admin-ctl-domain
@@ -81,9 +81,14 @@ allowed_gear_sizes = args["--allowed_gear_sizes"]
 role = args["--role"]
 member = args["--member"]
 
-if login.nil? or args["--help"]
+if args["--help"]
   usage
   exit 0
+end
+
+if login.nil?
+  usage
+  exit 255
 end
 
 require "#{ENV['OPENSHIFT_BROKER_DIR'] || '/var/www/openshift/broker'}/config/environment"

--- a/broker-util/oo-admin-ctl-region
+++ b/broker-util/oo-admin-ctl-region
@@ -56,9 +56,14 @@ rescue GetoptLong::Error => e
   exit 255
 end
 
-if args["--help"] || args.empty?
+if args["--help"]
   usage
   exit 0
+end
+
+if args.empty?
+  usage
+  exit 255
 end
 
 command     = args['--command']

--- a/broker-util/oo-admin-ctl-user
+++ b/broker-util/oo-admin-ctl-user
@@ -649,9 +649,14 @@ if args["--setusageaccountid"]
   usage_account_id = args["--setusageaccountid"].to_i
 end
 
-if logins.empty? or args["--help"]
+if args["--help"]
   usage
   exit 0
+end
+
+if logins.empty?
+  usage
+  exit 255
 end
 
 account_to_add = args["--addsubaccount"]

--- a/broker-util/oo-admin-repair
+++ b/broker-util/oo-admin-repair
@@ -107,7 +107,7 @@ if fix_ssh_keys.nil? and fix_district_uids.nil? and fix_consumed_gears.nil? and
    fix_orphaned_envs.nil?
   puts "You must specify at least one item to fix."
   usage
-  exit 0
+  exit 255
 end
 
 require "#{ENV['OPENSHIFT_BROKER_DIR'] || '/var/www/openshift/broker'}/config/environment"

--- a/broker-util/oo-register-dns
+++ b/broker-util/oo-register-dns
@@ -70,9 +70,14 @@ node_domain = args["--domain"] || "example.com"
 server = args["--dns-server"] || "127.0.0.1"
 key = args["--key-file"] || "/var/named/#{node_domain}.key"
 
-if args["--help"] || (ip.nil? || ip.empty? || node_hostname.nil? || node_hostname.empty?)
+if args["--help"]
   usage
   exit 0
+end
+
+if ip.nil? || ip.empty? || node_hostname.nil? || node_hostname.empty?
+  usage
+  exit 255
 end
 
 rectype = IPAddr.new(ip).ipv6? ? "AAAA" : "A"

--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/gear-scale-ctl
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/gear-scale-ctl
@@ -39,7 +39,7 @@ begin
 
   if 0 != ARGV.length
     usage
-    exit 0
+    exit 255
   end
 
   if opts['server'].nil? || opts['server'].empty? \

--- a/console/bin/oo-admin-console-cache
+++ b/console/bin/oo-admin-console-cache
@@ -58,9 +58,14 @@ rescue GetoptLong::Error => e
   exit 255
 end
 
-if args["--help"] || (STDIN.tty? && args.empty?)
+if args["--help"]
   usage
   exit 0
+end
+
+if STDIN.tty? && args.empty?
+  usage
+  exit 255
 end
 
 if args['--clear']


### PR DESCRIPTION
The exit code 255 should be returned if commands with missing or
incorrect required parameters are executed instead of exit code 0.

Signed-off-by: Vu Dinh vdinh@redhat.com
