### PR TITLE
rsync_destination_container: Fix free space check

### DIFF
--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -2416,7 +2416,7 @@ module OpenShift
 
       # check here to make sure addition of gear to destination_container
       # will not result in > 95% full destination_container
-      if (destination_avail_space - source_used_blocks.to_i)/destination_total_space > 0.05
+      if (destination_avail_space - source_used_blocks.to_f)/destination_total_space < 0.05
         raise OpenShift::NodeUnavailableException.new("Gear '#{gear.uuid}' cannot be moved to '#{destination_container.id}'.  Not enough disk space, node would be > 95% full after move.", 140)
       end
 


### PR DESCRIPTION
Use correct arithmetic when checking that the destination node has enough free space before copying a gear: the remaining space after the copying the gear should be _greater_ than 5% (not less), and the arithmetic must be performed using floating point arithmetic (not integer).

This commit is related https://github.com/openshift/origin-server/pull/6382.
## 

openshift-bot, please [test][extended:node]!
## 

@sallyom, @a13m, we are all implicated in this PR by our involvement in https://github.com/openshift/origin-server/pull/6382.
