### PR TITLE
Fix exit code issue on several oo commands

### DIFF
--- a/broker-util/oo-admin-ctl-app
+++ b/broker-util/oo-admin-ctl-app
@@ -290,6 +290,7 @@ begin
   else
     puts "Command must be one of: #{CTL_APP_COMMANDS}"
     usage
+    exit 255
   end
 rescue OpenShift::UserException => e
   puts e.message

--- a/node/misc/bin/oo-pam-disable
+++ b/node/misc/bin/oo-pam-disable
@@ -76,6 +76,7 @@ end
 
 unless all_containers or container_uuid
   usage
+  exit 255
 end
 
 begin


### PR DESCRIPTION
Exit code fix for incorrect arguments should be 255 and they are currently missing
from the code.

Signed-off-by: Vu Dinh vdinh@redhat.com
