### PR TITLE
routing-daemon: F5: Ignore HTTP 409 Conflict

### DIFF
--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -70,6 +70,17 @@ module OpenShift
             raise LBModelException.new "Expected HTTP #{expected_code} but got #{response.code} instead"
           end
         end
+      rescue RestClient::Conflict => e
+        msg = "Got #{e.class} exception: #{e.message}"
+        begin
+          resp = JSON.parse e.response
+          m = resp['message']
+          msg += " (#{m})" unless m.empty?
+        rescue
+        end
+        msg += '; assuming the intended resource already exists and ignoring.'
+
+        @logger.warn msg
       rescue RestClient::ExceptionWithResponse => e
         raise unless options[:wrap_exceptions]
 


### PR DESCRIPTION
`F5IControlRestLoadBalancerModel#rest_request`: Treat HTTP 409 Conflict responses as a non-error: log a warning, but do not raise an exception. Usually a 409 response means that the intended resource has already been created.

This commit is related to bug 1227472.

https://bugzilla.redhat.com/show_bug.cgi?id=1227472