### PR TITLE
oo-accept-broker incorrectly parses MONGO_HOST_PORT addition fix

### DIFF
--- a/broker-util/oo-accept-broker
+++ b/broker-util/oo-accept-broker
@@ -182,8 +182,8 @@ function check_mongo_connectivity() {
         verbose "At least one Mongo replicant is listening on the specified host and port."
       fi
     else
-      host=$(echo $MONGO_HOST | cut -d\: -f1)
-      port=$(echo $MONGO_HOST | cut -d\: -f2)
+      host=$(echo $MONGO_HOST | cut -d\: -f1 | tr -d \'\")
+      port=$(echo $MONGO_HOST | cut -d\: -f2 | tr -d \'\")
       timeout 1 bash -c "cat </dev/null > /dev/tcp/$host/$port"
 
       if [ $? != 0 ]


### PR DESCRIPTION
The issue has been partly addressed in PR 6365. However, the issue
with the else clause has not yet been fixed.

This commit will fix this issue with completely by correcting the
else clause as well.

Bug 1305688
Link https://bugzilla.redhat.com/show_bug.cgi?id=1305688

Signed-off-by: Vu Dinh vdinh@redhat.com
