### PR TITLE
Revert dfac396 and enable routing notifications during moves

### DIFF
--- a/broker-util/oo-admin-move
+++ b/broker-util/oo-admin-move
@@ -144,7 +144,7 @@ gear_uuid.split(',').each do |uuid|
     reply = nil
     begin
       gear.get_proxy.disable_log_debug! if json
-      reply = gear.get_proxy.move_gear_secure(gear, destination_container, destination_district_uuid, change_district, change_region, node_profile)
+      reply = gear.move(destination_container, destination_district_uuid, change_district, change_region, node_profile)
       if json
         app, gear = Application.find_by_gear_uuid(uuid)
         move_status[uuid].merge!({ :result => true, :destination => gear.server_identity })

--- a/controller/app/models/application.rb
+++ b/controller/app/models/application.rb
@@ -1735,7 +1735,13 @@ class Application
         if gear
           pi = PortInterface.create_port_interface(gear, component_id, *command_item[:args])
           gear.port_interfaces.push(pi)
-          pi.publish_endpoint(self)
+          # If available, use the public external ip address provided by the cartridge command.
+          # It is possible that if the NOTIFY_ENDPOINT_CREATE command was generated during the
+          # move of a gear (as opposed to the creation of a gear), the address from the gear
+          # object may not yet be updated. We prefer to use the address specified in the command
+          # itself.
+          public_ip = command_item[:args][0]["external_address"] || gear.get_public_ip_address
+          pi.publish_endpoint(self, public_ip)
         end
       when "NOTIFY_ENDPOINT_DELETE"
         if gear

--- a/controller/app/models/gear.rb
+++ b/controller/app/models/gear.rb
@@ -132,12 +132,6 @@ class Gear
     result_io
   end
 
-  def unpublish_routing_info
-    self.port_interfaces.each do |pi|
-      pi.unpublish_endpoint(self.application)
-    end
-  end
-
   def publish_routing_info
     self.port_interfaces.each do |pi|
       pi.publish_endpoint(self.application)
@@ -408,6 +402,12 @@ class Gear
     remove_envs.each  {|env|      RemoteJob.add_parallel_job(remote_job_handle, tag, self, get_proxy.get_env_var_remove_job(self, env["key"]))} if remove_envs.present?
 
     RemoteJob.add_parallel_job(remote_job_handle, tag, self, get_proxy.get_update_configuration_job(self, config)) unless config.nil? || config.empty?
+  end
+
+  def move(destination_container, destination_district_uuid, change_district, change_region, node_profile)
+    result_io = get_proxy.move_gear_secure(self, destination_container, destination_district_uuid, change_district, change_region, node_profile)
+    application.process_commands(result_io, nil, self)
+    result_io
   end
 
   def set_addtl_fs_gb(additional_filesystem_gb, remote_job_handle, tag = "addtl-fs-gb")

--- a/controller/app/models/port_interface.rb
+++ b/controller/app/models/port_interface.rb
@@ -57,8 +57,8 @@ class PortInterface
     gear.port_interfaces.find_by(external_port: public_port) rescue nil
   end
 
-  def publish_endpoint(app)
-    OpenShift::RoutingService.notify_create_public_endpoint(app, self.gear, self.cartridge_name, self.external_address, self.external_port, self.internal_address, self.internal_port, self.protocols, self.type, self.mappings)
+  def publish_endpoint(app, public_ip=external_address)
+    OpenShift::RoutingService.notify_create_public_endpoint(app, self.gear, self.cartridge_name, public_ip, self.external_port, self.internal_address, self.internal_port, self.protocols, self.type, self.mappings)
   end
 
   def unpublish_endpoint(app, public_ip=external_address)

--- a/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
+++ b/plugins/msg-broker/mcollective/lib/openshift/mcollective_application_container_proxy.rb
@@ -1931,8 +1931,6 @@ module OpenShift
       ensure
         dns.close
       end
-      log_debug "DEBUG: Updating routing information for gear '#{gear.uuid}' after move"
-      gear.publish_routing_info
       reply
     end
 
@@ -1958,8 +1956,6 @@ module OpenShift
       gear_comps = gear.component_instances.to_a
       start_order,stop_order = app.calculate_component_orders
 
-      log_debug "DEBUG: Unpublishing routing information for gear '#{gear.uuid}'"
-      gear.unpublish_routing_info
       app.update_proxy_status(action: :disable, gear_uuid: gear.uuid) if app.scalable
 
       do_force_stop = false
@@ -2167,7 +2163,7 @@ module OpenShift
             cart = cinst.cartridge
             idle, leave_stopped = state_map[cart.name]
 
-            if app.scalable and not cart.is_web_proxy?
+            if app.scalable
               begin
                 reply.append destination_container.expose_port(gear, cinst)
               rescue Exception=> e
@@ -2256,7 +2252,7 @@ module OpenShift
         end
       end
 
-      move_gear_destroy_old(gear, source_container, destination_container, district_changed)
+      reply.append move_gear_destroy_old(gear, source_container, destination_container, district_changed)
 
       # if gear is over disk quota limit, issue warning after move
       if Integer(gear_quota[1]) > @dest_quota_blocks_b4_bump  || Integer(gear_quota[4]) > @dest_quota_files_b4_bump


### PR DESCRIPTION
The routing daemon was previously not receiving updated endpoint
notifications during gear moves. A previous commit, dfac396, enabled
endpoints to be published but the endpoints published were the same
endpoints as before the move.

This change reverts dfac396 and properly sends endpoint creation and
deletion events to the routing daemon during a gear move.
