### PR TITLE
Add new update instruction for different gear types conf

### DIFF
--- a/node/conf/resource_limits.conf.large.m3.xlarge
+++ b/node/conf/resource_limits.conf.large.m3.xlarge
@@ -7,6 +7,12 @@
 #       oo-pam-enable --with-all-containers
 #       oo-admin-ctl-tc restart
 #
+# NOTE: If you change the memory_limit_in_bytes variable, run this command
+#       to update existing gears. Replace 512 with the new value in megabytes.
+#       Note the change in units from bytes to megabytes - memory_limit_in_bytes
+#       expects the value in bytes, where OPENSHIFT_GEAR_MEMORY_MB expects the
+#       value in megabytes.
+#       for i in /var/lib/openshift/*/.env/OPENSHIFT_GEAR_MEMORY_MB; do echo 512 > "$i"; done
 #
 # Large Profile
 #
@@ -40,6 +46,13 @@ quota_blocks=4194304
 # be the defaults for a gear.
 #
 # memory (RAM)
+#
+# NOTE: If you change the memory_limit_in_bytes variable, run this command
+#       to update existing gears. Replace 512 with the new value in megabytes.
+#       Note the change in units from bytes to megabytes - memory_limit_in_bytes
+#       expects the value in bytes, where OPENSHIFT_GEAR_MEMORY_MB expects the
+#       value in megabytes.
+#       for i in /var/lib/openshift/*/.env/OPENSHIFT_GEAR_MEMORY_MB; do echo 512 > "$i"; done
 memory_limit_in_bytes=2147483648        # 2G
 memory_memsw_limit_in_bytes=2252341248  # 2G + 100M (100M swap)
 # memory_soft_limit_in_bytes=-1

--- a/node/conf/resource_limits.conf.medium.m3.xlarge
+++ b/node/conf/resource_limits.conf.medium.m3.xlarge
@@ -7,6 +7,12 @@
 #       oo-pam-enable --with-all-containers
 #       oo-admin-ctl-tc restart
 #
+# NOTE: If you change the memory_limit_in_bytes variable, run this command
+#       to update existing gears. Replace 512 with the new value in megabytes.
+#       Note the change in units from bytes to megabytes - memory_limit_in_bytes
+#       expects the value in bytes, where OPENSHIFT_GEAR_MEMORY_MB expects the
+#       value in megabytes.
+#       for i in /var/lib/openshift/*/.env/OPENSHIFT_GEAR_MEMORY_MB; do echo 512 > "$i"; done
 #
 # medium Profile
 #
@@ -40,6 +46,13 @@ quota_blocks=2097152
 # be the defaults for a gear.
 #
 # memory (RAM)
+#
+# NOTE: If you change the memory_limit_in_bytes variable, run this command
+#       to update existing gears. Replace 512 with the new value in megabytes.
+#       Note the change in units from bytes to megabytes - memory_limit_in_bytes
+#       expects the value in bytes, where OPENSHIFT_GEAR_MEMORY_MB expects the
+#       value in megabytes.
+#       for i in /var/lib/openshift/*/.env/OPENSHIFT_GEAR_MEMORY_MB; do echo 512 > "$i"; done
 memory_limit_in_bytes=1073741824       # 1024MB = 1GB
 memory_memsw_limit_in_bytes=1178599424 # 1GB + 100M (100M swap)
 # memory_soft_limit_in_bytes=-1

--- a/node/conf/resource_limits.conf.small.m3.xlarge
+++ b/node/conf/resource_limits.conf.small.m3.xlarge
@@ -7,6 +7,12 @@
 #       oo-pam-enable --with-all-containers
 #       oo-admin-ctl-tc restart
 #
+# NOTE: If you change the memory_limit_in_bytes variable, run this command
+#       to update existing gears. Replace 512 with the new value in megabytes.
+#       Note the change in units from bytes to megabytes - memory_limit_in_bytes
+#       expects the value in bytes, where OPENSHIFT_GEAR_MEMORY_MB expects the
+#       value in megabytes.
+#       for i in /var/lib/openshift/*/.env/OPENSHIFT_GEAR_MEMORY_MB; do echo 512 > "$i"; done
 #
 # Small Profile
 #
@@ -39,6 +45,13 @@ quota_blocks=1048576
 # be the defaults for a gear.
 #
 # memory (RAM)
+#
+# NOTE: If you change the memory_limit_in_bytes variable, run this command
+#       to update existing gears. Replace 512 with the new value in megabytes.
+#       Note the change in units from bytes to megabytes - memory_limit_in_bytes
+#       expects the value in bytes, where OPENSHIFT_GEAR_MEMORY_MB expects the
+#       value in megabytes.
+#       for i in /var/lib/openshift/*/.env/OPENSHIFT_GEAR_MEMORY_MB; do echo 512 > "$i"; done
 memory_limit_in_bytes=536870912       # 512MB
 memory_memsw_limit_in_bytes=641728512 # 512M + 100M (100M swap)
 # memory_soft_limit_in_bytes=-1

--- a/node/conf/resource_limits.conf.xpaas.m3.xlarge
+++ b/node/conf/resource_limits.conf.xpaas.m3.xlarge
@@ -7,6 +7,12 @@
 #       oo-pam-enable --with-all-containers
 #       oo-admin-ctl-tc restart
 #
+# NOTE: If you change the memory_limit_in_bytes variable, run this command
+#       to update existing gears. Replace 512 with the new value in megabytes.
+#       Note the change in units from bytes to megabytes - memory_limit_in_bytes
+#       expects the value in bytes, where OPENSHIFT_GEAR_MEMORY_MB expects the
+#       value in megabytes.
+#       for i in /var/lib/openshift/*/.env/OPENSHIFT_GEAR_MEMORY_MB; do echo 512 > "$i"; done
 #
 # xPaaS Profile
 #
@@ -44,7 +50,14 @@ quota_blocks=5242880
 # Names and values may be implementation specific. These values will
 # be the defaults for a gear.
 #
-# memory
+# memory (RAM)
+#
+# NOTE: If you change the memory_limit_in_bytes variable, run this command
+#       to update existing gears. Replace 512 with the new value in megabytes.
+#       Note the change in units from bytes to megabytes - memory_limit_in_bytes
+#       expects the value in bytes, where OPENSHIFT_GEAR_MEMORY_MB expects the
+#       value in megabytes.
+#       for i in /var/lib/openshift/*/.env/OPENSHIFT_GEAR_MEMORY_MB; do echo 512 > "$i"; done
 memory_limit_in_bytes=1073741824       # 1024MB = 1 GB
 memory_memsw_limit_in_bytes=1610612736 # 1024MB + 512MB (512MB swap)
 # memory_soft_limit_in_bytes=-1


### PR DESCRIPTION
When the memory_limit_in_bytes variable in resource_limits.conf is updated, the
OPENSHIFT_GEAR_MEMORY_MB env variable does not get updated for existing gears.
Now there is an additional note for users to run a workaround to update that
variable for existing gears.

Bug 1196783
Link https://bugzilla.redhat.com/show_bug.cgi?id=1196783

Signed-off-by: Vu Dinh vdinh@redhat.com
