### PR TITLE
[TO_STAGE] Various fixes required for passing tests

### DIFF
--- a/controller/lib/openshift/controller/api_behavior.rb
+++ b/controller/lib/openshift/controller/api_behavior.rb
@@ -8,10 +8,15 @@ module OpenShift
 
       included do
         before_filter ->{ Mongoid.identity_map_enabled = true }
+        before_filter :default_format_json
       end
 
       protected
         attr :requested_api_version
+
+        def default_format_json
+          request.format ||= 'json'
+        end
 
         def check_version
           version = catch(:version) do

--- a/node/lib/openshift-origin-node/model/cartridge_repository.rb
+++ b/node/lib/openshift-origin-node/model/cartridge_repository.rb
@@ -220,7 +220,7 @@ module OpenShift
 
           FileUtils.rm_r(entry.repository_path)
           parent = Pathname.new(entry.repository_path).parent
-          FileUtils.rm_r(parent) if 0 == parent.children.count
+          FileUtils.rm_r(parent.to_s) if 0 == parent.children.count
         end
 
         entry


### PR DESCRIPTION
If no request format is specified for an REST API call, default to
responding with JSON.

The first commit fixes bug [1322543](https://bugzilla.redhat.com/show_bug.cgi?id=1322543)

The second commit fixes an issue with tests where a call to the fakefs package was done using an incorrect type.
