### PR TITLE
cron_runjobs.sh: Feature Enhancement for syslog tagging

### DIFF
--- a/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
+++ b/cartridges/openshift-origin-cartridge-cron/bin/cron_runjobs.sh
@@ -37,7 +37,7 @@ CART_CONF_DIR=$OPENSHIFT_CRON_DIR/configuration
 function log_message() {
    msg=${1-""}
    [ -z "$msg" ]  &&  return 0
-   logger -i -s "user-cron-jobs" -p user.info "`date`: $msg"
+   logger -i -s "user-cron-jobs" -p user.info -t "cron_sys_log:" "`date`: $msg"
 }
 
 # Ensure arguments.


### PR DESCRIPTION
Bug 1217403
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1217403

Adding the ability to filter/tag cron messages with syslog
