### PR TITLE
routing-daemon: F5: Try harder to delete client-ssl profile

### DIFF
--- a/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
+++ b/routing-daemon/lib/openshift/routing/models/f5-icontrol-rest.rb
@@ -358,17 +358,29 @@ module OpenShift
     end
 
     def remove_ssl pool_name, alias_str
-      @logger.debug("LTM removing #{URI.escape(alias_str)}-ssl-profile client-ssl from #{@https_vserver}")
-      delete(resource: "/mgmt/tm/ltm/virtual/#{@https_vserver}/profiles/#{URI.escape(alias_str)}-ssl-profile")
+      @exceptions = LBModelExceptionCollector.new
 
-      @logger.debug("LTM deleting removing #{URI.escape(alias_str)}-ssl-profile")
-      delete(resource: "/mgmt/tm/ltm/profile/client-ssl/#{URI.escape(alias_str)}-ssl-profile")
+      @exceptions.try do
+        @logger.debug("LTM removing #{URI.escape(alias_str)}-ssl-profile client-ssl from #{@https_vserver}")
+        delete(resource: "/mgmt/tm/ltm/virtual/#{@https_vserver}/profiles/#{URI.escape(alias_str)}-ssl-profile")
+      end
 
-      @logger.debug("LTM removing #{alias_str}-https-key")
-      delete(resource: "/mgmt/tm/sys/file/ssl-key/#{URI.escape(alias_str)}-https-key.key")
+      @exceptions.try do
+        @logger.debug("LTM deleting removing #{URI.escape(alias_str)}-ssl-profile")
+        delete(resource: "/mgmt/tm/ltm/profile/client-ssl/#{URI.escape(alias_str)}-ssl-profile")
+      end
 
-      @logger.debug("LTM removing #{alias_str}-https-cert")
-      delete(resource: "/mgmt/tm/sys/file/ssl-cert/#{URI.escape(alias_str)}-https-cert.crt")
+      @exceptions.try do
+        @logger.debug("LTM removing #{alias_str}-https-key")
+        delete(resource: "/mgmt/tm/sys/file/ssl-key/#{URI.escape(alias_str)}-https-key.key")
+      end
+
+      @exceptions.try do
+        @logger.debug("LTM removing #{alias_str}-https-cert")
+        delete(resource: "/mgmt/tm/sys/file/ssl-cert/#{URI.escape(alias_str)}-https-cert.crt")
+      end
+
+      @exceptions.done
     end
 
     def get_pool_certificates pool_name

--- a/routing-daemon/lib/openshift/routing/models/load_balancer.rb
+++ b/routing-daemon/lib/openshift/routing/models/load_balancer.rb
@@ -2,6 +2,27 @@ module OpenShift
 
   class LBModelException < StandardError; end
 
+  class LBModelExceptionCollector
+    def initialize
+      @exceptions = []
+    end
+
+    def try
+      yield
+    rescue LBModelException => e
+      @exceptions << e
+    end
+
+    def to_s
+      "got #{@exceptions.length} LBModelException exceptions: " +
+        @exceptions.map {|e| e.message}.join('; ')
+    end
+
+    def done
+      raise LBModelException.new self.to_s unless @exceptions.empty?
+    end
+  end
+
   # == Abstract routing model class
   #
   # Presents direct access to a load balancer.  This is an abstract class.


### PR DESCRIPTION
`F5IControlRestLoadBalancerModel#remove_ssl`: Try to delete the client-ssl profile even if deleting it from the virtual server fails; try to delete the key even if deleting the client-ssl fails; and try to delete the certificate even if deleting the key fails.

`LBModelExceptionCollector` New helper class to rescue, collect, and combine `LBModelException` exceptions.

F5 BIG-IP will not let us delete a resource that is in use (e.g., a client-ssl profile that is still associated with a virtual server), but this change will enable the routing-daemon to finish cleaning up a client-ssl profile or associated key or certificate that is already deleted from the virtual server.

This commit fixes bug 1406251.

https://bugzilla.redhat.com/show_bug.cgi?id=1406251

---

@thrasher-redhat

