### PR TITLE
routing-daemon: F5: Pin to API version 11.6.0

### DIFF
--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -14,6 +14,7 @@ module OpenShift
   class F5IControlRestLoadBalancerModel < LoadBalancerModel
 
     POLICY_NAME = 'openshift_application_aliases'
+    ICONTROL_API_VERSION = '11.6.0'
 
     def read_config cfgfile
       cfg = ParseConfig.new(cfgfile)
@@ -62,7 +63,7 @@ module OpenShift
       first = @hosts.first
 
       begin
-        options[:url] = "https://#{@hosts.first}#{options[:resource]}"
+        options[:url] = "https://#{@hosts.first}#{options[:resource]}?ver=#{ICONTROL_API_VERSION}"
 
         RestClient::Request.execute(options).tap do |response|
           unless response.code == expected_code


### PR DESCRIPTION
`F5IControlRestLoadBalancerModel#rest_request`: Specify iControl REST API version 11.6.0.

We have previously tested the routing-daemon successfully against F5 BIG-IP LTM 11.6 but have encountered problems with 12.1.  However, the F5 iControl REST API is supposed to provide backwards compatibility with older API versions if the API version is specified in the request.
