### PR TITLE
Update resource_limits.conf

### DIFF
--- a/node/conf/resource_limits.conf
+++ b/node/conf/resource_limits.conf
@@ -7,6 +7,12 @@
 #       oo-pam-enable --with-all-containers
 #       oo-admin-ctl-tc restart
 #
+# NOTE: If you change the memory_limit_in_bytes variable, run this command
+#       to update existing gears. Replace 512 with the new value in megabytes.
+#       Note the change in units from bytes to megabytes - memory_limit_in_bytes
+#       expects the value in bytes, where OPENSHIFT_GEAR_MEMORY_MB expects the
+#       value in megabytes.
+#       for i in /var/lib/openshift/*/.env/OPENSHIFT_GEAR_MEMORY_MB; do echo 512 > "$i"; done
 #
 # Default Profile
 #
@@ -39,6 +45,13 @@ quota_blocks=1048576
 # be the defaults for a gear.
 #
 # memory (RAM)
+#
+# NOTE: If you change the memory_limit_in_bytes variable, run this command
+#       to update existing gears. Replace 512 with the new value in megabytes.
+#       Note the change in units from bytes to megabytes - memory_limit_in_bytes
+#       expects the value in bytes, where OPENSHIFT_GEAR_MEMORY_MB expects the
+#       value in megabytes.
+#       for i in /var/lib/openshift/*/.env/OPENSHIFT_GEAR_MEMORY_MB; do echo 512 > "$i"; done
 memory_limit_in_bytes=536870912       # 512MB
 memory_memsw_limit_in_bytes=641728512 # 512M + 100M (100M swap)
 # memory_soft_limit_in_bytes=-1


### PR DESCRIPTION
Bug 1196783
https://bugzilla.redhat.com/show_bug.cgi?id=1196783

When the memory_limit_in_bytes variable in resource_limits.conf is updated, the
OPENSHIFT_GEAR_MEMORY_MB env variable does not get updated for existing gears.
Now there is an additional note for users to run a workaround to update that
variable for existing gears.
