### PR TITLE
Updates oo-admin-egenerate-gear-metadata man page

### DIFF
--- a/node-util/man8/oo-admin-regenerate-gear-metadata.8
+++ b/node-util/man8/oo-admin-regenerate-gear-metadata.8
@@ -8,7 +8,7 @@
 .SH NAME
 oo-admin-regenerate-gear-metadata \(em regenerate missing gear(s) metadata
 .SH SYNOPSIS
-.B "oo-admin-regenerate-gear-metadata [-y] [-q] [--no-accept-node]"
+.B "oo-admin-regenerate-gear-metadata [-y] [-q] [-n|--no-accept-node]"
 .SH DESCRIPTION
 .B "oo-admin-regenerate-gear-metadata"
 regenerate missing gear metadata from the gears on the filesystem
@@ -20,7 +20,7 @@ Assume 'yes' for all prompts
 .B "-q"
 Do not display progress messages
 .TP
-.B "--no-accept-node"
+.B "-n|--no-accept-node"
 Do not run oo-accept-node after updating the node with the gears' metadata
 .SH FILES
 .TP


### PR DESCRIPTION
Bug 1311730
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1311730

The options for oo-admin-regenerate previously had an implied short option of
'-n' for '--no-accept-node'.  A previous PR defined the '-n' option in the
command's help options, however the man page was not updated.  The '-n' option
has been added to the man page as well now.
