### PR TITLE
Allow unidling to ignore configurable user agent strings

### DIFF
--- a/node-util/sbin/oo-last-access
+++ b/node-util/sbin/oo-last-access
@@ -27,7 +27,13 @@ class LastAccessUpdater
     @last_access_data = Hash.new
     @addrs_ignore = Array.new
     @hosts_ignore = ["localhost"]
+    @useragent_ignore = []
   end
+
+  def load_useragent_ignore
+    ignore_list = OpenShift::Config.new.get("UNIDLER_IGNORE_LIST") || ""
+    @useragent_ignore = ignore_list.split(',')
+   end
 
   def load_addrs_ignore
     matchaddr = Regexp.new('inet6? (.*)\/[0-9]')
@@ -115,7 +121,8 @@ class LastAccessUpdater
     # Doing the file read with awk is 10x faster than doing it inside
     # Ruby and we desperately need speed here.
     ignore_cond = [@hosts_ignore.map { |a| "$2 != \"#{a}\"" },
-                   @addrs_ignore.map { |a| "$1 != \"#{a}\"" }].flatten.join(' && ')
+                   @addrs_ignore.map { |a| "$1 != \"#{a}\"" },
+                  "$_ !~ /#{ @useragent_ignore.join('|') }/" ].flatten.join(' && ')
     awk_cmd = %Q[{ if ( #{ignore_cond} ) h[$2]=$5" "$6 } END{ for ( i in h ) { printf("%s=%s\\n",i,h[i]) } }]
     # Pack separate log files one at a time so we can enforce the rule
     # that most recent timestamp wins.
@@ -207,6 +214,7 @@ single_instance do
   logfiles = [ENV["APACHE_ACCESS_LOG"], ENV["NODE_WEB_PROXY_ACCESS_LOG"], ENV["NODE_WEB_PROXY_WEBSOCKETS_LOG"]]
   l = LastAccessUpdater.new(ENV["GEAR_BASE_DIR"], logfiles)
   l.load_addrs_ignore
+  l.load_useragent_ignore
   l.load_gears_data
   l.add_alias_data
   gears_found_count = l.parse_log

--- a/node-util/www/html/restorer.php
+++ b/node-util/www/html/restorer.php
@@ -2,6 +2,24 @@
 
 list($blank, $uuid, $blank) = split("/", $_SERVER["PATH_INFO"]);
 if (preg_match('/^([0-9a-fA-F]{24,32}|\w+-\w+-\d+)$/', $uuid)) {
+    // Get the list of user agents to ignore
+    $node_conf = file('/etc/openshift/node.conf');
+    $useragent_ignore_list = array();
+    foreach ($node_conf as $conf_line) {
+      if (preg_match('/UNIDLER_IGNORE_LIST/', $conf_line)) {
+        $useragent_ignore_value = array();
+        preg_match('/UNIDLER_IGNORE_LIST=[\'"]*([^"\']+)[\'"]*/', $conf_line, $useragent_ignore_value);
+        $useragent_ignore_list = explode(",", $useragent_ignore_value[1]);
+        break;
+      }
+    }
+    // If the user agent matches one in the list, move on.
+    foreach ($useragent_ignore_list as $ignore) {
+      if (preg_match("/" . $ignore . "/", $_SERVER["HTTP_USER_AGENT"])) {
+        header('HTTP/1.0 403 Forbidden');
+        exit;
+      }
+    }
     $safe_uuid = escapeshellarg($uuid);
     shell_exec("/usr/sbin/oo-restorer-wrapper.sh $safe_uuid");
     sleep(2);

--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -92,6 +92,11 @@ REPORT_BUILD_ANALYTICS=false
 #       Run "oo-frontend-plugin-modify  --help" for more information.
 OPENSHIFT_FRONTEND_HTTP_PLUGINS=openshift-origin-frontend-apache-vhost,openshift-origin-frontend-nodejs-websocket
 
+# Comma seperated list of user agent strings to be ignored by the unidler.
+# When an idled gear receives a request whose user agent string matches one of
+# these entries, the gear will not be unidled.
+# UNIDLER_IGNORE_LIST=""
+
 # Default plugin for Node logs.  Logs to /var/log/openshift/node/platform*.log
 #PLATFORM_LOG_CLASS="SplitTraceLogger"
 


### PR DESCRIPTION
When undiling, it may be necessary to ignore certain user agent strings to avoid unidling gears that do not need to be unidled. For example, a request from a search engine spider should not cause the application to unidle. This change adds the ability to configure a list of strings that will be checked against the user agent string of each request and will cause the unilder to ignore the request if there is a match.

Bug 1305166
https://bugzilla.redhat.com/show_bug.cgi?id=1305166
