### PR TITLE
V2 cartridge version update for Online release

### DIFF
--- a/cartridges/openshift-origin-cartridge-cron/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-cron/metadata/manifest.yml
@@ -10,10 +10,11 @@ Description: The Cron cartridge allows you to run command line programs at sched
 License: ASL 2.0
 License-Url: http://www.apache.org/licenses/LICENSE-2.0.txt
 Website: http://www.openshift.com/
-Cartridge-Version: 0.0.14
+Cartridge-Version: 0.0.15
 Compatible-Versions:
 - 0.0.12
 - 0.0.13
+- 0.0.14
 Cartridge-Vendor: redhat
 Categories:
 - embedded

--- a/cartridges/openshift-origin-cartridge-haproxy/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-haproxy/metadata/manifest.yml
@@ -10,11 +10,12 @@ Version: '1.4'
 License: GPLv2+
 License-Url: http://www.gnu.org/licenses/gpl-2.0.html
 Vendor: http://haproxy.1wt.eu/
-Cartridge-Version: 0.0.24
+Cartridge-Version: 0.0.25
 Compatible-Versions:
 - 0.0.21
 - 0.0.22
 - 0.0.23
+- 0.0.24
 Cartridge-Vendor: redhat
 Categories:
 - web_proxy

--- a/cartridges/openshift-origin-cartridge-jbossews/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-jbossews/metadata/manifest.yml
@@ -2,7 +2,7 @@
 Name: jbossews
 Cartridge-Short-Name: JBOSSEWS
 Cartridge-Vendor: redhat
-Cartridge-Version: 0.0.30
+Cartridge-Version: 0.0.31
 Compatible-Versions:
 - 0.0.21
 - 0.0.22
@@ -13,6 +13,7 @@ Compatible-Versions:
 - 0.0.27
 - 0.0.28
 - 0.0.29
+- 0.0.30
 Display-Name: Tomcat 7 (JBoss EWS 2.0)
 Description: JBoss Enterprise Web Server is the enterprise-class Java web container
   for large-scale lightweight web applications based on Tomcat 7. Build and deploy

--- a/cartridges/openshift-origin-cartridge-mysql/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-mysql/metadata/manifest.yml
@@ -8,7 +8,7 @@ Version: '5.5'
 Versions:
 - '5.1'
 - '5.5'
-Cartridge-Version: 0.2.20
+Cartridge-Version: 0.2.21
 Compatible-Versions:
 - 0.2.11
 - 0.2.12
@@ -19,6 +19,7 @@ Compatible-Versions:
 - 0.2.17
 - 0.2.18
 - 0.2.19
+- 0.2.20
 Cartridge-Vendor: redhat
 License: GPL
 Vendor: Oracle

--- a/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-php/metadata/manifest.yml
@@ -21,7 +21,7 @@ Version-Overrides:
 License: The PHP License, version 3.0
 License-Url: http://www.php.net/license/3_0.txt
 Vendor: php.net
-Cartridge-Version: 0.0.28
+Cartridge-Version: 0.0.29
 Compatible-Versions:
 - 0.0.20
 - 0.0.21
@@ -31,6 +31,7 @@ Compatible-Versions:
 - 0.0.25
 - 0.0.26
 - 0.0.27
+- 0.0.28
 Cartridge-Vendor: redhat
 Categories:
 - service

--- a/cartridges/openshift-origin-cartridge-python/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-python/metadata/manifest.yml
@@ -13,7 +13,7 @@ Versions:
 License: The Python License, version 2.6
 License-Url: http://docs.python.org/3/license.html
 Vendor: python.org
-Cartridge-Version: 0.0.26
+Cartridge-Version: 0.0.27
 Compatible-Versions:
 - 0.0.19
 - 0.0.20
@@ -22,6 +22,7 @@ Compatible-Versions:
 - 0.0.23
 - 0.0.24
 - 0.0.25
+- 0.0.26
 Cartridge-Vendor: redhat
 Categories:
 - service


### PR DESCRIPTION
Version compatibility is checked for multiple OpenShift V2 cartridges.

The manifest files for all cartridge have been updated for OpenShift
Oneline release.

Signed-off-by: Vu Dinh vdinh@redhat.com
