### PR TITLE
Openshift doesn't accept app aliases containing an underscore

### DIFF
--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1376,7 +1376,7 @@ class Application
     fqdn.downcase!
     return false if fqdn =~ /^\d+\.\d+\.\d+\.\d+$/
     return false if fqdn =~ /\A[\S]+(\.(json|xml|yml|yaml|html|xhtml))\z/
-    return false if not fqdn =~ /\A[a-z0-9]+([\.]?[\-a-z0-9]+)+\z/
+    return false if not fqdn =~ /\A[a-z0-9]+([\.]?[\-a-z0-9_]+)+\z/
     conf = Rails.configuration.openshift
     if fqdn.end_with?(cloud_domain = conf[:domain_suffix])
       # Normally, do not allow creating an alias in the cloud domain. Unless configured.


### PR DESCRIPTION
Currently, application aliases with underscore(s) are not allowed due
to regex restriction during alias verification
(controller/app/models/application.rb validate_alias(fqdn)).

Having underscore(s) in URL is generally not recommended but it's not
technically wrong to have. So, the regex for validate_alias method
is modified to accept underscore(s).

Bug: 1329915
Link: https://bugzilla.redhat.com/show_bug.cgi?id=1329915

Signed-off-by: Vu Dinh vdinh@redhat.com
