### PR TITLE
node-proxy: Adds honor cipher order

### DIFF
--- a/node-proxy/lib/utils/http-utils.js
+++ b/node-proxy/lib/utils/http-utils.js
@@ -34,7 +34,7 @@ exports.createProtocolServer = function(protocol, opts) {
       ssl_opts.ca   = fs.readFileSync(opts.ca);
       ssl_opts.cert = fs.readFileSync(opts.certificate);
       ssl_opts.key  = fs.readFileSync(opts.private_key);
-
+      ssl_opts.honorCipherOrder = true;
       ssl_opts.ciphers = opts.ciphers || "kEECDH:+kEECDH+SHA:kEDH:+kEDH+SHA:+\
           kEDH+CAMELLIA:kECDH:+kECDH+SHA:kRSA:+kRSA+SHA:+kRSA+\
           CAMELLIA:!aNULL:!eNULL:!SSLv2:!RC4:!DES:!EXP:!SEED:!IDEA:+3DES";


### PR DESCRIPTION
Sets honorCipherOrder to true to prefer ciphers in the order that they are
listed to improve security.