### PR TITLE
Allow maximum allowed user defined env variables to be configured

### DIFF
--- a/node/conf/node.conf
+++ b/node/conf/node.conf
@@ -40,7 +40,8 @@ CARTRIDGE_BASE_PATH="/usr/libexec/openshift/cartridges"      # Locations where c
 LAST_ACCESS_DIR="/var/lib/openshift/.last_access"            # Location to maintain last accessed time for gears
 APACHE_ACCESS_LOG="/var/log/httpd/openshift_log"             # Location of httpd gear access log
 CREATE_APP_SYMLINKS=0                                        # If set to 1, creates gear-name symlinks to the UUID directories (debugging only)
-DISABLE_PASSWORD_AGING=true                                # Disable password aging for gear users, ignoring defaults set in /etc/logins.def
+DISABLE_PASSWORD_AGING=true                                  # Disable password aging for gear users, ignoring defaults set in /etc/logins.def
+USER_VARIABLE_MAX_COUNT=50                                   # The maximum number of user variables a user is allowed to add to a gear
 OPENSHIFT_HTTP_CONF_DIR="/etc/httpd/conf.d/openshift"
 
 # Apache vhost frontend plugin defaults


### PR DESCRIPTION
Bug 1266239
https://bugzilla.redhat.com/show_bug.cgi?id=1266239

Adds the `USER_VARIABLE_MAX_COUNT` option to the node configuration file. This option controls the maximum number of user environment variables allowed on the node.
