### PR TITLE
cron_runjobs.sh: adds setsid to timeout command

### DIFF
--- a/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
+++ b/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
@@ -64,10 +64,10 @@ log_message ":START: $freq cron run for openshift user '$OPENSHIFT_GEAR_UUID'"
 SCRIPTS_DIR="$OPENSHIFT_REPO_DIR/.openshift/cron/$freq"
 if [ -d "$SCRIPTS_DIR" ]; then
    # Run all scripts in the scripts directory serially.
-   executor="run-parts"
+   executor="setsid run-parts"
    if [ -n "$MAX_RUN_TIME" ]; then
      # TODO: use signal -s 1 --kill-after=$KILL_AFTER_TIME" when available
-     executor="timeout -s 9 $MAX_RUN_TIME run-parts"
+     executor="setsid timeout -s 9 $MAX_RUN_TIME run-parts"
    fi
 
    (


### PR DESCRIPTION
Bug 1305544
https://bugzilla.redhat.com/show_bug.cgi?id=1305544

Currently, cron jobs in OpenShift Online inherit the session from
/usr/libexec/openshift/cartridges/cron/bin/cron_runjobs.sh , which has SELinux
label system_u:system_r:system_cronjob_t:s0-s0:c0.c1023

This process is called under runcon, but only the child processes get a new
label (unconfined_u:system_r:openshift_t:s0:cXXX,cYYY).  Because of the label
change, calling getpgid against the sid fails.

Adds a 'setsid' to the timeout command to resolve the issue.
