### PR TITLE
Consistent session cookies across haproxies in HA apps

### DIFF
--- a/cartridges/openshift-origin-cartridge-haproxy/usr/bin/update-cluster
+++ b/cartridges/openshift-origin-cartridge-haproxy/usr/bin/update-cluster
@@ -45,7 +45,7 @@ for arg in $kvargs; do
     zarr=(${zinfo//|/ })
     ep="${zarr[1]}"
     #  Add gear to the proxy configuration if not already in there.
-    #  Gear end-point is the form: $gear-ipaddress:$gear-port
+    #  Gear end-point is the form: $gear-address:$gear-port
     gear_name=$(echo "${zarr[0]}" | cut -f 1 -d '.')
 
     # Ensure endpoint is valid.
@@ -64,8 +64,8 @@ for arg in $kvargs; do
     # Restore user-set locale
     LC_ALL="${ORIG_LC_ALL}"
 
-	# If this is the local gear, we are NOT creating an entry for it
-	# The local gear entry is made separately later below
+    # If this is the local gear, we are NOT creating an entry for it
+    # The local gear entry is made separately later below
     if [ "$OPENSHIFT_GEAR_DNS" != "${zarr[0]}" ]; then 
         flock 200
         curr_server_gears[$gear_name]="$ep"
@@ -111,8 +111,12 @@ fi
 local_ep=$local_ip:$local_port
 
 # Add the local gear
+# For cookie consistency with remote gears we'll use the gear's DNS name here,
+# which takes the form:   gearname-domain
+# (see the gear endpoint setup for remote gears in the for loop above)
+gear_name="${OPENSHIFT_GEAR_NAME}-${OPENSHIFT_NAMESPACE}"
 sed -i "/\s*server\s*local-gear\s.*/d" /tmp/haproxy.cfg.$$
-echo "    server local-gear $local_ep check fall 2 rise 3 inter 2000 cookie local-$OPENSHIFT_GEAR_UUID" >> /tmp/haproxy.cfg.$$
+echo "    server local-gear $local_ep check fall 2 rise 3 inter 2000 cookie $gear_name" >> /tmp/haproxy.cfg.$$
 
 cat /tmp/haproxy.cfg.$$ > "$haproxy_cfg"
 rm -f /tmp/haproxy.cfg.$$


### PR DESCRIPTION
Make the local-gear set a cookie value using the gear's DNS name, the same that remote gears do, so that HA applications get consistent session cookie values across multiple haproxies.

See https://bugzilla.redhat.com/1377433
