### PR TITLE
Making user provisioning configurable within the broker

### DIFF
--- a/broker/conf/broker.conf
+++ b/broker/conf/broker.conf
@@ -139,6 +139,12 @@ CART_DOWNLOAD_CONN_TIMEOUT="2"
 # Set to "true" to make application default to use https in advertised URL
 APP_ADVERTISE_HTTPS="false"
 
+# Set to true to block new user creation within OpenShift broker
+# If set to true, only allows existing users to access OpenShift
+# New users, even if authenticated, will not be provisioned in OpenShift broker
+# and will get an AccessDeniedException
+AUTH_USER_LOOKUP_ONLY="false"
+
 # Team collaboration settings
 MAX_MEMBERS_PER_RESOURCE="100"
 MAX_TEAMS_PER_RESOURCE="5"

--- a/broker/config/environments/development.rb
+++ b/broker/config/environments/development.rb
@@ -121,6 +121,7 @@ Broker::Application.configure do
     :use_predictable_gear_uuids => conf.get_bool("USE_PREDICTABLE_GEAR_UUIDS", false),
     :limit_app_name_chars => conf.get("LIMIT_APP_NAME_CHARS", -1).to_i,
     :app_advertise_https => conf.get_bool("APP_ADVERTISE_HTTPS", false),
+    :auth_user_lookup_only => conf.get_bool("AUTH_USER_LOOKUP_ONLY", false),
   }
 
   config.auth = {

--- a/broker/config/environments/production.rb
+++ b/broker/config/environments/production.rb
@@ -110,6 +110,7 @@ Broker::Application.configure do
     :use_predictable_gear_uuids => conf.get_bool("USE_PREDICTABLE_GEAR_UUIDS", false),
     :limit_app_name_chars => conf.get("LIMIT_APP_NAME_CHARS", -1).to_i,
     :app_advertise_https => conf.get_bool("APP_ADVERTISE_HTTPS", false),
+    :auth_user_lookup_only => conf.get_bool("AUTH_USER_LOOKUP_ONLY", false),
   }
 
   config.auth = {

--- a/broker/config/environments/test.rb
+++ b/broker/config/environments/test.rb
@@ -119,6 +119,7 @@ Broker::Application.configure do
     :use_predictable_gear_uuids => conf.get_bool("USE_PREDICTABLE_GEAR_UUIDS", false),
     :limit_app_name_chars => conf.get("LIMIT_APP_NAME_CHARS", -1).to_i,
     :app_advertise_https => conf.get_bool("APP_ADVERTISE_HTTPS", false),
+    :auth_user_lookup_only => conf.get_bool("AUTH_USER_LOOKUP_ONLY", false),
   }
 
   config.auth = {

--- a/controller/app/models/cloud_user.rb
+++ b/controller/app/models/cloud_user.rb
@@ -163,6 +163,10 @@ class CloudUser
     yield user, login if block_given?
     [user, false]
   rescue Mongoid::Errors::DocumentNotFound
+    # if new user creation is blocked, then return an exception
+    if Rails.application.config.openshift[:auth_user_lookup_only]
+      raise OpenShift::UserException.new("New user signups are not allowed on this cluster")
+    end
     user = new(create_attributes)
     #user.current_identity = user.identities.build(provider: provider, uid: login)
     #user.login = user.current_identity.id


### PR DESCRIPTION
Currently, a lookup is made in the broker for an authenticated user. If the user does not exist, a user document is created in mongo. With this change, a user will be provisioned only if the configuration is set to false.
