### PR TITLE
routing-daemon: Set ActiveMQ prefetch limit to 1

### DIFF
--- a/routing-daemon/lib/openshift/routing/daemon.rb
+++ b/routing-daemon/lib/openshift/routing/daemon.rb
@@ -197,6 +197,7 @@ module OpenShift
       subscription_hash = {
         'id' => @uuid,
         'ack' => 'client-individual',
+        'activemq.prefetchSize' => 1,
       }
 
       @logger.info "Subscribing to #{@destination}..."


### PR DESCRIPTION
Set the ActiveMQ prefetch limit to 1 to prevent the ActiveMQ broker from sending messages faster than the routing-daemon handles them.

See <http://activemq.apache.org/what-is-the-prefetch-limit-for.html>.

This commit is related to bug 1227472.

https://bugzilla.redhat.com/show_bug.cgi?id=1227472