### PR TITLE
help_helper.rb: update SSH help page link

### DIFF
--- a/console/app/helpers/console/help_helper.rb
+++ b/console/app/helpers/console/help_helper.rb
@@ -23,7 +23,7 @@ module Console::HelpHelper
   end
 
   def ssh_keys_help_path
-    community_base_url 'developers/remote-access#keys'
+    community_developer_portal_url 'managing-your-applications/remote-connection.html#setting-up-ssh-keys'
   end
 
   def deploy_hook_user_guide_topic_url
@@ -99,7 +99,7 @@ module Console::HelpHelper
   end
 
   def ssh_help_url
-    community_base_url 'developers/remote-access'
+    community_developer_portal_url 'managing-your-applications/remote-connection.html'
   end
 
   def client_tools_install_help_url


### PR DESCRIPTION
Bug 1331745
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1331745

The previous link for the SSH help page was
https://www.openshift.com/developers/remote-access.  This page used to
redirect to the newer page
https://developers.openshift.com/managing-your-applications/remote-connection.html,
but no longer redirects and now will 404.  This commit updates the links to
point to the correct page.
