### PR TITLE
Fix Documentation links pointing to github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ create and manage applications.
 SSL termination and deployment
 
 A [comprehensive architecture
-overview](http://openshift.github.io/documentation/oo_system_architecture_guide.html)
+overview](https://github.com/openshift/origin-server/blob/master/documentation/oo_system_architecture_guide.adoc)
 can be found on our wiki.
 
 The primary command line interface to OpenShift is [RHC](https://github.com/openshift/rhc).

--- a/admin-console/README.md
+++ b/admin-console/README.md
@@ -1,5 +1,5 @@
 # OpenShift Origin Administrative Console
-Deployment and use of the Administrative Console is documented in the [Administration Guide](http://openshift.github.io/documentation/oo_administration_guide.html#admin-console).
+Deployment and use of the Administrative Console is documented in the [Administration Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_administration_guide.adoc#admin-console).
 
 ## Developing / Contributing
 We expect code contributions to follow these standards:

--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/README.md
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/README.md
@@ -1,2 +1,2 @@
 # OpenShift 10gen-mms-agent Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#10gen-mms-agent).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#10gen-mms-agent).

--- a/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/setup
+++ b/cartridges/openshift-origin-cartridge-10gen-mms-agent/bin/setup
@@ -20,7 +20,7 @@ else
     client_error "Your settings.py file is missing the secret_key variable."
     exit 137
   fi
-  client_message "The settings.py was deprecated, please check your 10gen-mms-agent cartridge documentation at http://openshift.github.io/documentation/oo_cartridge_guide.html#10gen-mms-agent"
+  client_message "The settings.py was deprecated, please check your 10gen-mms-agent cartridge documentation at https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#10gen-mms-agent"
   shopt -s dotglob
   pushd "$OPENSHIFT_10GENMMSAGENT_DIR" > /dev/null
   cp -r /usr/local/share/mms-agent/* $OPENSHIFT_10GENMMSAGENT_DIR/mms-agent/

--- a/cartridges/openshift-origin-cartridge-cron/README.md
+++ b/cartridges/openshift-origin-cartridge-cron/README.md
@@ -1,2 +1,2 @@
 # OpenShift Cron Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#cron).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#cron).

--- a/cartridges/openshift-origin-cartridge-diy/README.md
+++ b/cartridges/openshift-origin-cartridge-diy/README.md
@@ -1,2 +1,2 @@
 # OpenShift DIY Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#diy).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#diy).

--- a/cartridges/openshift-origin-cartridge-diy/usr/template/.openshift/README.md
+++ b/cartridges/openshift-origin-cartridge-diy/usr/template/.openshift/README.md
@@ -1,3 +1,3 @@
 For information about .openshift directory, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#the-openshift-directory
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#the-openshift-directory

--- a/cartridges/openshift-origin-cartridge-diy/usr/template/.openshift/action_hooks/README.md
+++ b/cartridges/openshift-origin-cartridge-diy/usr/template/.openshift/action_hooks/README.md
@@ -1,3 +1,3 @@
 For information about action hooks, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#action-hooks
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#action-hooks

--- a/cartridges/openshift-origin-cartridge-diy/usr/template/README.md
+++ b/cartridges/openshift-origin-cartridge-diy/usr/template/README.md
@@ -1,3 +1,3 @@
 The OpenShift `diy` cartridge documentation can be found at:
 
-http://openshift.github.io/documentation/oo_cartridge_guide.html#diy
+https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#diy

--- a/cartridges/openshift-origin-cartridge-haproxy/README.md
+++ b/cartridges/openshift-origin-cartridge-haproxy/README.md
@@ -1,2 +1,2 @@
 # OpenShift HAProxy Cartridge
-OpenShift cartridges are documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html).
+OpenShift cartridges are documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc).

--- a/cartridges/openshift-origin-cartridge-jbossas/README.md
+++ b/cartridges/openshift-origin-cartridge-jbossas/README.md
@@ -1,2 +1,2 @@
 # OpenShift JBossAS Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#jbossas).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#jbossas).

--- a/cartridges/openshift-origin-cartridge-jbossas/versions/7/template/.openshift/README.md
+++ b/cartridges/openshift-origin-cartridge-jbossas/versions/7/template/.openshift/README.md
@@ -1,3 +1,3 @@
 For information about .openshift directory, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#the-openshift-directory
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#the-openshift-directory

--- a/cartridges/openshift-origin-cartridge-jbossas/versions/7/template/.openshift/action_hooks/README.md
+++ b/cartridges/openshift-origin-cartridge-jbossas/versions/7/template/.openshift/action_hooks/README.md
@@ -1,3 +1,3 @@
 For information about action hooks, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#action-hooks
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#action-hooks

--- a/cartridges/openshift-origin-cartridge-jbossas/versions/7/template/README.md
+++ b/cartridges/openshift-origin-cartridge-jbossas/versions/7/template/README.md
@@ -1,3 +1,3 @@
 The OpenShift `jbossas` cartridge documentation can be found at:
 
-http://openshift.github.io/documentation/oo_cartridge_guide.html#jbossas
+https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#jbossas

--- a/cartridges/openshift-origin-cartridge-jbosseap/README.md
+++ b/cartridges/openshift-origin-cartridge-jbosseap/README.md
@@ -1,2 +1,2 @@
 # OpenShift JBossEAP Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#jbosseap).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#jbosseap).

--- a/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/template/.openshift/README.md
+++ b/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/template/.openshift/README.md
@@ -1,3 +1,3 @@
 For information about .openshift directory, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#the-openshift-directory
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#the-openshift-directory

--- a/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/template/.openshift/action_hooks/README.md
+++ b/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/template/.openshift/action_hooks/README.md
@@ -1,3 +1,3 @@
 For information about action hooks, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#action-hooks
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#action-hooks

--- a/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/template/README.md
+++ b/cartridges/openshift-origin-cartridge-jbosseap/versions/shared/template/README.md
@@ -1,3 +1,3 @@
 The OpenShift `jbosseap` cartridge documentation can be found at:
 
-http://openshift.github.io/documentation/oo_cartridge_guide.html#jbosseap
+https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#jbosseap

--- a/cartridges/openshift-origin-cartridge-jbossews/README.md
+++ b/cartridges/openshift-origin-cartridge-jbossews/README.md
@@ -1,2 +1,2 @@
 # OpenShift Tomcat (JBossEWS) Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#tomcat).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#tomcat).

--- a/cartridges/openshift-origin-cartridge-jbossews/template/.openshift/README.md
+++ b/cartridges/openshift-origin-cartridge-jbossews/template/.openshift/README.md
@@ -1,3 +1,3 @@
 For information about .openshift directory, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#the-openshift-directory
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#the-openshift-directory

--- a/cartridges/openshift-origin-cartridge-jbossews/template/.openshift/action_hooks/README.md
+++ b/cartridges/openshift-origin-cartridge-jbossews/template/.openshift/action_hooks/README.md
@@ -1,3 +1,3 @@
 For information about action hooks, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#action-hooks
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#action-hooks

--- a/cartridges/openshift-origin-cartridge-jbossews/template/README.md
+++ b/cartridges/openshift-origin-cartridge-jbossews/template/README.md
@@ -1,3 +1,3 @@
 The OpenShift `jbossews` cartridge documentation can be found at:
 
-http://openshift.github.io/documentation/oo_cartridge_guide.html#tomcat
+https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#tomcat

--- a/cartridges/openshift-origin-cartridge-jenkins-client/README.md
+++ b/cartridges/openshift-origin-cartridge-jenkins-client/README.md
@@ -1,2 +1,2 @@
 # OpenShift Jenkins Client Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#jenkins-client).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#jenkins-client).

--- a/cartridges/openshift-origin-cartridge-jenkins/README.md
+++ b/cartridges/openshift-origin-cartridge-jenkins/README.md
@@ -1,2 +1,2 @@
 # OpenShift Jenkins Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#jenkins).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#jenkins).

--- a/cartridges/openshift-origin-cartridge-jenkins/usr/template/.openshift/README.md
+++ b/cartridges/openshift-origin-cartridge-jenkins/usr/template/.openshift/README.md
@@ -1,3 +1,3 @@
 For information about .openshift directory, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#the-openshift-directory
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#the-openshift-directory

--- a/cartridges/openshift-origin-cartridge-jenkins/usr/template/.openshift/action_hooks/README.md
+++ b/cartridges/openshift-origin-cartridge-jenkins/usr/template/.openshift/action_hooks/README.md
@@ -1,3 +1,3 @@
 For information about action hooks, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#action-hooks
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#action-hooks

--- a/cartridges/openshift-origin-cartridge-jenkins/usr/template/README.md
+++ b/cartridges/openshift-origin-cartridge-jenkins/usr/template/README.md
@@ -1,3 +1,3 @@
 The OpenShift `jenkins` cartridge documentation can be found at:
 
-http://openshift.github.io/documentation/oo_cartridge_guide.html#jenkins
+https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#jenkins

--- a/cartridges/openshift-origin-cartridge-mariadb/README.md
+++ b/cartridges/openshift-origin-cartridge-mariadb/README.md
@@ -1,2 +1,2 @@
 # OpenShift MariaDB Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#mariadb).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#mariadb).

--- a/cartridges/openshift-origin-cartridge-mock-plugin/README.md
+++ b/cartridges/openshift-origin-cartridge-mock-plugin/README.md
@@ -1,5 +1,5 @@
 # OpenShift Mock Plugin Cartridge
 
-This is a mock implementation of the [OpenShift cartridge API](http://openshift.github.io/documentation/oo_cartridge_developers_guide.html) which is used to test the OpenShift node platform functionality. The mock cartridge maintains a store of what actions have been performed and provides methods to test for those actions.  
+This is a mock implementation of the [OpenShift cartridge API](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_developers_guide.adoc) which is used to test the OpenShift node platform functionality. The mock cartridge maintains a store of what actions have been performed and provides methods to test for those actions.  
 
-This cartridge was intentionally omitted from the [OpenShift Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html).
+This cartridge was intentionally omitted from the [OpenShift Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc).

--- a/cartridges/openshift-origin-cartridge-mock/README.md
+++ b/cartridges/openshift-origin-cartridge-mock/README.md
@@ -1,5 +1,5 @@
 # OpenShift Mock Cartridge
 
-This is a mock implementation of the [OpenShift Cartridge API](http://openshift.github.io/documentation/oo_cartridge_developers_guide.html) which is used to test the OpenShift node platform functionality. The mock cartridges maintains a store of what actions have been performed and provides methods to test for those actions.  
+This is a mock implementation of the [OpenShift Cartridge API](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_developers_guide.adoc) which is used to test the OpenShift node platform functionality. The mock cartridges maintains a store of what actions have been performed and provides methods to test for those actions.  
 
-This cartridge was intentionally omitted from the [OpenShift Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html).
+This cartridge was intentionally omitted from the [OpenShift Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc).

--- a/cartridges/openshift-origin-cartridge-mock/template/.openshift/README.md
+++ b/cartridges/openshift-origin-cartridge-mock/template/.openshift/README.md
@@ -2,4 +2,4 @@ The OpenShift `mock` cartridge documentation can be found at:
 https://github.com/openshift/origin-server/blob/master/cartridges/openshift-origin-cartridge-mock/README.md
 
 For information about .openshift directory, consult the documentation:
-http://openshift.github.io/documentation/oo_user_guide.html#the-openshift-directory
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#the-openshift-directory

--- a/cartridges/openshift-origin-cartridge-mock/template/.openshift/action_hooks/README.md
+++ b/cartridges/openshift-origin-cartridge-mock/template/.openshift/action_hooks/README.md
@@ -1,3 +1,3 @@
 For information about action hooks, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#action-hooks
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#action-hooks

--- a/cartridges/openshift-origin-cartridge-mongodb/README.md
+++ b/cartridges/openshift-origin-cartridge-mongodb/README.md
@@ -1,2 +1,2 @@
 # OpenShift MongoDB Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#mongodb).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#mongodb).

--- a/cartridges/openshift-origin-cartridge-mysql/README.md
+++ b/cartridges/openshift-origin-cartridge-mysql/README.md
@@ -1,2 +1,2 @@
 # OpenShift MySQL Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#mysql).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#mysql).

--- a/cartridges/openshift-origin-cartridge-nodejs/README.md
+++ b/cartridges/openshift-origin-cartridge-nodejs/README.md
@@ -1,2 +1,2 @@
 # OpenShift NodeJS Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#nodejs).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#nodejs).

--- a/cartridges/openshift-origin-cartridge-nodejs/usr/template/.openshift/README.md
+++ b/cartridges/openshift-origin-cartridge-nodejs/usr/template/.openshift/README.md
@@ -1,3 +1,3 @@
 For information about .openshift directory, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#the-openshift-directory
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#the-openshift-directory

--- a/cartridges/openshift-origin-cartridge-nodejs/usr/template/.openshift/action_hooks/README.md
+++ b/cartridges/openshift-origin-cartridge-nodejs/usr/template/.openshift/action_hooks/README.md
@@ -1,3 +1,3 @@
 For information about action hooks, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#action-hooks
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#action-hooks

--- a/cartridges/openshift-origin-cartridge-nodejs/usr/template/README.md
+++ b/cartridges/openshift-origin-cartridge-nodejs/usr/template/README.md
@@ -1,3 +1,3 @@
 The OpenShift `nodejs` cartridge documentation can be found at:
 
-http://openshift.github.io/documentation/oo_cartridge_guide.html#nodejs
+https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#nodejs

--- a/cartridges/openshift-origin-cartridge-perl/README.md
+++ b/cartridges/openshift-origin-cartridge-perl/README.md
@@ -1,2 +1,2 @@
 # OpenShift Perl Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#perl).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#perl).

--- a/cartridges/openshift-origin-cartridge-perl/usr/template/.openshift/README.md
+++ b/cartridges/openshift-origin-cartridge-perl/usr/template/.openshift/README.md
@@ -1,5 +1,5 @@
 The OpenShift `perl` cartridge documentation can be found at:
-http://openshift.github.io/documentation/oo_cartridge_guide.html#perl
+https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#perl
 
 For information about .openshift directory, consult the documentation:
-http://openshift.github.io/documentation/oo_user_guide.html#the-openshift-directory
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#the-openshift-directory

--- a/cartridges/openshift-origin-cartridge-perl/usr/template/.openshift/action_hooks/README.md
+++ b/cartridges/openshift-origin-cartridge-perl/usr/template/.openshift/action_hooks/README.md
@@ -1,3 +1,3 @@
 For information about action hooks, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#action-hooks
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#action-hooks

--- a/cartridges/openshift-origin-cartridge-php/README.md
+++ b/cartridges/openshift-origin-cartridge-php/README.md
@@ -1,2 +1,2 @@
 # OpenShift PHP Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#php).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#php).

--- a/cartridges/openshift-origin-cartridge-php/usr/template/.openshift/README.md
+++ b/cartridges/openshift-origin-cartridge-php/usr/template/.openshift/README.md
@@ -1,5 +1,5 @@
 The OpenShift `php` cartridge documentation can be found at:
-http://openshift.github.io/documentation/oo_cartridge_guide.html#php
+https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#php
 
 For information about .openshift directory, consult the documentation:
-http://openshift.github.io/documentation/oo_user_guide.html#the-openshift-directory
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#the-openshift-directory

--- a/cartridges/openshift-origin-cartridge-php/usr/template/.openshift/action_hooks/README.md
+++ b/cartridges/openshift-origin-cartridge-php/usr/template/.openshift/action_hooks/README.md
@@ -1,3 +1,3 @@
 For information about action hooks, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#action-hooks
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#action-hooks

--- a/cartridges/openshift-origin-cartridge-phpmyadmin/README.md
+++ b/cartridges/openshift-origin-cartridge-phpmyadmin/README.md
@@ -1,2 +1,2 @@
 # OpenShift phpMyAdmin Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#phpmyadmin).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#phpmyadmin).

--- a/cartridges/openshift-origin-cartridge-postgresql/README.md
+++ b/cartridges/openshift-origin-cartridge-postgresql/README.md
@@ -1,2 +1,2 @@
 # OpenShift PostgreSQL Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#postgresql).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#postgresql).

--- a/cartridges/openshift-origin-cartridge-postgresql/template/README.md
+++ b/cartridges/openshift-origin-cartridge-postgresql/template/README.md
@@ -1,3 +1,3 @@
 The OpenShift `postgresql` cartridge documentation can be found at:
 
-http://openshift.github.io/documentation/oo_cartridge_guide.html#postgresql
+https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#postgresql

--- a/cartridges/openshift-origin-cartridge-python/README.md
+++ b/cartridges/openshift-origin-cartridge-python/README.md
@@ -1,2 +1,2 @@
 # OpenShift Python Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#python).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#python).

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/template/.openshift/README.md
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/template/.openshift/README.md
@@ -1,5 +1,5 @@
 The OpenShift `python` cartridge documentation can be found at:
-http://openshift.github.io/documentation/oo_cartridge_guide.html#python
+https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#python
 
 For information about .openshift directory, consult the documentation:
-http://openshift.github.io/documentation/oo_user_guide.html#the-openshift-directory
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#the-openshift-directory

--- a/cartridges/openshift-origin-cartridge-python/usr/versions/shared/template/.openshift/action_hooks/README.md
+++ b/cartridges/openshift-origin-cartridge-python/usr/versions/shared/template/.openshift/action_hooks/README.md
@@ -1,3 +1,3 @@
 For information about action hooks, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#action-hooks
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#action-hooks

--- a/cartridges/openshift-origin-cartridge-ruby/README.md
+++ b/cartridges/openshift-origin-cartridge-ruby/README.md
@@ -1,2 +1,2 @@
 # OpenShift Ruby Cartridge
-This cartridge is documented in the [Cartridge Guide](http://openshift.github.io/documentation/oo_cartridge_guide.html#ruby).
+This cartridge is documented in the [Cartridge Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#ruby).

--- a/cartridges/openshift-origin-cartridge-ruby/versions/shared/template/.openshift/README.md
+++ b/cartridges/openshift-origin-cartridge-ruby/versions/shared/template/.openshift/README.md
@@ -1,3 +1,3 @@
 For information about .openshift directory, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#the-openshift-directory
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#the-openshift-directory

--- a/cartridges/openshift-origin-cartridge-ruby/versions/shared/template/.openshift/action_hooks/README.md
+++ b/cartridges/openshift-origin-cartridge-ruby/versions/shared/template/.openshift/action_hooks/README.md
@@ -1,3 +1,3 @@
 For information about action hooks, consult the documentation:
 
-http://openshift.github.io/documentation/oo_user_guide.html#action-hooks
+https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc#action-hooks

--- a/cartridges/openshift-origin-cartridge-ruby/versions/shared/template/README.md
+++ b/cartridges/openshift-origin-cartridge-ruby/versions/shared/template/README.md
@@ -1,3 +1,3 @@
 The OpenShift `ruby` cartridge documentation can be found at:
 
-http://openshift.github.io/documentation/oo_cartridge_guide.html#ruby
+https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_guide.adoc#ruby

--- a/console/README.md
+++ b/console/README.md
@@ -1,5 +1,5 @@
 # OpenShift Origin Management Console
-Installation and use of the Management Console is documented in the [Administration Guide](http://openshift.github.io/documentation/oo_administration_guide.html#management-console)
+Installation and use of the Management Console is documented in the [Administration Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_administration_guide.adoc#management-console)
 
 ## Developing / Contributing
 We expect code contributions to follow these standards:

--- a/documentation/_origin_hangouts_footer.adoc
+++ b/documentation/_origin_hangouts_footer.adoc
@@ -1,7 +1,7 @@
 == Wait there's more!
 
 * Join the https://plus.google.com/u/0/communities/114361859072744017486[OpenShift Community on Google Plus]
-* http://openshift.github.io/documentation/oo_deployment_guide_vm.html[Download & deploy OpenShift] on your Cloud today
+* https://github.com/openshift/origin-server/blob/master/documentation/oo_deployment_guide_vm.adoc[Download & deploy OpenShift] on your Cloud today
 * Try out https://www.openshift.com/app/account/new?web_user$$[promo_code]$$=HangOut[OpenShift Online]
 * Ask a question on IRC (http://webchat.freenode.net/?randomnick=1&channels=openshift&uio=d4[#openshift] or http://webchat.freenode.net/?randomnick=1&channels=openshift-dev&uio=d4[#openshift-dev])
 

--- a/documentation/oo_contributors_guide.adoc
+++ b/documentation/oo_contributors_guide.adoc
@@ -195,7 +195,7 @@ Once you know you're dealing with an unreported bug, please don't hesitate to su
 **Source Control**: The source code for OpenShift origin lives in public repositories on https://github.com/[GitHub]. If you aren't familiar with http://git-scm.com/[git], there are numerous primers available on the web.
 
 === Broker
-The Broker itself is a Rails application that serves as the nerve center for OpenShift Origin. Everything from user creation to app deployment is handled through the Broker. The Broker exposes a http://openshift.github.io/documentation/rest_api/rest-api-1-6.html[REST API] and communicates with Node hosts via http://www.amqp.org/[AMQP].
+The Broker itself is a Rails application that serves as the nerve center for OpenShift Origin. Everything from user creation to app deployment is handled through the Broker. The Broker exposes a https://access.redhat.com/documentation/en-US/OpenShift_Enterprise/2/html/REST_API_Guide/index.html[REST API] and communicates with Node hosts via http://www.amqp.org/[AMQP].
 
 * https://trello.com/b/nbkIrqKa[Feature Backlog]
 * https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&bug_status=ASSIGNED&bug_status=MODIFIED&component=Broker&component=REST%20API&product=OpenShift%20Origin&query_format=advanced[Bugzilla Records] (components: Broker, REST API)
@@ -203,7 +203,7 @@ The Broker itself is a Rails application that serves as the nerve center for Ope
 
 === Runtime
 
-"Runtime" refers to the components of OpenShift that are related to the hosted applications. This includes both the Node and the application http://openshift.github.io/documentation/oo_cartridge_developers_guide.html[Cartridges].
+"Runtime" refers to the components of OpenShift that are related to the hosted applications. This includes both the Node and the application https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_developers_guide.adoc[Cartridges].
 
 * https://trello.com/b/qjfQ62lZ/openshift-origin-node[Feature Backlog]
 * https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&bug_status=ASSIGNED&bug_status=MODIFIED&component=Cartridge&component=Node&list_id=2209237&product=OpenShift%20Origin&query_format=advanced[Bugzilla Records] (components: Cartridge, Node)

--- a/documentation/oo_deployment_guide_comprehensive.adoc
+++ b/documentation/oo_deployment_guide_comprehensive.adoc
@@ -58,7 +58,7 @@ This document includes chapters on how to install and configure these services a
 
 [float]
 === Electronic version of this document
-This document is available online at http://openshift.github.io/documentation/oo_deployment_guide_comprehensive.html
+This document is available online at https://github.com/openshift/origin-server/blob/master/documentation/oo_deployment_guide_comprehensive.adoc
 
 == Prerequisite: Preparing the Host Systems
 
@@ -2382,7 +2382,7 @@ image:console.png[image]
 Now that you have a correctly configured installation, there are two important final steps to be done. These steps assume that your Broker and Node(s) are running and able to communicate with each other as described in this guide.
 
 === Add Nodes to Districts
-As of OpenShift Origin v4, Nodes _must_ belong to a district in order to work properly. Adding a Node to a district after the Node already has hosted apps running on it is very difficult, so this is a very important pre-deployment task. For a discussion of what districts are, refer to the http://openshift.github.io/documentation-latest/oo_administration_guide.html#the-purpose-of-districts[Administration Guide].
+As of OpenShift Origin v4, Nodes _must_ belong to a district in order to work properly. Adding a Node to a district after the Node already has hosted apps running on it is very difficult, so this is a very important pre-deployment task. For a discussion of what districts are, refer to the https://github.com/openshift/origin-server/blob/master/documentation-latest/oo_administration_guide.adoc#the-purpose-of-districts[Administration Guide].
 
 *Define one or more districts* + 
 From a Broker host, run the following command to define a new district:

--- a/documentation/oo_deployment_guide_vagrant.adoc
+++ b/documentation/oo_deployment_guide_vagrant.adoc
@@ -6,7 +6,7 @@ LATEST DOC UPDATES
 :icons:
 :numbered:
 
-If you are interested in deploying OpenShift into your network environment, you've got a few options - you can start with https://install.openshift.com/[oo-install], grab our http://openshift.github.io/documentation/oo_deployment_guide_puppet.html[Puppet module], or you can http://openshift.github.io/documentation/oo_deployment_guide_comprehensive.html[do it yourself]. This document describes a fourth deployment option that is specifically focused on **OpenShift Origin development**. If you want to spin up a bleeding-edge copy of OpenShift Origin and work on making this awesome Platform-as-a-Service even better, then you've come to the right place.
+If you are interested in deploying OpenShift into your network environment, you've got a few options - you can start with https://install.openshift.com/[oo-install], grab our https://github.com/openshift/origin-server/blob/master/documentation/oo_deployment_guide_puppet.adoc[Puppet module], or you can https://github.com/openshift/origin-server/blob/master/documentation/oo_deployment_guide_comprehensive.adoc[do it yourself]. This document describes a fourth deployment option that is specifically focused on **OpenShift Origin development**. If you want to spin up a bleeding-edge copy of OpenShift Origin and work on making this awesome Platform-as-a-Service even better, then you've come to the right place.
 
 == Prerequisites
 
@@ -14,7 +14,7 @@ This developer-focused deployment offers users maximum flexibility in their choi
 
 Here's what you will need:
 
-* **A basic development environment.** A bash shell, git, and GitHub account. If you need help with those, check out the http://openshift.github.io/documentation/oo_contributors_guide.html#creating-a-development-environment[Origin Contributor's Guide].
+* **A basic development environment.** A bash shell, git, and GitHub account. If you need help with those, check out the https://github.com/openshift/origin-server/blob/master/documentation/oo_contributors_guide.adoc#creating-a-development-environment[Origin Contributor's Guide].
 * http://www.vagrantup.com/[**Vagrant.**] The Vagrant framework is available as a ruby gem, but you should install the officially distributed Vagrant package for your OS directly from the Vagrant web site.
 * **A platform for virtual machines.** Vagrant provides out-of-the-box support for https://www.virtualbox.org/[VirtualBox], so this guide will focus on development with VirtualBox. However, other VM platforms are supported via Vagrant _Provider_ plugins; see the Vagrant site for details.
 

--- a/documentation/oo_install_users_guide.adoc
+++ b/documentation/oo_install_users_guide.adoc
@@ -437,7 +437,7 @@ OpenShift uses MongoDB to manage user and host application information. MongoDB 
 OpenShift uses ActiveMQ to handle inter-host messaging, and ActiveMQ has native support for failover clustering. This doesn't require any special configuration input from user. If you specify more than one MsgServer host, failover clustering is automatically instantiated.
 
 === Gear Sizes
-The installer will ask about three settings related to gear sizes. If you are not familiar with this concept, refer to the http://openshift.github.io/documentation/oo_administration_guide.html#set-default-gear-quotas-and-sizes[User Resource Management] section of the Administrators Guide.
+The installer will ask about three settings related to gear sizes. If you are not familiar with this concept, refer to the https://github.com/openshift/origin-server/blob/master/documentation/oo_administration_guide.adoc#set-default-gear-quotas-and-sizes[User Resource Management] section of the Administrators Guide.
 
 The installer configures these settings with the indicated defaults:
 
@@ -448,7 +448,7 @@ The installer configures these settings with the indicated defaults:
 The actual specifics about what each "gear size" means can be adjusted after installation is completed.
 
 === Node Districts
-The installer also gathers information about the http://openshift.github.io/documentation/oo_administration_guide.html#capacity-planning-and-districts[Node Districts] that you would like to deploy. As of Origin version 4, it is no longer possible to deploy a Node host without associating it with a Node District. By default, the install will create a single Node District called "Default" that is associated with the "small" gear size.
+The installer also gathers information about the https://github.com/openshift/origin-server/blob/master/documentation/oo_administration_guide.adoc#capacity-planning-and-districts[Node Districts] that you would like to deploy. As of Origin version 4, it is no longer possible to deploy a Node host without associating it with a Node District. By default, the install will create a single Node District called "Default" that is associated with the "small" gear size.
 
 === Subscription
 At this point, all that remains to configure your OpenShift deployment is to tell `oo-install` where you would like to get your OpenShift RPMs from. Refer to the notes on the link:#s-subscription-type-type[-s / --subscription-type] command-line argument for an explanation of your options.

--- a/node/README.writing_applications.md
+++ b/node/README.writing_applications.md
@@ -1,2 +1,2 @@
 # How To Write An Application To Host on OpenShift
-This information had been moved to the [OpenShift Origin User's Guide](http://openshift.github.io/documentation/oo_user_guide.html).
+This information had been moved to the [OpenShift Origin User's Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_user_guide.adoc).

--- a/node/README.writing_cartridges.md
+++ b/node/README.writing_cartridges.md
@@ -1,2 +1,2 @@
 # How To Write An OpenShift Origin Cartridge 2.0
-This information has been moved to the [OpenShift Origin Cartridge Developer's Guide](http://openshift.github.io/documentation/oo_cartridge_developers_guide.html).
+This information has been moved to the [OpenShift Origin Cartridge Developer's Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_developers_guide.adoc).

--- a/plugins/frontend/haproxy-sni-proxy/README.haproxy-sni-proxy.md
+++ b/plugins/frontend/haproxy-sni-proxy/README.haproxy-sni-proxy.md
@@ -87,7 +87,7 @@ The reported URL reports the protocol as "tls" instead of the
 application protocol (ex: "amqps").  It is up to the cartridge
 documentation to clarify client requirements.
 
-For more information, please refer to the [OpenShift Origin Cartridge Developer's Guide](http://openshift.github.io/documentation/oo_cartridge_developers_guide.html).
+For more information, please refer to the [OpenShift Origin Cartridge Developer's Guide](https://github.com/openshift/origin-server/blob/master/documentation/oo_cartridge_developers_guide.adoc).
 
 
 ## SNI Proxy Requirements and Configuration


### PR DESCRIPTION
Documentation links previously pointing to openshift.github.io are
broken and must be changed to point to the corresponding adoc file in
the github origin-server repository.

Any links to documentation not provided in the origin-server repository
(such as the api guide) have been changed to point to the publicly
available enterprise documentation.

Fixes issue #6401
