### PR TITLE
Verbose assertion in console.js test

### DIFF
--- a/console/test/integration/assets_test.rb
+++ b/console/test/integration/assets_test.rb
@@ -7,7 +7,7 @@ class AssetsTest < ActionDispatch::IntegrationTest
     get '/assets/console.js'
     assert_response :success
     assert_equal 'application/javascript', @response.content_type
-    assert @response.body.length > 10*1024
+    assert @response.body.length > 10*1024, "response body was shorter than expected: #{@response.body}"
     assert @response.body.include?("jQuery")
   end
 


### PR DESCRIPTION
Make the assertion failure in the console.js content length test more verbose in order to diagnose this failure in https://github.com/openshift/li/pull/3147:

```
test_retrieve_the_main_javascript_resource(AssetsTest) [/opt/rh/ruby193/root/usr/share/gems/gems/openshift-origin-console-1.35.4/test/integration/assets_test.rb:10]:
Failed assertion, no message given.
```

openshift-bot, please [test]!
