### PR TITLE
Gears exceeding quota should be allowed to stop, start, move

### DIFF
--- a/node/lib/openshift-origin-node/model/node.rb
+++ b/node/lib/openshift-origin-node/model/node.rb
@@ -180,15 +180,21 @@ module OpenShift
         end
 
         if current_quota > blocksmax.to_i
-          raise NodeCommandException.new(
+          # rather than raise Exception, allow current_quota to exceed limit and exceed buffer to allow gear moves, restarts, stops, idles to complete
+          if current_quota > blocksmax.to_i * 1.5
+             raise NodeCommandException.new(
                     Utils::Sdk.translate_out_for_client("Current usage #{current_quota} exceeds requested quota #{blocksmax}",
                                                         :error))
+          end
         end
 
         if current_inodes > inodemax.to_i
-          raise NodeCommandException.new(
+          # rather than raise Exception, allow current_inodes to exceed limit and exceed buffer to allow gear moves, restarts, stops, idles to complete
+          if current_inodes > inodemax.to_i * 1.5
+             raise NodeCommandException.new(
                     Utils::Sdk.translate_out_for_client("Current inodes #{current_inodes} exceeds requested inodes #{inodemax}",
                                                         :error))
+          end
         end
 
         mountpoint      = self.get_gear_mountpoint

--- a/node/test/node_functional/node_func_test.rb
+++ b/node/test/node_functional/node_func_test.rb
@@ -26,6 +26,9 @@ module OpenShift
         super
 
         @uid = 5994
+        # quota buffer multiplier is configured on broker
+        @quota_blocks_buffer = 1.2
+        @quota_inodes_buffer = 1.2
 
         @config.stubs(:get).with("GEAR_BASE_DIR").returns(GEAR_BASE_DIR)
         @config.stubs(:get).with("GEAR_GECOS").returns('Functional Test')
@@ -69,17 +72,20 @@ module OpenShift
       end
 
       def test_set_quota_fail_quota
+        # test won't fail until blocks exceed blocksmax * blocks buffer
         results = Runtime::Node.get_quota(@uuid)
+
         assert_raises(NodeCommandException) do
-          OpenShift::Runtime::Node.set_quota(@uuid, results[:blocks_used] - 1, '')
+          OpenShift::Runtime::Node.set_quota(@uuid, (results[:blocks_used] - 1) * @quota_blocks_buffer, '')
         end
       end
 
       def test_set_quota_fail_inodes
+        # test won't fail until inodes exceed inodesmax * inodes buffer
         results = Runtime::Node.get_quota(@uuid)
 
         assert_raises(NodeCommandException) do
-          OpenShift::Runtime::Node.set_quota(@uuid, results[:blocks_used], results[:inodes_used] - 1)
+          OpenShift::Runtime::Node.set_quota(@uuid, results[:blocks_used], (results[:inodes_used] - 1) * @quota_inodes_buffer)
         end
       end
 

--- a/plugins/msg-broker/mcollective/conf/openshift-origin-msg-broker-mcollective.conf.example
+++ b/plugins/msg-broker/mcollective/conf/openshift-origin-msg-broker-mcollective.conf.example
@@ -34,3 +34,8 @@ ZONES_MIN_PER_GEAR_GROUP=1
 # Specify how to address a node when doing rsync commands.  Valid options are
 # ip_address, server_identity, and public_hostname
 NODE_RSYNC_ADDRESS="ip_address"
+
+# Gear disk quota buffer.  This will ensure that nodes can be evacuated and gears
+# can be moved if a gear is over quota limits, up to this quota multiplier.
+QUOTA_BLOCKS_BUFFER=1.2
+QUOTA_INODES_BUFFER=1.2

--- a/plugins/msg-broker/mcollective/config/initializers/openshift-origin-msg-broker-mcollective.rb
+++ b/plugins/msg-broker/mcollective/config/initializers/openshift-origin-msg-broker-mcollective.rb
@@ -37,7 +37,9 @@ Broker::Application.configure do
         :min_zones_per_gear_group => conf.get("ZONES_MIN_PER_GEAR_GROUP", 1).to_i
       },
       :node_profile_enabled => conf.get_bool("NODE_PROFILE_ENABLED", "false"),
-      :node_rsync_address => conf.get("NODE_RSYNC_ADDRESS", "ip_address")
+      :node_rsync_address => conf.get("NODE_RSYNC_ADDRESS", "ip_address"),
+      :quota_blocks_buffer => conf.get("QUOTA_BLOCKS_BUFFER", 1.2),
+      :quota_inodes_buffer => conf.get("QUOTA_INODES_BUFFER", 1.2)
     }
   end
 end


### PR DESCRIPTION
bz 1292133
https://bugzilla.redhat.com/show_bug.cgi?id=1292133

Create a 1% quota buffer so that gears exceeding allowed quota can still be moved,
stopped or started.
