### PR TITLE
Bump python cartridge version

### DIFF
--- a/cartridges/openshift-origin-cartridge-python/metadata/manifest.yml
+++ b/cartridges/openshift-origin-cartridge-python/metadata/manifest.yml
@@ -13,7 +13,7 @@ Versions:
 License: The Python License, version 2.6
 License-Url: http://docs.python.org/3/license.html
 Vendor: python.org
-Cartridge-Version: 0.0.26
+Cartridge-Version: 0.0.27
 Compatible-Versions:
 - 0.0.19
 - 0.0.20


### PR DESCRIPTION
Note that the old version was not added to the compatible upgrade list, due to the addition of the following commit:

https://github.com/openshift/origin-server/commit/53619d51b37b07beb3084682f71fa0d23db7a7e6