### PR TITLE
controller: default to JSON for REST API

### DIFF
--- a/controller/lib/openshift/controller/api_behavior.rb
+++ b/controller/lib/openshift/controller/api_behavior.rb
@@ -8,10 +8,15 @@ module OpenShift
 
       included do
         before_filter ->{ Mongoid.identity_map_enabled = true }
+        before_filter :default_format_json
       end
 
       protected
         attr :requested_api_version
+
+        def default_format_json
+          request.format ||= 'json'
+        end
 
         def check_version
           version = catch(:version) do


### PR DESCRIPTION
If no request format is specified for an REST API call, default to responding with JSON.

This commit fixes bug 1322543.

https://bugzilla.redhat.com/show_bug.cgi?id=1322543
## 

@thrasher-redhat, @tiwillia.
## 

openshift-bot, please [test] [extended:node,broker,rhc,cartridge,gear]!

Edit: Exclude the site extended tests because they are known to be broken presently.
