### PR TITLE
routing-daemon: Resynchronize with load-balancer

### DIFF
--- a/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/asynchronous.rb
@@ -39,6 +39,11 @@ module OpenShift
         @aliases = @lb_model.get_pool_aliases pool_name
       end
 
+      def synch
+        @members = @lb_model.get_pool_members @name
+        @aliases = @lb_model.get_pool_aliases @name
+      end
+
       def members
         @members ||= @lb_model.get_pool_members @name
       end
@@ -490,6 +495,12 @@ module OpenShift
         @logger.info "Requesting list of pools from load balancer..."
         Hash[@lb_model.get_pool_names.map {|pool_name| [pool_name, Pool.new(self, @lb_model, pool_name)]}]
       end
+    end
+
+    def synch_pools
+      # Set @pools to nil so that it will be lazily resynchronized the next time
+      # the pools method is used.
+      @pools = nil
     end
 
     # If a monitor is already created or is being created in the load balancer, it will be in monitors.

--- a/routing-daemon/lib/openshift/routing/controllers/load_balancer.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/load_balancer.rb
@@ -16,6 +16,11 @@ module OpenShift
     class Pool
       attr_reader :name, :members
 
+      # Synchronize pool members, aliases, and certificates from the load
+      # balancer.
+      def synch
+      end
+
       # Add a member to the object's internal list of members.
       #
       # The arguments should be a String comprising an IP address in
@@ -119,6 +124,12 @@ module OpenShift
     # @pools is a hash that maps String to LoadBalancerPool.
     # @monitors is an array of strings.
     attr_reader :pools, :monitors
+
+    # Resynchronize @pools with the load balancer.  Depending on the
+    # implementation, the resynchronization may be performed immediately
+    # or lazily.
+    def synch_pools
+    end
 
     def create_pool pool_name, monitor_name=nil
     end

--- a/routing-daemon/lib/openshift/routing/controllers/simple.rb
+++ b/routing-daemon/lib/openshift/routing/controllers/simple.rb
@@ -22,9 +22,13 @@ module OpenShift
     class Pool < LoadBalancerController::Pool
       def initialize lb_controller, lb_model, pool_name
         @lb_controller, @lb_model, @name = lb_controller, lb_model, pool_name
-        @members = @lb_model.get_pool_members pool_name
-        @aliases = @lb_model.get_pool_aliases pool_name
-        @certs = @lb_model.get_pool_certificates pool_name
+        synch
+      end
+
+      def synch
+        @members = @lb_model.get_pool_members @name
+        @aliases = @lb_model.get_pool_aliases @name
+        @certs = @lb_model.get_pool_certificates @name
       end
 
       def add_member address, port
@@ -131,6 +135,12 @@ module OpenShift
         @logger.info "Requesting list of pools from load balancer..."
         Hash[@lb_model.get_pool_names.map {|pool_name| [pool_name, Pool.new(self, @lb_model, pool_name)]}]
       end
+    end
+
+    def synch_pools
+      # Set @pools to nil so that it will be lazily resynchronized the next time
+      # the pools method is used.
+      @pools = nil
     end
 
     def monitors


### PR DESCRIPTION
Resynchronize the routing daemon with the load balancer when the daemon attempts to perform on operation on an unrecognized pool or pool member.

The intention of this commit is to improve the daemon's reliability when something other than the current instance of the daemon changes the load balancer's state, for example the system administrator or clustered routing daemons.

`AsyncLoadBalancerController::Pool`, `BatchedLoadBalancerController::Pool`, `LoadBalancerController::Pool`, `SimpleLoadBalancerController::Pool`: Add `synch` method.

`AsyncLoadBalancerController`, `BatchedLoadBalancerController`, `LoadBalancerController`, `SimpleLoadBalancerController`: Add `synch_pools` method.

`RoutingDaemon`: Add `with_pool` method, which checks whether a pool exists, resynchronizes the daemon with the load balancer if it is not found (using the new `synch_pools` controller method), optionally creates the pool if it is still not found, and invokes the supplied block if the pool is found.

`RoutingDaemon#create_application`: Take `pool_name` as a parameter rather than generating the value itself since callers will already have generated the value themselves.

`RoutingDaemon#delete_application`, `RoutingDaemon#add_endpoint`, `RoutingDaemon#remove_endpoint`, `RoutingDaemon#add_alias`, `RoutingDaemon#remove_alias`, `RoutingDaemon#add_ssl`, `RoutingDaemon#remove_ssl`: Use the daemon's new `with_pool` method in order to check whether the pool exists,  esynchronize the daemon with the load balancer if an operation is attempted on an unrecognized pool, and (in the case of add methods) create the pool if it does not exist.

`RoutingDaemon#remove_endpoint`: Use the controller's new `synch` method for pools to resynchronize the daemon with the load balancer if the operation is attempted on an unknown pool member.
