### PR TITLE
Remove double warning msg when adding cartridges

### DIFF
--- a/plugins/msg-node/mcollective/src/openshift.rb
+++ b/plugins/msg-node/mcollective/src/openshift.rb
@@ -157,7 +157,9 @@ module MCollective
         exitcode, output, addtl_params = execute_action(action, args)
 
         if args['--with-container-uuid']
-          report_quota(output, args['--with-container-uuid'])
+          if action != "configure"
+            report_quota(output, args['--with-container-uuid'])
+          end
           if report_resource(output, args['--with-app-name'])
             exitcode = 222
           end


### PR DESCRIPTION
bz1169690
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1169690

When adding cartridges to an app that is approaching quota limits,
the "Warning: Gear <uuid> is using <percent> of disk quota" is printed twice.
This PR removes the report_quota when installing a cartridge, so the
quota is only reported once after the cartridge is installed.
