### PR TITLE
Use updated fakefs to ensure support for File.absolute_path

### DIFF
--- a/node/openshift-origin-node.gemspec
+++ b/node/openshift-origin-node.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.files       += %w(README.md Rakefile Gemfile rubygem-openshift-origin-node.spec openshift-origin-node.gemspec COPYRIGHT LICENSE)
   s.require_paths = ["lib"]
   s.add_dependency("json")
+  s.add_dependency('fakefs', ">=0.5.4")
   s.add_dependency("parseconfig", ">= 0.5.2")
   s.add_dependency("openshift-origin-common")
   s.add_dependency("safe_yaml")


### PR DESCRIPTION
The use of fakes-0.4.2 causes erroneous test failures due to the lack of `File.absolute_path` support. Updating to 0.5.\* allows tests to succeed without causing further issues.

In origin-server tests, fakefs-0.9 is used by default. This change will have no affect on origin-server tests, but will ensure that tests run in other deployments will be run properly.

@thrasher-redhat fyi
