### PR TITLE
Fix pip cache directory permission denied

### DIFF
--- a/cartridges/openshift-origin-cartridge-python/bin/install
+++ b/cartridges/openshift-origin-cartridge-python/bin/install
@@ -10,6 +10,7 @@ esac
 echo "$version" > ${OPENSHIFT_PYTHON_DIR}env/OPENSHIFT_PYTHON_VERSION
 
 mkdir -p ${OPENSHIFT_PYTHON_DIR}template
+mkdir $OPENSHIFT_HOMEDIR/.cache
 
 # Call the version specific install script
 exec ${OPENSHIFT_PYTHON_DIR}usr/versions/${version}/bin/install $version


### PR DESCRIPTION
For Python 2.7, a new version of PIP (7.1.0) attemps to write into .cache
directory in gear's home directory which will cause permission denied error.
Users do not have permission to create files or folders in gear's home directory.
The .cache directory needs to be created during the installation process. As
a result, a piece of code is added to "install" script to create .cache dir
before pip install step happens to address the issue.

Bug 1361755
Link https://bugzilla.redhat.com/show_bug.cgi?id=1361755

Signed-off-by: Vu Dinh vdinh@redhat.com
