### PR TITLE
Fix input/output deadlock condition

### DIFF
--- a/logshifter/core_test.go
+++ b/logshifter/core_test.go
@@ -91,7 +91,7 @@ func TestDropOnBlockedOutput(t *testing.T) {
 	// and the writer is unblocked.
 	ag.AssertStatsEqual(t, map[string]float64{
 		"input.read":   1000,
-		"input.drop":   998,
+		"input.evict":  998,
 		"output.write": 2,
 	})
 

--- a/logshifter/input_test.go
+++ b/logshifter/input_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestInputBlocking ensures that Input never blocks, regardless of the queue
+// consumption rate.
+func TestInputBlocking(t *testing.T) {
+	messageCount := int64(10000)
+	messageSize := 1024
+
+	// Use a small queue to help ensure an input backup.
+	queue := make(chan []byte, 1)
+
+	// Set up a fast output sink to help ensure an input backup.
+	go func() {
+		for {
+			<-queue
+		}
+	}()
+
+	// Collect stats.
+	stats := make(map[string]float64)
+	statsCh := make(chan Stat)
+	stop := make(chan struct{})
+	statsWg := sync.WaitGroup{}
+	statsWg.Add(1)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				statsWg.Done()
+				return
+			case s := <-statsCh:
+				stats[s.name] = stats[s.name] + s.value
+			}
+		}
+	}()
+
+	// Create an input Reader.
+	var data string
+	var i int64 = 0
+	for ; i < messageCount; i++ {
+		data += strings.Repeat("0", messageSize-1) + "\n"
+	}
+	buffer := bytes.NewBufferString(data)
+	t.Logf("created %d byte test input (%d lines @ %d bytes each)\n", buffer.Len(), messageCount, messageSize)
+
+	// Read until the test reader closes.
+	input := &Input{
+		reader:       buffer,
+		queue:        queue,
+		bufferSize:   messageSize,
+		statsChannel: statsCh,
+	}
+	input.read()
+
+	// If execution reaches this point, the Input hasn't wedged and the test is
+	// successful.
+
+	// Shut down the stats collector.
+	close(stop)
+	statsWg.Wait()
+	t.Logf("stats: %#v", stats)
+}


### PR DESCRIPTION
If the rate of input and output are very high, the message queue size
can trend towards zero. In this case, it's possible that the Input will
decide to evict from the queue, but by the time the eviction occurs the
output has drained the queue to zero, causing the eviction dequeue to
block forever. In this case, Input is now blocked trying to evict, and
Output is blocked waiting for Input.

Fix the deadlock by distinguishing between eviction of old messages and
dropping of new messages, and making those operations non-blocking.

Add a test which verifies the fix under these conditions.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1464125