### PR TITLE
Updates _mandir to properly add node man pages

### DIFF
--- a/node/rubygem-openshift-origin-node.spec
+++ b/node/rubygem-openshift-origin-node.spec
@@ -115,7 +115,7 @@ mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}/usr/sbin
 mkdir -p %{buildroot}%{appdir}/.tc_user_dir
 mkdir -p %{buildroot}%{_var}/log/openshift/node
-mkdir -p %{buildroot}%{_mandir}/man8/
+mkdir -p %{buildroot}%{_root_mandir}/man8/
 
 # Move the gem configs to the standard filesystem location
 mkdir -p %{buildroot}/etc/openshift
@@ -130,7 +130,7 @@ install -D -p -m 644 %{buildroot}%{gem_instdir}/misc/etc/openshift-origin-node.l
 install -D -p -m 644 %{buildroot}%{gem_instdir}/misc/etc/openshift-origin-node.logrotate.service %{buildroot}/etc/logrotate.d/%{name}
 %endif
 
-cp -p misc/man8/*.8 %{buildroot}%{_mandir}/man8/
+cp -p misc/man8/*.8 %{buildroot}%{_root_mandir}/man8/
 
 #move pam limit binaries to proper location
 mkdir -p %{buildroot}/usr/libexec/openshift/lib
@@ -287,8 +287,8 @@ fi
 %attr(0755,-,-) /etc/cron.monthly/openshift-origin-cron-monthly
 %attr(0755,-,-) /etc/cron.daily/openshift-origin-stale-lockfiles
 
-%{_mandir}/man8/oo-admin-ctl-tc.8.gz
-%{_mandir}/man8/oo-admin-ctl-iptables-port-proxy.8.gz
+%{_root_mandir}/man8/oo-admin-ctl-tc.8.gz
+%{_root_mandir}/man8/oo-admin-ctl-iptables-port-proxy.8.gz
 
 %changelog
 * Fri Oct 23 2015 Wesley Hearn <whearn@redhat.com> 1.38.4-1


### PR DESCRIPTION
Bug 1031796
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1031796

Updates _mandir to _root_mandir in the node .spec file.  The node uses SCL, so
_mandir would incorrectly put the man pages into
/opt/rh/ruby193/root/user/share/man instead of into /usr/share/man, which would
require users to enable SCL to update the $MANPATH.  The node
will now add the man pages to the correct location.

Specifically the man pages for oo-admin-ctl-tc and oo-admin-ctl-iptables-port-proxy.
