### PR TITLE
Add ENABLE_BROKER_STATS to broker.conf

### DIFF
--- a/broker/conf/broker.conf
+++ b/broker/conf/broker.conf
@@ -241,3 +241,7 @@ MIN_NODE_DISK_BUFFER="5"
 
 # Additional rubygems (space seperated) that will be loaded in the broker's Gemfile.
 # ADDITIONAL_RUBYGEMS=""
+
+# Enables logging of stats like current request id,
+# heap memory, #objects, #symbols for the broker process.
+ENABLE_BROKER_STATS="false"

--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -124,6 +124,7 @@ Broker::Application.configure do
     :auth_user_lookup_only => conf.get_bool("AUTH_USER_LOOKUP_ONLY", false),
     :auth_user_lookup_fail_msg => conf.get("AUTH_USER_LOOKUP_FAIL_MESSAGE", "This cluster is configured for user lookup only. Please contact your system administrator for provisioning your user account."),
     :min_node_disk_buffer => (conf.get("MIN_NODE_DISK_BUFFER", "5")).to_i
+    :broker_stats_enabled => conf.get_bool("ENABLE_BROKER_STATS", "false"),
   }
 
   config.auth = {

--- a/broker/config/environments/production.rb
+++ b/broker/config/environments/production.rb
@@ -113,6 +113,7 @@ Broker::Application.configure do
     :auth_user_lookup_only => conf.get_bool("AUTH_USER_LOOKUP_ONLY", false),
     :auth_user_lookup_fail_msg => conf.get("AUTH_USER_LOOKUP_FAIL_MESSAGE", "This cluster is configured for user lookup only. Please contact your system administrator for provisioning your user account."),
     :min_node_disk_buffer => (conf.get("MIN_NODE_DISK_BUFFER", "5")).to_i
+    :broker_stats_enabled => conf.get_bool("ENABLE_BROKER_STATS", "false"),
   }
 
   config.auth = {

--- a/broker/config/environments/test.rb
+++ b/broker/config/environments/test.rb
@@ -122,6 +122,7 @@ Broker::Application.configure do
     :auth_user_lookup_only => conf.get_bool("AUTH_USER_LOOKUP_ONLY", false),
     :auth_user_lookup_fail_msg => conf.get("AUTH_USER_LOOKUP_FAIL_MESSAGE", "This cluster is configured for user lookup only. Please contact your system administrator for provisioning your user account."),
     :min_node_disk_buffer => (conf.get("MIN_NODE_DISK_BUFFER", "5")).to_i
+    :broker_stats_enabled => conf.get_bool("ENABLE_BROKER_STATS", "false"),
   }
 
   config.auth = {


### PR DESCRIPTION
Add instrumentation in the controller to log Passenger memory usage statistics after every request.

Add `ENABLE_BROKER_STATS` setting (default false) to `/etc/openshift/broker.conf` to enable collecting and logging of these statistics.

These log entries can be used by the `oo-plot-broker-stats` command, added in commit 10d64633d0d37d48ab782727957e818935edf8e2, to generate data for gnuplot.
## 

openshift-bot, please [test] [extended:broker,site]!
