### PR TITLE
ensure that gears are moved to nodes with adequate free disk space

### DIFF
--- a/node/test/unit/node_test.rb
+++ b/node/test/unit/node_test.rb
@@ -18,6 +18,16 @@ require 'fakefs/safe'
 require 'yaml'
 require 'pp'
 
+module FakeFS
+  class File
+    class Stat
+      def dev
+        return 5555
+      end
+    end
+  end
+end
+
 class NodeTest < OpenShift::NodeTestCase
 
   def setup

--- a/plugins/msg-node/mcollective/facts/openshift_facts.rb
+++ b/plugins/msg-node/mcollective/facts/openshift_facts.rb
@@ -50,6 +50,8 @@ Facter.add(:host_ip) { setcode { host_public_ip } }
 #
 results = OpenShift::Runtime::Node.node_utilization
 
+Facter.add(:node_disk_free) { setcode { results['node_disk_free'] } }
+Facter.add(:node_total_size) { setcode { results['node_total_size'] } }
 Facter.add(:node_profile) { setcode { results['node_profile'] } }
 Facter.add(:max_active_gears) { setcode { results['max_active_gears'] || '0' } }
 Facter.add(:no_overcommit_active) { setcode { results['no_overcommit_active'] || false } }


### PR DESCRIPTION
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1122084
bz 1122084
If a gear is moved to a node and that node has no free space left
after the move, the node becomes unusable.
This PR ensures adequate free space + a buffer of free space on
destination nodes when moving gears.
