### PR TITLE
oo-accept-node: check-quotas: fix mnt opts parsing

### DIFF
--- a/node-util/sbin/oo-accept-node
+++ b/node-util/sbin/oo-accept-node
@@ -549,7 +549,8 @@ def check_quotas
     oo_device, fs_type, _, _, _, _, oo_mount =
       %x[/bin/df -PT #{$GEAR_BASE_DIR}].split("\n").last.split
     awk = %[{ if ($1 == "#{oo_device}" && $3 == "#{oo_mount}") { print $6 } }]
-    fs_options = %x[mount | /bin/awk '#{awk}'].split('\n').last rescue ""
+    fs_options = %x[mount | /bin/awk '#{awk}'].
+      split("\n").last.sub(/^\((.*)\)$/, '\1') rescue ""
     if fs_options.match /loop=([^,]+)/
       oo_device = $1
       do_warn "#{oo_mount} is a loop mount (loop device: #{oo_device}).  Using a loop mount may reduce performance."


### PR DESCRIPTION
Improve the parsing of mount options from the `mount` command's output by properly splitting on newlines and then removing the parentheses around the mount options.

Before this commit, the pattern match `/loop=([^,]+)/` on the mount options was capturing the right parenthesis and newline from the `mount` command's output if the loop option was the last mount option.

This commit is related to bug 1265811.

https://bugzilla.redhat.com/show_bug.cgi?id=1265811
