### PR TITLE
routing-daemon: F5: Rescue more network errors

### DIFF
--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -81,7 +81,9 @@ module OpenShift
         end
 
         raise LBModelException.new msg
-      rescue RestClient::Exception => e
+      rescue RestClient::Exception, SocketError, EOFError, IOError,
+             Errno::ECONNABORTED, Errno::ECONNRESET, Errno::EPIPE,
+             Errno::EINVAL, Timeout::Error, Errno::ETIMEDOUT => e
         @logger.warn "Got #{e.class} exception for host #{@hosts.first}:" +
           " #{e.message}" if @hosts.length > 0
 


### PR DESCRIPTION
`F5IControlRestLoadBalancerModel#rest_request`: Rescue several additional exceptions that failure to connect to the F5 BIG-IP host can raise, and attempt retries for these exceptions.

Newer versions of the restclient gem should wrap these exceptions, but there has been at least one report where restclient let through an unwrapped exception (`Errno::ETIMEDOUT`), and as a result, `F5IControlRestLoadBalancerModel#rest_request` did not rescue the exception and thus did not follow the retry logic.

This commit is related to commit f9d47828016d5085bdd9da252300c6feb642e9d6.

This commit is related to bug 1227472.

https://bugzilla.redhat.com/show_bug.cgi?id=1227472
